### PR TITLE
typescript: generate types for resolvers

### DIFF
--- a/packages/graphql-codegen-cli/tests/cli.spec.ts
+++ b/packages/graphql-codegen-cli/tests/cli.spec.ts
@@ -35,7 +35,7 @@ describe('executeWithOptions', () => {
       config: '../../dev-test/config/gql-gen.json'
     });
 
-    expect(result[0].content).toContain('Generated in');
+    expect(result[0].content).toMatch('Generated in');
   });
 
   it('execute the correct results when using schema export as object', async () => {
@@ -61,8 +61,7 @@ describe('executeWithOptions', () => {
       skipSchema: true
     });
 
-    expect(result[0].content).toBe(`/* tslint:disable */
-`);
+    expect(result[0].content).toMatch(/^\/\* tslint:disable \*\//);
   });
 
   it('execute the correct results when using skipDocuments', async () => {
@@ -74,7 +73,7 @@ describe('executeWithOptions', () => {
       skipSchema: true
     });
 
-    expect(result[0].content).not.toContain('HeroDetails');
+    expect(result[0].content).not.toMatch('HeroDetails');
   });
 
   it('execute the correct results when using schema export as ast', async () => {

--- a/packages/templates/typescript/README.md
+++ b/packages/templates/typescript/README.md
@@ -21,3 +21,7 @@ Will generate the declared enums as TypeScript `type` instead of `enums`. This i
 ### `immutableTypes` (or `CODEGEN_IMMUTABLE_TYPES`, defualt value: `false`)
 
 This will cause the codegen to output `readonly` properties and `ReadonlyArray`.
+
+### `resolvers` (or `CODEGEN_RESOLVERS`, default value: `true`)
+
+This will cause the codegen to output types for resolvers.

--- a/packages/templates/typescript/src/config.ts
+++ b/packages/templates/typescript/src/config.ts
@@ -1,6 +1,7 @@
 import * as index from './template.handlebars';
 import * as type from './type.handlebars';
 import * as schema from './schema.handlebars';
+import * as resolver from './resolver.handlebars';
 import * as documents from './documents.handlebars';
 import * as selectionSet from './selection-set.handlebars';
 import * as fragments from './fragments.handlebars';
@@ -8,6 +9,8 @@ import * as enumTemplate from './enum.handlebars';
 import { EInputType, GeneratorConfig } from 'graphql-codegen-core';
 import { getType } from './helpers/get-type';
 import { getOptionals } from './helpers/get-optionals';
+import { getFieldResolver } from './helpers/get-field-resolver';
+import { getFieldResolverName } from './helpers/get-field-resolver-name';
 
 export const config: GeneratorConfig = {
   inputType: EInputType.SINGLE_FILE,
@@ -15,6 +18,7 @@ export const config: GeneratorConfig = {
     index,
     type,
     schema,
+    resolver,
     documents,
     selectionSet,
     fragments,
@@ -30,6 +34,8 @@ export const config: GeneratorConfig = {
   },
   customHelpers: {
     convertedType: getType,
+    getFieldResolver,
+    getFieldResolverName,
     getOptionals
   },
   outFile: 'types.ts'

--- a/packages/templates/typescript/src/helpers/get-field-resolver-name.ts
+++ b/packages/templates/typescript/src/helpers/get-field-resolver-name.ts
@@ -1,0 +1,5 @@
+import { capitalize } from '../utils/capitalize';
+
+export function getFieldResolverName(name) {
+  return `${capitalize(name)}Resolver`;
+}

--- a/packages/templates/typescript/src/helpers/get-field-resolver.ts
+++ b/packages/templates/typescript/src/helpers/get-field-resolver.ts
@@ -1,0 +1,20 @@
+import { SafeString } from 'handlebars';
+import { getResultType } from '../utils/get-result-type';
+import { capitalize } from '../utils/capitalize';
+
+export function getFieldResolver(type, options) {
+  if (!type) {
+    return '';
+  }
+
+  let result;
+  const realType = getResultType(type, options);
+
+  if (type.hasArguments) {
+    result = `Resolver<${realType}, ${capitalize(type.name)}Args>`;
+  } else {
+    result = `Resolver<${realType}>`;
+  }
+
+  return new SafeString(result);
+}

--- a/packages/templates/typescript/src/helpers/get-type.ts
+++ b/packages/templates/typescript/src/helpers/get-type.ts
@@ -1,37 +1,12 @@
 import { SafeString } from 'handlebars';
+import { getResultType } from '../utils/get-result-type';
 
 export function getType(type, options) {
   if (!type) {
     return '';
   }
 
-  const baseType = type.type;
-  const realType = options.data.root.primitivesMap[baseType] || baseType;
-  const useImmutable = !!(options.data.root.config || {}).immutableTypes;
+  const result = getResultType(type, options);
 
-  if (type.isArray) {
-    let result = realType;
-
-    if (type.isNullableArray) {
-      result = useImmutable ? [realType, 'null'].join(' | ') : `(${[realType, 'null'].join(' | ')})`;
-    }
-
-    if (useImmutable) {
-      result = `ReadonlyArray<${result}>`;
-    } else {
-      result = `${result}[]`;
-    }
-
-    if (!type.isRequired) {
-      result = [result, 'null'].join(' | ');
-    }
-
-    return new SafeString(result);
-  } else {
-    if (type.isRequired) {
-      return realType;
-    } else {
-      return [realType, 'null'].join(' | ');
-    }
-  }
+  return new SafeString(result);
 }

--- a/packages/templates/typescript/src/resolver.handlebars
+++ b/packages/templates/typescript/src/resolver.handlebars
@@ -2,7 +2,7 @@
 export namespace {{ name }}Resolvers {
   export interface Resolvers {
     {{#each fields}}
-    {{ name }}{{ getOptionals this }}: {{ getFieldResolverName name }}; {{ toComment description }}
+    {{ name }}?: {{ getFieldResolverName name }}; {{ toComment description }}
     {{/each}}
   }
 

--- a/packages/templates/typescript/src/resolver.handlebars
+++ b/packages/templates/typescript/src/resolver.handlebars
@@ -1,0 +1,23 @@
+{{ toComment description }}
+export namespace {{ name }}Resolvers {
+  export interface Resolvers {
+    {{#each fields}}
+    {{ name }}{{ getOptionals this }}: {{ getFieldResolverName name }}; {{ toComment description }}
+    {{/each}}
+  }
+
+  {{#each fields}}
+  export type {{ getFieldResolverName name }} = {{ getFieldResolver this }};
+
+  {{~# if hasArguments }}
+
+  export interface {{ toPascalCase name }}Args {
+  {{#each arguments}}
+    {{ name }}{{ getOptionals this }}: {{ convertedType this }}; {{ toComment description }}
+  {{/each}}
+  }
+
+  {{/if}}
+  {{/each}}
+  
+}

--- a/packages/templates/typescript/src/schema.handlebars
+++ b/packages/templates/typescript/src/schema.handlebars
@@ -1,3 +1,4 @@
+{{#ifCond @root.config.resolvers "!==" false}}
 import { GraphQLResolveInfo } from 'graphql';
 
 type Resolver<Result, Args = any> = (
@@ -6,6 +7,7 @@ type Resolver<Result, Args = any> = (
   context: any,
   info: GraphQLResolveInfo
 ) => Promise<Result> | Result;
+{{/ifCond}}
 
 {{#each scalars}}
 
@@ -20,10 +22,12 @@ export type {{ name }} = any;
   {{~> type }}
 
 {{/each}}
+{{#ifCond @root.config.resolvers "!==" false }}
 {{#each types}}
-  {{~> resolver }}
-  
+  {{~> resolver }}  
+
 {{/each}}
+{{/ifCond}}
 {{#each inputTypes}}
   {{~> type }}
 

--- a/packages/templates/typescript/src/schema.handlebars
+++ b/packages/templates/typescript/src/schema.handlebars
@@ -1,3 +1,12 @@
+import { GraphQLResolveInfo } from 'graphql';
+
+type Resolver<Result, Args = any> = (
+  parent: any,
+  args: Args,
+  context: any,
+  info: GraphQLResolveInfo
+) => Promise<Result> | Result;
+
 {{#each scalars}}
 
 {{ toComment description }}
@@ -10,6 +19,10 @@ export type {{ name }} = any;
 {{#each types}}
   {{~> type }}
 
+{{/each}}
+{{#each types}}
+  {{~> resolver }}
+  
 {{/each}}
 {{#each inputTypes}}
   {{~> type }}

--- a/packages/templates/typescript/src/utils/capitalize.ts
+++ b/packages/templates/typescript/src/utils/capitalize.ts
@@ -1,0 +1,3 @@
+export function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/packages/templates/typescript/src/utils/get-result-type.ts
+++ b/packages/templates/typescript/src/utils/get-result-type.ts
@@ -1,0 +1,31 @@
+export function getResultType(type, options) {
+  const baseType = type.type;
+  const realType = options.data.root.primitivesMap[baseType] || baseType;
+  const useImmutable = !!(options.data.root.config || {}).immutableTypes;
+
+  if (type.isArray) {
+    let result = realType;
+
+    if (type.isNullableArray) {
+      result = useImmutable ? [realType, 'null'].join(' | ') : `(${[realType, 'null'].join(' | ')})`;
+    }
+
+    if (useImmutable) {
+      result = `ReadonlyArray<${result}>`;
+    } else {
+      result = `${result}[]`;
+    }
+
+    if (!type.isRequired) {
+      result = [result, 'null'].join(' | ');
+    }
+
+    return result;
+  } else {
+    if (type.isRequired) {
+      return realType;
+    } else {
+      return [realType, 'null'].join(' | ');
+    }
+  }
+}

--- a/packages/templates/typescript/tests/custom-matchers.ts
+++ b/packages/templates/typescript/tests/custom-matchers.ts
@@ -11,11 +11,15 @@ declare global {
   }
 }
 
+function compareStrings(a: string, b: string): boolean {
+  return a.includes(b);
+}
+
 function toBeSimilarStringTo(received: string, argument: string) {
   const strippedA = oneLine`${received}`.replace(/\s\s+/g, ' ');
   const strippedB = oneLine`${argument}`.replace(/\s\s+/g, ' ');
 
-  if (strippedA === strippedB) {
+  if (compareStrings(strippedA, strippedB)) {
     return {
       message: () =>
         `expected 

--- a/packages/templates/typescript/tests/typescript.spec.ts
+++ b/packages/templates/typescript/tests/typescript.spec.ts
@@ -962,6 +962,30 @@ describe('TypeScript template', () => {
       `);
     });
 
+    it('should make fields optional', async () => {
+      const { context } = compileAndBuildContext(`
+        type Query {
+          fieldTest: String 
+        }
+        
+        schema {
+          query: Query
+        }
+      `);
+
+      const compiled = await compileTemplate(config, context);
+
+      const content = compiled[0].content;
+
+      expect(content).toBeSimilarStringTo(`
+        export namespace QueryResolvers {
+          export interface Resolvers {
+            fieldTest?: FieldTestResolver;
+          }
+        }
+      `);
+    });
+
     it('should provide a generic type of result', async () => {
       const { context } = compileAndBuildContext(`
         type Query {
@@ -988,7 +1012,7 @@ describe('TypeScript template', () => {
       `);
     });
 
-    it('should provide a generic type of arguments', async () => {
+    it('should provide a generic type of arguments and support optionals', async () => {
       const { context } = compileAndBuildContext(`
         type Query {
           fieldTest(last: Int!, sort: String): String

--- a/packages/templates/typescript/tests/typescript.spec.ts
+++ b/packages/templates/typescript/tests/typescript.spec.ts
@@ -49,16 +49,21 @@ describe('TypeScript template', () => {
         context
       );
 
-      expect(compiled[0].content).toBeSimilarStringTo(`
-      /* tslint:disable */
-      export interface Query {
-        readonly fieldTest?: string | null;
-        readonly arrayTest1?: ReadonlyArray<string | null> | null; 
-        readonly arrayTest2: ReadonlyArray<string | null>; 
-        readonly arrayTest3: ReadonlyArray<string>; 
-        readonly arrayTest4?: ReadonlyArray<string> | null; 
+      const content = compiled[0].content;
 
-      }`);
+      expect(content).toBeSimilarStringTo(`
+      /* tslint:disable */
+      `);
+
+      expect(content).toBeSimilarStringTo(`
+        export interface Query {
+          readonly fieldTest?: string | null;
+          readonly arrayTest1?: ReadonlyArray<string | null> | null; 
+          readonly arrayTest2: ReadonlyArray<string | null>; 
+          readonly arrayTest3: ReadonlyArray<string>; 
+          readonly arrayTest4?: ReadonlyArray<string> | null; 
+        }
+      `);
     });
 
     it('should handle optional correctly', async () => {
@@ -82,8 +87,13 @@ describe('TypeScript template', () => {
         context
       );
 
-      expect(compiled[0].content).toBeSimilarStringTo(`
+      const content = compiled[0].content;
+
+      expect(content).toBeSimilarStringTo(`
       /* tslint:disable */
+      `);
+
+      expect(content).toBeSimilarStringTo(`
       export interface Query {
         fieldTest: string | null;
       }`);
@@ -115,14 +125,18 @@ describe('TypeScript template', () => {
         context
       );
 
-      expect(compiled[0].content).toBeSimilarStringTo(`
+      const content = compiled[0].content;
+
+      expect(content).toBeSimilarStringTo(`
        /* tslint:disable */
-      
-      export interface Query {
-        fieldTest?: string | null; 
-      }
-      
-      export type A = "ONE" | "TWO";
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export interface Query {
+          fieldTest?: string | null; 
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export type A = "ONE" | "TWO";
       `);
     });
 
@@ -140,13 +154,15 @@ describe('TypeScript template', () => {
       `);
 
       const compiled = await compileTemplate(config, context);
+      const content = compiled[0].content;
 
-      expect(compiled[0].content).toBeSimilarStringTo(`
-      /* tslint:disable */
-      /** type-description */
-      export interface Query {
-        fieldTest?: string | null; /** field-description */
-      }`);
+      expect(compiled[0].content).toBeSimilarStringTo(`/* tslint:disable */`);
+      expect(content).toBeSimilarStringTo(`/** type-description */`);
+      expect(content).toBeSimilarStringTo(`
+        export interface Query {
+          fieldTest?: string | null; /** field-description */
+        }
+      `);
     });
 
     it('should support custom handlebar ifDirective when directive added', async () => {
@@ -262,12 +278,15 @@ describe('TypeScript template', () => {
       `);
       const compiled = await compileTemplate(config, context);
       const content = compiled[0].content;
+
       expect(content).toBeSimilarStringTo(`
-      /* tslint:disable */
-      
-      export interface Query {
-        fieldTest?: string | null;
-      }`);
+        /* tslint:disable */
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export interface Query {
+          fieldTest?: string | null;
+        }
+      `);
     });
 
     it('should compile template correctly when using a simple Query with some fields and types', async () => {
@@ -283,17 +302,21 @@ describe('TypeScript template', () => {
       `);
       const compiled = await compileTemplate(config, context);
       const content = compiled[0].content;
+
       expect(content).toBeSimilarStringTo(`
       /* tslint:disable */
-      
-      export interface Query {
-        fieldTest?: string | null;
-      }
-      
-      export interface T {
-        f1?: string | null;
-        f2?: number | null;
-      }`);
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export interface Query {
+          fieldTest?: string | null;
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export interface T {
+          f1?: string | null;
+          f2?: number | null;
+        }
+      `);
     });
 
     it('should compile template correctly when using a simple Query with arrays and required', async () => {
@@ -314,22 +337,27 @@ describe('TypeScript template', () => {
       `);
       const compiled = await compileTemplate(config, context);
       const content = compiled[0].content;
+
       expect(content).toBeSimilarStringTo(`
-      /* tslint:disable */
-      
-      export interface Query {
-        fieldTest?: string | null;
-      }
-      
-      export interface T {
-        f1?: (string | null)[] | null;
-        f2: number;
-        f3?: A | null;
-      }
-        
-      export interface A {
-        f4?: string | null;
-      }`);
+        /* tslint:disable */
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export interface Query {
+          fieldTest?: string | null;
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export interface T {
+          f1?: (string | null)[] | null;
+          f2: number;
+          f3?: A | null;
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export interface A {
+          f4?: string | null;
+        }
+      `);
     });
 
     it('should generate correctly when using simple type that extends interface', async () => {
@@ -350,21 +378,26 @@ describe('TypeScript template', () => {
 
       const compiled = await compileTemplate(config, context);
       const content = compiled[0].content;
+
       expect(content).toBeSimilarStringTo(`
         /* tslint:disable */
-        
+      `);
+      expect(content).toBeSimilarStringTo(`
         export interface Base {
           f1?: string | null;
         }
-      
+      `);
+      expect(content).toBeSimilarStringTo(`
         export interface Query {
           fieldTest: A;
         }
-      
+      `);
+      expect(content).toBeSimilarStringTo(`
         export interface A extends Base {
           f1?: string | null;
           f2?: string | null;
-        }`);
+        }
+      `);
     });
 
     it('should generate correctly when using custom scalar', async () => {
@@ -378,14 +411,18 @@ describe('TypeScript template', () => {
 
       const compiled = await compileTemplate(config, context);
       const content = compiled[0].content;
-      expect(content).toBeSimilarStringTo(`
-      /* tslint:disable */
 
-      export type Date = any;
-      
-      export interface Query {
-        fieldTest?: (Date | null)[] | null;
-      }`);
+      expect(content).toBeSimilarStringTo(`
+        /* tslint:disable */
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export type Date = any;
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export interface Query {
+          fieldTest?: (Date | null)[] | null;
+        }
+      `);
     });
 
     it('should generate enums correctly', async () => {
@@ -403,17 +440,21 @@ describe('TypeScript template', () => {
 
       const compiled = await compileTemplate(config, context);
       const content = compiled[0].content;
+
       expect(content).toBeSimilarStringTo(`
-      /* tslint:disable */
-      
-      export interface Query {
-        fieldTest: MyEnum;
-      }
-      export enum MyEnum {
-        A = "A",
-        B = "B",
-        C = "C",
-      }
+        /* tslint:disable */
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export interface Query {
+          fieldTest: MyEnum;
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export enum MyEnum {
+          A = "A",
+          B = "B",
+          C = "C",
+        }
       `);
     });
 
@@ -437,21 +478,26 @@ describe('TypeScript template', () => {
 
       const compiled = await compileTemplate(config, context);
       const content = compiled[0].content;
+
       expect(content).toBeSimilarStringTo(`
         /* tslint:disable */
-        
+      `);
+      expect(content).toBeSimilarStringTo(`  
         export interface Query {
           fieldTest: C;
         }
-        
+      `);
+      expect(content).toBeSimilarStringTo(`
         export interface A {
           f1?: string | null;
         }
-        
+      `);
+      expect(content).toBeSimilarStringTo(`
         export interface B {
           f2?: string | null;
         }
-        
+      `);
+      expect(content).toBeSimilarStringTo(`
         /** Union description */
         export type C = A | B;
       `);
@@ -468,14 +514,17 @@ describe('TypeScript template', () => {
       const content = compiled[0].content;
       expect(content).toBeSimilarStringTo(`
         /* tslint:disable */
-        
+      `);
+      expect(content).toBeSimilarStringTo(`
         export interface Query {
           fieldTest: string;
         }
-        
+      `);
+      expect(content).toBeSimilarStringTo(`
         export interface FieldTestQueryArgs {
           arg1?: string | null;
-        }`);
+        }
+      `);
     });
 
     it('should generate type arguments types correctly when using custom input', async () => {
@@ -503,16 +552,19 @@ describe('TypeScript template', () => {
       const content = compiled[0].content;
       expect(content).toBeSimilarStringTo(`
        /* tslint:disable */
-        
+      `);
+      expect(content).toBeSimilarStringTo(`
        export interface Query {
           fieldTest?: Return | null; 
         }
-        
+      `);
+      expect(content).toBeSimilarStringTo(`
         export interface Return {
           ok: boolean; 
           msg: string; 
         }
-        
+      `);
+      expect(content).toBeSimilarStringTo(`
         export interface T {
           f1?: string | null; 
           f2: number; 
@@ -521,11 +573,12 @@ describe('TypeScript template', () => {
           f5: string[]; 
           f6?: string[] | null; 
         }
-        
+      `);
+      expect(content).toBeSimilarStringTo(`
         export interface FieldTestQueryArgs {
           myArgument: T;
         }
-    `);
+      `);
     });
 
     it('should generate from a whole schema object correctly', async () => {
@@ -558,7 +611,7 @@ describe('TypeScript template', () => {
   });
 
   describe('Operations', () => {
-    it('Should compile simple Query correctly', async () => {
+    it.skip('Should compile simple Query correctly', async () => {
       const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
       const context = schemaToTemplateContext(schema);
 
@@ -580,53 +633,59 @@ describe('TypeScript template', () => {
 
       const transformedDocument = transformDocument(schema, documents);
       const compiled = await compileTemplate(config, context, [transformedDocument], { generateSchema: false });
+      const content = compiled[0].content;
 
       expect(compiled[0].content).toBeSimilarStringTo(`
-          /* tslint:disable */
-          /** A list of options for the sort order of the feed */
-          export enum FeedType {
-            HOT = "HOT",
-            NEW = "NEW",
-            TOP = "TOP",
+        /* tslint:disable */
+      `);
+      expect(content).toBeSimilarStringTo(`
+        /** A list of options for the sort order of the feed */
+        export enum FeedType {
+          HOT = "HOT",
+          NEW = "NEW",
+          TOP = "TOP",
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        /** The type of vote to record, when submitting a vote */
+        export enum VoteType {
+          UP = "UP",
+          DOWN = "DOWN",
+          CANCEL = "CANCEL",
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export namespace MyFeed {
+          export type Variables = {
           }
-          
-          /** The type of vote to record, when submitting a vote */
-          export enum VoteType {
-            UP = "UP",
-            DOWN = "DOWN",
-            CANCEL = "CANCEL",
+
+          export type Query = {
+            __typename?: "Query";
+            feed?: (Feed | null)[] | null;
           }
-          
-          export namespace MyFeed {
-            export type Variables = {
-            }
-          
-            export type Query = {
-              __typename?: "Query";
-              feed?: (Feed | null)[] | null;
-            }
-          
-            export type Feed = {
-              __typename?: "Entry";
-              id: number; 
-              commentCount: number; 
-              repository: Repository; 
-            }
-          
-            export type Repository = {
-              __typename?: "Repository";
-              full_name: string; 
-              html_url: string; 
-              owner?: Owner | null; 
-            }
-          
-            export type Owner = {
-              __typename?: "User";
-              avatar_url: string; 
-            }
-          }`);
+
+          export type Feed = {
+            __typename?: "Entry";
+            id: number; 
+            commentCount: number; 
+            repository: Repository; 
+          }
+
+          export type Repository = {
+            __typename?: "Repository";
+            full_name: string; 
+            html_url: string; 
+            owner?: Owner | null; 
+          }
+
+          export type Owner = {
+            __typename?: "User";
+            avatar_url: string; 
+          }
+        }
+      `);
     });
-    it('Should compile anonymous Query correctly', async () => {
+    it.skip('Should compile anonymous Query correctly', async () => {
       const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
       const context = schemaToTemplateContext(schema);
 
@@ -648,54 +707,60 @@ describe('TypeScript template', () => {
 
       const transformedDocument = transformDocument(schema, documents);
       const compiled = await compileTemplate(config, context, [transformedDocument], { generateSchema: false });
+      const content = compiled[0].content;
 
       expect(compiled[0].content).toBeSimilarStringTo(`
-          /* tslint:disable */
-          /** A list of options for the sort order of the feed */
-          export enum FeedType {
-            HOT = "HOT",
-            NEW = "NEW",
-            TOP = "TOP",
+        /* tslint:disable */
+      `);
+      expect(content).toBeSimilarStringTo(`
+        /** A list of options for the sort order of the feed */
+        export enum FeedType {
+          HOT = "HOT",
+          NEW = "NEW",
+          TOP = "TOP",
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        /** The type of vote to record, when submitting a vote */
+        export enum VoteType {
+          UP = "UP",
+          DOWN = "DOWN",
+          CANCEL = "CANCEL",
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export namespace AnonymousQuery_1 {
+          export type Variables = {
           }
-          
-          /** The type of vote to record, when submitting a vote */
-          export enum VoteType {
-            UP = "UP",
-            DOWN = "DOWN",
-            CANCEL = "CANCEL",
+
+          export type Query = {
+            __typename?: "Query";
+            feed?: (Feed | null)[] | null;
           }
-          
-          export namespace AnonymousQuery_1 {
-            export type Variables = {
-            }
-          
-            export type Query = {
-              __typename?: "Query";
-              feed?: (Feed | null)[] | null;
-            }
-          
-            export type Feed = {
-              __typename?: "Entry";
-              id: number; 
-              commentCount: number; 
-              repository: Repository; 
-            }
-          
-            export type Repository = {
-              __typename?: "Repository";
-              full_name: string; 
-              html_url: string; 
-              owner?: Owner | null; 
-            }
-          
-            export type Owner = {
-              __typename?: "User";
-              avatar_url: string; 
-            }
-          }`);
+
+          export type Feed = {
+            __typename?: "Entry";
+            id: number; 
+            commentCount: number; 
+            repository: Repository; 
+          }
+
+          export type Repository = {
+            __typename?: "Repository";
+            full_name: string; 
+            html_url: string; 
+            owner?: Owner | null; 
+          }
+
+          export type Owner = {
+            __typename?: "User";
+            avatar_url: string; 
+          }
+        }
+      `);
     });
 
-    it('Should compile simple Query with Fragment spread correctly', async () => {
+    it.skip('Should compile simple Query with Fragment spread correctly', async () => {
       const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
       const context = schemaToTemplateContext(schema);
 
@@ -724,58 +789,64 @@ describe('TypeScript template', () => {
       const content = compiled[0].content;
 
       expect(content).toBeSimilarStringTo(`
-          /* tslint:disable */
-          /** A list of options for the sort order of the feed */
-          export enum FeedType {
-            HOT = "HOT",
-            NEW = "NEW",
-            TOP = "TOP",
+        /* tslint:disable */
+      `);
+      expect(content).toBeSimilarStringTo(`
+        /** A list of options for the sort order of the feed */
+        export enum FeedType {
+          HOT = "HOT",
+          NEW = "NEW",
+          TOP = "TOP",
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        /** The type of vote to record, when submitting a vote */
+        export enum VoteType {
+          UP = "UP",
+          DOWN = "DOWN",
+          CANCEL = "CANCEL",
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export namespace MyFeed {
+          export type Variables = {
           }
-          
-          /** The type of vote to record, when submitting a vote */
-          export enum VoteType {
-            UP = "UP",
-            DOWN = "DOWN",
-            CANCEL = "CANCEL",
+
+          export type Query = {
+            __typename?: "Query";
+            feed?: (Feed | null)[] | null;
           }
-          
-          export namespace MyFeed {
-            export type Variables = {
-            }
-          
-            export type Query = {
-              __typename?: "Query";
-              feed?: (Feed | null)[] | null;
-            }
-          
-            export type Feed = {
-              __typename?: "Entry";
-              id: number; 
-              commentCount: number; 
-              repository: Repository; 
-            }
-          
-            export type Repository = {
-              __typename?: "Repository";
-              full_name: string; 
-            } & RepoFields.Fragment
+
+          export type Feed = {
+            __typename?: "Entry";
+            id: number; 
+            commentCount: number; 
+            repository: Repository; 
           }
-          
-          export namespace RepoFields {
-            export type Fragment = {
-              __typename?: "Repository";
-              html_url: string; 
-              owner?: Owner | null; 
-            }
-          
-            export type Owner = {
-              __typename?: "User";
-              avatar_url: string; 
-            }
-          }`);
+
+          export type Repository = {
+            __typename?: "Repository";
+            full_name: string; 
+          } & RepoFields.Fragment
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export namespace RepoFields {
+          export type Fragment = {
+            __typename?: "Repository";
+            html_url: string; 
+            owner?: Owner | null; 
+          }
+
+          export type Owner = {
+            __typename?: "User";
+            avatar_url: string; 
+          }
+        }
+      `);
     });
 
-    it('Should compile simple Query with inline Fragment', async () => {
+    it.skip('Should compile simple Query with inline Fragment', async () => {
       const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
       const context = schemaToTemplateContext(schema);
 
@@ -805,56 +876,171 @@ describe('TypeScript template', () => {
 
       expect(content).toBeSimilarStringTo(`
        /* tslint:disable */
-    /** A list of options for the sort order of the feed */
-    export enum FeedType {
-      HOT = "HOT",
-      NEW = "NEW",
-      TOP = "TOP",
-    }
+       `);
+      expect(content).toBeSimilarStringTo(`
+        /** A list of options for the sort order of the feed */
+        export enum FeedType {
+          HOT = "HOT",
+          NEW = "NEW",
+          TOP = "TOP",
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        /** The type of vote to record, when submitting a vote */
+        export enum VoteType {
+          UP = "UP",
+          DOWN = "DOWN",
+          CANCEL = "CANCEL",
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export namespace MyFeed {
+          export type Variables = {
+          }
+        
+          export type Query = {
+            __typename?: "Query";
+            feed?: (Feed | null)[] | null;
+          }
+        
+          export type Feed = {
+            __typename?: "Entry";
+            id: number; 
+            commentCount: number; 
+            repository: Repository; 
+          }
+        
+          export type Repository = {
+            __typename?: RepositoryInlineFragment["__typename"] | _RepositoryInlineFragment["__typename"];
+            html_url: string; 
+          } & (RepositoryInlineFragment | _RepositoryInlineFragment)
+        
+          export type RepositoryInlineFragment = {
+            __typename?: "Repository";
+            full_name: string; 
+          }
+        
+          export type _RepositoryInlineFragment = {
+            __typename?: "Repository";
+            owner?: Owner | null; 
+          }
+        
+          export type Owner = {
+            __typename?: "User";
+            avatar_url: string; 
+          }
+        }
+      `);
+    });
+  });
+
+  describe('resolver types', () => {
+    it('should contain the Resolver type', async () => {
+      const { context } = compileAndBuildContext(`
+        type Query {
+          fieldTest: String 
+        }
+        
+        schema {
+          query: Query
+        }
+      `);
+
+      const compiled = await compileTemplate(
+        {
+          ...config,
+          config: {
+            avoidOptionals: true
+          }
+        },
+        context
+      );
+
+      const content = compiled[0].content;
+
+      expect(content).toBeSimilarStringTo(`
+        import { GraphQLResolveInfo } from 'graphql';
+
+        type Resolver<Result, Args = any> = (
+          parent: any,
+          args: Args,
+          context: any,
+          info: GraphQLResolveInfo
+        ) => Promise<Result> | Result;
+      `);
+    });
+
+    it('should provide a generic type of result', async () => {
+      const { context } = compileAndBuildContext(`
+        type Query {
+          fieldTest: String 
+        }
+        
+        schema {
+          query: Query
+        }
+      `);
+
+      const compiled = await compileTemplate(
+        {
+          ...config,
+          config: {
+            avoidOptionals: true
+          }
+        },
+        context
+      );
+
+      const content = compiled[0].content;
+
+      expect(content).toBeSimilarStringTo(`
+        export namespace QueryResolvers {
+          export interface Resolvers {
+            fieldTest: FieldTestResolver;
+          }
     
-    /** The type of vote to record, when submitting a vote */
-    export enum VoteType {
-      UP = "UP",
-      DOWN = "DOWN",
-      CANCEL = "CANCEL",
-    }
+          export type FieldTestResolver = Resolver<string | null>;
+        }
+      `);
+    });
+
+    it('should provide a generic type of arguments', async () => {
+      const { context } = compileAndBuildContext(`
+        type Query {
+          fieldTest(last: Int!, sort: String): String
+        }
+        
+        schema {
+          query: Query
+        }
+      `);
+
+      const compiled = await compileTemplate(
+        {
+          ...config,
+          config: {
+            avoidOptionals: true
+          }
+        },
+        context
+      );
+
+      const content = compiled[0].content;
+
+      expect(content).toBeSimilarStringTo(`
+        export namespace QueryResolvers {
+          export interface Resolvers {
+            fieldTest: FieldTestResolver;
+          }
     
-    export namespace MyFeed {
-      export type Variables = {
-      }
-    
-      export type Query = {
-        __typename?: "Query";
-        feed?: (Feed | null)[] | null;
-      }
-    
-      export type Feed = {
-        __typename?: "Entry";
-        id: number; 
-        commentCount: number; 
-        repository: Repository; 
-      }
-    
-      export type Repository = {
-        __typename?: RepositoryInlineFragment["__typename"] | _RepositoryInlineFragment["__typename"];
-        html_url: string; 
-      } & (RepositoryInlineFragment | _RepositoryInlineFragment)
-    
-      export type RepositoryInlineFragment = {
-        __typename?: "Repository";
-        full_name: string; 
-      }
-    
-      export type _RepositoryInlineFragment = {
-        __typename?: "Repository";
-        owner?: Owner | null; 
-      }
-    
-      export type Owner = {
-        __typename?: "User";
-        avatar_url: string; 
-      }
-    }`);
+          export type FieldTestResolver = Resolver<string | null, FieldTestArgs>;
+          
+          export interface FieldTestArgs {
+            last: number;
+            sort: string | null;
+          }
+        }
+      `);
     });
   });
 });

--- a/packages/templates/typescript/tests/typescript.spec.ts
+++ b/packages/templates/typescript/tests/typescript.spec.ts
@@ -982,8 +982,7 @@ describe('TypeScript template', () => {
           export interface Resolvers {
             fieldTest?: FieldTestResolver;
           }
-        }
-      `);
+        `);
     });
 
     it('should provide a generic type of result', async () => {
@@ -1040,6 +1039,47 @@ describe('TypeScript template', () => {
             sort?: string | null;
           }
         }
+      `);
+    });
+
+    it('should handle resolvers flag, true by default', async () => {
+      const { context } = compileAndBuildContext(`
+        type Query {
+          fieldTest: String 
+        }
+        
+        schema {
+          query: Query
+        }
+      `);
+
+      const compiled = await compileTemplate(
+        {
+          ...config,
+          config: {
+            resolvers: false
+          }
+        },
+        context
+      );
+
+      const content = compiled[0].content;
+
+      expect(content).not.toBeSimilarStringTo(`
+        import { GraphQLResolveInfo } from 'graphql';
+      `);
+
+      expect(content).not.toBeSimilarStringTo(`
+        type Resolver<Result, Args = any> = (
+          parent: any,
+          args: Args,
+          context: any,
+          info: GraphQLResolveInfo
+        ) => Promise<Result> | Result;
+      `);
+
+      expect(content).not.toBeSimilarStringTo(`
+        export namespace QueryResolvers {
       `);
     });
   });

--- a/packages/templates/typescript/tests/typescript.spec.ts
+++ b/packages/templates/typescript/tests/typescript.spec.ts
@@ -611,7 +611,7 @@ describe('TypeScript template', () => {
   });
 
   describe('Operations', () => {
-    it.skip('Should compile simple Query correctly', async () => {
+    it('Should compile simple Query correctly', async () => {
       const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
       const context = schemaToTemplateContext(schema);
 
@@ -685,7 +685,7 @@ describe('TypeScript template', () => {
         }
       `);
     });
-    it.skip('Should compile anonymous Query correctly', async () => {
+    it('Should compile anonymous Query correctly', async () => {
       const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
       const context = schemaToTemplateContext(schema);
 
@@ -760,7 +760,7 @@ describe('TypeScript template', () => {
       `);
     });
 
-    it.skip('Should compile simple Query with Fragment spread correctly', async () => {
+    it('Should compile simple Query with Fragment spread correctly', async () => {
       const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
       const context = schemaToTemplateContext(schema);
 
@@ -846,7 +846,7 @@ describe('TypeScript template', () => {
       `);
     });
 
-    it.skip('Should compile simple Query with inline Fragment', async () => {
+    it('Should compile simple Query with inline Fragment', async () => {
       const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
       const context = schemaToTemplateContext(schema);
 
@@ -934,7 +934,7 @@ describe('TypeScript template', () => {
     });
   });
 
-  describe('resolver types', () => {
+  describe('Resolvers', () => {
     it('should contain the Resolver type', async () => {
       const { context } = compileAndBuildContext(`
         type Query {
@@ -946,15 +946,7 @@ describe('TypeScript template', () => {
         }
       `);
 
-      const compiled = await compileTemplate(
-        {
-          ...config,
-          config: {
-            avoidOptionals: true
-          }
-        },
-        context
-      );
+      const compiled = await compileTemplate(config, context);
 
       const content = compiled[0].content;
 
@@ -981,22 +973,14 @@ describe('TypeScript template', () => {
         }
       `);
 
-      const compiled = await compileTemplate(
-        {
-          ...config,
-          config: {
-            avoidOptionals: true
-          }
-        },
-        context
-      );
+      const compiled = await compileTemplate(config, context);
 
       const content = compiled[0].content;
 
       expect(content).toBeSimilarStringTo(`
         export namespace QueryResolvers {
           export interface Resolvers {
-            fieldTest: FieldTestResolver;
+            fieldTest?: FieldTestResolver;
           }
     
           export type FieldTestResolver = Resolver<string | null>;
@@ -1015,29 +999,21 @@ describe('TypeScript template', () => {
         }
       `);
 
-      const compiled = await compileTemplate(
-        {
-          ...config,
-          config: {
-            avoidOptionals: true
-          }
-        },
-        context
-      );
+      const compiled = await compileTemplate(config, context);
 
       const content = compiled[0].content;
 
       expect(content).toBeSimilarStringTo(`
         export namespace QueryResolvers {
           export interface Resolvers {
-            fieldTest: FieldTestResolver;
+            fieldTest?: FieldTestResolver;
           }
     
           export type FieldTestResolver = Resolver<string | null, FieldTestArgs>;
           
           export interface FieldTestArgs {
             last: number;
-            sort: string | null;
+            sort?: string | null;
           }
         }
       `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6303,9 +6303,9 @@ webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
-webpack-cli@3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.0.7.tgz#d4171aa6a52f28d3a40048db3d0764e1c601c029"
+webpack-cli@3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.0.8.tgz#90eddcf04a4bfc31aa8c0edc4c76785bc4f1ccd9"
   dependencies:
     chalk "^2.4.1"
     cross-spawn "^6.0.5"


### PR DESCRIPTION
Closes #319

I changed a bit how `expect().toBeSimilarStringTo` works, it was comparing a template from start to end now it checks if a template contains a part we're looking for.

- [x] some tests are breaking other tests
- [x] add more tests
- [x] issue with `graphql-tools` ([show it to me!](https://github.com/kamilkisiela/gql-gen-with-resolvers/blob/7cc59d6c1020ec1e98ee189e80cb737c3d81d898/src/index.ts#L5-L10) / [show an example](https://stackblitz.com/edit/typescript-mpc1c7?file=index.ts))
- [x] maybe a flag that enables / disables generating types for resolvers?
- [x] maybe a different template that does that

Example: https://github.com/kamilkisiela/gql-gen-with-resolvers

@dotansimha 