### PR TITLE
chore(dependencies): Removes unnecessary optional @types/graphql dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,9 +105,6 @@
     "tslint": "^4.0.2",
     "typescript": "^2.1.4"
   },
-  "optionalDependencies": {
-    "@types/graphql": "^0.8.2"
-  },
   "typings": "dist/index.d.ts",
   "typescript": {
     "definition": "dist/index.d.ts"


### PR DESCRIPTION
I don't believe `optionalDependency` is necessary. It installs `@types/graphql` which apparently conflicts with `graphql` typings causing issues like so:

```
$ tsc -p .
...
node_modules/@types/graphql/index.d.ts(126,9): error TS2484: Export declaration conflicts with exported declaration of 'IntrospectionNonNullTypeRef'
```