### PR TITLE
Fixes #111: Prevent primitives from being output like other models

### DIFF
--- a/src/engine/codegen.ts
+++ b/src/engine/codegen.ts
@@ -20,7 +20,9 @@ export const prepareCodegen = (schema: GraphQLSchema,
   let typesMap: { [typeName: string]: GraphQLNamedType } = schema.getTypeMap();
 
   Object.keys(typesMap).forEach(typeName => {
-    models.push(...handleType(schema, primitivesMap, typesMap[typeName]));
+    if (!(typeName in primitivesMap)) {
+      models.push(...handleType(schema, primitivesMap, typesMap[typeName]));
+    }
   });
 
   if (!config.noDocuments) {


### PR DESCRIPTION
I'm not actually sure this is the best way to go about doing this. Maybe the logic should've went in the handleType method? Regardless, this gets the desired result. 

By the way, I think some of these methods really should be broken down to be more testable. 