### PR TITLE
Update enumeration handling to emit Typescript string-backed enums

### DIFF
--- a/packages/graphql-codegen-compiler/tests/multiple.spec.ts
+++ b/packages/graphql-codegen-compiler/tests/multiple.spec.ts
@@ -456,7 +456,7 @@ describe('Multiple Files', () => {
         /* A list of options for the sort order of the feed */
         export enum FeedType {
           HOT = "HOT",
-          NEW = NEW",
+          NEW = "NEW",
           TOP = "TOP",
         }
       `);

--- a/packages/graphql-codegen-compiler/tests/multiple.spec.ts
+++ b/packages/graphql-codegen-compiler/tests/multiple.spec.ts
@@ -378,7 +378,7 @@ describe('Multiple Files', () => {
         /* A list of options for the sort order of the feed */
         export enum FeedType {
           HOT = "HOT",
-          NEW = NEW",
+          NEW = "NEW",
           TOP = "TOP",
         }
       `);

--- a/packages/graphql-codegen-compiler/tests/multiple.spec.ts
+++ b/packages/graphql-codegen-compiler/tests/multiple.spec.ts
@@ -113,7 +113,7 @@ describe('Multiple Files', () => {
       expect(compiled[1].content).toBeSimilarStringTo(`
         export enum MyEnum {
           V1 = "V1",
-          V2 = "V2"
+          V2 = "V2",
         }
       `);
     });
@@ -376,11 +376,19 @@ describe('Multiple Files', () => {
 
       expect(compiled[0].content).toBeSimilarStringTo(`
         /* A list of options for the sort order of the feed */
-        export type FeedType = "HOT" | "NEW" | "TOP";
+        export enum FeedType {
+          HOT = "HOT",
+          NEW = NEW",
+          TOP = "TOP",
+        }
       `);
       expect(compiled[1].content).toBeSimilarStringTo(`
         /* The type of vote to record, when submitting a vote */
-        export type VoteType = "UP" | "DOWN" | "CANCEL";
+        export enum VoteType {
+          UP = "UP",
+          DOWN = "DOWN",
+          CANCEL = "CANCEL",
+        }
       `);
       expect(compiled[2].content).toBeSimilarStringTo(`
         export namespace MyFeed {
@@ -446,11 +454,19 @@ describe('Multiple Files', () => {
 
       expect(compiled[0].content).toBeSimilarStringTo(`
         /* A list of options for the sort order of the feed */
-        export type FeedType = "HOT" | "NEW" | "TOP";
+        export enum FeedType {
+          HOT = "HOT",
+          NEW = NEW",
+          TOP = "TOP",
+        }
       `);
       expect(compiled[1].content).toBeSimilarStringTo(`
         /* The type of vote to record, when submitting a vote */
-        export type VoteType = "UP" | "DOWN" | "CANCEL";
+        export enum VoteType {
+          UP = "UP",
+          DOWN = "DOWN",
+          CANCEL = "CANCEL",
+        }
       `);
       expect(compiled[2].content).toBeSimilarStringTo(`
         import { RepoFields } from './repofields.fragment';

--- a/packages/graphql-codegen-compiler/tests/multiple.spec.ts
+++ b/packages/graphql-codegen-compiler/tests/multiple.spec.ts
@@ -111,7 +111,10 @@ describe('Multiple Files', () => {
       `);
       expect(compiled[1].filename).toBe('myenum.enum.d.ts');
       expect(compiled[1].content).toBeSimilarStringTo(`
-        export type MyEnum = "V1" | "V2";
+        export enum MyEnum {
+          V1 = "V1",
+          V2 = "V2"
+        }
       `);
     });
 

--- a/packages/graphql-codegen-compiler/tests/single.spec.ts
+++ b/packages/graphql-codegen-compiler/tests/single.spec.ts
@@ -275,7 +275,7 @@ describe('Single File', () => {
       export enum MyEnum {
         A = "A",
         B = "B",
-        C = "C"
+        C = "C",
       `);
     });
 

--- a/packages/graphql-codegen-compiler/tests/single.spec.ts
+++ b/packages/graphql-codegen-compiler/tests/single.spec.ts
@@ -397,8 +397,8 @@ describe('Single File', () => {
       expect(content).toContain('export interface Mutation');
       expect(content).toContain('export interface Subscription');
 
-      expect(content).toContain('export type FeedType');
-      expect(content).toContain('export type VoteType');
+      expect(content).toContain('export enum FeedType');
+      expect(content).toContain('export enum VoteType');
 
       expect(content).toContain('export interface Entry');
       expect(content).toContain('export interface User');
@@ -443,10 +443,18 @@ describe('Single File', () => {
       expect(compiled[0].content).toBeSimilarStringTo(`
           /* tslint:disable */
           /* A list of options for the sort order of the feed */
-          export type FeedType = "HOT" | "NEW" | "TOP";
+          export enum FeedType {
+            HOT = "HOT",
+            NEW = "NEW",
+            TOP = "TOP",
+          }
           
           /* The type of vote to record, when submitting a vote */
-          export type VoteType = "UP" | "DOWN" | "CANCEL";
+          export enum VoteType {
+            UP = "UP",
+            DOWN = "DOWN",
+            CANCEL = "CANCEL",
+          }
           
           export namespace MyFeed {
             export type Variables = {
@@ -505,10 +513,18 @@ describe('Single File', () => {
       expect(content).toBeSimilarStringTo(`
           /* tslint:disable */
           /* A list of options for the sort order of the feed */
-          export type FeedType = "HOT" | "NEW" | "TOP";
+          export enum FeedType {
+            HOT = "HOT",
+            NEW = "NEW",
+            TOP = "TOP",
+          }
           
           /* The type of vote to record, when submitting a vote */
-          export type VoteType = "UP" | "DOWN" | "CANCEL";
+          export enum VoteType {
+            UP = "UP",
+            DOWN = "DOWN",
+            CANCEL = "CANCEL",
+          }
           
           export namespace MyFeed {
             export type Variables = {
@@ -572,10 +588,18 @@ describe('Single File', () => {
       expect(content).toBeSimilarStringTo(`
        /* tslint:disable */
     /* A list of options for the sort order of the feed */
-    export type FeedType = "HOT" | "NEW" | "TOP";
+    export enum FeedType {
+      HOT = "HOT",
+      NEW = "NEW",
+      TOP = "TOP",
+    }
     
     /* The type of vote to record, when submitting a vote */
-    export type VoteType = "UP" | "DOWN" | "CANCEL";
+    export enum VoteType {
+      UP = "UP",
+      DOWN = "DOWN",
+      CANCEL = "CANCEL",
+    }
     
     export namespace MyFeed {
       export type Variables = {

--- a/packages/graphql-codegen-compiler/tests/single.spec.ts
+++ b/packages/graphql-codegen-compiler/tests/single.spec.ts
@@ -272,7 +272,11 @@ describe('Single File', () => {
       export interface Query {
         fieldTest: MyEnum;
       }
-      export type MyEnum = "A" | "B" | "C";`);
+      export enum MyEnum {
+        A = "A",
+        B = "B",
+        C = "C"
+      `);
     });
 
     it('should generate unions correctly', () => {

--- a/packages/graphql-codegen-compiler/tests/single.spec.ts
+++ b/packages/graphql-codegen-compiler/tests/single.spec.ts
@@ -276,6 +276,7 @@ describe('Single File', () => {
         A = "A",
         B = "B",
         C = "C",
+      }
       `);
     });
 

--- a/packages/graphql-codegen-generators/src/typescript-multi-file/enum.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-multi-file/enum.handlebars
@@ -1,5 +1,5 @@
 {{ toComment description }}
 export enum {{ name }} {
-  {{#each values }}{{value}}: "{{ value }}"{{#unless @last}},
+  {{#each values }}{{value}}= "{{ value }}",{{#unless @last}}
   {{/unless}}{{/each}}
 }

--- a/packages/graphql-codegen-generators/src/typescript-multi-file/enum.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-multi-file/enum.handlebars
@@ -1,5 +1,5 @@
 {{ toComment description }}
 export enum {{ name }} {
-  {{#each values }}{{value}}= "{{ value }}",{{#unless @last}}
+  {{#each values }}{{value}} = "{{ value }}",{{#unless @last}}
   {{/unless}}{{/each}}
 }

--- a/packages/graphql-codegen-generators/src/typescript-multi-file/enum.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-multi-file/enum.handlebars
@@ -1,2 +1,5 @@
 {{ toComment description }}
-export type {{ name }} = {{#each values }}"{{ value }}"{{#unless @last}} | {{/unless}}{{/each}};
+export enum {{ name }} {
+  = {{#each values }}{{value}}: "{{ value }}"{{#unless @last}},
+  {{/unless}}{{/each}};
+}

--- a/packages/graphql-codegen-generators/src/typescript-multi-file/enum.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-multi-file/enum.handlebars
@@ -1,5 +1,5 @@
 {{ toComment description }}
 export enum {{ name }} {
-  = {{#each values }}{{value}}: "{{ value }}"{{#unless @last}},
-  {{/unless}}{{/each}};
+  {{#each values }}{{value}}: "{{ value }}"{{#unless @last}},
+  {{/unless}}{{/each}}
 }

--- a/packages/graphql-codegen-generators/src/typescript-single-file/schema.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-single-file/schema.handlebars
@@ -25,7 +25,10 @@ export interface {{ toPascalCase name }}{{ toPascalCase ../name }}Args {
 {{/each}}
 {{#each enums}}
 {{ toComment description }}
-export type {{ name }} = {{#each values }}"{{ value }}"{{#unless @last}} | {{/unless}}{{/each}};
+export enum {{ name }} {
+  {{#each values }}{{value}} = "{{ value }}",{{#unless @last}}
+  {{/unless}}{{/each}}
+}
 
 {{/each}}
 {{#each unions}}


### PR DESCRIPTION
Recent versions of Typescript allow for string-values based enumerations. This allows enums that looks like this: 

```ts
enum Color {
  RED='red',
  GREEN='green',
  BLUE='blue',
}
```

The benefit of this in client code is that you can reference enumeration values as symbols instead of just relying on raw string values.

e.g. 

```ts
const color: Color  = 'red'
// becomes
const color = Color.RED
```