### PR TITLE
Fix error in template file resolutions

### DIFF
--- a/src/engine/templates.ts
+++ b/src/engine/templates.ts
@@ -23,7 +23,7 @@ const getConfig = (generatorPath: string): TemplateConfig => {
   let dirString = __dirname;
   const configPath = path.resolve(dirString, generatorPath, 'config.json');
   let config = <TemplateConfig>(JSON.parse(fs.readFileSync(configPath, 'utf8')));
-  config.basePath = generatorPath;
+  config.basePath = path.resolve(dirString, generatorPath);
 
   return config;
 };


### PR DESCRIPTION
Currently when trying to run the multi-file typescript setup the user gets the following error:

```
(node:94403) UnhandledPromiseRejectionWarning: Unhandled promise rejection 
  (rejection id: 1): 
    Error: Template file /home/<user>/generators/type....index.handlebars does not exist
```

This issue is because the generator path wasn't being resolved as the config.js path was. 