### PR TITLE
Output custom template output to --out

### DIFF
--- a/packages/graphql-codegen-cli/src/loaders/templates-scanner.ts
+++ b/packages/graphql-codegen-cli/src/loaders/templates-scanner.ts
@@ -13,7 +13,7 @@ export function scanForTemplatesInPath(dirPath: string, fileExtensions: string[]
   debugLog(`[scanForTemplatesInPath] Got results from glob: `, results);
 
   return results.reduce((prev, filePath) => {
-    prev[filePath] = fs.readFileSync(filePath).toString();
+    prev[filePath.substr(absolutePath.length + 1)] = fs.readFileSync(filePath).toString();
 
     return prev;
   }, {});

--- a/packages/graphql-codegen-compiler/src/compile.ts
+++ b/packages/graphql-codegen-compiler/src/compile.ts
@@ -33,7 +33,9 @@ export function compileTemplate(
   Object.keys(templates).forEach((templateName: string) => {
     debugLog(`[compileTemplate] register partial template ${templateName}`);
 
-    registerPartial(templateName, templates[templateName].trim());
+    // TODO needs to be configurable
+    // Should probably have prefix information or something
+    registerPartial(templateName.split('.').reverse()[1], templates[templateName].trim());
   });
 
   let mergedDocuments: Document;

--- a/packages/graphql-codegen-compiler/src/compile.ts
+++ b/packages/graphql-codegen-compiler/src/compile.ts
@@ -33,9 +33,8 @@ export function compileTemplate(
   Object.keys(templates).forEach((templateName: string) => {
     debugLog(`[compileTemplate] register partial template ${templateName}`);
 
-    // TODO needs to be configurable
-    // Should probably have prefix information or something
-    registerPartial(templateName.split('.').reverse()[1], templates[templateName].trim());
+    const partialName = templateName.includes('.') ? templateName.split('.').reverse()[1] : templateName;
+    registerPartial(partialName, templates[templateName].trim());
   });
 
   let mergedDocuments: Document;

--- a/packages/graphql-codegen-compiler/src/generate-multiple-files.ts
+++ b/packages/graphql-codegen-compiler/src/generate-multiple-files.ts
@@ -281,12 +281,10 @@ function parseTemplateName(templateName: string): { prefix: string; handler: Fun
     const handler = handlersMap[compilationContext];
 
     if (handler) {
-      const pref = path.resolve(path.dirname(templateName) + '/', prefix);
-
       return {
         prefix: hasPrefix
-          ? ['all', 'documents', 'schema'].includes(compilationContext) ? pref : pref + '.'
-          : pref + '/',
+          ? ['all', 'documents', 'schema'].includes(compilationContext) ? prefix : prefix + '.'
+          : ['all', 'documents', 'schema'].includes(compilationContext) ? compilationContext : prefix,
         handler,
         fileExtension
       };

--- a/packages/graphql-codegen-compiler/src/generate-multiple-files.ts
+++ b/packages/graphql-codegen-compiler/src/generate-multiple-files.ts
@@ -259,7 +259,16 @@ function handleFragment(
   }));
 }
 
-function parseTemplateName(templateName: string): { prefix: string; handler: Function; fileExtension: string } {
+type TemplateNameElements = {
+  compilationContext: string;
+  prefix: string;
+  fileExtension: string;
+  pathPrefix: string;
+};
+
+function parseTemplateNameElements(templateName: string): TemplateNameElements | null {
+  let basename = path.basename(templateName);
+  let pathPrefix = templateName.substr(0, templateName.length - basename.length);
   let splitted = path.basename(templateName).split('.');
   let hasPrefix = true;
 
@@ -275,22 +284,30 @@ function parseTemplateName(templateName: string): { prefix: string; handler: Fun
   const templateExtension = splitted[3];
 
   if (templateExtension && ALLOWED_CUSTOM_TEMPLATE_EXT.includes(templateExtension)) {
-    const compilationContext = splitted[2];
     const prefix = splitted[0];
-    const fileExtension = splitted[1];
-    const handler = handlersMap[compilationContext];
-
-    if (handler) {
-      return {
-        prefix: hasPrefix
-          ? ['all', 'documents', 'schema'].includes(compilationContext) ? prefix : prefix + '.'
-          : ['all', 'documents', 'schema'].includes(compilationContext) ? compilationContext : prefix,
-        handler,
-        fileExtension
-      };
-    }
+    const compilationContext = splitted[2];
+    return {
+      pathPrefix,
+      fileExtension: splitted[1],
+      compilationContext,
+      prefix: hasPrefix
+        ? ['all', 'documents', 'schema'].includes(compilationContext) ? prefix : prefix + '.'
+        : ['all', 'documents', 'schema'].includes(compilationContext) ? compilationContext : prefix
+    };
   }
+  return null;
+}
 
+function parseTemplateName(templateName: string): { prefix: string; handler: Function; fileExtension: string } {
+  let elements = parseTemplateNameElements(templateName);
+  if (elements && handlersMap[elements.compilationContext]) {
+    let { compilationContext, pathPrefix, prefix, fileExtension } = elements;
+    return {
+      handler: handlersMap[compilationContext],
+      prefix: pathPrefix + prefix,
+      fileExtension
+    };
+  }
   return null;
 }
 

--- a/packages/graphql-codegen-compiler/src/handlebars-extensions.ts
+++ b/packages/graphql-codegen-compiler/src/handlebars-extensions.ts
@@ -83,7 +83,7 @@ export const initHelpers = (config: GeneratorConfig, schemaContext: SchemaTempla
       return '';
     }
 
-    return '/* ' + oneLineTrim`${str || ''}` + ' */';
+    return new SafeString('/* ' + oneLineTrim`${str || ''}` + ' */');
   });
 
   registerHelper('eachImport', function(context: any, options: { fn: Function }) {

--- a/packages/graphql-codegen-generators/CUSTOM_TEMPLATES.md
+++ b/packages/graphql-codegen-generators/CUSTOM_TEMPLATES.md
@@ -4,7 +4,7 @@ This generator also allow you to generate custom custom template from your Graph
 
 This way you can generate custom code based on your GraphQL schema / operations.
 
-To start using GraphQL code generator with custom templates, install the CLI module, and then create a JSON file called `gqlgen.json` in your project's root directory, specifying the following:
+To start using GraphQL code generator with custom templates, install the CLI module, and then create a JSON file called `gql-gen.json` in your project's root directory, specifying the following:
 
 ```json
 {
@@ -21,7 +21,7 @@ To start using GraphQL code generator with custom templates, install the CLI mod
 
 > The purpose of this file to to tell the GraphQL code generate if you want to flatten selection set, and specify your environment's scalars transformation, for example: `String` from GraphQL is `string` in TypeScript.
 
-> To understand what `primitives` and `flattenTypes` are doing behind the scenes, [refer to `graphql-codegen-generators` package README](https://github.com/dotansimha/graphql-code-generators/blob/master/packages/graphql-codegen-core/README.md#flattentypes)
+> To understand what `primitives` and `flattenTypes` are doing behind the scenes, [refer to `graphql-codegen-generators` package README](https://github.com/dotansimha/graphql-code-generator/blob/master/packages/graphql-codegen-core/README.md#flattentypes)
 
 Now create a simple template file with this special structure: `{file-prefix}.{file-extension}.{required-context}.gqlgen`, for example: `hoc.js.all.gqlgen`, and use any custom template, for example:
 
@@ -38,6 +38,5 @@ To see a full list of available contexts, [refer to `graphql-codegen-generators`
 Next, run the generator from the CLI, but use `project` flag (instead of `template`), and specify the base path for you templates (the generator will look for the following file extensions: `template`, `tmpl`, `gqlgen`, `handlebars`):
 
     $ gql-gen --project ./src/ --file ./schema.json "./src/graphql/**/*.graphql"
-    
+
 > No need to specify the output directory, since the generator will create the generated files next to the template.
-    

--- a/packages/graphql-codegen-generators/CUSTOM_TEMPLATES.md
+++ b/packages/graphql-codegen-generators/CUSTOM_TEMPLATES.md
@@ -33,7 +33,7 @@ Now create a simple template file with this special structure: `{file-prefix}.{f
 
 This file will compile by the generator as Handlebars template, with the `all` context, and the result file name will be `hoc.js`.
 
-To see a full list of available contexts, [refer to `graphql-codegen-generators` package README](https://github.com/dotansimha/graphql-code-generators/blob/master/packages/graphql-codegen-core/README.md#templates)
+To see a full list of available contexts, [refer to `graphql-codegen-generators` package README](https://github.com/dotansimha/graphql-code-generators/blob/master/packages/graphql-codegen-generators/README.md#templates)
 
 Next, run the generator from the CLI, but use `project` flag (instead of `template`), and specify the base path for you templates (the generator will look for the following file extensions: `template`, `tmpl`, `gqlgen`, `handlebars`):
 

--- a/packages/graphql-codegen-generators/CUSTOM_TEMPLATES.md
+++ b/packages/graphql-codegen-generators/CUSTOM_TEMPLATES.md
@@ -33,10 +33,14 @@ Now create a simple template file with this special structure: `{file-prefix}.{f
 
 This file will compile by the generator as Handlebars template, with the `all` context, and the result file name will be `hoc.js`.
 
-To see a full list of available contexts, [refer to `graphql-codegen-generators` package README](https://github.com/dotansimha/graphql-code-generators/blob/master/packages/graphql-codegen-generators/README.md#templates)
+To see a full list of available contexts, [refer to `graphql-codegen-generators` package README](https://github.com/dotansimha/graphql-code-generator/blob/master/packages/graphql-codegen-generators/README.md#templates)
 
 Next, run the generator from the CLI, but use `project` flag (instead of `template`), and specify the base path for you templates (the generator will look for the following file extensions: `template`, `tmpl`, `gqlgen`, `handlebars`):
 
-    $ gql-gen --project ./src/ --file ./schema.json "./src/graphql/**/*.graphql"
+    $ gql-gen --project ./templates/ --out ./src/generated --file ./schema.json "./src/graphql/**/*.graphql"
 
-> No need to specify the output directory, since the generator will create the generated files next to the template.
+#### tips, tricks, and gotchas
+
+**Any subdirectory structure will be maintained in the output.** When using the `eachImport` helper, note that the import `file` is just the filename, so you'll have to [handle relative paths yourself](https://github.com/micimize/graphql-to-io-ts/blob/master/src/helpers/relative-import.js).
+
+**All templates in your template directory will be registered with `registerPartial(filename.split('.').reverse()[1], template)`, so `ts.type.gqlgen` becomes the partial `type`.** This means you can easily use `{{> type }}` in `ts.inputType.gqlgen`, but also means that multiple templates using the same context might clobber eachother in the partial registry. If this is a problem, simply make a seperate partial with a unique name like `prefixPartial.handlebars`.


### PR DESCRIPTION
Address #209, as well as:
* preserve directory structure to `--out` 
* make `ts.{ schema, documents }.handlebars` work without a prefix
  (e.g. `ts.schema.handlebars` => `schema.ts`)
* automatically `registerPartial` custom templates without breaking normal partial registration (`registerPartial(filename.split('.').reverse()[1], template)`)
* mark comments safe to avoid url escaping
* fixes some links in the docs and add relevant docs for the included changes