### PR TITLE
Use snapshots for tests

### DIFF
--- a/packages/graphql-codegen-cli/tests/__snapshots__/document-finder.spec.ts.snap
+++ b/packages/graphql-codegen-cli/tests/__snapshots__/document-finder.spec.ts.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`extractDocumentStringFromCodeFile file with commented code 1`] = `
+"query myQuery2 {
+    data {
+      field1
+      field2
+    }
+  }"
+`;
+
+exports[`extractDocumentStringFromCodeFile file with gql and string and function use 1`] = `
+"query myQuery {
+    data {
+      field1
+      field2
+    }
+  }"
+`;
+
+exports[`extractDocumentStringFromCodeFile file with gql and template literal 1`] = `
+"query myQuery {
+    data {
+      field1
+      field2
+    }
+  }"
+`;
+
+exports[`extractDocumentStringFromCodeFile file with gql and template literal in ts/tsx file 1`] = `
+"query GPlayerList {
+    allPlayers {
+      id
+      tier
+      name
+    }
+  }"
+`;
+
+exports[`extractDocumentStringFromCodeFile file with gql and template literal, with use of string variables 1`] = `
+"query ArticleDetail {
+    Article(id: \\"thisisnotarealID\\") {
+      title
+    }
+  }"
+`;
+
+exports[`extractDocumentStringFromCodeFile file with simple gql content 1`] = `
+"query myQuery {
+  data {
+    field1
+    field2
+  }
+}"
+`;

--- a/packages/graphql-codegen-cli/tests/document-finder.spec.ts
+++ b/packages/graphql-codegen-cli/tests/document-finder.spec.ts
@@ -1,59 +1,48 @@
 import * as fs from 'fs';
-import { extractDocumentStringFromCodeFile } from '../src/utils/document-finder';
 import { parse } from 'graphql';
+import { Source } from 'graphql-codegen-core';
+
+import { extractDocumentStringFromCodeFile } from '../src/utils/document-finder';
 
 describe('extractDocumentStringFromCodeFile', () => {
-  it('file with gql and template literal', () => {
-    const fileContent = fs.readFileSync('./tests/test-files/1.ts').toString();
+  function extract(fileName: string) {
+    const fileContent = fs.readFileSync(`./tests/test-files/${fileName}`).toString();
     const doc = extractDocumentStringFromCodeFile(fileContent);
-    const parsingTest = parse.bind(null, doc);
-    expect(doc).toContain('query');
-    expect(parsingTest).not.toThrow();
+    expect(tryParse(doc)).not.toThrow();
+    return doc.trim();
+  }
+
+  function tryParse(doc: string) {
+    return () => parse(new Source(doc));
+  }
+
+  it('file with gql and template literal', () => {
+    const doc = extract('1.ts');
+    expect(doc).toMatchSnapshot();
   });
 
   it('file with gql and string and function use', () => {
-    const fileContent = fs.readFileSync('./tests/test-files/2.ts').toString();
-    const doc = extractDocumentStringFromCodeFile(fileContent);
-    const parsingTest = parse.bind(null, doc);
-    expect(doc).toContain('query');
-    expect(parsingTest).not.toThrow();
+    const doc = extract('2.ts');
+    expect(doc).toMatchSnapshot();
   });
 
   it('file with simple gql content', () => {
-    const fileContent = fs.readFileSync('./tests/test-files/3.graphql').toString();
-    const doc = extractDocumentStringFromCodeFile(fileContent);
-    const parsingTest = parse.bind(null, doc);
-
-    expect(doc).toContain('query');
-    expect(parsingTest).not.toThrow();
+    const doc = extract('3.graphql');
+    expect(doc).toMatchSnapshot();
   });
 
   it('file with commented code', () => {
-    const fileContent = fs.readFileSync('./tests/test-files/4.ts').toString();
-    const doc = extractDocumentStringFromCodeFile(fileContent);
-    const parsingTest = parse.bind(null, doc);
-
-    expect(doc).toContain('myQuery2');
-    expect(doc).not.toContain('myQuery1');
-    expect(doc).not.toContain('myQuery3');
-    expect(parsingTest).not.toThrow();
+    const doc = extract('4.ts');
+    expect(doc).toMatchSnapshot();
   });
 
   it('file with gql and template literal in ts/tsx file', () => {
-    const fileContent = fs.readFileSync('./tests/test-files/5.tsx').toString();
-    const doc = extractDocumentStringFromCodeFile(fileContent);
-    const parsingTest = parse.bind(null, doc);
-
-    expect(doc).toContain('query');
-    expect(parsingTest).not.toThrow();
+    const doc = extract('5.tsx');
+    expect(doc).toMatchSnapshot();
   });
 
   it('file with gql and template literal, with use of string variables', () => {
-    const fileContent = fs.readFileSync('./tests/test-files/6.ts').toString();
-    const doc = extractDocumentStringFromCodeFile(fileContent);
-    const parsingTest = parse.bind(null, doc);
-
-    expect(doc).toContain('query');
-    expect(parsingTest).not.toThrow();
+    const doc = extract('6.ts');
+    expect(doc).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
So it turns out that tests for document-finder that were simply checking for the existence of some text were not sufficient. Instead, I've added snapshot testing so every small change in the output matters. Then I've manually tweaked the snapshot to a form that will pass through the parser.

There is some sort of breaking change in 0.8.19 (works in 0.8.18) which includes brackets in the output while those are not part of `gql` literal string and parsing fails afterward.

```graphql
query GPlayerList {
    allPlayers {
      id
      tier
      name
    }
  }
) # this bracket should not be here
```

I am not strong with regexp, so looking at the actual code, I am not sure how to fix this. However, at least now there is failing test.