### PR TITLE
add graphql to typescript template dependencies

### DIFF
--- a/packages/templates/typescript/package.json
+++ b/packages/templates/typescript/package.json
@@ -13,6 +13,7 @@
     "@types/common-tags": "1.4.0",
     "codegen-templates-scripts": "0.10.0",
     "common-tags": "1.8.0",
+    "graphql": "0.13.2",
     "graphql-codegen-compiler": "0.10.0",
     "graphql-codegen-core": "0.10.0"
   },


### PR DESCRIPTION
It won't compile as a stand-alone package if it isn't here.
It complains about missing types.
The same thing as #390 