### PR TITLE
Added generator-specific config in `gql-gen.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="NEXT"></a>
+## NEXT
+
+* Added support for generator-specific config in `gql-gen.json` file.
+* Generated config is now exposed in the template under the name `config` in the root context.
+* Added `currentTime` to the context.
+
+### Breaking Changes
+
+* Changed CLI option that points to `gql-gen.json` file from `--project-config` to `--config`.
+
 <a name="0.8.14"></a>
 ## [0.8.14](https://github.com/dotansimha/graphql-codegen/compare/0.8.12...0.8.14) (2017-10-29)
 

--- a/dev-test/config/gql-gen.json
+++ b/dev-test/config/gql-gen.json
@@ -1,0 +1,5 @@
+{
+  "generatorConfig": {
+    "printTime": true
+  }
+}

--- a/packages/graphql-codegen-cli/README.md
+++ b/packages/graphql-codegen-cli/README.md
@@ -33,3 +33,23 @@ This is an example for a valid file:
 You can override the config for `flattenTypes` and `primitives` (refer to `graphql-codegen-compiler` package README for more info).
 
 You can also specify JavaScript files for `customHelpers` when generating custom templates (the custom files should export a `Function` as default).
+
+### Generator Specific Config
+
+You can also pass configuration object to the output generator, by adding `generatorConfig` to the `gql-gen.json` file:
+
+```json
+{
+  "generatorConfig": {
+    "myConfig": "my value"
+  },
+  "flattenTypes": true,
+  "primitives": {
+    "String": "string",
+    "Int": "number",
+    "Float": "number",
+    "Boolean": "boolean",
+    "ID": "string"
+  }
+}
+```

--- a/packages/graphql-codegen-cli/tests/cli.spec.ts
+++ b/packages/graphql-codegen-cli/tests/cli.spec.ts
@@ -9,4 +9,14 @@ describe('executeWithOptions', () => {
 
     expect(result.length).toBe(1);
   });
+
+  it('execute the correct results when using custom config file', async () => {
+    const result = await executeWithOptions({
+      file: '../../dev-test/githunt/schema.json',
+      template: 'ts',
+      config: '../../dev-test/config/gql-gen.json',
+    });
+
+    expect(result[0].content).toContain('Generated in');
+  });
 });

--- a/packages/graphql-codegen-compiler/package.json
+++ b/packages/graphql-codegen-compiler/package.json
@@ -23,12 +23,14 @@
   },
   "dependencies": {
     "@types/handlebars": "^4.0.33",
+    "@types/moment": "^2.13.0",
     "change-case": "^3.0.1",
     "common-tags": "^1.4.0",
     "graphql-codegen-compiler": "0.8.14",
     "graphql-codegen-core": "0.8.14",
     "graphql-codegen-generators": "0.8.14",
-    "handlebars": "^4.0.10"
+    "handlebars": "^4.0.10",
+    "moment": "^2.19.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/graphql-codegen-compiler/src/compile.ts
+++ b/packages/graphql-codegen-compiler/src/compile.ts
@@ -15,7 +15,7 @@ export const DEFAULT_SETTINGS: Settings = {
 
 export function compileTemplate(config: GeneratorConfig, templateContext: SchemaTemplateContext, documents: Document[] = [], settings: Settings = DEFAULT_SETTINGS): FileOutput[] {
   if (!config) {
-    throw new Error(`compileTemplate required valid config!`);
+    throw new Error(`compileTemplate requires a valid GeneratorConfig object!`);
   }
 
   debugLog(`[compileTemplate] starting to compile template with input type = ${config.inputType}`);
@@ -52,10 +52,12 @@ export function compileTemplate(config: GeneratorConfig, templateContext: Schema
         fragments: frArr,
         hasFragments: frArr.length > 0,
         hasOperations: opArr.length > 0,
-      }
+      };
     }, { hasFragments: false, hasOperations: false, operations: [], fragments: [] } as Document);
 
-    debugLog(`[compileTemplate] all documents merged into single document, total of ${mergedDocuments.operations.length} operations and ${mergedDocuments.fragments.length} fragments`);
+    debugLog(
+      `[compileTemplate] all documents merged into single document, total of ${mergedDocuments.operations.length} operations and ${mergedDocuments.fragments.length} fragments`
+    );
 
     if (config.flattenTypes) {
       debugLog(`[compileTemplate] flattenTypes is true, flattening all selection sets from all documents...`);
@@ -70,7 +72,7 @@ export function compileTemplate(config: GeneratorConfig, templateContext: Schema
     }
 
     if (!config.outFile) {
-      throw new Error('Config outFile is required when using inputType = SINGLE_FILE!')
+      throw new Error('Config outFile is required when using inputType = SINGLE_FILE!');
     }
 
     debugLog(`[compileTemplate] Executing generateSingleFile...`);
@@ -85,7 +87,7 @@ export function compileTemplate(config: GeneratorConfig, templateContext: Schema
   } else if (config.inputType === EInputType.MULTIPLE_FILES || config.inputType === EInputType.PROJECT) {
     if (config.inputType === EInputType.MULTIPLE_FILES) {
       if (!config.filesExtension) {
-        throw new Error('Config filesExtension is required when using inputType = MULTIPLE_FILES!')
+        throw new Error('Config filesExtension is required when using inputType = MULTIPLE_FILES!');
       }
     }
 
@@ -103,7 +105,7 @@ export function compileTemplate(config: GeneratorConfig, templateContext: Schema
       prev[item.key] = item.value;
 
       return prev;
-    }, {}) as {[name: string]: Function[]};
+    }, {}) as { [name: string]: Function[] };
 
     debugLog(`[compileTemplate] Templates names: `, Object.keys(compiledTemplates));
 

--- a/packages/graphql-codegen-compiler/src/generate-multiple-files.ts
+++ b/packages/graphql-codegen-compiler/src/generate-multiple-files.ts
@@ -14,6 +14,7 @@ import {
 import { sanitizeFilename } from './sanitizie-filename';
 import { prepareSchemaForDocumentsOnly } from './prepare-documents-only';
 import * as path from 'path';
+import * as moment from 'moment';
 
 const handlersMap = {
   type: handleType,
@@ -36,24 +37,30 @@ export const ALLOWED_CUSTOM_TEMPLATE_EXT = [
   'gqlgen'
 ];
 
-function handleSchema(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
+interface ExtraConfig {
+  [configName: string]: any;
+}
+
+function handleSchema(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, extraConfig: ExtraConfig, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
   debugLog(`[handleSchema] called`);
 
   return [{
     filename: prefixAndPath + '.' + (fileExtension || ''),
     content: compiledTemplate({
+      config: extraConfig,
       ...schemaContext
     }),
   }];
 }
 
-function handleAll(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
+function handleAll(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, extraConfig: ExtraConfig, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
   debugLog(`[handleAll] called`);
 
   return [{
     filename: prefixAndPath + '.' + (fileExtension || ''),
     content: compiledTemplate({
       ...schemaContext,
+      config: extraConfig,
       operations: documents.operations,
       fragments: documents.fragments,
       hasFragments: documents.hasFragments,
@@ -62,12 +69,13 @@ function handleAll(compiledTemplate: Function, schemaContext: SchemaTemplateCont
   }];
 }
 
-function handleDocuments(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
+function handleDocuments(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, extraConfig: ExtraConfig, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
   debugLog(`[handleDocuments] called`);
 
   return [{
     filename: prefixAndPath + '.' + (fileExtension || ''),
     content: compiledTemplate({
+      config: extraConfig,
       operations: documents.operations,
       fragments: documents.fragments,
       hasFragments: documents.hasFragments,
@@ -76,75 +84,99 @@ function handleDocuments(compiledTemplate: Function, schemaContext: SchemaTempla
   }];
 }
 
-function handleType(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
+function handleType(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, extraConfig: ExtraConfig, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
   debugLog(`[handleType] called`);
 
   return schemaContext.types.map((type: Type) => ({
     filename: prefixAndPath + sanitizeFilename(type.name, 'type') + '.' + (fileExtension || ''),
-    content: compiledTemplate(type),
+    content: compiledTemplate({
+      ...type,
+      config: extraConfig,
+    }),
   }));
 }
 
-function handleInputType(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
+function handleInputType(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, extraConfig: ExtraConfig, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
   debugLog(`[handleInputType] called`);
 
   return schemaContext.inputTypes.map((type: Type) => ({
     filename: prefixAndPath + sanitizeFilename(type.name, 'input-type') + '.' + (fileExtension || ''),
-    content: compiledTemplate(type),
+    content: compiledTemplate({
+      ...type,
+      config: extraConfig,
+    }),
   }));
 }
 
-function handleUnion(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
+function handleUnion(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, extraConfig: ExtraConfig, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
   debugLog(`[handleUnion] called`);
 
   return schemaContext.unions.map((union: Union) => ({
     filename: prefixAndPath + sanitizeFilename(union.name, 'union') + '.' + (fileExtension || ''),
-    content: compiledTemplate(union),
+    content: compiledTemplate({
+      ...union,
+      config: extraConfig,
+    }),
   }));
 }
 
-function handleEnum(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
+function handleEnum(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, extraConfig: ExtraConfig, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
   debugLog(`[handleEnum] called`);
 
   return schemaContext.enums.map((en: Enum) => ({
     filename: prefixAndPath + sanitizeFilename(en.name, 'enum') + '.' + (fileExtension || ''),
-    content: compiledTemplate(en),
+    content: compiledTemplate({
+      ...en,
+      config: extraConfig,
+    }),
   }));
 }
 
-function handleScalar(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
+function handleScalar(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, extraConfig: ExtraConfig, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
   debugLog(`[handleScalar] called`);
 
   return schemaContext.scalars.map((scalar: Scalar) => ({
     filename: prefixAndPath + sanitizeFilename(scalar.name, 'scalar') + '.' + (fileExtension || ''),
-    content: compiledTemplate(scalar),
+    content: compiledTemplate({
+      ...scalar,
+      config: extraConfig,
+    }),
   }));
 }
 
-function handleInterface(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
+function handleInterface(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, extraConfig: ExtraConfig, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
   debugLog(`[handleInterface] called`);
 
   return schemaContext.interfaces.map((inf: Interface) => ({
     filename: prefixAndPath + sanitizeFilename(inf.name, 'interface') + '.' + (fileExtension || ''),
-    content: compiledTemplate(inf),
+    content: compiledTemplate({
+      ...inf,
+      config: extraConfig,
+    }),
   }));
 }
 
-function handleOperation(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
+function handleOperation(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, extraConfig: ExtraConfig, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
   debugLog(`[handleOperation] called`);
 
   return documents.operations.map((operation: Operation) => ({
     filename: prefixAndPath + sanitizeFilename(operation.name, operation.operationType) + '.' + (fileExtension || ''),
-    content: compiledTemplate(operation),
+    content: compiledTemplate({
+      ...operation,
+      config: extraConfig,
+    }),
   }));
 }
 
-function handleFragment(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
+function handleFragment(compiledTemplate: Function, schemaContext: SchemaTemplateContext, documents: Document, extraConfig: ExtraConfig, fileExtension: string, prefixAndPath: string = ''): FileOutput[] {
   debugLog(`[handleFragment] called`);
 
   return documents.fragments.map((fragment: Fragment) => ({
     filename: prefixAndPath + sanitizeFilename(fragment.name, 'fragment') + '.' + (fileExtension || ''),
-    content: compiledTemplate(fragment),
+    content: compiledTemplate({
+      ...fragment,
+      config: extraConfig,
+    }),
   }));
 }
 
@@ -203,13 +235,19 @@ export function generateMultipleFiles(templates: MultiFileTemplates, executionSe
 
       const handler = handlersMap[templateName];
 
-      result.push(...handler(templateFn, schemaContext, documents, config.filesExtension))
+      result.push(...handler(templateFn, schemaContext, documents, {
+        ...(config.config),
+        currentTime: moment().format(),
+      }, config.filesExtension));
     } else {
       const parsedTemplateName = parseTemplateName(templateName);
       debugLog(`[generateMultipleFiles] Using custom template handlers, parsed template name result: `, parsedTemplateName);
 
       if (parsedTemplateName !== null) {
-        result.push(...parsedTemplateName.handler(templateFn, schemaContext, documents, parsedTemplateName.fileExtension, parsedTemplateName.prefix))
+        result.push(...parsedTemplateName.handler(templateFn, schemaContext, documents, {
+          ...config.config,
+          currentTime: moment().format(),
+        }, parsedTemplateName.fileExtension, parsedTemplateName.prefix));
       }
     }
   });

--- a/packages/graphql-codegen-compiler/src/generate-single-file.ts
+++ b/packages/graphql-codegen-compiler/src/generate-single-file.ts
@@ -2,6 +2,7 @@ import { prepareSchemaForDocumentsOnly } from './prepare-documents-only';
 import { FileOutput, Settings } from './types';
 import { SchemaTemplateContext, Document, debugLog } from 'graphql-codegen-core';
 import { GeneratorConfig } from 'graphql-codegen-generators';
+import * as moment from 'moment';
 
 export function generateSingleFile(compiledIndexTemplate: HandlebarsTemplateDelegate, executionSettings: Settings, config: GeneratorConfig, templateContext: SchemaTemplateContext, documents: Document): FileOutput[] {
   debugLog(`[generateSingleFile] Compiling single file to: ${config.outFile}`);
@@ -10,6 +11,8 @@ export function generateSingleFile(compiledIndexTemplate: HandlebarsTemplateDele
     {
       filename: config.outFile,
       content: compiledIndexTemplate({
+        config: config.config,
+        currentTime: moment().format(),
         ...(!executionSettings.generateSchema) ? prepareSchemaForDocumentsOnly(templateContext) : templateContext,
         operations: documents.operations,
         fragments: documents.fragments,

--- a/packages/graphql-codegen-compiler/tests/multiple.spec.ts
+++ b/packages/graphql-codegen-compiler/tests/multiple.spec.ts
@@ -6,9 +6,9 @@ import {
 import { gql, makeExecutableSchema, GraphQLSchema } from 'graphql-codegen-core';
 import { compileTemplate } from '../src/compile';
 import * as fs from 'fs';
-import { TypescriptMultiFile } from 'graphql-codegen-generators';
+import { TypescriptMultiFile, GeneratorConfig } from 'graphql-codegen-generators';
 
-describe('TypeScript Multi File', () => {
+describe('Multiple Files', () => {
   const compileAndBuildContext = (typeDefs: string): SchemaTemplateContext => {
     const schema = makeExecutableSchema({ typeDefs, resolvers: {}, allowUndefinedInResolve: true }) as GraphQLSchema;
 
@@ -22,6 +22,28 @@ describe('TypeScript Multi File', () => {
   });
 
   describe('Schema', () => {
+    it('should pass custom config correctly to the generator', () => {
+      const templateContext = compileAndBuildContext(`
+        type Query {
+          fieldTest: String
+        }
+      `);
+
+      const compiled = compileTemplate({
+        ...config,
+        templates: {
+          type: `{{ config.custom }}`
+        },
+        config: {
+          custom: 'A',
+        },
+      } as GeneratorConfig, templateContext);
+
+      expect(compiled.length).toBe(1);
+      expect(compiled[0].filename).toBe('query.type.d.ts');
+      expect(compiled[0].content).toBeSimilarStringTo(`A`);
+    });
+
     it('should generate the correct types when using only simple Query', () => {
       const templateContext = compileAndBuildContext(`
         type Query {

--- a/packages/graphql-codegen-compiler/tests/single.spec.ts
+++ b/packages/graphql-codegen-compiler/tests/single.spec.ts
@@ -8,9 +8,9 @@ import {
 import { gql, makeExecutableSchema, GraphQLSchema } from 'graphql-codegen-core';
 import * as fs from 'fs';
 import { compileTemplate } from '../src/compile';
-import { TypescriptSingleFile } from 'graphql-codegen-generators';
+import { TypescriptSingleFile, GeneratorConfig } from 'graphql-codegen-generators';
 
-describe('TypeScript Single File', () => {
+describe('Single File', () => {
   const compileAndBuildContext = (typeDefs: string): SchemaTemplateContext => {
     const schema = makeExecutableSchema({ typeDefs, resolvers: {}, allowUndefinedInResolve: true }) as GraphQLSchema;
 
@@ -42,9 +42,33 @@ describe('TypeScript Single File', () => {
         templates: {
           index: '{{#each types}}{{#ifDirective this "app"}}directive{{/ifDirective}}{{/each}}',
         }
-      }, templateContext);
+      } as GeneratorConfig, templateContext);
 
       expect(compiled[0].content).toBe('directive');
+    });
+
+    it('should pass custom config to template', () => {
+      const templateContext = compileAndBuildContext(`
+        type Query {
+          fieldTest: String
+        }
+        
+        schema {
+          query: Query
+        }
+      `);
+
+      const compiled = compileTemplate({
+        ...config,
+        templates: {
+          index: '{{ config.custom }}',
+        },
+        config: {
+          custom: 'A',
+        },
+      } as GeneratorConfig, templateContext);
+
+      expect(compiled[0].content).toBe('A');
     });
 
     it('should support custom handlebar ifDirective when no directive added', () => {
@@ -65,7 +89,7 @@ describe('TypeScript Single File', () => {
         templates: {
           index: '{{#each types}}{{#ifDirective this "app"}}directive{{/ifDirective}}{{/each}}',
         }
-      }, templateContext);
+      } as GeneratorConfig, templateContext);
 
       expect(compiled[0].content).toBe('');
     });
@@ -88,7 +112,7 @@ describe('TypeScript Single File', () => {
         templates: {
           index: '{{#ifDirective this "app"}}directive{{test}}{{/ifDirective}}',
         }
-      }, templateContext);
+      } as GeneratorConfig, templateContext);
 
       expect(compiled[0].content).toBe('directive123');
     });

--- a/packages/graphql-codegen-compiler/yarn.lock
+++ b/packages/graphql-codegen-compiler/yarn.lock
@@ -24,6 +24,12 @@
   version "20.0.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-20.0.2.tgz#86c751121fb53dbd39bb1a08c45083da13f2dc67"
 
+"@types/moment@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@types/moment/-/moment-2.13.0.tgz#604ebd189bc3bc34a1548689404e61a2a4aac896"
+  dependencies:
+    moment "*"
+
 "@types/node@7":
   version "7.0.36"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.36.tgz#54286fcce8a4f7498cea1ec5fce5f5edd3521948"
@@ -1482,6 +1488,10 @@ mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+moment@*, moment@^2.19.2:
+  version "2.19.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.2.tgz#8a7f774c95a64550b4c7ebd496683908f9419dbe"
 
 ms@2.0.0:
   version "2.0.0"

--- a/packages/graphql-codegen-generators/src/types.ts
+++ b/packages/graphql-codegen-generators/src/types.ts
@@ -7,6 +7,7 @@ export const EInputType = {
 export interface GeneratorConfig {
   inputType: string; // EInputType
   flattenTypes: boolean;
+  config?: { [configName: string]: any };
   templates: { [templateName: string]: string | string[] } | string;
   primitives: {
     String: string;

--- a/packages/graphql-codegen-generators/src/typescript-single-file/template.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-single-file/template.handlebars
@@ -1,3 +1,6 @@
 /* tslint:disable */
+{{#if config.printTime }}
+// Generated in {{ currentTime }}
+{{/if}}
 {{> schema }}
 {{> documents }}


### PR DESCRIPTION
- change cli from `projectConfig` to be `config`
- use gql-gen not only in project generation
- expose `config` as part of the root context of the template
- export `currentTime` as part of the root context of the template
- added `generated in...` to ts single file template

Related to:
https://github.com/dotansimha/graphql-code-generator/issues/148

Usage example is `gql-gen.json`:
https://github.com/dotansimha/graphql-code-generator/blob/f54696ebf550a25ef8b70f376d9ff030653aface/dev-test/config/gql-gen.json

And then it's available as part of the template context:
https://github.com/dotansimha/graphql-code-generator/blob/f54696ebf550a25ef8b70f376d9ff030653aface/packages/graphql-codegen-generators/src/typescript-single-file/template.handlebars