### PR TITLE
Remove '?' (optional properties) in tsgeneration to match apollo-codegen

### DIFF
--- a/packages/graphql-codegen-generators/src/typescript-multi-file/operation.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-multi-file/operation.handlebars
@@ -4,7 +4,7 @@ import { {{ name }} } from './{{ file }}';
 export namespace {{ toPascalCase name }} {
   export type Variables = {
 {{#each variables}}
-    {{ name }}{{#unless isRequired}}?{{/unless}}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}};
+    {{ name }}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}};
 {{/each}}
   }
 

--- a/packages/graphql-codegen-generators/src/typescript-multi-file/type.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-multi-file/type.handlebars
@@ -4,7 +4,7 @@ import { {{ name }} } from './{{ file }}';
 {{ toComment description }}
 export interface {{ name }}{{#if hasInterfaces}} extends {{#each interfaces}}{{this}}{{#unless @last}},{{/unless}}{{/each}}{{/if}} {
 {{#each fields}}
-  {{ name }}{{#unless isRequired}}?{{/unless}}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}}; {{ toComment description }}
+  {{ name }}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}}; {{ toComment description }}
 {{/each}}
 }
 
@@ -12,7 +12,7 @@ export interface {{ name }}{{#if hasInterfaces}} extends {{#each interfaces}}{{t
   {{~# if hasArguments }}
 export interface {{ toPascalCase name }}{{ toPascalCase ../name }}Args {
 {{#each arguments}}
-  {{ name }}{{#unless isRequired}}?{{/unless}}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}}; {{ toComment description }}
+  {{ name }}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}}; {{ toComment description }}
 {{/each}}
 }
   {{/if}}

--- a/packages/graphql-codegen-generators/src/typescript-single-file/documents.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-single-file/documents.handlebars
@@ -2,7 +2,7 @@
 export namespace {{ toPascalCase name }} {
   export type Variables = {
   {{#each variables}}
-    {{ name }}{{#unless isRequired}}?{{/unless}}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}};
+    {{ name }}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}};
   {{/each}}
   }
 

--- a/packages/graphql-codegen-generators/src/typescript-single-file/schema.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-single-file/schema.handlebars
@@ -20,7 +20,7 @@ export type {{ name }} = any;
     {{~# if hasArguments }}
 export interface {{ toPascalCase name }}{{ toPascalCase ../name }}Args {
 {{#each arguments}}
-  {{ name }}{{#unless isRequired}}?{{/unless}}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}}; {{ toComment description }}
+  {{ name }}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}}; {{ toComment description }}
 {{/each}}
 }
     {{/if}}

--- a/packages/graphql-codegen-generators/src/typescript-single-file/selection-set.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-single-file/selection-set.handlebars
@@ -1,3 +1,3 @@
 {{#each this}}
-{{ name }}{{#unless isRequired}}?{{/unless}}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}}; {{#if description }}  // {{description}}{{/if}}
+{{ name }}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}}; {{#if description }}  // {{description}}{{/if}}
 {{/each}}

--- a/packages/graphql-codegen-generators/src/typescript-single-file/type.handlebars
+++ b/packages/graphql-codegen-generators/src/typescript-single-file/type.handlebars
@@ -1,6 +1,6 @@
 {{ toComment description }}
 export interface {{ name }}{{#if hasInterfaces}} extends {{#each interfaces}}{{this}}{{#unless @last}},{{/unless}}{{/each}}{{/if}} {
 {{#each fields}}
-  {{ name }}{{#unless isRequired}}?{{/unless}}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}}; {{ toComment description }}
+  {{ name }}: {{ toPrimitive type }}{{#if isArray}}[]{{/if}}{{#unless isRequired}} | null{{/unless}}; {{ toComment description }}
 {{/each}}
 }


### PR DESCRIPTION
I think the apollo client-side codegen off queries is correct, in that the typescript optional (?) annotation on keys should not be used for generated schema code.

Most GQL resolver frameworks require keys to be defined and set to null, not undefined (as the ? allows). 

This is now the only thing preventing typescript types from exactly matching between my backend and front-end codegen, which would enable some code-sharing even as they use different code generators.