### PR TITLE
Accept more formats for the --export flag

### DIFF
--- a/dev-test/test-schema/schema-ast.js
+++ b/dev-test/test-schema/schema-ast.js
@@ -1,0 +1,2 @@
+const schemaFormats = require("./schema-formats");
+module.exports.schema = schemaFormats.schemaAst;

--- a/dev-test/test-schema/schema-formats.js
+++ b/dev-test/test-schema/schema-formats.js
@@ -1,0 +1,22 @@
+/**
+ * There are four formats the schema can be in:
+ * 1. GraphQLSchema object
+ * 2. Text (the GraphQL schema language textual format)
+ * 3. AST (the GraphQL schema language textual format parsed into an AST)
+ * 4. Introspection JSON (result returned by introspection query)
+ * 
+ * This file imports the textual and introspection json files and
+ * exports all four formats to be used in tests.
+ */
+
+const GraphQL = require("graphql");
+const fs = require('fs');
+const path = require('path');
+const schemaText = fs.readFileSync(path.join(__dirname, "schema.graphql"), 'utf8');
+const schemaObject = GraphQL.buildSchema(schemaText);
+const schemaAst = GraphQL.parse(schemaText);
+const schemaJson = require("./schema.json");
+module.exports.schemaText = schemaText;
+module.exports.schemaAst = schemaAst;
+module.exports.schemaObject = schemaObject;
+module.exports.schemaJson = schemaJson;

--- a/dev-test/test-schema/schema-json.js
+++ b/dev-test/test-schema/schema-json.js
@@ -1,0 +1,2 @@
+const schemaFormats = require("./schema-formats");
+module.exports.schema = schemaFormats.schemaJson;

--- a/dev-test/test-schema/schema-object.js
+++ b/dev-test/test-schema/schema-object.js
@@ -1,0 +1,2 @@
+const schemaFormats = require("./schema-formats");
+module.exports.schema = schemaFormats.schemaObject;

--- a/dev-test/test-schema/schema-text.js
+++ b/dev-test/test-schema/schema-text.js
@@ -1,0 +1,2 @@
+const schemaFormats = require("./schema-formats");
+module.exports.schema = schemaFormats.schemaText;

--- a/packages/graphql-codegen-cli/src/loaders/schema-from-export.ts
+++ b/packages/graphql-codegen-cli/src/loaders/schema-from-export.ts
@@ -1,9 +1,18 @@
 import * as fs from 'fs';
-import { GraphQLSchema } from 'graphql-codegen-core';
 import * as path from 'path';
+import {
+  GraphQLSchema,
+  DocumentNode,
+  parse,
+  buildASTSchema,
+  extendSchema,
+  IntrospectionQuery,
+  buildClientSchema
+} from 'graphql';
+import { extractExtensionDefinitions } from 'graphql-tools';
 
 export const schemaFromExport = (file: string): Promise<GraphQLSchema> => {
-  console.log(`Loading GraphQL Introspection from JavaScript ES6 export: ${file}...`);
+  console.log(`Loading GraphQL schema object, text, ast, or introspection json from JavaScript ES6 export: ${file}...`);
 
   return new Promise<any>((resolve, reject) => {
     const fullPath = path.isAbsolute(file) ? file : path.resolve(process.cwd(), file);
@@ -16,7 +25,22 @@ export const schemaFromExport = (file: string): Promise<GraphQLSchema> => {
           const schema = exports.default || exports.schema;
 
           if (schema) {
-            resolve(schema as GraphQLSchema);
+            if (isSchemaObject(schema)) {
+              resolve(schema);
+            }
+            else if (isSchemaAst(schema)) {
+              resolve(buildASTSchema(schema));
+            }
+            else if (isSchemaText(schema)) {
+              const ast = parse(schema);
+              resolve(buildASTSchema(ast));
+            }
+            else if (isSchemaJson(schema)) {
+              resolve(buildClientSchema(schema.data));
+            }
+            else {
+              reject('Exported schema must be of type GraphQLSchema, text, AST, or introspection JSON.');
+            }
           } else {
             reject(
               new Error(`Invalid export from export file ${fullPath}: missing default export or 'schema' export!`)
@@ -33,3 +57,22 @@ export const schemaFromExport = (file: string): Promise<GraphQLSchema> => {
     }
   });
 };
+
+function isSchemaText(obj: any): obj is string {
+  return (typeof obj === 'string');
+}
+
+function isSchemaJson(obj: any): obj is { data: IntrospectionQuery } {
+  const json = obj as { data: IntrospectionQuery };
+  return json.data !== undefined && json.data.__schema !== undefined;
+}
+
+function isSchemaObject(obj: any): obj is GraphQLSchema {
+  return obj instanceof GraphQLSchema;
+}
+
+function isSchemaAst(
+  obj: string | DocumentNode
+): obj is DocumentNode {
+  return (obj as DocumentNode).kind !== undefined;
+}

--- a/packages/graphql-codegen-cli/tests/cli.spec.ts
+++ b/packages/graphql-codegen-cli/tests/cli.spec.ts
@@ -20,15 +20,41 @@ describe('executeWithOptions', () => {
     expect(result[0].content).toContain('Generated in');
   });
 
-  it.skip('execute the correct results when using export', async () => {
+  it('execute the correct results when using schema export as object', async () => {
     const result = await executeWithOptions({
-      export: '../../dev-test/githunt/schema.js',
-      template: 'ts'
+      // export: '../../dev-test/githunt/schema.js',
+      // template: 'ts'
+      export: '../../dev-test/test-schema/schema-object.js',
+      template: 'ts',
     });
     expect(result.length).toBe(1);
   });
 
-  it.skip('execute the correct results when using export and require', async () => {
+  it('execute the correct results when using schema export as text', async () => {
+    const result = await executeWithOptions({
+      export: '../../dev-test/test-schema/schema-text.js',
+      template: 'ts',
+    });
+    expect(result.length).toBe(1);
+  });
+
+  it('execute the correct results when using schema export as ast', async () => {
+    const result = await executeWithOptions({
+      export: '../../dev-test/test-schema/schema-ast.js',
+      template: 'ts',
+    });
+    expect(result.length).toBe(1);
+  });
+
+  it('execute the correct results when using schema export as json', async () => {
+    const result = await executeWithOptions({
+      export: '../../dev-test/test-schema/schema-json.js',
+      template: 'ts',
+    });
+    expect(result.length).toBe(1);
+  });
+
+  it('execute the correct results when using export and require', async () => {
     const result = await executeWithOptions({
       export: '../../dev-test/githunt/schema.js',
       template: 'ts',

--- a/packages/graphql-codegen-core/src/schema/schema-to-template-context.ts
+++ b/packages/graphql-codegen-core/src/schema/schema-to-template-context.ts
@@ -77,7 +77,8 @@ export function schemaToTemplateContext(schema: GraphQLSchema): SchemaTemplateCo
     } else if (actualTypeDef instanceof GraphQLScalarType) {
       result.scalars.push(transformScalar(schema, actualTypeDef));
     } else {
-      throw new Error(`Unexpected GraphQL type definition: ${graphQlType.key} (As string: ${String(actualTypeDef)})`);
+      throw new Error(`Unexpected GraphQL type definition: ${graphQlType.key} (As string: ${String(actualTypeDef)}).`
+        + `Please check that you are importing only one instance of the 'graphql' package.`);
     }
   });
 


### PR DESCRIPTION
This is a PR to be able to accept more formats for the `--export` flag. It will now accept all of these formats:

1. GraphQLSchema object
2. Text (the GraphQL schema language textual format)
3. AST (the GraphQL schema language textual format parsed into an AST)
4. Introspection JSON (result returned by introspection query)

The PR adds tests for all of the above cases.

In order for the tests to work there can only be one instance of the `graphql` package imported or the `instanceof` checks [here](https://github.com/dotansimha/graphql-code-generator/blob/master/packages/graphql-codegen-core/src/schema/schema-to-template-context.ts#L61) will fail. They will fail even if the exact same version of the `graphql` package is imported by all packages. In order for the `instanceof` operator to work, all packages must import the exact same classes from the exact same files (this is how the `instanceof` operator works). In order to make this work this PR adds the `--hoist` flag to `lerna bootstrap` (read [docs here](https://github.com/lerna/lerna/blob/master/doc/hoist.md)). This will cause all common packages to be installed in the top-level node_modules, which will make sure all packages import the same `graphql` package. It will also speed up the bootstrapping, and save diskspace as common dependencies are only installed once. (It works similar to yarn workspaces).

Fixes #170.