### PR TITLE
Add TypeScript React Apollo Template

### DIFF
--- a/dev-test/generate-all.sh
+++ b/dev-test/generate-all.sh
@@ -9,6 +9,7 @@ CODEGEN_ENUMS_AS_TYPES=true node packages/graphql-codegen-cli/dist/cli.js --temp
 CODEGEN_AVOID_OPTIONALS=true node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescript-template --schema ./dev-test/githunt/schema.json --out ./dev-test/githunt/types.avoidOptionals.ts "./dev-test/githunt/**/*.graphql"
 CODEGEN_IMMUTABLE_TYPES=true node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescript-template --schema ./dev-test/githunt/schema.json --out ./dev-test/githunt/types.immutableTypes.ts "./dev-test/githunt/**/*.graphql"
 CODEGEN_NO_NAMESPACES=true node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescript-template --schema ./dev-test/githunt/schema.json --out ./dev-test/githunt/types.noNamespaces.ts "./dev-test/githunt/**/*.graphql"
+node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescript-react-apollo-template --schema ./dev-test/githunt/schema.json --out ./dev-test/githunt/types.reactApollo.ts "./dev-test/githunt/**/*.graphql"
 node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescript-template-multiple --schema ./dev-test/githunt/schema.json --out ./dev-test/githunt/ts-multiple/ "./dev-test/githunt/**/*.graphql"
 
 node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescript-template --schema ./dev-test/star-wars/schema.json --out ./dev-test/star-wars/types.ts "./dev-test/star-wars/**/*.graphql"

--- a/dev-test/githunt/types.reactApollo.ts
+++ b/dev-test/githunt/types.reactApollo.ts
@@ -1,0 +1,578 @@
+/* tslint:disable */
+import { GraphQLResolveInfo } from 'graphql';
+
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
+  parent?: Parent,
+  args?: Args,
+  context?: Context,
+  info?: GraphQLResolveInfo
+) => Promise<Result> | Result;
+
+export interface Query {
+  feed?: (Entry | null)[] | null /** A feed of repository submissions */;
+  entry?: Entry | null /** A single entry */;
+  currentUser?: User | null /** Return the currently logged in user, or null if nobody is logged in */;
+}
+/** Information about a GitHub repository submitted to GitHunt */
+export interface Entry {
+  repository: Repository /** Information about the repository from GitHub */;
+  postedBy: User /** The GitHub user who submitted this entry */;
+  createdAt: number /** A timestamp of when the entry was submitted */;
+  score: number /** The score of this repository, upvotes - downvotes */;
+  hotScore: number /** The hot score of this repository */;
+  comments: (Comment | null)[] /** Comments posted about this repository */;
+  commentCount: number /** The number of comments posted about this repository */;
+  id: number /** The SQL ID of this entry */;
+  vote: Vote /** XXX to be changed */;
+}
+/** A repository object from the GitHub API. This uses the exact field names returned by theGitHub API for simplicity, even though the convention for GraphQL is usually to camel case. */
+export interface Repository {
+  name: string /** Just the name of the repository, e.g. GitHunt-API */;
+  full_name: string /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */;
+  description?: string | null /** The description of the repository */;
+  html_url: string /** The link to the repository on GitHub */;
+  stargazers_count: number /** The number of people who have starred this repository on GitHub */;
+  open_issues_count?: number | null /** The number of open issues on this repository on GitHub */;
+  owner?: User | null /** The owner of this repository on GitHub, e.g. apollostack */;
+}
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export interface User {
+  login: string /** The name of the user, e.g. apollostack */;
+  avatar_url: string /** The URL to a directly embeddable image for this user's avatar */;
+  html_url: string /** The URL of this user's GitHub page */;
+}
+/** A comment about an entry, submitted by a user */
+export interface Comment {
+  id: number /** The SQL ID of this entry */;
+  postedBy: User /** The GitHub user who posted the comment */;
+  createdAt: number /** A timestamp of when the comment was posted */;
+  content: string /** The text of the comment */;
+  repoName: string /** The repository which this comment is about */;
+}
+/** XXX to be removed */
+export interface Vote {
+  vote_value: number;
+}
+
+export interface Mutation {
+  submitRepository?: Entry | null /** Submit a new repository, returns the new submission */;
+  vote?: Entry | null /** Vote on a repository submission, returns the submission that was voted on */;
+  submitComment?: Comment | null /** Comment on a repository, returns the new comment */;
+}
+
+export interface Subscription {
+  commentAdded?: Comment | null /** Subscription fires on every comment added */;
+}
+export interface FeedQueryArgs {
+  type: FeedType /** The sort order for the feed */;
+  offset?: number | null /** The number of items to skip, for pagination */;
+  limit?: number | null /** The number of items to fetch starting from the offset, for pagination */;
+}
+export interface EntryQueryArgs {
+  repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
+}
+export interface CommentsEntryArgs {
+  limit?: number | null;
+  offset?: number | null;
+}
+export interface SubmitRepositoryMutationArgs {
+  repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
+}
+export interface VoteMutationArgs {
+  repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
+  type: VoteType /** The type of vote - UP, DOWN, or CANCEL */;
+}
+export interface SubmitCommentMutationArgs {
+  repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
+  commentContent: string /** The text content for the new comment */;
+}
+export interface CommentAddedSubscriptionArgs {
+  repoFullName: string;
+}
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  HOT = 'HOT',
+  NEW = 'NEW',
+  TOP = 'TOP'
+}
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  UP = 'UP',
+  DOWN = 'DOWN',
+  CANCEL = 'CANCEL'
+}
+
+export namespace QueryResolvers {
+  export interface Resolvers<Context = any, Parent = Query> {
+    feed?: FeedResolver<(Entry | null)[] | null, Parent, Context> /** A feed of repository submissions */;
+    entry?: EntryResolver<Entry | null, Parent, Context> /** A single entry */;
+    currentUser?: CurrentUserResolver<
+      User | null,
+      Parent,
+      Context
+    > /** Return the currently logged in user, or null if nobody is logged in */;
+  }
+
+  export type FeedResolver<R = (Entry | null)[] | null, Parent = Query, Context = any> = Resolver<
+    R,
+    Parent,
+    Context,
+    FeedArgs
+  >;
+  export interface FeedArgs {
+    type: FeedType /** The sort order for the feed */;
+    offset?: number | null /** The number of items to skip, for pagination */;
+    limit?: number | null /** The number of items to fetch starting from the offset, for pagination */;
+  }
+
+  export type EntryResolver<R = Entry | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, EntryArgs>;
+  export interface EntryArgs {
+    repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
+  }
+
+  export type CurrentUserResolver<R = User | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+}
+/** Information about a GitHub repository submitted to GitHunt */
+export namespace EntryResolvers {
+  export interface Resolvers<Context = any, Parent = Entry> {
+    repository?: RepositoryResolver<Repository, Parent, Context> /** Information about the repository from GitHub */;
+    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who submitted this entry */;
+    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the entry was submitted */;
+    score?: ScoreResolver<number, Parent, Context> /** The score of this repository, upvotes - downvotes */;
+    hotScore?: HotScoreResolver<number, Parent, Context> /** The hot score of this repository */;
+    comments?: CommentsResolver<(Comment | null)[], Parent, Context> /** Comments posted about this repository */;
+    commentCount?: CommentCountResolver<
+      number,
+      Parent,
+      Context
+    > /** The number of comments posted about this repository */;
+    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
+    vote?: VoteResolver<Vote, Parent, Context> /** XXX to be changed */;
+  }
+
+  export type RepositoryResolver<R = Repository, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type ScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type HotScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentsResolver<R = (Comment | null)[], Parent = Entry, Context = any> = Resolver<
+    R,
+    Parent,
+    Context,
+    CommentsArgs
+  >;
+  export interface CommentsArgs {
+    limit?: number | null;
+    offset?: number | null;
+  }
+
+  export type CommentCountResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type VoteResolver<R = Vote, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+}
+/** A repository object from the GitHub API. This uses the exact field names returned by theGitHub API for simplicity, even though the convention for GraphQL is usually to camel case. */
+export namespace RepositoryResolvers {
+  export interface Resolvers<Context = any, Parent = Repository> {
+    name?: NameResolver<string, Parent, Context> /** Just the name of the repository, e.g. GitHunt-API */;
+    full_name?: FullNameResolver<
+      string,
+      Parent,
+      Context
+    > /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */;
+    description?: DescriptionResolver<string | null, Parent, Context> /** The description of the repository */;
+    html_url?: HtmlUrlResolver<string, Parent, Context> /** The link to the repository on GitHub */;
+    stargazers_count?: StargazersCountResolver<
+      number,
+      Parent,
+      Context
+    > /** The number of people who have starred this repository on GitHub */;
+    open_issues_count?: OpenIssuesCountResolver<
+      number | null,
+      Parent,
+      Context
+    > /** The number of open issues on this repository on GitHub */;
+    owner?: OwnerResolver<User | null, Parent, Context> /** The owner of this repository on GitHub, e.g. apollostack */;
+  }
+
+  export type NameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+  export type FullNameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+  export type DescriptionResolver<R = string | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+  export type StargazersCountResolver<R = number, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+  export type OpenIssuesCountResolver<R = number | null, Parent = Repository, Context = any> = Resolver<
+    R,
+    Parent,
+    Context
+  >;
+  export type OwnerResolver<R = User | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+}
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export namespace UserResolvers {
+  export interface Resolvers<Context = any, Parent = User> {
+    login?: LoginResolver<string, Parent, Context> /** The name of the user, e.g. apollostack */;
+    avatar_url?: AvatarUrlResolver<
+      string,
+      Parent,
+      Context
+    > /** The URL to a directly embeddable image for this user's avatar */;
+    html_url?: HtmlUrlResolver<string, Parent, Context> /** The URL of this user's GitHub page */;
+  }
+
+  export type LoginResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type AvatarUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+}
+/** A comment about an entry, submitted by a user */
+export namespace CommentResolvers {
+  export interface Resolvers<Context = any, Parent = Comment> {
+    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
+    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who posted the comment */;
+    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the comment was posted */;
+    content?: ContentResolver<string, Parent, Context> /** The text of the comment */;
+    repoName?: RepoNameResolver<string, Parent, Context> /** The repository which this comment is about */;
+  }
+
+  export type IdResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
+  export type ContentResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
+  export type RepoNameResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
+}
+/** XXX to be removed */
+export namespace VoteResolvers {
+  export interface Resolvers<Context = any, Parent = Vote> {
+    vote_value?: VoteValueResolver<number, Parent, Context>;
+  }
+
+  export type VoteValueResolver<R = number, Parent = Vote, Context = any> = Resolver<R, Parent, Context>;
+}
+
+export namespace MutationResolvers {
+  export interface Resolvers<Context = any, Parent = Mutation> {
+    submitRepository?: SubmitRepositoryResolver<
+      Entry | null,
+      Parent,
+      Context
+    > /** Submit a new repository, returns the new submission */;
+    vote?: VoteResolver<
+      Entry | null,
+      Parent,
+      Context
+    > /** Vote on a repository submission, returns the submission that was voted on */;
+    submitComment?: SubmitCommentResolver<
+      Comment | null,
+      Parent,
+      Context
+    > /** Comment on a repository, returns the new comment */;
+  }
+
+  export type SubmitRepositoryResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<
+    R,
+    Parent,
+    Context,
+    SubmitRepositoryArgs
+  >;
+  export interface SubmitRepositoryArgs {
+    repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
+  }
+
+  export type VoteResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<R, Parent, Context, VoteArgs>;
+  export interface VoteArgs {
+    repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
+    type: VoteType /** The type of vote - UP, DOWN, or CANCEL */;
+  }
+
+  export type SubmitCommentResolver<R = Comment | null, Parent = Mutation, Context = any> = Resolver<
+    R,
+    Parent,
+    Context,
+    SubmitCommentArgs
+  >;
+  export interface SubmitCommentArgs {
+    repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
+    commentContent: string /** The text content for the new comment */;
+  }
+}
+
+export namespace SubscriptionResolvers {
+  export interface Resolvers<Context = any, Parent = Subscription> {
+    commentAdded?: CommentAddedResolver<
+      Comment | null,
+      Parent,
+      Context
+    > /** Subscription fires on every comment added */;
+  }
+
+  export type CommentAddedResolver<R = Comment | null, Parent = Subscription, Context = any> = Resolver<
+    R,
+    Parent,
+    Context,
+    CommentAddedArgs
+  >;
+  export interface CommentAddedArgs {
+    repoFullName: string;
+  }
+}
+
+export namespace OnCommentAdded {
+  export type Variables = {
+    repoFullName: string;
+  };
+
+  export type Subscription = {
+    __typename?: 'Subscription';
+    commentAdded?: CommentAdded | null;
+  };
+
+  export type CommentAdded = {
+    __typename?: 'Comment';
+    id: number;
+    postedBy: PostedBy;
+    createdAt: number;
+    content: string;
+  };
+
+  export type PostedBy = {
+    __typename?: 'User';
+    login: string;
+    html_url: string;
+  };
+}
+
+export namespace Comment {
+  export type Variables = {
+    repoFullName: string;
+    limit?: number | null;
+    offset?: number | null;
+  };
+
+  export type Query = {
+    __typename?: 'Query';
+    currentUser?: CurrentUser | null;
+    entry?: Entry | null;
+  };
+
+  export type CurrentUser = {
+    __typename?: 'User';
+    login: string;
+    html_url: string;
+  };
+
+  export type Entry = {
+    __typename?: 'Entry';
+    id: number;
+    postedBy: PostedBy;
+    createdAt: number;
+    comments: (Comments | null)[];
+    commentCount: number;
+    repository: Repository;
+  };
+
+  export type PostedBy = {
+    __typename?: 'User';
+    login: string;
+    html_url: string;
+  };
+
+  export type Comments = CommentsPageComment.Fragment;
+
+  export type Repository = {
+    __typename?: RepositoryInlineFragment['__typename'];
+    full_name: string;
+    html_url: string;
+  } & (RepositoryInlineFragment);
+
+  export type RepositoryInlineFragment = {
+    __typename?: 'Repository';
+    description?: string | null;
+    open_issues_count?: number | null;
+    stargazers_count: number;
+  };
+}
+
+export namespace CurrentUserForProfile {
+  export type Variables = {};
+
+  export type Query = {
+    __typename?: 'Query';
+    currentUser?: CurrentUser | null;
+  };
+
+  export type CurrentUser = {
+    __typename?: 'User';
+    login: string;
+    avatar_url: string;
+  };
+}
+
+export namespace Feed {
+  export type Variables = {
+    type: FeedType;
+    offset?: number | null;
+    limit?: number | null;
+  };
+
+  export type Query = {
+    __typename?: 'Query';
+    currentUser?: CurrentUser | null;
+    feed?: (Feed | null)[] | null;
+  };
+
+  export type CurrentUser = {
+    __typename?: 'User';
+    login: string;
+  };
+
+  export type Feed = FeedEntry.Fragment;
+}
+
+export namespace SubmitRepository {
+  export type Variables = {
+    repoFullName: string;
+  };
+
+  export type Mutation = {
+    __typename?: 'Mutation';
+    submitRepository?: SubmitRepository | null;
+  };
+
+  export type SubmitRepository = {
+    __typename?: 'Entry';
+    createdAt: number;
+  };
+}
+
+export namespace SubmitComment {
+  export type Variables = {
+    repoFullName: string;
+    commentContent: string;
+  };
+
+  export type Mutation = {
+    __typename?: 'Mutation';
+    submitComment?: SubmitComment | null;
+  };
+
+  export type SubmitComment = CommentsPageComment.Fragment;
+}
+
+export namespace Vote {
+  export type Variables = {
+    repoFullName: string;
+    type: VoteType;
+  };
+
+  export type Mutation = {
+    __typename?: 'Mutation';
+    vote?: Vote | null;
+  };
+
+  export type Vote = {
+    __typename?: 'Entry';
+    score: number;
+    id: number;
+    vote: Vote;
+  };
+
+  export type _Vote = {
+    __typename?: 'Vote';
+    vote_value: number;
+  };
+}
+
+export namespace CommentsPageComment {
+  export type Fragment = {
+    __typename?: 'Comment';
+    id: number;
+    postedBy: PostedBy;
+    createdAt: number;
+    content: string;
+  };
+
+  export type PostedBy = {
+    __typename?: 'User';
+    login: string;
+    html_url: string;
+  };
+}
+
+export namespace FeedEntry {
+  export type Fragment = {
+    __typename?: 'Entry';
+    id: number;
+    commentCount: number;
+    repository: Repository;
+  } & VoteButtons.Fragment &
+    RepoInfo.Fragment;
+
+  export type Repository = {
+    __typename?: 'Repository';
+    full_name: string;
+    html_url: string;
+    owner?: Owner | null;
+  };
+
+  export type Owner = {
+    __typename?: 'User';
+    avatar_url: string;
+  };
+}
+
+export namespace RepoInfo {
+  export type Fragment = {
+    __typename?: 'Entry';
+    createdAt: number;
+    repository: Repository;
+    postedBy: PostedBy;
+  };
+
+  export type Repository = {
+    __typename?: 'Repository';
+    description?: string | null;
+    stargazers_count: number;
+    open_issues_count?: number | null;
+  };
+
+  export type PostedBy = {
+    __typename?: 'User';
+    html_url: string;
+    login: string;
+  };
+}
+
+export namespace VoteButtons {
+  export type Fragment = {
+    __typename?: 'Entry';
+    score: number;
+    vote: Vote;
+  };
+
+  export type Vote = {
+    __typename?: 'Vote';
+    vote_value: number;
+  };
+}
+
+import * as ReactApollo from 'react-apollo';
+
+export namespace OnCommentAdded {
+  export class Component extends ReactApollo.Subscription<Subscription, Variables> {}
+}
+export namespace Comment {
+  export class Component extends ReactApollo.Query<Query, Variables> {}
+}
+export namespace CurrentUserForProfile {
+  export class Component extends ReactApollo.Query<Query, Variables> {}
+}
+export namespace Feed {
+  export class Component extends ReactApollo.Query<Query, Variables> {}
+}
+export namespace SubmitRepository {
+  export class Component extends ReactApollo.Mutation<Mutation, Variables> {}
+}
+export namespace SubmitComment {
+  export class Component extends ReactApollo.Mutation<Mutation, Variables> {}
+}
+export namespace Vote {
+  export class Component extends ReactApollo.Mutation<Mutation, Variables> {}
+}

--- a/packages/templates/typescript-react-apollo/.gitignore
+++ b/packages/templates/typescript-react-apollo/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+dist
+temp
+yarn-error.log

--- a/packages/templates/typescript-react-apollo/.npmignore
+++ b/packages/templates/typescript-react-apollo/.npmignore
@@ -1,0 +1,4 @@
+src
+node_modules
+tests
+!dist

--- a/packages/templates/typescript-react-apollo/.npmrc
+++ b/packages/templates/typescript-react-apollo/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true

--- a/packages/templates/typescript-react-apollo/README.md
+++ b/packages/templates/typescript-react-apollo/README.md
@@ -1,0 +1,30 @@
+# TypeScript React Apollo Template
+
+This template generates React Apollo components with TypeScript typings.
+This template is extended version of TypeScript template, so the configuration is same with `graphql-codegen-typescript-template`.
+
+- Example Input
+
+```graphql
+query Test {
+  feed {
+    id
+    commentCount
+    repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+```
+
+- Example Usage
+
+```tsx
+  <Test.Component query={...} variables={...}>
+    ...
+  </Test.Component>
+```

--- a/packages/templates/typescript-react-apollo/package.json
+++ b/packages/templates/typescript-react-apollo/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "graphql-codegen-typescript-react-apollo-template",
+  "version": "0.0.1",
+  "description": "",
+  "license": "MIT",
+  "scripts": {
+    "prepublishOnly": "yarn build",
+    "build": "codegen-templates-scripts build",
+    "pretest": "yarn build",
+    "test": "codegen-templates-scripts test"
+  },
+  "devDependencies": {
+    "@types/graphql": "0.13.0",
+    "codegen-templates-scripts": "0.10.5",
+    "graphql": "0.13.2",
+    "graphql-codegen-compiler": "0.10.5",
+    "graphql-codegen-core": "0.10.5"
+  },
+  "main": "./dist/index.js",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "enableTsDiagnostics": false
+      }
+    },
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
+  },
+  "dependencies": {
+    "graphql-codegen-typescript-template": "0.10.5"
+  }
+}

--- a/packages/templates/typescript-react-apollo/src/components.handlebars
+++ b/packages/templates/typescript-react-apollo/src/components.handlebars
@@ -1,0 +1,11 @@
+import * as ReactApollo from 'react-apollo';
+
+{{#each operations }}
+    {{#unless @root.config.noNamespaces}}
+    export namespace {{toPascalCase name}} {
+    {{/unless}}
+        export class {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Component extends ReactApollo.{{toPascalCase operationType}}<{{toPascalCase operationType}}, {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Variables> { }   
+    {{#unless @root.config.noNamespaces}}
+    }
+    {{/unless}}
+{{/each}}

--- a/packages/templates/typescript-react-apollo/src/config.ts
+++ b/packages/templates/typescript-react-apollo/src/config.ts
@@ -1,0 +1,7 @@
+import typescriptConfig from 'graphql-codegen-typescript-template';
+
+import * as components from './components.handlebars';
+
+typescriptConfig.templates['documents'] += components;
+
+export { typescriptConfig as config };

--- a/packages/templates/typescript-react-apollo/src/index.ts
+++ b/packages/templates/typescript-react-apollo/src/index.ts
@@ -1,0 +1,3 @@
+import { config } from './config';
+
+export default config;

--- a/packages/templates/typescript-react-apollo/src/polyfills.d.ts
+++ b/packages/templates/typescript-react-apollo/src/polyfills.d.ts
@@ -1,0 +1,4 @@
+declare module '*.handlebars' {
+  const content: string;
+  export = content;
+}

--- a/packages/templates/typescript-react-apollo/tests/components.spec.ts
+++ b/packages/templates/typescript-react-apollo/tests/components.spec.ts
@@ -1,0 +1,48 @@
+import './custom-matchers';
+import {
+  GeneratorConfig,
+  gql,
+  GraphQLSchema,
+  introspectionToGraphQLSchema,
+  makeExecutableSchema,
+  SchemaTemplateContext,
+  schemaToTemplateContext,
+  transformDocument
+} from 'graphql-codegen-core';
+import { compileTemplate } from 'graphql-codegen-compiler';
+import config from '../dist';
+import * as fs from 'fs';
+
+describe('Components', () => {
+  it('should generate Component', async () => {
+    const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
+    const context = schemaToTemplateContext(schema);
+
+    const documents = gql`
+      query {
+        feed {
+          id
+          commentCount
+          repository {
+            full_name
+            html_url
+            owner {
+              avatar_url
+            }
+          }
+        }
+      }
+    `;
+
+    const transformedDocument = transformDocument(schema, documents);
+    const compiled = await compileTemplate(config, context, [transformedDocument], { generateSchema: false });
+    const content = compiled[0].content;
+
+    expect(content).toBeSimilarStringTo(`
+          import * as ReactApollo from 'react-apollo';
+        `);
+    expect(content).toBeSimilarStringTo(`
+          export class Component extends ReactApollo.Query<Query, Variables> { }
+        `);
+  });
+});

--- a/packages/templates/typescript-react-apollo/tests/custom-matchers.ts
+++ b/packages/templates/typescript-react-apollo/tests/custom-matchers.ts
@@ -1,0 +1,45 @@
+import { oneLine } from 'common-tags';
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      /**
+       * Normalizes whitespace and performs string comparisons
+       */
+      toBeSimilarStringTo(expected: string): R;
+    }
+  }
+}
+
+function compareStrings(a: string, b: string): boolean {
+  return a.includes(b);
+}
+
+function toBeSimilarStringTo(received: string, argument: string) {
+  const strippedA = oneLine`${received}`.replace(/\s\s+/g, ' ');
+  const strippedB = oneLine`${argument}`.replace(/\s\s+/g, ' ');
+
+  if (compareStrings(strippedA, strippedB)) {
+    return {
+      message: () =>
+        `expected 
+ ${received}
+ not to be similar (strip-indent) string to
+ ${argument}`,
+      pass: true
+    };
+  } else {
+    return {
+      message: () =>
+        `expected 
+ ${received}
+ to be similar (strip-indent) string to
+ ${argument}`,
+      pass: false
+    };
+  }
+}
+
+expect.extend({
+  toBeSimilarStringTo
+});

--- a/packages/templates/typescript-react-apollo/tests/files/schema.json
+++ b/packages/templates/typescript-react-apollo/tests/files/schema.json
@@ -1,0 +1,1753 @@
+{
+  "__schema": {
+    "queryType": {
+      "name": "Query"
+    },
+    "mutationType": {
+      "name": "Mutation"
+    },
+    "subscriptionType": {
+      "name": "Subscription"
+    },
+    "types": [
+      {
+        "kind": "OBJECT",
+        "name": "Query",
+        "description": "",
+        "fields": [
+          {
+            "name": "feed",
+            "description": "A feed of repository submissions",
+            "args": [
+              {
+                "name": "type",
+                "description": "The sort order for the feed",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "FeedType",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "The number of items to skip, for pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": "The number of items to fetch starting from the offset, for pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Entry",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "entry",
+            "description": "A single entry",
+            "args": [
+              {
+                "name": "repoFullName",
+                "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Entry",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentUser",
+            "description": "Return the currently logged in user, or null if nobody is logged in",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "FeedType",
+        "description": "A list of options for the sort order of the feed",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "HOT",
+            "description": "Sort by a combination of freshness and score, using Reddit's algorithm",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NEW",
+            "description": "Newest entries first",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TOP",
+            "description": "Highest score entries first",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Int",
+        "description":
+          "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Entry",
+        "description": "Information about a GitHub repository submitted to GitHunt",
+        "fields": [
+          {
+            "name": "repository",
+            "description": "Information about the repository from GitHub",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Repository",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postedBy",
+            "description": "The GitHub user who submitted this entry",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "A timestamp of when the entry was submitted",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "score",
+            "description": "The score of this repository, upvotes - downvotes",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hotScore",
+            "description": "The hot score of this repository",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "comments",
+            "description": "Comments posted about this repository",
+            "args": [
+              {
+                "name": "limit",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Comment",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "commentCount",
+            "description": "The number of comments posted about this repository",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The SQL ID of this entry",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vote",
+            "description": "XXX to be changed",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Vote",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Repository",
+        "description":
+          "A repository object from the GitHub API. This uses the exact field names returned by the\nGitHub API for simplicity, even though the convention for GraphQL is usually to camel case.",
+        "fields": [
+          {
+            "name": "name",
+            "description": "Just the name of the repository, e.g. GitHunt-API",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "full_name",
+            "description": "The full name of the repository with the username, e.g. apollostack/GitHunt-API",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the repository",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "html_url",
+            "description": "The link to the repository on GitHub",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stargazers_count",
+            "description": "The number of people who have starred this repository on GitHub",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "open_issues_count",
+            "description": "The number of open issues on this repository on GitHub",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner",
+            "description": "The owner of this repository on GitHub, e.g. apollostack",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "String",
+        "description":
+          "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "User",
+        "description":
+          "A user object from the GitHub API. This uses the exact field names returned from the GitHub API.",
+        "fields": [
+          {
+            "name": "login",
+            "description": "The name of the user, e.g. apollostack",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "avatar_url",
+            "description": "The URL to a directly embeddable image for this user's avatar",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "html_url",
+            "description": "The URL of this user's GitHub page",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float",
+        "description":
+          "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Comment",
+        "description": "A comment about an entry, submitted by a user",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The SQL ID of this entry",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postedBy",
+            "description": "The GitHub user who posted the comment",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "A timestamp of when the comment was posted",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "content",
+            "description": "The text of the comment",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "repoName",
+            "description": "The repository which this comment is about",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Vote",
+        "description": "XXX to be removed",
+        "fields": [
+          {
+            "name": "vote_value",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Mutation",
+        "description": "",
+        "fields": [
+          {
+            "name": "submitRepository",
+            "description": "Submit a new repository, returns the new submission",
+            "args": [
+              {
+                "name": "repoFullName",
+                "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Entry",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vote",
+            "description": "Vote on a repository submission, returns the submission that was voted on",
+            "args": [
+              {
+                "name": "repoFullName",
+                "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "type",
+                "description": "The type of vote - UP, DOWN, or CANCEL",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "VoteType",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Entry",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "submitComment",
+            "description": "Comment on a repository, returns the new comment",
+            "args": [
+              {
+                "name": "repoFullName",
+                "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "commentContent",
+                "description": "The text content for the new comment",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Comment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "VoteType",
+        "description": "The type of vote to record, when submitting a vote",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "UP",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DOWN",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CANCEL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Subscription",
+        "description": "",
+        "fields": [
+          {
+            "name": "commentAdded",
+            "description": "Subscription fires on every comment added",
+            "args": [
+              {
+                "name": "repoFullName",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Comment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__Schema",
+        "description":
+          "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+        "fields": [
+          {
+            "name": "types",
+            "description": "A list of all types supported by this server.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "queryType",
+            "description": "The type that query operations will be rooted at.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mutationType",
+            "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "__Type",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subscriptionType",
+            "description":
+              "If this server support subscription, the type that subscription operations will be rooted at.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "__Type",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "directives",
+            "description": "A list of all directives supported by this server.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Directive",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__Type",
+        "description":
+          "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+        "fields": [
+          {
+            "name": "kind",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "__TypeKind",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fields",
+            "description": null,
+            "args": [
+              {
+                "name": "includeDeprecated",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false"
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Field",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "interfaces",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "possibleTypes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "enumValues",
+            "description": null,
+            "args": [
+              {
+                "name": "includeDeprecated",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false"
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__EnumValue",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "inputFields",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__InputValue",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ofType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "__Type",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "__TypeKind",
+        "description": "An enum describing what kind of type a given `__Type` is.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "SCALAR",
+            "description": "Indicates this type is a scalar.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OBJECT",
+            "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INTERFACE",
+            "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNION",
+            "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ENUM",
+            "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INPUT_OBJECT",
+            "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LIST",
+            "description": "Indicates this type is a list. `ofType` is a valid field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NON_NULL",
+            "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Boolean",
+        "description": "The `Boolean` scalar type represents `true` or `false`.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__Field",
+        "description":
+          "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+        "fields": [
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "args",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isDeprecated",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deprecationReason",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__InputValue",
+        "description":
+          "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+        "fields": [
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "defaultValue",
+            "description": "A GraphQL-formatted string representing the default value for this input value.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__EnumValue",
+        "description":
+          "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+        "fields": [
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isDeprecated",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deprecationReason",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__Directive",
+        "description":
+          "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+        "fields": [
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "locations",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "__DirectiveLocation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "args",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "onOperation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `locations`."
+          },
+          {
+            "name": "onFragment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `locations`."
+          },
+          {
+            "name": "onField",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `locations`."
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "__DirectiveLocation",
+        "description":
+          "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "QUERY",
+            "description": "Location adjacent to a query operation.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MUTATION",
+            "description": "Location adjacent to a mutation operation.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUBSCRIPTION",
+            "description": "Location adjacent to a subscription operation.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FIELD",
+            "description": "Location adjacent to a field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FRAGMENT_DEFINITION",
+            "description": "Location adjacent to a fragment definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FRAGMENT_SPREAD",
+            "description": "Location adjacent to a fragment spread.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INLINE_FRAGMENT",
+            "description": "Location adjacent to an inline fragment.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SCHEMA",
+            "description": "Location adjacent to a schema definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SCALAR",
+            "description": "Location adjacent to a scalar definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OBJECT",
+            "description": "Location adjacent to an object type definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FIELD_DEFINITION",
+            "description": "Location adjacent to a field definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ARGUMENT_DEFINITION",
+            "description": "Location adjacent to an argument definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INTERFACE",
+            "description": "Location adjacent to an interface definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNION",
+            "description": "Location adjacent to a union definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ENUM",
+            "description": "Location adjacent to an enum definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ENUM_VALUE",
+            "description": "Location adjacent to an enum value definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INPUT_OBJECT",
+            "description": "Location adjacent to an input object type definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INPUT_FIELD_DEFINITION",
+            "description": "Location adjacent to an input object field definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      }
+    ],
+    "directives": [
+      {
+        "name": "skip",
+        "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "args": [
+          {
+            "name": "if",
+            "description": "Skipped when true.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ]
+      },
+      {
+        "name": "include",
+        "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "args": [
+          {
+            "name": "if",
+            "description": "Included when true.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ]
+      },
+      {
+        "name": "deprecated",
+        "description": "Marks an element of a GraphQL schema as no longer supported.",
+        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
+        "args": [
+          {
+            "name": "reason",
+            "description":
+              "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": "\"No longer supported\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/templates/typescript-react-apollo/tsconfig.json
+++ b/packages/templates/typescript-react-apollo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "target": "es5",
+    "lib": ["es6", "esnext", "es2015"],
+    "noImplicitAny": false,
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "./dist/"
+  },
+  "exclude": ["node_modules", "tests", "dist"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,10 @@
   version "0.12.6"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.12.6.tgz#3d619198585fcabe5f4e1adfb5cf5f3388c66c13"
 
+"@types/graphql@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.13.0.tgz#78a33a7f429a06a64714817d9130d578e0f35ecb"
+
 "@types/graphql@0.13.3":
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.13.3.tgz#23af65796d341f93ef5b485138bd52c67786452d"
@@ -6178,9 +6182,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+typescript@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
This template generates React Apollo components with TypeScript typings.
This template is extended version of TypeScript template, so the configuration is same with `graphql-codegen-typescript-template`.

- Example Input

```graphql
query Test {
  feed {
    id
    commentCount
    repository {
      full_name
      html_url
      owner {
        avatar_url
      }
    }
  }
}
```

- Example Usage

```tsx
  <Test.Component query={...} variables={...}>
    ...
  </Test.Component>
```
