### PR TITLE
Feature/add require option

### DIFF
--- a/dev-test/githunt/schema.js
+++ b/dev-test/githunt/schema.js
@@ -1,0 +1,3 @@
+const introspectionSchema = require("./schema.json");
+const GraphQL = require("graphql");
+module.exports.default = GraphQL.buildClientSchema(introspectionSchema);

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -78,6 +78,9 @@
     "tslint": "^5.4.3",
     "typescript": "^2.4.1"
   },
+  "peerDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0"
+  },
   "dependencies": {
     "commander": "^2.11.0",
     "glob": "^7.1.2",

--- a/packages/graphql-codegen-cli/src/cli.ts
+++ b/packages/graphql-codegen-cli/src/cli.ts
@@ -73,6 +73,7 @@ export const initCLI = (args): any => {
     .option('-m, --no-schema', 'Generates only client side documents, without server side schema types')
     .option('-c, --no-documents', 'Generates only server side schema types, without client side documents')
     .option('-o, --out <path>', 'Output file(s) path', String, './')
+    .option('-r, --require [module]', 'module to preload (option can be repeated)', collect, [])
     .arguments('<options> [documents...]')
     .parse(args);
 

--- a/packages/graphql-codegen-cli/src/cli.ts
+++ b/packages/graphql-codegen-cli/src/cli.ts
@@ -39,6 +39,7 @@ export interface CLIOptions {
   schema?: any;
   documents?: any;
   config?: string;
+  require?: string[];
 }
 
 interface GqlGenConfig {
@@ -73,7 +74,7 @@ export const initCLI = (args): any => {
     .option('-m, --no-schema', 'Generates only client side documents, without server side schema types')
     .option('-c, --no-documents', 'Generates only server side schema types, without client side documents')
     .option('-o, --out <path>', 'Output file(s) path', String, './')
-    .option('-r, --require [module]', 'module to preload (option can be repeated)', collect, [])
+    .option('-r, --require [require]', 'module to preload (option can be repeated)', collect, [])
     .arguments('<options> [documents...]')
     .parse(args);
 
@@ -121,7 +122,10 @@ export const executeWithOptions = async (options: CLIOptions): Promise<FileOutpu
   const headers: string[] = options.header;
   const generateSchema: boolean = options.schema;
   const generateDocuments: boolean = options.documents;
+  const modulesToRequire: string[] = options.require || [];
   let schemaExportPromise;
+
+  modulesToRequire.forEach((mod) => require(mod));
 
   if (file) {
     schemaExportPromise = introspectionFromFile(file).then(introspectionToGraphQLSchema);

--- a/packages/graphql-codegen-cli/tests/cli.spec.ts
+++ b/packages/graphql-codegen-cli/tests/cli.spec.ts
@@ -19,4 +19,13 @@ describe('executeWithOptions', () => {
 
     expect(result[0].content).toContain('Generated in');
   });
+
+  it('execute the correct results when using export', async () => {
+    const result = await executeWithOptions({
+      export: '../../dev-test/githunt/schema.js',
+      template: 'ts',
+    });
+    expect(result.length).toBe(1);
+  });
+
 });

--- a/packages/graphql-codegen-cli/tests/cli.spec.ts
+++ b/packages/graphql-codegen-cli/tests/cli.spec.ts
@@ -28,4 +28,14 @@ describe('executeWithOptions', () => {
     expect(result.length).toBe(1);
   });
 
+  it('execute the correct results when using export and require', async () => {
+    const result = await executeWithOptions({
+      export: '../../dev-test/githunt/schema.js',
+      template: 'ts',
+      require: ['../tests/dummy-require.js']
+    });
+    expect(result.length).toBe(1);
+    expect(global.dummyWasLoaded).toBe(true);
+  });
+
 });

--- a/packages/graphql-codegen-cli/tests/dummy-require.js
+++ b/packages/graphql-codegen-cli/tests/dummy-require.js
@@ -1,0 +1,3 @@
+// Just set something in global so the test can verify that it got set and thereby know that this module was loaded
+
+global.dummyWasLoaded = true;

--- a/packages/graphql-codegen-core/package.json
+++ b/packages/graphql-codegen-core/package.json
@@ -80,7 +80,6 @@
     "@types/graphql": "^0.10.0",
     "@types/jest": "^20.0.2",
     "@types/node": "7",
-    "graphql": "^0.10.4",
     "jest": "^20.0.4",
     "rimraf": "^2.6.1",
     "tslint": "^5.4.3",

--- a/packages/graphql-codegen-core/src/types.ts
+++ b/packages/graphql-codegen-core/src/types.ts
@@ -105,7 +105,7 @@ export interface SelectionSetInlineFragment extends SelectionSetItem {
   onType: string;
   fields: SelectionSetFieldNode[];
   fragmentsSpread: SelectionSetFragmentSpread[];
-  inlineFragments: SelectionSetInlineFragment[],
+  inlineFragments: SelectionSetInlineFragment[];
   hasFragmentsSpread: boolean;
   hasInlineFragments: boolean;
   hasFields: boolean;
@@ -123,7 +123,7 @@ export interface SelectionSetFieldNode extends SelectionSetItem {
   isArray: boolean;
   fields: SelectionSetFieldNode[];
   fragmentsSpread: SelectionSetFragmentSpread[];
-  inlineFragments: SelectionSetInlineFragment[],
+  inlineFragments: SelectionSetInlineFragment[];
   hasFragmentsSpread: boolean;
   hasInlineFragments: boolean;
   hasFields: boolean;
@@ -155,7 +155,7 @@ export interface Fragment extends AstNode {
   document: string;
   fields: SelectionSetFieldNode[];
   fragmentsSpread: SelectionSetFragmentSpread[];
-  inlineFragments: SelectionSetInlineFragment[],
+  inlineFragments: SelectionSetInlineFragment[];
   hasFragmentsSpread: boolean;
   hasInlineFragments: boolean;
   hasFields: boolean;
@@ -173,7 +173,7 @@ export interface Operation extends AstNode {
   document: string;
   fields: SelectionSetFieldNode[];
   fragmentsSpread: SelectionSetFragmentSpread[];
-  inlineFragments: SelectionSetInlineFragment[],
+  inlineFragments: SelectionSetInlineFragment[];
   hasFragmentsSpread: boolean;
   hasInlineFragments: boolean;
   hasFields: boolean;

--- a/packages/graphql-codegen-core/yarn.lock
+++ b/packages/graphql-codegen-core/yarn.lock
@@ -711,12 +711,6 @@ graphql-tools@^1.0.0:
   optionalDependencies:
     "@types/graphql" "^0.9.0"
 
-graphql@^0.10.4:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.4.tgz#55ae6857ae521e3592aec4265587e5e94c477667"
-  dependencies:
-    iterall "^1.1.0"
-
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -979,10 +973,6 @@ istanbul-reports@^1.1.1:
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.1.tgz#042be5c89e175bc3f86523caab29c014e77fee4e"
   dependencies:
     handlebars "^4.0.3"
-
-iterall@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.1.tgz#f7f0af11e9a04ec6426260f5019d9fcca4d50214"
 
 jest-changed-files@^20.0.3:
   version "20.0.3"


### PR DESCRIPTION
This pull request adds a `--require` option similar to the same option in `node`. It will enable the `--export` option to accept a `.ts` file by doing `--require ts-node/register`.

It also adds a test case for the `--export` option (I could not find any test for it). To make this work I needed to have `graphql` only as peer dependency so all packages uses the same version. Before it was specified both as peer dependency and devDependency in `graphql-codegen-core`.

I tried very hard to make a test case for ts-node/register but in the end it was not just possible because of the way `jest` loads modules. Since `ts-node/register` patches `require` you need to use the real patched `require` to test it. But `jest` always gives all files its own fake `require` and there is no way to turn it off. See [here](https://stackoverflow.com/questions/46433678/specify-code-to-run-before-any-jest-setup-happens) for some more info.

Fixes #171.