### PR TITLE
Parent of resolver should always be any; Use Resolver or SubscriptionResolver directly on field

### DIFF
--- a/dev-test/githunt/types.avoidOptionals.ts
+++ b/dev-test/githunt/types.avoidOptionals.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -22,10 +22,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 };
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
 
 export interface Query {
   feed: (Entry | null)[] | null /** A feed of repository submissions */;
@@ -122,17 +118,17 @@ export enum VoteType {
 }
 
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    feed?: FeedResolver<(Entry | null)[] | null, Parent, Context> /** A feed of repository submissions */;
-    entry?: EntryResolver<Entry | null, Parent, Context> /** A single entry */;
+  export interface Resolvers<Context = any> {
+    feed?: FeedResolver<(Entry | null)[] | null, any, Context> /** A feed of repository submissions */;
+    entry?: EntryResolver<Entry | null, any, Context> /** A single entry */;
     currentUser?: CurrentUserResolver<
       User | null,
-      Parent,
+      any,
       Context
     > /** Return the currently logged in user, or null if nobody is logged in */;
   }
 
-  export type FeedResolver<R = (Entry | null)[] | null, Parent = Query, Context = any> = Resolver<
+  export type FeedResolver<R = (Entry | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -144,37 +140,37 @@ export namespace QueryResolvers {
     limit: number | null /** The number of items to fetch starting from the offset, for pagination */;
   }
 
-  export type EntryResolver<R = Entry | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, EntryArgs>;
+  export type EntryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context, EntryArgs>;
   export interface EntryArgs {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
   }
 
-  export type CurrentUserResolver<R = User | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+  export type CurrentUserResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Information about a GitHub repository submitted to GitHunt */
 export namespace EntryResolvers {
-  export interface Resolvers<Context = any, Parent = Entry> {
-    repository?: RepositoryResolver<Repository, Parent, Context> /** Information about the repository from GitHub */;
-    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who submitted this entry */;
-    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the entry was submitted */;
-    score?: ScoreResolver<number, Parent, Context> /** The score of this repository, upvotes - downvotes */;
-    hotScore?: HotScoreResolver<number, Parent, Context> /** The hot score of this repository */;
-    comments?: CommentsResolver<(Comment | null)[], Parent, Context> /** Comments posted about this repository */;
+  export interface Resolvers<Context = any> {
+    repository?: RepositoryResolver<Repository, any, Context> /** Information about the repository from GitHub */;
+    postedBy?: PostedByResolver<User, any, Context> /** The GitHub user who submitted this entry */;
+    createdAt?: CreatedAtResolver<number, any, Context> /** A timestamp of when the entry was submitted */;
+    score?: ScoreResolver<number, any, Context> /** The score of this repository, upvotes - downvotes */;
+    hotScore?: HotScoreResolver<number, any, Context> /** The hot score of this repository */;
+    comments?: CommentsResolver<(Comment | null)[], any, Context> /** Comments posted about this repository */;
     commentCount?: CommentCountResolver<
       number,
-      Parent,
+      any,
       Context
     > /** The number of comments posted about this repository */;
-    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-    vote?: VoteResolver<Vote, Parent, Context> /** XXX to be changed */;
+    id?: IdResolver<number, any, Context> /** The SQL ID of this entry */;
+    vote?: VoteResolver<Vote, any, Context> /** XXX to be changed */;
   }
 
-  export type RepositoryResolver<R = Repository, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type PostedByResolver<R = User, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type CreatedAtResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type ScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type HotScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type CommentsResolver<R = (Comment | null)[], Parent = Entry, Context = any> = Resolver<
+  export type RepositoryResolver<R = Repository, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type ScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HotScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentsResolver<R = (Comment | null)[], Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -185,107 +181,103 @@ export namespace EntryResolvers {
     offset: number | null;
   }
 
-  export type CommentCountResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type IdResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type VoteResolver<R = Vote, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type VoteResolver<R = Vote, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A repository object from the GitHub API. This uses the exact field names returned by theGitHub API for simplicity, even though the convention for GraphQL is usually to camel case. */
 export namespace RepositoryResolvers {
-  export interface Resolvers<Context = any, Parent = Repository> {
-    name?: NameResolver<string, Parent, Context> /** Just the name of the repository, e.g. GitHunt-API */;
+  export interface Resolvers<Context = any> {
+    name?: NameResolver<string, any, Context> /** Just the name of the repository, e.g. GitHunt-API */;
     full_name?: FullNameResolver<
       string,
-      Parent,
+      any,
       Context
     > /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */;
-    description?: DescriptionResolver<string | null, Parent, Context> /** The description of the repository */;
-    html_url?: HtmlUrlResolver<string, Parent, Context> /** The link to the repository on GitHub */;
+    description?: DescriptionResolver<string | null, any, Context> /** The description of the repository */;
+    html_url?: HtmlUrlResolver<string, any, Context> /** The link to the repository on GitHub */;
     stargazers_count?: StargazersCountResolver<
       number,
-      Parent,
+      any,
       Context
     > /** The number of people who have starred this repository on GitHub */;
     open_issues_count?: OpenIssuesCountResolver<
       number | null,
-      Parent,
+      any,
       Context
     > /** The number of open issues on this repository on GitHub */;
-    owner?: OwnerResolver<User | null, Parent, Context> /** The owner of this repository on GitHub, e.g. apollostack */;
+    owner?: OwnerResolver<User | null, any, Context> /** The owner of this repository on GitHub, e.g. apollostack */;
   }
 
-  export type NameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type FullNameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type DescriptionResolver<R = string | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type HtmlUrlResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type StargazersCountResolver<R = number, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type OpenIssuesCountResolver<R = number | null, Parent = Repository, Context = any> = Resolver<
-    R,
-    Parent,
-    Context
-  >;
-  export type OwnerResolver<R = User | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FullNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type DescriptionResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type StargazersCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type OpenIssuesCountResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type OwnerResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export namespace UserResolvers {
-  export interface Resolvers<Context = any, Parent = User> {
-    login?: LoginResolver<string, Parent, Context> /** The name of the user, e.g. apollostack */;
+  export interface Resolvers<Context = any> {
+    login?: LoginResolver<string, any, Context> /** The name of the user, e.g. apollostack */;
     avatar_url?: AvatarUrlResolver<
       string,
-      Parent,
+      any,
       Context
     > /** The URL to a directly embeddable image for this user's avatar */;
-    html_url?: HtmlUrlResolver<string, Parent, Context> /** The URL of this user's GitHub page */;
+    html_url?: HtmlUrlResolver<string, any, Context> /** The URL of this user's GitHub page */;
   }
 
-  export type LoginResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type AvatarUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type HtmlUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type LoginResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type AvatarUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A comment about an entry, submitted by a user */
 export namespace CommentResolvers {
-  export interface Resolvers<Context = any, Parent = Comment> {
-    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who posted the comment */;
-    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the comment was posted */;
-    content?: ContentResolver<string, Parent, Context> /** The text of the comment */;
-    repoName?: RepoNameResolver<string, Parent, Context> /** The repository which this comment is about */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<number, any, Context> /** The SQL ID of this entry */;
+    postedBy?: PostedByResolver<User, any, Context> /** The GitHub user who posted the comment */;
+    createdAt?: CreatedAtResolver<number, any, Context> /** A timestamp of when the comment was posted */;
+    content?: ContentResolver<string, any, Context> /** The text of the comment */;
+    repoName?: RepoNameResolver<string, any, Context> /** The repository which this comment is about */;
   }
 
-  export type IdResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type PostedByResolver<R = User, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type CreatedAtResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type ContentResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type RepoNameResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type ContentResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type RepoNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** XXX to be removed */
 export namespace VoteResolvers {
-  export interface Resolvers<Context = any, Parent = Vote> {
-    vote_value?: VoteValueResolver<number, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    vote_value?: VoteValueResolver<number, any, Context>;
   }
 
-  export type VoteValueResolver<R = number, Parent = Vote, Context = any> = Resolver<R, Parent, Context>;
+  export type VoteValueResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 
 export namespace MutationResolvers {
-  export interface Resolvers<Context = any, Parent = Mutation> {
+  export interface Resolvers<Context = any> {
     submitRepository?: SubmitRepositoryResolver<
       Entry | null,
-      Parent,
+      any,
       Context
     > /** Submit a new repository, returns the new submission */;
     vote?: VoteResolver<
       Entry | null,
-      Parent,
+      any,
       Context
     > /** Vote on a repository submission, returns the submission that was voted on */;
     submitComment?: SubmitCommentResolver<
       Comment | null,
-      Parent,
+      any,
       Context
     > /** Comment on a repository, returns the new comment */;
   }
 
-  export type SubmitRepositoryResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<
+  export type SubmitRepositoryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -295,13 +287,13 @@ export namespace MutationResolvers {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
   }
 
-  export type VoteResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<R, Parent, Context, VoteArgs>;
+  export type VoteResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context, VoteArgs>;
   export interface VoteArgs {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
     type: VoteType /** The type of vote - UP, DOWN, or CANCEL */;
   }
 
-  export type SubmitCommentResolver<R = Comment | null, Parent = Mutation, Context = any> = Resolver<
+  export type SubmitCommentResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -314,15 +306,11 @@ export namespace MutationResolvers {
 }
 
 export namespace SubscriptionResolvers {
-  export interface Resolvers<Context = any, Parent = Subscription> {
-    commentAdded?: CommentAddedResolver<
-      Comment | null,
-      Parent,
-      Context
-    > /** Subscription fires on every comment added */;
+  export interface Resolvers<Context = any> {
+    commentAdded?: CommentAddedResolver<Comment | null, any, Context> /** Subscription fires on every comment added */;
   }
 
-  export type CommentAddedResolver<R = Comment | null, Parent = Subscription, Context = any> = Resolver<
+  export type CommentAddedResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,

--- a/dev-test/githunt/types.d.ts
+++ b/dev-test/githunt/types.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -22,10 +22,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 };
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
 
 export interface Query {
   feed?: (Entry | null)[] | null /** A feed of repository submissions */;
@@ -114,17 +110,17 @@ export type FeedType = 'HOT' | 'NEW' | 'TOP';
 export type VoteType = 'UP' | 'DOWN' | 'CANCEL';
 
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    feed?: FeedResolver<(Entry | null)[] | null, Parent, Context> /** A feed of repository submissions */;
-    entry?: EntryResolver<Entry | null, Parent, Context> /** A single entry */;
+  export interface Resolvers<Context = any> {
+    feed?: FeedResolver<(Entry | null)[] | null, any, Context> /** A feed of repository submissions */;
+    entry?: EntryResolver<Entry | null, any, Context> /** A single entry */;
     currentUser?: CurrentUserResolver<
       User | null,
-      Parent,
+      any,
       Context
     > /** Return the currently logged in user, or null if nobody is logged in */;
   }
 
-  export type FeedResolver<R = (Entry | null)[] | null, Parent = Query, Context = any> = Resolver<
+  export type FeedResolver<R = (Entry | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -136,37 +132,37 @@ export namespace QueryResolvers {
     limit?: number | null /** The number of items to fetch starting from the offset, for pagination */;
   }
 
-  export type EntryResolver<R = Entry | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, EntryArgs>;
+  export type EntryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context, EntryArgs>;
   export interface EntryArgs {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
   }
 
-  export type CurrentUserResolver<R = User | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+  export type CurrentUserResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Information about a GitHub repository submitted to GitHunt */
 export namespace EntryResolvers {
-  export interface Resolvers<Context = any, Parent = Entry> {
-    repository?: RepositoryResolver<Repository, Parent, Context> /** Information about the repository from GitHub */;
-    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who submitted this entry */;
-    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the entry was submitted */;
-    score?: ScoreResolver<number, Parent, Context> /** The score of this repository, upvotes - downvotes */;
-    hotScore?: HotScoreResolver<number, Parent, Context> /** The hot score of this repository */;
-    comments?: CommentsResolver<(Comment | null)[], Parent, Context> /** Comments posted about this repository */;
+  export interface Resolvers<Context = any> {
+    repository?: RepositoryResolver<Repository, any, Context> /** Information about the repository from GitHub */;
+    postedBy?: PostedByResolver<User, any, Context> /** The GitHub user who submitted this entry */;
+    createdAt?: CreatedAtResolver<number, any, Context> /** A timestamp of when the entry was submitted */;
+    score?: ScoreResolver<number, any, Context> /** The score of this repository, upvotes - downvotes */;
+    hotScore?: HotScoreResolver<number, any, Context> /** The hot score of this repository */;
+    comments?: CommentsResolver<(Comment | null)[], any, Context> /** Comments posted about this repository */;
     commentCount?: CommentCountResolver<
       number,
-      Parent,
+      any,
       Context
     > /** The number of comments posted about this repository */;
-    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-    vote?: VoteResolver<Vote, Parent, Context> /** XXX to be changed */;
+    id?: IdResolver<number, any, Context> /** The SQL ID of this entry */;
+    vote?: VoteResolver<Vote, any, Context> /** XXX to be changed */;
   }
 
-  export type RepositoryResolver<R = Repository, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type PostedByResolver<R = User, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type CreatedAtResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type ScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type HotScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type CommentsResolver<R = (Comment | null)[], Parent = Entry, Context = any> = Resolver<
+  export type RepositoryResolver<R = Repository, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type ScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HotScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentsResolver<R = (Comment | null)[], Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -177,107 +173,103 @@ export namespace EntryResolvers {
     offset?: number | null;
   }
 
-  export type CommentCountResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type IdResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type VoteResolver<R = Vote, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type VoteResolver<R = Vote, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A repository object from the GitHub API. This uses the exact field names returned by theGitHub API for simplicity, even though the convention for GraphQL is usually to camel case. */
 export namespace RepositoryResolvers {
-  export interface Resolvers<Context = any, Parent = Repository> {
-    name?: NameResolver<string, Parent, Context> /** Just the name of the repository, e.g. GitHunt-API */;
+  export interface Resolvers<Context = any> {
+    name?: NameResolver<string, any, Context> /** Just the name of the repository, e.g. GitHunt-API */;
     full_name?: FullNameResolver<
       string,
-      Parent,
+      any,
       Context
     > /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */;
-    description?: DescriptionResolver<string | null, Parent, Context> /** The description of the repository */;
-    html_url?: HtmlUrlResolver<string, Parent, Context> /** The link to the repository on GitHub */;
+    description?: DescriptionResolver<string | null, any, Context> /** The description of the repository */;
+    html_url?: HtmlUrlResolver<string, any, Context> /** The link to the repository on GitHub */;
     stargazers_count?: StargazersCountResolver<
       number,
-      Parent,
+      any,
       Context
     > /** The number of people who have starred this repository on GitHub */;
     open_issues_count?: OpenIssuesCountResolver<
       number | null,
-      Parent,
+      any,
       Context
     > /** The number of open issues on this repository on GitHub */;
-    owner?: OwnerResolver<User | null, Parent, Context> /** The owner of this repository on GitHub, e.g. apollostack */;
+    owner?: OwnerResolver<User | null, any, Context> /** The owner of this repository on GitHub, e.g. apollostack */;
   }
 
-  export type NameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type FullNameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type DescriptionResolver<R = string | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type HtmlUrlResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type StargazersCountResolver<R = number, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type OpenIssuesCountResolver<R = number | null, Parent = Repository, Context = any> = Resolver<
-    R,
-    Parent,
-    Context
-  >;
-  export type OwnerResolver<R = User | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FullNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type DescriptionResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type StargazersCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type OpenIssuesCountResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type OwnerResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export namespace UserResolvers {
-  export interface Resolvers<Context = any, Parent = User> {
-    login?: LoginResolver<string, Parent, Context> /** The name of the user, e.g. apollostack */;
+  export interface Resolvers<Context = any> {
+    login?: LoginResolver<string, any, Context> /** The name of the user, e.g. apollostack */;
     avatar_url?: AvatarUrlResolver<
       string,
-      Parent,
+      any,
       Context
     > /** The URL to a directly embeddable image for this user's avatar */;
-    html_url?: HtmlUrlResolver<string, Parent, Context> /** The URL of this user's GitHub page */;
+    html_url?: HtmlUrlResolver<string, any, Context> /** The URL of this user's GitHub page */;
   }
 
-  export type LoginResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type AvatarUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type HtmlUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type LoginResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type AvatarUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A comment about an entry, submitted by a user */
 export namespace CommentResolvers {
-  export interface Resolvers<Context = any, Parent = Comment> {
-    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who posted the comment */;
-    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the comment was posted */;
-    content?: ContentResolver<string, Parent, Context> /** The text of the comment */;
-    repoName?: RepoNameResolver<string, Parent, Context> /** The repository which this comment is about */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<number, any, Context> /** The SQL ID of this entry */;
+    postedBy?: PostedByResolver<User, any, Context> /** The GitHub user who posted the comment */;
+    createdAt?: CreatedAtResolver<number, any, Context> /** A timestamp of when the comment was posted */;
+    content?: ContentResolver<string, any, Context> /** The text of the comment */;
+    repoName?: RepoNameResolver<string, any, Context> /** The repository which this comment is about */;
   }
 
-  export type IdResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type PostedByResolver<R = User, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type CreatedAtResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type ContentResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type RepoNameResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type ContentResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type RepoNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** XXX to be removed */
 export namespace VoteResolvers {
-  export interface Resolvers<Context = any, Parent = Vote> {
-    vote_value?: VoteValueResolver<number, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    vote_value?: VoteValueResolver<number, any, Context>;
   }
 
-  export type VoteValueResolver<R = number, Parent = Vote, Context = any> = Resolver<R, Parent, Context>;
+  export type VoteValueResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 
 export namespace MutationResolvers {
-  export interface Resolvers<Context = any, Parent = Mutation> {
+  export interface Resolvers<Context = any> {
     submitRepository?: SubmitRepositoryResolver<
       Entry | null,
-      Parent,
+      any,
       Context
     > /** Submit a new repository, returns the new submission */;
     vote?: VoteResolver<
       Entry | null,
-      Parent,
+      any,
       Context
     > /** Vote on a repository submission, returns the submission that was voted on */;
     submitComment?: SubmitCommentResolver<
       Comment | null,
-      Parent,
+      any,
       Context
     > /** Comment on a repository, returns the new comment */;
   }
 
-  export type SubmitRepositoryResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<
+  export type SubmitRepositoryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -287,13 +279,13 @@ export namespace MutationResolvers {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
   }
 
-  export type VoteResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<R, Parent, Context, VoteArgs>;
+  export type VoteResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context, VoteArgs>;
   export interface VoteArgs {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
     type: VoteType /** The type of vote - UP, DOWN, or CANCEL */;
   }
 
-  export type SubmitCommentResolver<R = Comment | null, Parent = Mutation, Context = any> = Resolver<
+  export type SubmitCommentResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -306,15 +298,11 @@ export namespace MutationResolvers {
 }
 
 export namespace SubscriptionResolvers {
-  export interface Resolvers<Context = any, Parent = Subscription> {
-    commentAdded?: CommentAddedResolver<
-      Comment | null,
-      Parent,
-      Context
-    > /** Subscription fires on every comment added */;
+  export interface Resolvers<Context = any> {
+    commentAdded?: CommentAddedResolver<Comment | null, any, Context> /** Subscription fires on every comment added */;
   }
 
-  export type CommentAddedResolver<R = Comment | null, Parent = Subscription, Context = any> = Resolver<
+  export type CommentAddedResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,

--- a/dev-test/githunt/types.immutableTypes.ts
+++ b/dev-test/githunt/types.immutableTypes.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -22,10 +22,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 };
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
 
 export interface Query {
   readonly feed?: ReadonlyArray<Entry | null> | null /** A feed of repository submissions */;
@@ -122,17 +118,17 @@ export enum VoteType {
 }
 
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    feed?: FeedResolver<ReadonlyArray<Entry | null> | null, Parent, Context> /** A feed of repository submissions */;
-    entry?: EntryResolver<Entry | null, Parent, Context> /** A single entry */;
+  export interface Resolvers<Context = any> {
+    feed?: FeedResolver<ReadonlyArray<Entry | null> | null, any, Context> /** A feed of repository submissions */;
+    entry?: EntryResolver<Entry | null, any, Context> /** A single entry */;
     currentUser?: CurrentUserResolver<
       User | null,
-      Parent,
+      any,
       Context
     > /** Return the currently logged in user, or null if nobody is logged in */;
   }
 
-  export type FeedResolver<R = ReadonlyArray<Entry | null> | null, Parent = Query, Context = any> = Resolver<
+  export type FeedResolver<R = ReadonlyArray<Entry | null> | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -144,41 +140,41 @@ export namespace QueryResolvers {
     limit?: number | null /** The number of items to fetch starting from the offset, for pagination */;
   }
 
-  export type EntryResolver<R = Entry | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, EntryArgs>;
+  export type EntryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context, EntryArgs>;
   export interface EntryArgs {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
   }
 
-  export type CurrentUserResolver<R = User | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+  export type CurrentUserResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Information about a GitHub repository submitted to GitHunt */
 export namespace EntryResolvers {
-  export interface Resolvers<Context = any, Parent = Entry> {
-    repository?: RepositoryResolver<Repository, Parent, Context> /** Information about the repository from GitHub */;
-    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who submitted this entry */;
-    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the entry was submitted */;
-    score?: ScoreResolver<number, Parent, Context> /** The score of this repository, upvotes - downvotes */;
-    hotScore?: HotScoreResolver<number, Parent, Context> /** The hot score of this repository */;
+  export interface Resolvers<Context = any> {
+    repository?: RepositoryResolver<Repository, any, Context> /** Information about the repository from GitHub */;
+    postedBy?: PostedByResolver<User, any, Context> /** The GitHub user who submitted this entry */;
+    createdAt?: CreatedAtResolver<number, any, Context> /** A timestamp of when the entry was submitted */;
+    score?: ScoreResolver<number, any, Context> /** The score of this repository, upvotes - downvotes */;
+    hotScore?: HotScoreResolver<number, any, Context> /** The hot score of this repository */;
     comments?: CommentsResolver<
       ReadonlyArray<Comment | null>,
-      Parent,
+      any,
       Context
     > /** Comments posted about this repository */;
     commentCount?: CommentCountResolver<
       number,
-      Parent,
+      any,
       Context
     > /** The number of comments posted about this repository */;
-    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-    vote?: VoteResolver<Vote, Parent, Context> /** XXX to be changed */;
+    id?: IdResolver<number, any, Context> /** The SQL ID of this entry */;
+    vote?: VoteResolver<Vote, any, Context> /** XXX to be changed */;
   }
 
-  export type RepositoryResolver<R = Repository, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type PostedByResolver<R = User, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type CreatedAtResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type ScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type HotScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type CommentsResolver<R = ReadonlyArray<Comment | null>, Parent = Entry, Context = any> = Resolver<
+  export type RepositoryResolver<R = Repository, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type ScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HotScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentsResolver<R = ReadonlyArray<Comment | null>, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -189,107 +185,103 @@ export namespace EntryResolvers {
     offset?: number | null;
   }
 
-  export type CommentCountResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type IdResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type VoteResolver<R = Vote, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type VoteResolver<R = Vote, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A repository object from the GitHub API. This uses the exact field names returned by theGitHub API for simplicity, even though the convention for GraphQL is usually to camel case. */
 export namespace RepositoryResolvers {
-  export interface Resolvers<Context = any, Parent = Repository> {
-    name?: NameResolver<string, Parent, Context> /** Just the name of the repository, e.g. GitHunt-API */;
+  export interface Resolvers<Context = any> {
+    name?: NameResolver<string, any, Context> /** Just the name of the repository, e.g. GitHunt-API */;
     full_name?: FullNameResolver<
       string,
-      Parent,
+      any,
       Context
     > /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */;
-    description?: DescriptionResolver<string | null, Parent, Context> /** The description of the repository */;
-    html_url?: HtmlUrlResolver<string, Parent, Context> /** The link to the repository on GitHub */;
+    description?: DescriptionResolver<string | null, any, Context> /** The description of the repository */;
+    html_url?: HtmlUrlResolver<string, any, Context> /** The link to the repository on GitHub */;
     stargazers_count?: StargazersCountResolver<
       number,
-      Parent,
+      any,
       Context
     > /** The number of people who have starred this repository on GitHub */;
     open_issues_count?: OpenIssuesCountResolver<
       number | null,
-      Parent,
+      any,
       Context
     > /** The number of open issues on this repository on GitHub */;
-    owner?: OwnerResolver<User | null, Parent, Context> /** The owner of this repository on GitHub, e.g. apollostack */;
+    owner?: OwnerResolver<User | null, any, Context> /** The owner of this repository on GitHub, e.g. apollostack */;
   }
 
-  export type NameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type FullNameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type DescriptionResolver<R = string | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type HtmlUrlResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type StargazersCountResolver<R = number, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type OpenIssuesCountResolver<R = number | null, Parent = Repository, Context = any> = Resolver<
-    R,
-    Parent,
-    Context
-  >;
-  export type OwnerResolver<R = User | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FullNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type DescriptionResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type StargazersCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type OpenIssuesCountResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type OwnerResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export namespace UserResolvers {
-  export interface Resolvers<Context = any, Parent = User> {
-    login?: LoginResolver<string, Parent, Context> /** The name of the user, e.g. apollostack */;
+  export interface Resolvers<Context = any> {
+    login?: LoginResolver<string, any, Context> /** The name of the user, e.g. apollostack */;
     avatar_url?: AvatarUrlResolver<
       string,
-      Parent,
+      any,
       Context
     > /** The URL to a directly embeddable image for this user's avatar */;
-    html_url?: HtmlUrlResolver<string, Parent, Context> /** The URL of this user's GitHub page */;
+    html_url?: HtmlUrlResolver<string, any, Context> /** The URL of this user's GitHub page */;
   }
 
-  export type LoginResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type AvatarUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type HtmlUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type LoginResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type AvatarUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A comment about an entry, submitted by a user */
 export namespace CommentResolvers {
-  export interface Resolvers<Context = any, Parent = Comment> {
-    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who posted the comment */;
-    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the comment was posted */;
-    content?: ContentResolver<string, Parent, Context> /** The text of the comment */;
-    repoName?: RepoNameResolver<string, Parent, Context> /** The repository which this comment is about */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<number, any, Context> /** The SQL ID of this entry */;
+    postedBy?: PostedByResolver<User, any, Context> /** The GitHub user who posted the comment */;
+    createdAt?: CreatedAtResolver<number, any, Context> /** A timestamp of when the comment was posted */;
+    content?: ContentResolver<string, any, Context> /** The text of the comment */;
+    repoName?: RepoNameResolver<string, any, Context> /** The repository which this comment is about */;
   }
 
-  export type IdResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type PostedByResolver<R = User, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type CreatedAtResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type ContentResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type RepoNameResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type ContentResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type RepoNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** XXX to be removed */
 export namespace VoteResolvers {
-  export interface Resolvers<Context = any, Parent = Vote> {
-    vote_value?: VoteValueResolver<number, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    vote_value?: VoteValueResolver<number, any, Context>;
   }
 
-  export type VoteValueResolver<R = number, Parent = Vote, Context = any> = Resolver<R, Parent, Context>;
+  export type VoteValueResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 
 export namespace MutationResolvers {
-  export interface Resolvers<Context = any, Parent = Mutation> {
+  export interface Resolvers<Context = any> {
     submitRepository?: SubmitRepositoryResolver<
       Entry | null,
-      Parent,
+      any,
       Context
     > /** Submit a new repository, returns the new submission */;
     vote?: VoteResolver<
       Entry | null,
-      Parent,
+      any,
       Context
     > /** Vote on a repository submission, returns the submission that was voted on */;
     submitComment?: SubmitCommentResolver<
       Comment | null,
-      Parent,
+      any,
       Context
     > /** Comment on a repository, returns the new comment */;
   }
 
-  export type SubmitRepositoryResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<
+  export type SubmitRepositoryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -299,13 +291,13 @@ export namespace MutationResolvers {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
   }
 
-  export type VoteResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<R, Parent, Context, VoteArgs>;
+  export type VoteResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context, VoteArgs>;
   export interface VoteArgs {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
     type: VoteType /** The type of vote - UP, DOWN, or CANCEL */;
   }
 
-  export type SubmitCommentResolver<R = Comment | null, Parent = Mutation, Context = any> = Resolver<
+  export type SubmitCommentResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -318,15 +310,11 @@ export namespace MutationResolvers {
 }
 
 export namespace SubscriptionResolvers {
-  export interface Resolvers<Context = any, Parent = Subscription> {
-    commentAdded?: CommentAddedResolver<
-      Comment | null,
-      Parent,
-      Context
-    > /** Subscription fires on every comment added */;
+  export interface Resolvers<Context = any> {
+    commentAdded?: CommentAddedResolver<Comment | null, any, Context> /** Subscription fires on every comment added */;
   }
 
-  export type CommentAddedResolver<R = Comment | null, Parent = Subscription, Context = any> = Resolver<
+  export type CommentAddedResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,

--- a/dev-test/githunt/types.noNamespaces.ts
+++ b/dev-test/githunt/types.noNamespaces.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -22,10 +22,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 };
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
 
 export interface Query {
   feed?: Entry[] | null /** A feed of repository submissions */;
@@ -121,160 +117,156 @@ export enum VoteType {
   CANCEL = 'CANCEL'
 }
 
-export interface QueryResolvers<Context = any, Parent = Query> {
-  feed?: QueryFeedResolver<Entry[] | null, Parent, Context> /** A feed of repository submissions */;
-  entry?: QueryEntryResolver<Entry | null, Parent, Context> /** A single entry */;
+export interface QueryResolvers<Context = any> {
+  feed?: QueryFeedResolver<Entry[] | null, any, Context> /** A feed of repository submissions */;
+  entry?: QueryEntryResolver<Entry | null, any, Context> /** A single entry */;
   currentUser?: QueryCurrentUserResolver<
     User | null,
-    Parent,
+    any,
     Context
   > /** Return the currently logged in user, or null if nobody is logged in */;
 }
 
-export type QueryFeedResolver<R = Entry[] | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+export type QueryFeedResolver<R = Entry[] | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface QueryFeedArgs {
   type: FeedType /** The sort order for the feed */;
   offset?: number | null /** The number of items to skip, for pagination */;
   limit?: number | null /** The number of items to fetch starting from the offset, for pagination */;
 }
 
-export type QueryEntryResolver<R = Entry | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+export type QueryEntryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface QueryEntryArgs {
   repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
 }
 
-export type QueryCurrentUserResolver<R = User | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+export type QueryCurrentUserResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 /** Information about a GitHub repository submitted to GitHunt */
-export interface EntryResolvers<Context = any, Parent = Entry> {
-  repository?: EntryRepositoryResolver<Repository, Parent, Context> /** Information about the repository from GitHub */;
-  postedBy?: EntryPostedByResolver<User, Parent, Context> /** The GitHub user who submitted this entry */;
-  createdAt?: EntryCreatedAtResolver<number, Parent, Context> /** A timestamp of when the entry was submitted */;
-  score?: EntryScoreResolver<number, Parent, Context> /** The score of this repository, upvotes - downvotes */;
-  hotScore?: EntryHotScoreResolver<number, Parent, Context> /** The hot score of this repository */;
-  comments?: EntryCommentsResolver<Comment[], Parent, Context> /** Comments posted about this repository */;
+export interface EntryResolvers<Context = any> {
+  repository?: EntryRepositoryResolver<Repository, any, Context> /** Information about the repository from GitHub */;
+  postedBy?: EntryPostedByResolver<User, any, Context> /** The GitHub user who submitted this entry */;
+  createdAt?: EntryCreatedAtResolver<number, any, Context> /** A timestamp of when the entry was submitted */;
+  score?: EntryScoreResolver<number, any, Context> /** The score of this repository, upvotes - downvotes */;
+  hotScore?: EntryHotScoreResolver<number, any, Context> /** The hot score of this repository */;
+  comments?: EntryCommentsResolver<Comment[], any, Context> /** Comments posted about this repository */;
   commentCount?: EntryCommentCountResolver<
     number,
-    Parent,
+    any,
     Context
   > /** The number of comments posted about this repository */;
-  id?: EntryIdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-  vote?: EntryVoteResolver<Vote, Parent, Context> /** XXX to be changed */;
+  id?: EntryIdResolver<number, any, Context> /** The SQL ID of this entry */;
+  vote?: EntryVoteResolver<Vote, any, Context> /** XXX to be changed */;
 }
 
-export type EntryRepositoryResolver<R = Repository, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-export type EntryPostedByResolver<R = User, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-export type EntryCreatedAtResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-export type EntryScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-export type EntryHotScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-export type EntryCommentsResolver<R = Comment[], Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+export type EntryRepositoryResolver<R = Repository, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type EntryPostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type EntryCreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type EntryScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type EntryHotScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type EntryCommentsResolver<R = Comment[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface EntryCommentsArgs {
   limit?: number | null;
   offset?: number | null;
 }
 
-export type EntryCommentCountResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-export type EntryIdResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-export type EntryVoteResolver<R = Vote, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+export type EntryCommentCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type EntryIdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type EntryVoteResolver<R = Vote, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 /** A repository object from the GitHub API. This uses the exact field names returned by theGitHub API for simplicity, even though the convention for GraphQL is usually to camel case. */
-export interface RepositoryResolvers<Context = any, Parent = Repository> {
-  name?: RepositoryNameResolver<string, Parent, Context> /** Just the name of the repository, e.g. GitHunt-API */;
+export interface RepositoryResolvers<Context = any> {
+  name?: RepositoryNameResolver<string, any, Context> /** Just the name of the repository, e.g. GitHunt-API */;
   full_name?: RepositoryFullNameResolver<
     string,
-    Parent,
+    any,
     Context
   > /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */;
-  description?: RepositoryDescriptionResolver<string | null, Parent, Context> /** The description of the repository */;
-  html_url?: RepositoryHtmlUrlResolver<string, Parent, Context> /** The link to the repository on GitHub */;
+  description?: RepositoryDescriptionResolver<string | null, any, Context> /** The description of the repository */;
+  html_url?: RepositoryHtmlUrlResolver<string, any, Context> /** The link to the repository on GitHub */;
   stargazers_count?: RepositoryStargazersCountResolver<
     number,
-    Parent,
+    any,
     Context
   > /** The number of people who have starred this repository on GitHub */;
   open_issues_count?: RepositoryOpenIssuesCountResolver<
     number | null,
-    Parent,
+    any,
     Context
   > /** The number of open issues on this repository on GitHub */;
   owner?: RepositoryOwnerResolver<
     User | null,
-    Parent,
+    any,
     Context
   > /** The owner of this repository on GitHub, e.g. apollostack */;
 }
 
-export type RepositoryNameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-export type RepositoryFullNameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-export type RepositoryDescriptionResolver<R = string | null, Parent = Repository, Context = any> = Resolver<
+export type RepositoryNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type RepositoryFullNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type RepositoryDescriptionResolver<R = string | null, Parent = any, Context = any> = Resolver<
   R,
   Parent,
   Context
 >;
-export type RepositoryHtmlUrlResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-export type RepositoryStargazersCountResolver<R = number, Parent = Repository, Context = any> = Resolver<
+export type RepositoryHtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type RepositoryStargazersCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type RepositoryOpenIssuesCountResolver<R = number | null, Parent = any, Context = any> = Resolver<
   R,
   Parent,
   Context
 >;
-export type RepositoryOpenIssuesCountResolver<R = number | null, Parent = Repository, Context = any> = Resolver<
-  R,
-  Parent,
-  Context
->;
-export type RepositoryOwnerResolver<R = User | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+export type RepositoryOwnerResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
-export interface UserResolvers<Context = any, Parent = User> {
-  login?: UserLoginResolver<string, Parent, Context> /** The name of the user, e.g. apollostack */;
+export interface UserResolvers<Context = any> {
+  login?: UserLoginResolver<string, any, Context> /** The name of the user, e.g. apollostack */;
   avatar_url?: UserAvatarUrlResolver<
     string,
-    Parent,
+    any,
     Context
   > /** The URL to a directly embeddable image for this user's avatar */;
-  html_url?: UserHtmlUrlResolver<string, Parent, Context> /** The URL of this user's GitHub page */;
+  html_url?: UserHtmlUrlResolver<string, any, Context> /** The URL of this user's GitHub page */;
 }
 
-export type UserLoginResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-export type UserAvatarUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-export type UserHtmlUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+export type UserLoginResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type UserAvatarUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type UserHtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 /** A comment about an entry, submitted by a user */
-export interface CommentResolvers<Context = any, Parent = Comment> {
-  id?: CommentIdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-  postedBy?: CommentPostedByResolver<User, Parent, Context> /** The GitHub user who posted the comment */;
-  createdAt?: CommentCreatedAtResolver<number, Parent, Context> /** A timestamp of when the comment was posted */;
-  content?: CommentContentResolver<string, Parent, Context> /** The text of the comment */;
-  repoName?: CommentRepoNameResolver<string, Parent, Context> /** The repository which this comment is about */;
+export interface CommentResolvers<Context = any> {
+  id?: CommentIdResolver<number, any, Context> /** The SQL ID of this entry */;
+  postedBy?: CommentPostedByResolver<User, any, Context> /** The GitHub user who posted the comment */;
+  createdAt?: CommentCreatedAtResolver<number, any, Context> /** A timestamp of when the comment was posted */;
+  content?: CommentContentResolver<string, any, Context> /** The text of the comment */;
+  repoName?: CommentRepoNameResolver<string, any, Context> /** The repository which this comment is about */;
 }
 
-export type CommentIdResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-export type CommentPostedByResolver<R = User, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-export type CommentCreatedAtResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-export type CommentContentResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-export type CommentRepoNameResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
+export type CommentIdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type CommentPostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type CommentCreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type CommentContentResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type CommentRepoNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 /** XXX to be removed */
-export interface VoteResolvers<Context = any, Parent = Vote> {
-  vote_value?: VoteVoteValueResolver<number, Parent, Context>;
+export interface VoteResolvers<Context = any> {
+  vote_value?: VoteVoteValueResolver<number, any, Context>;
 }
 
-export type VoteVoteValueResolver<R = number, Parent = Vote, Context = any> = Resolver<R, Parent, Context>;
+export type VoteVoteValueResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 
-export interface MutationResolvers<Context = any, Parent = Mutation> {
+export interface MutationResolvers<Context = any> {
   submitRepository?: MutationSubmitRepositoryResolver<
     Entry | null,
-    Parent,
+    any,
     Context
   > /** Submit a new repository, returns the new submission */;
   vote?: MutationVoteResolver<
     Entry | null,
-    Parent,
+    any,
     Context
   > /** Vote on a repository submission, returns the submission that was voted on */;
   submitComment?: MutationSubmitCommentResolver<
     Comment | null,
-    Parent,
+    any,
     Context
   > /** Comment on a repository, returns the new comment */;
 }
 
-export type MutationSubmitRepositoryResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<
+export type MutationSubmitRepositoryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<
   R,
   Parent,
   Context
@@ -283,13 +275,13 @@ export interface MutationSubmitRepositoryArgs {
   repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
 }
 
-export type MutationVoteResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<R, Parent, Context>;
+export type MutationVoteResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface MutationVoteArgs {
   repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
   type: VoteType /** The type of vote - UP, DOWN, or CANCEL */;
 }
 
-export type MutationSubmitCommentResolver<R = Comment | null, Parent = Mutation, Context = any> = Resolver<
+export type MutationSubmitCommentResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
   R,
   Parent,
   Context
@@ -299,15 +291,15 @@ export interface MutationSubmitCommentArgs {
   commentContent: string /** The text content for the new comment */;
 }
 
-export interface SubscriptionResolvers<Context = any, Parent = Subscription> {
+export interface SubscriptionResolvers<Context = any> {
   commentAdded?: SubscriptionCommentAddedResolver<
     Comment | null,
-    Parent,
+    any,
     Context
   > /** Subscription fires on every comment added */;
 }
 
-export type SubscriptionCommentAddedResolver<R = Comment | null, Parent = Subscription, Context = any> = Resolver<
+export type SubscriptionCommentAddedResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
   R,
   Parent,
   Context

--- a/dev-test/githunt/types.reactApollo.ts
+++ b/dev-test/githunt/types.reactApollo.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -22,10 +22,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 };
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
 
 export interface Query {
   feed?: (Entry | null)[] | null /** A feed of repository submissions */;
@@ -122,17 +118,17 @@ export enum VoteType {
 }
 
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    feed?: FeedResolver<(Entry | null)[] | null, Parent, Context> /** A feed of repository submissions */;
-    entry?: EntryResolver<Entry | null, Parent, Context> /** A single entry */;
+  export interface Resolvers<Context = any> {
+    feed?: FeedResolver<(Entry | null)[] | null, any, Context> /** A feed of repository submissions */;
+    entry?: EntryResolver<Entry | null, any, Context> /** A single entry */;
     currentUser?: CurrentUserResolver<
       User | null,
-      Parent,
+      any,
       Context
     > /** Return the currently logged in user, or null if nobody is logged in */;
   }
 
-  export type FeedResolver<R = (Entry | null)[] | null, Parent = Query, Context = any> = Resolver<
+  export type FeedResolver<R = (Entry | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -144,37 +140,37 @@ export namespace QueryResolvers {
     limit?: number | null /** The number of items to fetch starting from the offset, for pagination */;
   }
 
-  export type EntryResolver<R = Entry | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, EntryArgs>;
+  export type EntryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context, EntryArgs>;
   export interface EntryArgs {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
   }
 
-  export type CurrentUserResolver<R = User | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+  export type CurrentUserResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Information about a GitHub repository submitted to GitHunt */
 export namespace EntryResolvers {
-  export interface Resolvers<Context = any, Parent = Entry> {
-    repository?: RepositoryResolver<Repository, Parent, Context> /** Information about the repository from GitHub */;
-    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who submitted this entry */;
-    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the entry was submitted */;
-    score?: ScoreResolver<number, Parent, Context> /** The score of this repository, upvotes - downvotes */;
-    hotScore?: HotScoreResolver<number, Parent, Context> /** The hot score of this repository */;
-    comments?: CommentsResolver<(Comment | null)[], Parent, Context> /** Comments posted about this repository */;
+  export interface Resolvers<Context = any> {
+    repository?: RepositoryResolver<Repository, any, Context> /** Information about the repository from GitHub */;
+    postedBy?: PostedByResolver<User, any, Context> /** The GitHub user who submitted this entry */;
+    createdAt?: CreatedAtResolver<number, any, Context> /** A timestamp of when the entry was submitted */;
+    score?: ScoreResolver<number, any, Context> /** The score of this repository, upvotes - downvotes */;
+    hotScore?: HotScoreResolver<number, any, Context> /** The hot score of this repository */;
+    comments?: CommentsResolver<(Comment | null)[], any, Context> /** Comments posted about this repository */;
     commentCount?: CommentCountResolver<
       number,
-      Parent,
+      any,
       Context
     > /** The number of comments posted about this repository */;
-    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-    vote?: VoteResolver<Vote, Parent, Context> /** XXX to be changed */;
+    id?: IdResolver<number, any, Context> /** The SQL ID of this entry */;
+    vote?: VoteResolver<Vote, any, Context> /** XXX to be changed */;
   }
 
-  export type RepositoryResolver<R = Repository, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type PostedByResolver<R = User, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type CreatedAtResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type ScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type HotScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type CommentsResolver<R = (Comment | null)[], Parent = Entry, Context = any> = Resolver<
+  export type RepositoryResolver<R = Repository, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type ScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HotScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentsResolver<R = (Comment | null)[], Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -185,107 +181,103 @@ export namespace EntryResolvers {
     offset?: number | null;
   }
 
-  export type CommentCountResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type IdResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type VoteResolver<R = Vote, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type VoteResolver<R = Vote, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A repository object from the GitHub API. This uses the exact field names returned by theGitHub API for simplicity, even though the convention for GraphQL is usually to camel case. */
 export namespace RepositoryResolvers {
-  export interface Resolvers<Context = any, Parent = Repository> {
-    name?: NameResolver<string, Parent, Context> /** Just the name of the repository, e.g. GitHunt-API */;
+  export interface Resolvers<Context = any> {
+    name?: NameResolver<string, any, Context> /** Just the name of the repository, e.g. GitHunt-API */;
     full_name?: FullNameResolver<
       string,
-      Parent,
+      any,
       Context
     > /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */;
-    description?: DescriptionResolver<string | null, Parent, Context> /** The description of the repository */;
-    html_url?: HtmlUrlResolver<string, Parent, Context> /** The link to the repository on GitHub */;
+    description?: DescriptionResolver<string | null, any, Context> /** The description of the repository */;
+    html_url?: HtmlUrlResolver<string, any, Context> /** The link to the repository on GitHub */;
     stargazers_count?: StargazersCountResolver<
       number,
-      Parent,
+      any,
       Context
     > /** The number of people who have starred this repository on GitHub */;
     open_issues_count?: OpenIssuesCountResolver<
       number | null,
-      Parent,
+      any,
       Context
     > /** The number of open issues on this repository on GitHub */;
-    owner?: OwnerResolver<User | null, Parent, Context> /** The owner of this repository on GitHub, e.g. apollostack */;
+    owner?: OwnerResolver<User | null, any, Context> /** The owner of this repository on GitHub, e.g. apollostack */;
   }
 
-  export type NameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type FullNameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type DescriptionResolver<R = string | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type HtmlUrlResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type StargazersCountResolver<R = number, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type OpenIssuesCountResolver<R = number | null, Parent = Repository, Context = any> = Resolver<
-    R,
-    Parent,
-    Context
-  >;
-  export type OwnerResolver<R = User | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FullNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type DescriptionResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type StargazersCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type OpenIssuesCountResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type OwnerResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export namespace UserResolvers {
-  export interface Resolvers<Context = any, Parent = User> {
-    login?: LoginResolver<string, Parent, Context> /** The name of the user, e.g. apollostack */;
+  export interface Resolvers<Context = any> {
+    login?: LoginResolver<string, any, Context> /** The name of the user, e.g. apollostack */;
     avatar_url?: AvatarUrlResolver<
       string,
-      Parent,
+      any,
       Context
     > /** The URL to a directly embeddable image for this user's avatar */;
-    html_url?: HtmlUrlResolver<string, Parent, Context> /** The URL of this user's GitHub page */;
+    html_url?: HtmlUrlResolver<string, any, Context> /** The URL of this user's GitHub page */;
   }
 
-  export type LoginResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type AvatarUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type HtmlUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type LoginResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type AvatarUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A comment about an entry, submitted by a user */
 export namespace CommentResolvers {
-  export interface Resolvers<Context = any, Parent = Comment> {
-    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who posted the comment */;
-    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the comment was posted */;
-    content?: ContentResolver<string, Parent, Context> /** The text of the comment */;
-    repoName?: RepoNameResolver<string, Parent, Context> /** The repository which this comment is about */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<number, any, Context> /** The SQL ID of this entry */;
+    postedBy?: PostedByResolver<User, any, Context> /** The GitHub user who posted the comment */;
+    createdAt?: CreatedAtResolver<number, any, Context> /** A timestamp of when the comment was posted */;
+    content?: ContentResolver<string, any, Context> /** The text of the comment */;
+    repoName?: RepoNameResolver<string, any, Context> /** The repository which this comment is about */;
   }
 
-  export type IdResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type PostedByResolver<R = User, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type CreatedAtResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type ContentResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type RepoNameResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type ContentResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type RepoNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** XXX to be removed */
 export namespace VoteResolvers {
-  export interface Resolvers<Context = any, Parent = Vote> {
-    vote_value?: VoteValueResolver<number, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    vote_value?: VoteValueResolver<number, any, Context>;
   }
 
-  export type VoteValueResolver<R = number, Parent = Vote, Context = any> = Resolver<R, Parent, Context>;
+  export type VoteValueResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 
 export namespace MutationResolvers {
-  export interface Resolvers<Context = any, Parent = Mutation> {
+  export interface Resolvers<Context = any> {
     submitRepository?: SubmitRepositoryResolver<
       Entry | null,
-      Parent,
+      any,
       Context
     > /** Submit a new repository, returns the new submission */;
     vote?: VoteResolver<
       Entry | null,
-      Parent,
+      any,
       Context
     > /** Vote on a repository submission, returns the submission that was voted on */;
     submitComment?: SubmitCommentResolver<
       Comment | null,
-      Parent,
+      any,
       Context
     > /** Comment on a repository, returns the new comment */;
   }
 
-  export type SubmitRepositoryResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<
+  export type SubmitRepositoryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -295,13 +287,13 @@ export namespace MutationResolvers {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
   }
 
-  export type VoteResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<R, Parent, Context, VoteArgs>;
+  export type VoteResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context, VoteArgs>;
   export interface VoteArgs {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
     type: VoteType /** The type of vote - UP, DOWN, or CANCEL */;
   }
 
-  export type SubmitCommentResolver<R = Comment | null, Parent = Mutation, Context = any> = Resolver<
+  export type SubmitCommentResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -314,15 +306,11 @@ export namespace MutationResolvers {
 }
 
 export namespace SubscriptionResolvers {
-  export interface Resolvers<Context = any, Parent = Subscription> {
-    commentAdded?: CommentAddedResolver<
-      Comment | null,
-      Parent,
-      Context
-    > /** Subscription fires on every comment added */;
+  export interface Resolvers<Context = any> {
+    commentAdded?: CommentAddedResolver<Comment | null, any, Context> /** Subscription fires on every comment added */;
   }
 
-  export type CommentAddedResolver<R = Comment | null, Parent = Subscription, Context = any> = Resolver<
+  export type CommentAddedResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,

--- a/dev-test/githunt/types.ts
+++ b/dev-test/githunt/types.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -22,10 +22,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 };
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
 
 export interface Query {
   feed?: (Entry | null)[] | null /** A feed of repository submissions */;
@@ -122,17 +118,17 @@ export enum VoteType {
 }
 
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    feed?: FeedResolver<(Entry | null)[] | null, Parent, Context> /** A feed of repository submissions */;
-    entry?: EntryResolver<Entry | null, Parent, Context> /** A single entry */;
+  export interface Resolvers<Context = any> {
+    feed?: FeedResolver<(Entry | null)[] | null, any, Context> /** A feed of repository submissions */;
+    entry?: EntryResolver<Entry | null, any, Context> /** A single entry */;
     currentUser?: CurrentUserResolver<
       User | null,
-      Parent,
+      any,
       Context
     > /** Return the currently logged in user, or null if nobody is logged in */;
   }
 
-  export type FeedResolver<R = (Entry | null)[] | null, Parent = Query, Context = any> = Resolver<
+  export type FeedResolver<R = (Entry | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -144,37 +140,37 @@ export namespace QueryResolvers {
     limit?: number | null /** The number of items to fetch starting from the offset, for pagination */;
   }
 
-  export type EntryResolver<R = Entry | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, EntryArgs>;
+  export type EntryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context, EntryArgs>;
   export interface EntryArgs {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
   }
 
-  export type CurrentUserResolver<R = User | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+  export type CurrentUserResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Information about a GitHub repository submitted to GitHunt */
 export namespace EntryResolvers {
-  export interface Resolvers<Context = any, Parent = Entry> {
-    repository?: RepositoryResolver<Repository, Parent, Context> /** Information about the repository from GitHub */;
-    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who submitted this entry */;
-    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the entry was submitted */;
-    score?: ScoreResolver<number, Parent, Context> /** The score of this repository, upvotes - downvotes */;
-    hotScore?: HotScoreResolver<number, Parent, Context> /** The hot score of this repository */;
-    comments?: CommentsResolver<(Comment | null)[], Parent, Context> /** Comments posted about this repository */;
+  export interface Resolvers<Context = any> {
+    repository?: RepositoryResolver<Repository, any, Context> /** Information about the repository from GitHub */;
+    postedBy?: PostedByResolver<User, any, Context> /** The GitHub user who submitted this entry */;
+    createdAt?: CreatedAtResolver<number, any, Context> /** A timestamp of when the entry was submitted */;
+    score?: ScoreResolver<number, any, Context> /** The score of this repository, upvotes - downvotes */;
+    hotScore?: HotScoreResolver<number, any, Context> /** The hot score of this repository */;
+    comments?: CommentsResolver<(Comment | null)[], any, Context> /** Comments posted about this repository */;
     commentCount?: CommentCountResolver<
       number,
-      Parent,
+      any,
       Context
     > /** The number of comments posted about this repository */;
-    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-    vote?: VoteResolver<Vote, Parent, Context> /** XXX to be changed */;
+    id?: IdResolver<number, any, Context> /** The SQL ID of this entry */;
+    vote?: VoteResolver<Vote, any, Context> /** XXX to be changed */;
   }
 
-  export type RepositoryResolver<R = Repository, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type PostedByResolver<R = User, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type CreatedAtResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type ScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type HotScoreResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type CommentsResolver<R = (Comment | null)[], Parent = Entry, Context = any> = Resolver<
+  export type RepositoryResolver<R = Repository, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type ScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HotScoreResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentsResolver<R = (Comment | null)[], Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -185,107 +181,103 @@ export namespace EntryResolvers {
     offset?: number | null;
   }
 
-  export type CommentCountResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type IdResolver<R = number, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
-  export type VoteResolver<R = Vote, Parent = Entry, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type VoteResolver<R = Vote, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A repository object from the GitHub API. This uses the exact field names returned by theGitHub API for simplicity, even though the convention for GraphQL is usually to camel case. */
 export namespace RepositoryResolvers {
-  export interface Resolvers<Context = any, Parent = Repository> {
-    name?: NameResolver<string, Parent, Context> /** Just the name of the repository, e.g. GitHunt-API */;
+  export interface Resolvers<Context = any> {
+    name?: NameResolver<string, any, Context> /** Just the name of the repository, e.g. GitHunt-API */;
     full_name?: FullNameResolver<
       string,
-      Parent,
+      any,
       Context
     > /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */;
-    description?: DescriptionResolver<string | null, Parent, Context> /** The description of the repository */;
-    html_url?: HtmlUrlResolver<string, Parent, Context> /** The link to the repository on GitHub */;
+    description?: DescriptionResolver<string | null, any, Context> /** The description of the repository */;
+    html_url?: HtmlUrlResolver<string, any, Context> /** The link to the repository on GitHub */;
     stargazers_count?: StargazersCountResolver<
       number,
-      Parent,
+      any,
       Context
     > /** The number of people who have starred this repository on GitHub */;
     open_issues_count?: OpenIssuesCountResolver<
       number | null,
-      Parent,
+      any,
       Context
     > /** The number of open issues on this repository on GitHub */;
-    owner?: OwnerResolver<User | null, Parent, Context> /** The owner of this repository on GitHub, e.g. apollostack */;
+    owner?: OwnerResolver<User | null, any, Context> /** The owner of this repository on GitHub, e.g. apollostack */;
   }
 
-  export type NameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type FullNameResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type DescriptionResolver<R = string | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type HtmlUrlResolver<R = string, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type StargazersCountResolver<R = number, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
-  export type OpenIssuesCountResolver<R = number | null, Parent = Repository, Context = any> = Resolver<
-    R,
-    Parent,
-    Context
-  >;
-  export type OwnerResolver<R = User | null, Parent = Repository, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FullNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type DescriptionResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type StargazersCountResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type OpenIssuesCountResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type OwnerResolver<R = User | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export namespace UserResolvers {
-  export interface Resolvers<Context = any, Parent = User> {
-    login?: LoginResolver<string, Parent, Context> /** The name of the user, e.g. apollostack */;
+  export interface Resolvers<Context = any> {
+    login?: LoginResolver<string, any, Context> /** The name of the user, e.g. apollostack */;
     avatar_url?: AvatarUrlResolver<
       string,
-      Parent,
+      any,
       Context
     > /** The URL to a directly embeddable image for this user's avatar */;
-    html_url?: HtmlUrlResolver<string, Parent, Context> /** The URL of this user's GitHub page */;
+    html_url?: HtmlUrlResolver<string, any, Context> /** The URL of this user's GitHub page */;
   }
 
-  export type LoginResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type AvatarUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type HtmlUrlResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type LoginResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type AvatarUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HtmlUrlResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A comment about an entry, submitted by a user */
 export namespace CommentResolvers {
-  export interface Resolvers<Context = any, Parent = Comment> {
-    id?: IdResolver<number, Parent, Context> /** The SQL ID of this entry */;
-    postedBy?: PostedByResolver<User, Parent, Context> /** The GitHub user who posted the comment */;
-    createdAt?: CreatedAtResolver<number, Parent, Context> /** A timestamp of when the comment was posted */;
-    content?: ContentResolver<string, Parent, Context> /** The text of the comment */;
-    repoName?: RepoNameResolver<string, Parent, Context> /** The repository which this comment is about */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<number, any, Context> /** The SQL ID of this entry */;
+    postedBy?: PostedByResolver<User, any, Context> /** The GitHub user who posted the comment */;
+    createdAt?: CreatedAtResolver<number, any, Context> /** A timestamp of when the comment was posted */;
+    content?: ContentResolver<string, any, Context> /** The text of the comment */;
+    repoName?: RepoNameResolver<string, any, Context> /** The repository which this comment is about */;
   }
 
-  export type IdResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type PostedByResolver<R = User, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type CreatedAtResolver<R = number, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type ContentResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
-  export type RepoNameResolver<R = string, Parent = Comment, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PostedByResolver<R = User, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CreatedAtResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type ContentResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type RepoNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** XXX to be removed */
 export namespace VoteResolvers {
-  export interface Resolvers<Context = any, Parent = Vote> {
-    vote_value?: VoteValueResolver<number, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    vote_value?: VoteValueResolver<number, any, Context>;
   }
 
-  export type VoteValueResolver<R = number, Parent = Vote, Context = any> = Resolver<R, Parent, Context>;
+  export type VoteValueResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 
 export namespace MutationResolvers {
-  export interface Resolvers<Context = any, Parent = Mutation> {
+  export interface Resolvers<Context = any> {
     submitRepository?: SubmitRepositoryResolver<
       Entry | null,
-      Parent,
+      any,
       Context
     > /** Submit a new repository, returns the new submission */;
     vote?: VoteResolver<
       Entry | null,
-      Parent,
+      any,
       Context
     > /** Vote on a repository submission, returns the submission that was voted on */;
     submitComment?: SubmitCommentResolver<
       Comment | null,
-      Parent,
+      any,
       Context
     > /** Comment on a repository, returns the new comment */;
   }
 
-  export type SubmitRepositoryResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<
+  export type SubmitRepositoryResolver<R = Entry | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -295,13 +287,13 @@ export namespace MutationResolvers {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
   }
 
-  export type VoteResolver<R = Entry | null, Parent = Mutation, Context = any> = Resolver<R, Parent, Context, VoteArgs>;
+  export type VoteResolver<R = Entry | null, Parent = any, Context = any> = Resolver<R, Parent, Context, VoteArgs>;
   export interface VoteArgs {
     repoFullName: string /** The full repository name from GitHub, e.g. "apollostack/GitHunt-API" */;
     type: VoteType /** The type of vote - UP, DOWN, or CANCEL */;
   }
 
-  export type SubmitCommentResolver<R = Comment | null, Parent = Mutation, Context = any> = Resolver<
+  export type SubmitCommentResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -314,15 +306,11 @@ export namespace MutationResolvers {
 }
 
 export namespace SubscriptionResolvers {
-  export interface Resolvers<Context = any, Parent = Subscription> {
-    commentAdded?: CommentAddedResolver<
-      Comment | null,
-      Parent,
-      Context
-    > /** Subscription fires on every comment added */;
+  export interface Resolvers<Context = any> {
+    commentAdded?: CommentAddedResolver<Comment | null, any, Context> /** Subscription fires on every comment added */;
   }
 
-  export type CommentAddedResolver<R = Comment | null, Parent = Subscription, Context = any> = Resolver<
+  export type CommentAddedResolver<R = Comment | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,

--- a/dev-test/star-wars/ts-multiple/heroparenttypedependentfield.query.ts
+++ b/dev-test/star-wars/ts-multiple/heroparenttypedependentfield.query.ts
@@ -35,11 +35,11 @@ export namespace HeroParentTypeDependentField {
   };
 
   export type _Friends = {
-    __typename?: __HumanInlineFragment['__typename'];
+    __typename?: _HumanInlineFragment['__typename'];
     name: string;
-  } & (__HumanInlineFragment);
+  } & (_HumanInlineFragment);
 
-  export type __HumanInlineFragment = {
+  export type _HumanInlineFragment = {
     __typename?: 'Human';
     height?: number | null;
   };

--- a/dev-test/star-wars/types.avoidOptionals.ts
+++ b/dev-test/star-wars/types.avoidOptionals.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -22,10 +22,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 };
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
 
 /** A character from the Star Wars universe */
 export interface Character {
@@ -166,27 +162,22 @@ export type SearchResult = Human | Droid | Starship;
 
 /** The query type, represents all of the entry points into our object graph */
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    hero?: HeroResolver<Character | null, Parent, Context>;
-    reviews?: ReviewsResolver<(Review | null)[] | null, Parent, Context>;
-    search?: SearchResolver<(SearchResult | null)[] | null, Parent, Context>;
-    character?: CharacterResolver<Character | null, Parent, Context>;
-    droid?: DroidResolver<Droid | null, Parent, Context>;
-    human?: HumanResolver<Human | null, Parent, Context>;
-    starship?: StarshipResolver<Starship | null, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    hero?: HeroResolver<Character | null, any, Context>;
+    reviews?: ReviewsResolver<(Review | null)[] | null, any, Context>;
+    search?: SearchResolver<(SearchResult | null)[] | null, any, Context>;
+    character?: CharacterResolver<Character | null, any, Context>;
+    droid?: DroidResolver<Droid | null, any, Context>;
+    human?: HumanResolver<Human | null, any, Context>;
+    starship?: StarshipResolver<Starship | null, any, Context>;
   }
 
-  export type HeroResolver<R = Character | null, Parent = Query, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    HeroArgs
-  >;
+  export type HeroResolver<R = Character | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HeroArgs>;
   export interface HeroArgs {
     episode: Episode | null;
   }
 
-  export type ReviewsResolver<R = (Review | null)[] | null, Parent = Query, Context = any> = Resolver<
+  export type ReviewsResolver<R = (Review | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -196,7 +187,7 @@ export namespace QueryResolvers {
     episode: Episode;
   }
 
-  export type SearchResolver<R = (SearchResult | null)[] | null, Parent = Query, Context = any> = Resolver<
+  export type SearchResolver<R = (SearchResult | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -206,7 +197,7 @@ export namespace QueryResolvers {
     text: string | null;
   }
 
-  export type CharacterResolver<R = Character | null, Parent = Query, Context = any> = Resolver<
+  export type CharacterResolver<R = Character | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -216,17 +207,17 @@ export namespace QueryResolvers {
     id: string;
   }
 
-  export type DroidResolver<R = Droid | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, DroidArgs>;
+  export type DroidResolver<R = Droid | null, Parent = any, Context = any> = Resolver<R, Parent, Context, DroidArgs>;
   export interface DroidArgs {
     id: string;
   }
 
-  export type HumanResolver<R = Human | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, HumanArgs>;
+  export type HumanResolver<R = Human | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HumanArgs>;
   export interface HumanArgs {
     id: string;
   }
 
-  export type StarshipResolver<R = Starship | null, Parent = Query, Context = any> = Resolver<
+  export type StarshipResolver<R = Starship | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -238,120 +229,111 @@ export namespace QueryResolvers {
 }
 /** A connection object for a character's friends */
 export namespace FriendsConnectionResolvers {
-  export interface Resolvers<Context = any, Parent = FriendsConnection> {
-    totalCount?: TotalCountResolver<number | null, Parent, Context> /** The total number of friends */;
+  export interface Resolvers<Context = any> {
+    totalCount?: TotalCountResolver<number | null, any, Context> /** The total number of friends */;
     edges?: EdgesResolver<
       (FriendsEdge | null)[] | null,
-      Parent,
+      any,
       Context
     > /** The edges for each of the character's friends. */;
     friends?: FriendsResolver<
       (Character | null)[] | null,
-      Parent,
+      any,
       Context
     > /** A list of the friends, as a convenience when edges are not needed. */;
-    pageInfo?: PageInfoResolver<PageInfo, Parent, Context> /** Information for paginating this connection */;
+    pageInfo?: PageInfoResolver<PageInfo, any, Context> /** Information for paginating this connection */;
   }
 
-  export type TotalCountResolver<R = number | null, Parent = FriendsConnection, Context = any> = Resolver<
+  export type TotalCountResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type EdgesResolver<R = (FriendsEdge | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type EdgesResolver<R = (FriendsEdge | null)[] | null, Parent = FriendsConnection, Context = any> = Resolver<
+  export type FriendsResolver<R = (Character | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type FriendsResolver<R = (Character | null)[] | null, Parent = FriendsConnection, Context = any> = Resolver<
-    R,
-    Parent,
-    Context
-  >;
-  export type PageInfoResolver<R = PageInfo, Parent = FriendsConnection, Context = any> = Resolver<R, Parent, Context>;
+  export type PageInfoResolver<R = PageInfo, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** An edge object for a character's friends */
 export namespace FriendsEdgeResolvers {
-  export interface Resolvers<Context = any, Parent = FriendsEdge> {
-    cursor?: CursorResolver<string, Parent, Context> /** A cursor used for pagination */;
-    node?: NodeResolver<Character | null, Parent, Context> /** The character represented by this friendship edge */;
+  export interface Resolvers<Context = any> {
+    cursor?: CursorResolver<string, any, Context> /** A cursor used for pagination */;
+    node?: NodeResolver<Character | null, any, Context> /** The character represented by this friendship edge */;
   }
 
-  export type CursorResolver<R = string, Parent = FriendsEdge, Context = any> = Resolver<R, Parent, Context>;
-  export type NodeResolver<R = Character | null, Parent = FriendsEdge, Context = any> = Resolver<R, Parent, Context>;
+  export type CursorResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NodeResolver<R = Character | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Information for paginating this connection */
 export namespace PageInfoResolvers {
-  export interface Resolvers<Context = any, Parent = PageInfo> {
-    startCursor?: StartCursorResolver<string | null, Parent, Context>;
-    endCursor?: EndCursorResolver<string | null, Parent, Context>;
-    hasNextPage?: HasNextPageResolver<boolean, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    startCursor?: StartCursorResolver<string | null, any, Context>;
+    endCursor?: EndCursorResolver<string | null, any, Context>;
+    hasNextPage?: HasNextPageResolver<boolean, any, Context>;
   }
 
-  export type StartCursorResolver<R = string | null, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
-  export type EndCursorResolver<R = string | null, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
-  export type HasNextPageResolver<R = boolean, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
+  export type StartCursorResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type EndCursorResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HasNextPageResolver<R = boolean, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Represents a review for a movie */
 export namespace ReviewResolvers {
-  export interface Resolvers<Context = any, Parent = Review> {
-    stars?: StarsResolver<number, Parent, Context> /** The number of stars this review gave, 1-5 */;
-    commentary?: CommentaryResolver<string | null, Parent, Context> /** Comment about the movie */;
+  export interface Resolvers<Context = any> {
+    stars?: StarsResolver<number, any, Context> /** The number of stars this review gave, 1-5 */;
+    commentary?: CommentaryResolver<string | null, any, Context> /** Comment about the movie */;
   }
 
-  export type StarsResolver<R = number, Parent = Review, Context = any> = Resolver<R, Parent, Context>;
-  export type CommentaryResolver<R = string | null, Parent = Review, Context = any> = Resolver<R, Parent, Context>;
+  export type StarsResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentaryResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A humanoid creature from the Star Wars universe */
 export namespace HumanResolvers {
-  export interface Resolvers<Context = any, Parent = Human> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the human */;
-    name?: NameResolver<string, Parent, Context> /** What this human calls themselves */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the human */;
+    name?: NameResolver<string, any, Context> /** What this human calls themselves */;
     homePlanet?: HomePlanetResolver<
       string | null,
-      Parent,
+      any,
       Context
     > /** The home planet of the human, or null if unknown */;
-    height?: HeightResolver<number | null, Parent, Context> /** Height in the preferred unit, default is meters */;
-    mass?: MassResolver<number | null, Parent, Context> /** Mass in kilograms, or null if unknown */;
+    height?: HeightResolver<number | null, any, Context> /** Height in the preferred unit, default is meters */;
+    mass?: MassResolver<number | null, any, Context> /** Mass in kilograms, or null if unknown */;
     friends?: FriendsResolver<
       (Character | null)[] | null,
-      Parent,
+      any,
       Context
     > /** This human's friends, or an empty list if they have none */;
     friendsConnection?: FriendsConnectionResolver<
       FriendsConnection,
-      Parent,
+      any,
       Context
     > /** The friends of the human exposed as a connection with edges */;
-    appearsIn?: AppearsInResolver<(Episode | null)[], Parent, Context> /** The movies this human appears in */;
+    appearsIn?: AppearsInResolver<(Episode | null)[], any, Context> /** The movies this human appears in */;
     starships?: StarshipsResolver<
       (Starship | null)[] | null,
-      Parent,
+      any,
       Context
     > /** A list of starships this person has piloted, or an empty list if none */;
   }
 
-  export type IdResolver<R = string, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type HomePlanetResolver<R = string | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type HeightResolver<R = number | null, Parent = Human, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    HeightArgs
-  >;
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HomePlanetResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HeightResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HeightArgs>;
   export interface HeightArgs {
     unit: LengthUnit | null;
   }
 
-  export type MassResolver<R = number | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type FriendsResolver<R = (Character | null)[] | null, Parent = Human, Context = any> = Resolver<
+  export type MassResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FriendsResolver<R = (Character | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type FriendsConnectionResolver<R = FriendsConnection, Parent = Human, Context = any> = Resolver<
+  export type FriendsConnectionResolver<R = FriendsConnection, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -362,8 +344,8 @@ export namespace HumanResolvers {
     after: string | null;
   }
 
-  export type AppearsInResolver<R = (Episode | null)[], Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type StarshipsResolver<R = (Starship | null)[] | null, Parent = Human, Context = any> = Resolver<
+  export type AppearsInResolver<R = (Episode | null)[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type StarshipsResolver<R = (Starship | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
@@ -371,51 +353,46 @@ export namespace HumanResolvers {
 }
 
 export namespace StarshipResolvers {
-  export interface Resolvers<Context = any, Parent = Starship> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the starship */;
-    name?: NameResolver<string, Parent, Context> /** The name of the starship */;
-    length?: LengthResolver<number | null, Parent, Context> /** Length of the starship, along the longest axis */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the starship */;
+    name?: NameResolver<string, any, Context> /** The name of the starship */;
+    length?: LengthResolver<number | null, any, Context> /** Length of the starship, along the longest axis */;
   }
 
-  export type IdResolver<R = string, Parent = Starship, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Starship, Context = any> = Resolver<R, Parent, Context>;
-  export type LengthResolver<R = number | null, Parent = Starship, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    LengthArgs
-  >;
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type LengthResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context, LengthArgs>;
   export interface LengthArgs {
     unit: LengthUnit | null;
   }
 }
 /** An autonomous mechanical character in the Star Wars universe */
 export namespace DroidResolvers {
-  export interface Resolvers<Context = any, Parent = Droid> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the droid */;
-    name?: NameResolver<string, Parent, Context> /** What others call this droid */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the droid */;
+    name?: NameResolver<string, any, Context> /** What others call this droid */;
     friends?: FriendsResolver<
       (Character | null)[] | null,
-      Parent,
+      any,
       Context
     > /** This droid's friends, or an empty list if they have none */;
     friendsConnection?: FriendsConnectionResolver<
       FriendsConnection,
-      Parent,
+      any,
       Context
     > /** The friends of the droid exposed as a connection with edges */;
-    appearsIn?: AppearsInResolver<(Episode | null)[], Parent, Context> /** The movies this droid appears in */;
-    primaryFunction?: PrimaryFunctionResolver<string | null, Parent, Context> /** This droid's primary function */;
+    appearsIn?: AppearsInResolver<(Episode | null)[], any, Context> /** The movies this droid appears in */;
+    primaryFunction?: PrimaryFunctionResolver<string | null, any, Context> /** This droid's primary function */;
   }
 
-  export type IdResolver<R = string, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-  export type FriendsResolver<R = (Character | null)[] | null, Parent = Droid, Context = any> = Resolver<
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FriendsResolver<R = (Character | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type FriendsConnectionResolver<R = FriendsConnection, Parent = Droid, Context = any> = Resolver<
+  export type FriendsConnectionResolver<R = FriendsConnection, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -426,16 +403,16 @@ export namespace DroidResolvers {
     after: string | null;
   }
 
-  export type AppearsInResolver<R = (Episode | null)[], Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-  export type PrimaryFunctionResolver<R = string | null, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
+  export type AppearsInResolver<R = (Episode | null)[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PrimaryFunctionResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** The mutation type, represents all updates we can make to our data */
 export namespace MutationResolvers {
-  export interface Resolvers<Context = any, Parent = Mutation> {
-    createReview?: CreateReviewResolver<Review | null, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    createReview?: CreateReviewResolver<Review | null, any, Context>;
   }
 
-  export type CreateReviewResolver<R = Review | null, Parent = Mutation, Context = any> = Resolver<
+  export type CreateReviewResolver<R = Review | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -627,11 +604,11 @@ export namespace HeroParentTypeDependentField {
   };
 
   export type _Friends = {
-    __typename?: __HumanInlineFragment['__typename'];
+    __typename?: _HumanInlineFragment['__typename'];
     name: string;
-  } & (__HumanInlineFragment);
+  } & (_HumanInlineFragment);
 
-  export type __HumanInlineFragment = {
+  export type _HumanInlineFragment = {
     __typename?: 'Human';
     height: number | null;
   };

--- a/dev-test/star-wars/types.d.ts
+++ b/dev-test/star-wars/types.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -22,10 +22,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 };
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
 
 /** A character from the Star Wars universe */
 export interface Character {
@@ -159,27 +155,22 @@ export type SearchResult = Human | Droid | Starship;
 
 /** The query type, represents all of the entry points into our object graph */
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    hero?: HeroResolver<Character | null, Parent, Context>;
-    reviews?: ReviewsResolver<(Review | null)[] | null, Parent, Context>;
-    search?: SearchResolver<(SearchResult | null)[] | null, Parent, Context>;
-    character?: CharacterResolver<Character | null, Parent, Context>;
-    droid?: DroidResolver<Droid | null, Parent, Context>;
-    human?: HumanResolver<Human | null, Parent, Context>;
-    starship?: StarshipResolver<Starship | null, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    hero?: HeroResolver<Character | null, any, Context>;
+    reviews?: ReviewsResolver<(Review | null)[] | null, any, Context>;
+    search?: SearchResolver<(SearchResult | null)[] | null, any, Context>;
+    character?: CharacterResolver<Character | null, any, Context>;
+    droid?: DroidResolver<Droid | null, any, Context>;
+    human?: HumanResolver<Human | null, any, Context>;
+    starship?: StarshipResolver<Starship | null, any, Context>;
   }
 
-  export type HeroResolver<R = Character | null, Parent = Query, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    HeroArgs
-  >;
+  export type HeroResolver<R = Character | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HeroArgs>;
   export interface HeroArgs {
     episode?: Episode | null;
   }
 
-  export type ReviewsResolver<R = (Review | null)[] | null, Parent = Query, Context = any> = Resolver<
+  export type ReviewsResolver<R = (Review | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -189,7 +180,7 @@ export namespace QueryResolvers {
     episode: Episode;
   }
 
-  export type SearchResolver<R = (SearchResult | null)[] | null, Parent = Query, Context = any> = Resolver<
+  export type SearchResolver<R = (SearchResult | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -199,7 +190,7 @@ export namespace QueryResolvers {
     text?: string | null;
   }
 
-  export type CharacterResolver<R = Character | null, Parent = Query, Context = any> = Resolver<
+  export type CharacterResolver<R = Character | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -209,17 +200,17 @@ export namespace QueryResolvers {
     id: string;
   }
 
-  export type DroidResolver<R = Droid | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, DroidArgs>;
+  export type DroidResolver<R = Droid | null, Parent = any, Context = any> = Resolver<R, Parent, Context, DroidArgs>;
   export interface DroidArgs {
     id: string;
   }
 
-  export type HumanResolver<R = Human | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, HumanArgs>;
+  export type HumanResolver<R = Human | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HumanArgs>;
   export interface HumanArgs {
     id: string;
   }
 
-  export type StarshipResolver<R = Starship | null, Parent = Query, Context = any> = Resolver<
+  export type StarshipResolver<R = Starship | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -231,120 +222,111 @@ export namespace QueryResolvers {
 }
 /** A connection object for a character's friends */
 export namespace FriendsConnectionResolvers {
-  export interface Resolvers<Context = any, Parent = FriendsConnection> {
-    totalCount?: TotalCountResolver<number | null, Parent, Context> /** The total number of friends */;
+  export interface Resolvers<Context = any> {
+    totalCount?: TotalCountResolver<number | null, any, Context> /** The total number of friends */;
     edges?: EdgesResolver<
       (FriendsEdge | null)[] | null,
-      Parent,
+      any,
       Context
     > /** The edges for each of the character's friends. */;
     friends?: FriendsResolver<
       (Character | null)[] | null,
-      Parent,
+      any,
       Context
     > /** A list of the friends, as a convenience when edges are not needed. */;
-    pageInfo?: PageInfoResolver<PageInfo, Parent, Context> /** Information for paginating this connection */;
+    pageInfo?: PageInfoResolver<PageInfo, any, Context> /** Information for paginating this connection */;
   }
 
-  export type TotalCountResolver<R = number | null, Parent = FriendsConnection, Context = any> = Resolver<
+  export type TotalCountResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type EdgesResolver<R = (FriendsEdge | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type EdgesResolver<R = (FriendsEdge | null)[] | null, Parent = FriendsConnection, Context = any> = Resolver<
+  export type FriendsResolver<R = (Character | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type FriendsResolver<R = (Character | null)[] | null, Parent = FriendsConnection, Context = any> = Resolver<
-    R,
-    Parent,
-    Context
-  >;
-  export type PageInfoResolver<R = PageInfo, Parent = FriendsConnection, Context = any> = Resolver<R, Parent, Context>;
+  export type PageInfoResolver<R = PageInfo, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** An edge object for a character's friends */
 export namespace FriendsEdgeResolvers {
-  export interface Resolvers<Context = any, Parent = FriendsEdge> {
-    cursor?: CursorResolver<string, Parent, Context> /** A cursor used for pagination */;
-    node?: NodeResolver<Character | null, Parent, Context> /** The character represented by this friendship edge */;
+  export interface Resolvers<Context = any> {
+    cursor?: CursorResolver<string, any, Context> /** A cursor used for pagination */;
+    node?: NodeResolver<Character | null, any, Context> /** The character represented by this friendship edge */;
   }
 
-  export type CursorResolver<R = string, Parent = FriendsEdge, Context = any> = Resolver<R, Parent, Context>;
-  export type NodeResolver<R = Character | null, Parent = FriendsEdge, Context = any> = Resolver<R, Parent, Context>;
+  export type CursorResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NodeResolver<R = Character | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Information for paginating this connection */
 export namespace PageInfoResolvers {
-  export interface Resolvers<Context = any, Parent = PageInfo> {
-    startCursor?: StartCursorResolver<string | null, Parent, Context>;
-    endCursor?: EndCursorResolver<string | null, Parent, Context>;
-    hasNextPage?: HasNextPageResolver<boolean, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    startCursor?: StartCursorResolver<string | null, any, Context>;
+    endCursor?: EndCursorResolver<string | null, any, Context>;
+    hasNextPage?: HasNextPageResolver<boolean, any, Context>;
   }
 
-  export type StartCursorResolver<R = string | null, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
-  export type EndCursorResolver<R = string | null, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
-  export type HasNextPageResolver<R = boolean, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
+  export type StartCursorResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type EndCursorResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HasNextPageResolver<R = boolean, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Represents a review for a movie */
 export namespace ReviewResolvers {
-  export interface Resolvers<Context = any, Parent = Review> {
-    stars?: StarsResolver<number, Parent, Context> /** The number of stars this review gave, 1-5 */;
-    commentary?: CommentaryResolver<string | null, Parent, Context> /** Comment about the movie */;
+  export interface Resolvers<Context = any> {
+    stars?: StarsResolver<number, any, Context> /** The number of stars this review gave, 1-5 */;
+    commentary?: CommentaryResolver<string | null, any, Context> /** Comment about the movie */;
   }
 
-  export type StarsResolver<R = number, Parent = Review, Context = any> = Resolver<R, Parent, Context>;
-  export type CommentaryResolver<R = string | null, Parent = Review, Context = any> = Resolver<R, Parent, Context>;
+  export type StarsResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentaryResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A humanoid creature from the Star Wars universe */
 export namespace HumanResolvers {
-  export interface Resolvers<Context = any, Parent = Human> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the human */;
-    name?: NameResolver<string, Parent, Context> /** What this human calls themselves */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the human */;
+    name?: NameResolver<string, any, Context> /** What this human calls themselves */;
     homePlanet?: HomePlanetResolver<
       string | null,
-      Parent,
+      any,
       Context
     > /** The home planet of the human, or null if unknown */;
-    height?: HeightResolver<number | null, Parent, Context> /** Height in the preferred unit, default is meters */;
-    mass?: MassResolver<number | null, Parent, Context> /** Mass in kilograms, or null if unknown */;
+    height?: HeightResolver<number | null, any, Context> /** Height in the preferred unit, default is meters */;
+    mass?: MassResolver<number | null, any, Context> /** Mass in kilograms, or null if unknown */;
     friends?: FriendsResolver<
       (Character | null)[] | null,
-      Parent,
+      any,
       Context
     > /** This human's friends, or an empty list if they have none */;
     friendsConnection?: FriendsConnectionResolver<
       FriendsConnection,
-      Parent,
+      any,
       Context
     > /** The friends of the human exposed as a connection with edges */;
-    appearsIn?: AppearsInResolver<(Episode | null)[], Parent, Context> /** The movies this human appears in */;
+    appearsIn?: AppearsInResolver<(Episode | null)[], any, Context> /** The movies this human appears in */;
     starships?: StarshipsResolver<
       (Starship | null)[] | null,
-      Parent,
+      any,
       Context
     > /** A list of starships this person has piloted, or an empty list if none */;
   }
 
-  export type IdResolver<R = string, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type HomePlanetResolver<R = string | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type HeightResolver<R = number | null, Parent = Human, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    HeightArgs
-  >;
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HomePlanetResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HeightResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HeightArgs>;
   export interface HeightArgs {
     unit?: LengthUnit | null;
   }
 
-  export type MassResolver<R = number | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type FriendsResolver<R = (Character | null)[] | null, Parent = Human, Context = any> = Resolver<
+  export type MassResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FriendsResolver<R = (Character | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type FriendsConnectionResolver<R = FriendsConnection, Parent = Human, Context = any> = Resolver<
+  export type FriendsConnectionResolver<R = FriendsConnection, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -355,8 +337,8 @@ export namespace HumanResolvers {
     after?: string | null;
   }
 
-  export type AppearsInResolver<R = (Episode | null)[], Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type StarshipsResolver<R = (Starship | null)[] | null, Parent = Human, Context = any> = Resolver<
+  export type AppearsInResolver<R = (Episode | null)[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type StarshipsResolver<R = (Starship | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
@@ -364,51 +346,46 @@ export namespace HumanResolvers {
 }
 
 export namespace StarshipResolvers {
-  export interface Resolvers<Context = any, Parent = Starship> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the starship */;
-    name?: NameResolver<string, Parent, Context> /** The name of the starship */;
-    length?: LengthResolver<number | null, Parent, Context> /** Length of the starship, along the longest axis */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the starship */;
+    name?: NameResolver<string, any, Context> /** The name of the starship */;
+    length?: LengthResolver<number | null, any, Context> /** Length of the starship, along the longest axis */;
   }
 
-  export type IdResolver<R = string, Parent = Starship, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Starship, Context = any> = Resolver<R, Parent, Context>;
-  export type LengthResolver<R = number | null, Parent = Starship, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    LengthArgs
-  >;
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type LengthResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context, LengthArgs>;
   export interface LengthArgs {
     unit?: LengthUnit | null;
   }
 }
 /** An autonomous mechanical character in the Star Wars universe */
 export namespace DroidResolvers {
-  export interface Resolvers<Context = any, Parent = Droid> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the droid */;
-    name?: NameResolver<string, Parent, Context> /** What others call this droid */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the droid */;
+    name?: NameResolver<string, any, Context> /** What others call this droid */;
     friends?: FriendsResolver<
       (Character | null)[] | null,
-      Parent,
+      any,
       Context
     > /** This droid's friends, or an empty list if they have none */;
     friendsConnection?: FriendsConnectionResolver<
       FriendsConnection,
-      Parent,
+      any,
       Context
     > /** The friends of the droid exposed as a connection with edges */;
-    appearsIn?: AppearsInResolver<(Episode | null)[], Parent, Context> /** The movies this droid appears in */;
-    primaryFunction?: PrimaryFunctionResolver<string | null, Parent, Context> /** This droid's primary function */;
+    appearsIn?: AppearsInResolver<(Episode | null)[], any, Context> /** The movies this droid appears in */;
+    primaryFunction?: PrimaryFunctionResolver<string | null, any, Context> /** This droid's primary function */;
   }
 
-  export type IdResolver<R = string, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-  export type FriendsResolver<R = (Character | null)[] | null, Parent = Droid, Context = any> = Resolver<
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FriendsResolver<R = (Character | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type FriendsConnectionResolver<R = FriendsConnection, Parent = Droid, Context = any> = Resolver<
+  export type FriendsConnectionResolver<R = FriendsConnection, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -419,16 +396,16 @@ export namespace DroidResolvers {
     after?: string | null;
   }
 
-  export type AppearsInResolver<R = (Episode | null)[], Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-  export type PrimaryFunctionResolver<R = string | null, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
+  export type AppearsInResolver<R = (Episode | null)[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PrimaryFunctionResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** The mutation type, represents all updates we can make to our data */
 export namespace MutationResolvers {
-  export interface Resolvers<Context = any, Parent = Mutation> {
-    createReview?: CreateReviewResolver<Review | null, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    createReview?: CreateReviewResolver<Review | null, any, Context>;
   }
 
-  export type CreateReviewResolver<R = Review | null, Parent = Mutation, Context = any> = Resolver<
+  export type CreateReviewResolver<R = Review | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -620,11 +597,11 @@ export namespace HeroParentTypeDependentField {
   };
 
   export type _Friends = {
-    __typename?: __HumanInlineFragment['__typename'];
+    __typename?: _HumanInlineFragment['__typename'];
     name: string;
-  } & (__HumanInlineFragment);
+  } & (_HumanInlineFragment);
 
-  export type __HumanInlineFragment = {
+  export type _HumanInlineFragment = {
     __typename?: 'Human';
     height?: number | null;
   };

--- a/dev-test/star-wars/types.immutableTypes.ts
+++ b/dev-test/star-wars/types.immutableTypes.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -22,10 +22,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 };
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
 
 /** A character from the Star Wars universe */
 export interface Character {
@@ -166,27 +162,22 @@ export type SearchResult = Human | Droid | Starship;
 
 /** The query type, represents all of the entry points into our object graph */
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    hero?: HeroResolver<Character | null, Parent, Context>;
-    reviews?: ReviewsResolver<ReadonlyArray<Review | null> | null, Parent, Context>;
-    search?: SearchResolver<ReadonlyArray<SearchResult | null> | null, Parent, Context>;
-    character?: CharacterResolver<Character | null, Parent, Context>;
-    droid?: DroidResolver<Droid | null, Parent, Context>;
-    human?: HumanResolver<Human | null, Parent, Context>;
-    starship?: StarshipResolver<Starship | null, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    hero?: HeroResolver<Character | null, any, Context>;
+    reviews?: ReviewsResolver<ReadonlyArray<Review | null> | null, any, Context>;
+    search?: SearchResolver<ReadonlyArray<SearchResult | null> | null, any, Context>;
+    character?: CharacterResolver<Character | null, any, Context>;
+    droid?: DroidResolver<Droid | null, any, Context>;
+    human?: HumanResolver<Human | null, any, Context>;
+    starship?: StarshipResolver<Starship | null, any, Context>;
   }
 
-  export type HeroResolver<R = Character | null, Parent = Query, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    HeroArgs
-  >;
+  export type HeroResolver<R = Character | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HeroArgs>;
   export interface HeroArgs {
     episode?: Episode | null;
   }
 
-  export type ReviewsResolver<R = ReadonlyArray<Review | null> | null, Parent = Query, Context = any> = Resolver<
+  export type ReviewsResolver<R = ReadonlyArray<Review | null> | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -196,7 +187,7 @@ export namespace QueryResolvers {
     episode: Episode;
   }
 
-  export type SearchResolver<R = ReadonlyArray<SearchResult | null> | null, Parent = Query, Context = any> = Resolver<
+  export type SearchResolver<R = ReadonlyArray<SearchResult | null> | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -206,7 +197,7 @@ export namespace QueryResolvers {
     text?: string | null;
   }
 
-  export type CharacterResolver<R = Character | null, Parent = Query, Context = any> = Resolver<
+  export type CharacterResolver<R = Character | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -216,17 +207,17 @@ export namespace QueryResolvers {
     id: string;
   }
 
-  export type DroidResolver<R = Droid | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, DroidArgs>;
+  export type DroidResolver<R = Droid | null, Parent = any, Context = any> = Resolver<R, Parent, Context, DroidArgs>;
   export interface DroidArgs {
     id: string;
   }
 
-  export type HumanResolver<R = Human | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, HumanArgs>;
+  export type HumanResolver<R = Human | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HumanArgs>;
   export interface HumanArgs {
     id: string;
   }
 
-  export type StarshipResolver<R = Starship | null, Parent = Query, Context = any> = Resolver<
+  export type StarshipResolver<R = Starship | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -238,124 +229,111 @@ export namespace QueryResolvers {
 }
 /** A connection object for a character's friends */
 export namespace FriendsConnectionResolvers {
-  export interface Resolvers<Context = any, Parent = FriendsConnection> {
-    totalCount?: TotalCountResolver<number | null, Parent, Context> /** The total number of friends */;
+  export interface Resolvers<Context = any> {
+    totalCount?: TotalCountResolver<number | null, any, Context> /** The total number of friends */;
     edges?: EdgesResolver<
       ReadonlyArray<FriendsEdge | null> | null,
-      Parent,
+      any,
       Context
     > /** The edges for each of the character's friends. */;
     friends?: FriendsResolver<
       ReadonlyArray<Character | null> | null,
-      Parent,
+      any,
       Context
     > /** A list of the friends, as a convenience when edges are not needed. */;
-    pageInfo?: PageInfoResolver<PageInfo, Parent, Context> /** Information for paginating this connection */;
+    pageInfo?: PageInfoResolver<PageInfo, any, Context> /** Information for paginating this connection */;
   }
 
-  export type TotalCountResolver<R = number | null, Parent = FriendsConnection, Context = any> = Resolver<
+  export type TotalCountResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type EdgesResolver<R = ReadonlyArray<FriendsEdge | null> | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type EdgesResolver<
-    R = ReadonlyArray<FriendsEdge | null> | null,
-    Parent = FriendsConnection,
-    Context = any
-  > = Resolver<R, Parent, Context>;
-  export type FriendsResolver<
-    R = ReadonlyArray<Character | null> | null,
-    Parent = FriendsConnection,
-    Context = any
-  > = Resolver<R, Parent, Context>;
-  export type PageInfoResolver<R = PageInfo, Parent = FriendsConnection, Context = any> = Resolver<R, Parent, Context>;
+  export type FriendsResolver<R = ReadonlyArray<Character | null> | null, Parent = any, Context = any> = Resolver<
+    R,
+    Parent,
+    Context
+  >;
+  export type PageInfoResolver<R = PageInfo, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** An edge object for a character's friends */
 export namespace FriendsEdgeResolvers {
-  export interface Resolvers<Context = any, Parent = FriendsEdge> {
-    cursor?: CursorResolver<string, Parent, Context> /** A cursor used for pagination */;
-    node?: NodeResolver<Character | null, Parent, Context> /** The character represented by this friendship edge */;
+  export interface Resolvers<Context = any> {
+    cursor?: CursorResolver<string, any, Context> /** A cursor used for pagination */;
+    node?: NodeResolver<Character | null, any, Context> /** The character represented by this friendship edge */;
   }
 
-  export type CursorResolver<R = string, Parent = FriendsEdge, Context = any> = Resolver<R, Parent, Context>;
-  export type NodeResolver<R = Character | null, Parent = FriendsEdge, Context = any> = Resolver<R, Parent, Context>;
+  export type CursorResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NodeResolver<R = Character | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Information for paginating this connection */
 export namespace PageInfoResolvers {
-  export interface Resolvers<Context = any, Parent = PageInfo> {
-    startCursor?: StartCursorResolver<string | null, Parent, Context>;
-    endCursor?: EndCursorResolver<string | null, Parent, Context>;
-    hasNextPage?: HasNextPageResolver<boolean, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    startCursor?: StartCursorResolver<string | null, any, Context>;
+    endCursor?: EndCursorResolver<string | null, any, Context>;
+    hasNextPage?: HasNextPageResolver<boolean, any, Context>;
   }
 
-  export type StartCursorResolver<R = string | null, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
-  export type EndCursorResolver<R = string | null, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
-  export type HasNextPageResolver<R = boolean, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
+  export type StartCursorResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type EndCursorResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HasNextPageResolver<R = boolean, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Represents a review for a movie */
 export namespace ReviewResolvers {
-  export interface Resolvers<Context = any, Parent = Review> {
-    stars?: StarsResolver<number, Parent, Context> /** The number of stars this review gave, 1-5 */;
-    commentary?: CommentaryResolver<string | null, Parent, Context> /** Comment about the movie */;
+  export interface Resolvers<Context = any> {
+    stars?: StarsResolver<number, any, Context> /** The number of stars this review gave, 1-5 */;
+    commentary?: CommentaryResolver<string | null, any, Context> /** Comment about the movie */;
   }
 
-  export type StarsResolver<R = number, Parent = Review, Context = any> = Resolver<R, Parent, Context>;
-  export type CommentaryResolver<R = string | null, Parent = Review, Context = any> = Resolver<R, Parent, Context>;
+  export type StarsResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentaryResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A humanoid creature from the Star Wars universe */
 export namespace HumanResolvers {
-  export interface Resolvers<Context = any, Parent = Human> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the human */;
-    name?: NameResolver<string, Parent, Context> /** What this human calls themselves */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the human */;
+    name?: NameResolver<string, any, Context> /** What this human calls themselves */;
     homePlanet?: HomePlanetResolver<
       string | null,
-      Parent,
+      any,
       Context
     > /** The home planet of the human, or null if unknown */;
-    height?: HeightResolver<number | null, Parent, Context> /** Height in the preferred unit, default is meters */;
-    mass?: MassResolver<number | null, Parent, Context> /** Mass in kilograms, or null if unknown */;
+    height?: HeightResolver<number | null, any, Context> /** Height in the preferred unit, default is meters */;
+    mass?: MassResolver<number | null, any, Context> /** Mass in kilograms, or null if unknown */;
     friends?: FriendsResolver<
       ReadonlyArray<Character | null> | null,
-      Parent,
+      any,
       Context
     > /** This human's friends, or an empty list if they have none */;
     friendsConnection?: FriendsConnectionResolver<
       FriendsConnection,
-      Parent,
+      any,
       Context
     > /** The friends of the human exposed as a connection with edges */;
-    appearsIn?: AppearsInResolver<
-      ReadonlyArray<Episode | null>,
-      Parent,
-      Context
-    > /** The movies this human appears in */;
+    appearsIn?: AppearsInResolver<ReadonlyArray<Episode | null>, any, Context> /** The movies this human appears in */;
     starships?: StarshipsResolver<
       ReadonlyArray<Starship | null> | null,
-      Parent,
+      any,
       Context
     > /** A list of starships this person has piloted, or an empty list if none */;
   }
 
-  export type IdResolver<R = string, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type HomePlanetResolver<R = string | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type HeightResolver<R = number | null, Parent = Human, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    HeightArgs
-  >;
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HomePlanetResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HeightResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HeightArgs>;
   export interface HeightArgs {
     unit?: LengthUnit | null;
   }
 
-  export type MassResolver<R = number | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type FriendsResolver<R = ReadonlyArray<Character | null> | null, Parent = Human, Context = any> = Resolver<
+  export type MassResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FriendsResolver<R = ReadonlyArray<Character | null> | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type FriendsConnectionResolver<R = FriendsConnection, Parent = Human, Context = any> = Resolver<
+  export type FriendsConnectionResolver<R = FriendsConnection, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -366,12 +344,12 @@ export namespace HumanResolvers {
     after?: string | null;
   }
 
-  export type AppearsInResolver<R = ReadonlyArray<Episode | null>, Parent = Human, Context = any> = Resolver<
+  export type AppearsInResolver<R = ReadonlyArray<Episode | null>, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type StarshipsResolver<R = ReadonlyArray<Starship | null> | null, Parent = Human, Context = any> = Resolver<
+  export type StarshipsResolver<R = ReadonlyArray<Starship | null> | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
@@ -379,55 +357,46 @@ export namespace HumanResolvers {
 }
 
 export namespace StarshipResolvers {
-  export interface Resolvers<Context = any, Parent = Starship> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the starship */;
-    name?: NameResolver<string, Parent, Context> /** The name of the starship */;
-    length?: LengthResolver<number | null, Parent, Context> /** Length of the starship, along the longest axis */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the starship */;
+    name?: NameResolver<string, any, Context> /** The name of the starship */;
+    length?: LengthResolver<number | null, any, Context> /** Length of the starship, along the longest axis */;
   }
 
-  export type IdResolver<R = string, Parent = Starship, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Starship, Context = any> = Resolver<R, Parent, Context>;
-  export type LengthResolver<R = number | null, Parent = Starship, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    LengthArgs
-  >;
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type LengthResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context, LengthArgs>;
   export interface LengthArgs {
     unit?: LengthUnit | null;
   }
 }
 /** An autonomous mechanical character in the Star Wars universe */
 export namespace DroidResolvers {
-  export interface Resolvers<Context = any, Parent = Droid> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the droid */;
-    name?: NameResolver<string, Parent, Context> /** What others call this droid */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the droid */;
+    name?: NameResolver<string, any, Context> /** What others call this droid */;
     friends?: FriendsResolver<
       ReadonlyArray<Character | null> | null,
-      Parent,
+      any,
       Context
     > /** This droid's friends, or an empty list if they have none */;
     friendsConnection?: FriendsConnectionResolver<
       FriendsConnection,
-      Parent,
+      any,
       Context
     > /** The friends of the droid exposed as a connection with edges */;
-    appearsIn?: AppearsInResolver<
-      ReadonlyArray<Episode | null>,
-      Parent,
-      Context
-    > /** The movies this droid appears in */;
-    primaryFunction?: PrimaryFunctionResolver<string | null, Parent, Context> /** This droid's primary function */;
+    appearsIn?: AppearsInResolver<ReadonlyArray<Episode | null>, any, Context> /** The movies this droid appears in */;
+    primaryFunction?: PrimaryFunctionResolver<string | null, any, Context> /** This droid's primary function */;
   }
 
-  export type IdResolver<R = string, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-  export type FriendsResolver<R = ReadonlyArray<Character | null> | null, Parent = Droid, Context = any> = Resolver<
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FriendsResolver<R = ReadonlyArray<Character | null> | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type FriendsConnectionResolver<R = FriendsConnection, Parent = Droid, Context = any> = Resolver<
+  export type FriendsConnectionResolver<R = FriendsConnection, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -438,20 +407,20 @@ export namespace DroidResolvers {
     after?: string | null;
   }
 
-  export type AppearsInResolver<R = ReadonlyArray<Episode | null>, Parent = Droid, Context = any> = Resolver<
+  export type AppearsInResolver<R = ReadonlyArray<Episode | null>, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type PrimaryFunctionResolver<R = string | null, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
+  export type PrimaryFunctionResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** The mutation type, represents all updates we can make to our data */
 export namespace MutationResolvers {
-  export interface Resolvers<Context = any, Parent = Mutation> {
-    createReview?: CreateReviewResolver<Review | null, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    createReview?: CreateReviewResolver<Review | null, any, Context>;
   }
 
-  export type CreateReviewResolver<R = Review | null, Parent = Mutation, Context = any> = Resolver<
+  export type CreateReviewResolver<R = Review | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -643,11 +612,11 @@ export namespace HeroParentTypeDependentField {
   };
 
   export type _Friends = {
-    readonly __typename?: __HumanInlineFragment['__typename'];
+    readonly __typename?: _HumanInlineFragment['__typename'];
     readonly name: string;
-  } & (__HumanInlineFragment);
+  } & (_HumanInlineFragment);
 
-  export type __HumanInlineFragment = {
+  export type _HumanInlineFragment = {
     readonly __typename?: 'Human';
     readonly height?: number | null;
   };

--- a/dev-test/star-wars/types.noNamespaces.ts
+++ b/dev-test/star-wars/types.noNamespaces.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -22,10 +22,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 };
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
 
 /** A character from the Star Wars universe */
 export interface Character {
@@ -165,177 +161,157 @@ export enum LengthUnit {
 export type SearchResult = Human | Droid | Starship;
 
 /** The query type, represents all of the entry points into our object graph */
-export interface QueryResolvers<Context = any, Parent = Query> {
-  hero?: QueryHeroResolver<Character | null, Parent, Context>;
-  reviews?: QueryReviewsResolver<Review[] | null, Parent, Context>;
-  search?: QuerySearchResolver<SearchResult[] | null, Parent, Context>;
-  character?: QueryCharacterResolver<Character | null, Parent, Context>;
-  droid?: QueryDroidResolver<Droid | null, Parent, Context>;
-  human?: QueryHumanResolver<Human | null, Parent, Context>;
-  starship?: QueryStarshipResolver<Starship | null, Parent, Context>;
+export interface QueryResolvers<Context = any> {
+  hero?: QueryHeroResolver<Character | null, any, Context>;
+  reviews?: QueryReviewsResolver<Review[] | null, any, Context>;
+  search?: QuerySearchResolver<SearchResult[] | null, any, Context>;
+  character?: QueryCharacterResolver<Character | null, any, Context>;
+  droid?: QueryDroidResolver<Droid | null, any, Context>;
+  human?: QueryHumanResolver<Human | null, any, Context>;
+  starship?: QueryStarshipResolver<Starship | null, any, Context>;
 }
 
-export type QueryHeroResolver<R = Character | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+export type QueryHeroResolver<R = Character | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface QueryHeroArgs {
   episode?: Episode | null;
 }
 
-export type QueryReviewsResolver<R = Review[] | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+export type QueryReviewsResolver<R = Review[] | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface QueryReviewsArgs {
   episode: Episode;
 }
 
-export type QuerySearchResolver<R = SearchResult[] | null, Parent = Query, Context = any> = Resolver<
-  R,
-  Parent,
-  Context
->;
+export type QuerySearchResolver<R = SearchResult[] | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface QuerySearchArgs {
   text?: string | null;
 }
 
-export type QueryCharacterResolver<R = Character | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+export type QueryCharacterResolver<R = Character | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface QueryCharacterArgs {
   id: string;
 }
 
-export type QueryDroidResolver<R = Droid | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+export type QueryDroidResolver<R = Droid | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface QueryDroidArgs {
   id: string;
 }
 
-export type QueryHumanResolver<R = Human | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+export type QueryHumanResolver<R = Human | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface QueryHumanArgs {
   id: string;
 }
 
-export type QueryStarshipResolver<R = Starship | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+export type QueryStarshipResolver<R = Starship | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface QueryStarshipArgs {
   id: string;
 }
 
 /** A connection object for a character's friends */
-export interface FriendsConnectionResolvers<Context = any, Parent = FriendsConnection> {
-  totalCount?: FriendsConnectionTotalCountResolver<number | null, Parent, Context> /** The total number of friends */;
+export interface FriendsConnectionResolvers<Context = any> {
+  totalCount?: FriendsConnectionTotalCountResolver<number | null, any, Context> /** The total number of friends */;
   edges?: FriendsConnectionEdgesResolver<
     FriendsEdge[] | null,
-    Parent,
+    any,
     Context
   > /** The edges for each of the character's friends. */;
   friends?: FriendsConnectionFriendsResolver<
     Character[] | null,
-    Parent,
+    any,
     Context
   > /** A list of the friends, as a convenience when edges are not needed. */;
   pageInfo?: FriendsConnectionPageInfoResolver<
     PageInfo,
-    Parent,
+    any,
     Context
   > /** Information for paginating this connection */;
 }
 
-export type FriendsConnectionTotalCountResolver<
-  R = number | null,
-  Parent = FriendsConnection,
-  Context = any
-> = Resolver<R, Parent, Context>;
-export type FriendsConnectionEdgesResolver<
-  R = FriendsEdge[] | null,
-  Parent = FriendsConnection,
-  Context = any
-> = Resolver<R, Parent, Context>;
-export type FriendsConnectionFriendsResolver<
-  R = Character[] | null,
-  Parent = FriendsConnection,
-  Context = any
-> = Resolver<R, Parent, Context>;
-export type FriendsConnectionPageInfoResolver<R = PageInfo, Parent = FriendsConnection, Context = any> = Resolver<
+export type FriendsConnectionTotalCountResolver<R = number | null, Parent = any, Context = any> = Resolver<
   R,
   Parent,
   Context
 >;
+export type FriendsConnectionEdgesResolver<R = FriendsEdge[] | null, Parent = any, Context = any> = Resolver<
+  R,
+  Parent,
+  Context
+>;
+export type FriendsConnectionFriendsResolver<R = Character[] | null, Parent = any, Context = any> = Resolver<
+  R,
+  Parent,
+  Context
+>;
+export type FriendsConnectionPageInfoResolver<R = PageInfo, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 /** An edge object for a character's friends */
-export interface FriendsEdgeResolvers<Context = any, Parent = FriendsEdge> {
-  cursor?: FriendsEdgeCursorResolver<string, Parent, Context> /** A cursor used for pagination */;
+export interface FriendsEdgeResolvers<Context = any> {
+  cursor?: FriendsEdgeCursorResolver<string, any, Context> /** A cursor used for pagination */;
   node?: FriendsEdgeNodeResolver<
     Character | null,
-    Parent,
+    any,
     Context
   > /** The character represented by this friendship edge */;
 }
 
-export type FriendsEdgeCursorResolver<R = string, Parent = FriendsEdge, Context = any> = Resolver<R, Parent, Context>;
-export type FriendsEdgeNodeResolver<R = Character | null, Parent = FriendsEdge, Context = any> = Resolver<
-  R,
-  Parent,
-  Context
->;
+export type FriendsEdgeCursorResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type FriendsEdgeNodeResolver<R = Character | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 /** Information for paginating this connection */
-export interface PageInfoResolvers<Context = any, Parent = PageInfo> {
-  startCursor?: PageInfoStartCursorResolver<string | null, Parent, Context>;
-  endCursor?: PageInfoEndCursorResolver<string | null, Parent, Context>;
-  hasNextPage?: PageInfoHasNextPageResolver<boolean, Parent, Context>;
+export interface PageInfoResolvers<Context = any> {
+  startCursor?: PageInfoStartCursorResolver<string | null, any, Context>;
+  endCursor?: PageInfoEndCursorResolver<string | null, any, Context>;
+  hasNextPage?: PageInfoHasNextPageResolver<boolean, any, Context>;
 }
 
-export type PageInfoStartCursorResolver<R = string | null, Parent = PageInfo, Context = any> = Resolver<
-  R,
-  Parent,
-  Context
->;
-export type PageInfoEndCursorResolver<R = string | null, Parent = PageInfo, Context = any> = Resolver<
-  R,
-  Parent,
-  Context
->;
-export type PageInfoHasNextPageResolver<R = boolean, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
+export type PageInfoStartCursorResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type PageInfoEndCursorResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type PageInfoHasNextPageResolver<R = boolean, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 /** Represents a review for a movie */
-export interface ReviewResolvers<Context = any, Parent = Review> {
-  stars?: ReviewStarsResolver<number, Parent, Context> /** The number of stars this review gave, 1-5 */;
-  commentary?: ReviewCommentaryResolver<string | null, Parent, Context> /** Comment about the movie */;
+export interface ReviewResolvers<Context = any> {
+  stars?: ReviewStarsResolver<number, any, Context> /** The number of stars this review gave, 1-5 */;
+  commentary?: ReviewCommentaryResolver<string | null, any, Context> /** Comment about the movie */;
 }
 
-export type ReviewStarsResolver<R = number, Parent = Review, Context = any> = Resolver<R, Parent, Context>;
-export type ReviewCommentaryResolver<R = string | null, Parent = Review, Context = any> = Resolver<R, Parent, Context>;
+export type ReviewStarsResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type ReviewCommentaryResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 /** A humanoid creature from the Star Wars universe */
-export interface HumanResolvers<Context = any, Parent = Human> {
-  id?: HumanIdResolver<string, Parent, Context> /** The ID of the human */;
-  name?: HumanNameResolver<string, Parent, Context> /** What this human calls themselves */;
+export interface HumanResolvers<Context = any> {
+  id?: HumanIdResolver<string, any, Context> /** The ID of the human */;
+  name?: HumanNameResolver<string, any, Context> /** What this human calls themselves */;
   homePlanet?: HumanHomePlanetResolver<
     string | null,
-    Parent,
+    any,
     Context
   > /** The home planet of the human, or null if unknown */;
-  height?: HumanHeightResolver<number | null, Parent, Context> /** Height in the preferred unit, default is meters */;
-  mass?: HumanMassResolver<number | null, Parent, Context> /** Mass in kilograms, or null if unknown */;
+  height?: HumanHeightResolver<number | null, any, Context> /** Height in the preferred unit, default is meters */;
+  mass?: HumanMassResolver<number | null, any, Context> /** Mass in kilograms, or null if unknown */;
   friends?: HumanFriendsResolver<
     Character[] | null,
-    Parent,
+    any,
     Context
   > /** This human's friends, or an empty list if they have none */;
   friendsConnection?: HumanFriendsConnectionResolver<
     FriendsConnection,
-    Parent,
+    any,
     Context
   > /** The friends of the human exposed as a connection with edges */;
-  appearsIn?: HumanAppearsInResolver<Episode[], Parent, Context> /** The movies this human appears in */;
+  appearsIn?: HumanAppearsInResolver<Episode[], any, Context> /** The movies this human appears in */;
   starships?: HumanStarshipsResolver<
     Starship[] | null,
-    Parent,
+    any,
     Context
   > /** A list of starships this person has piloted, or an empty list if none */;
 }
 
-export type HumanIdResolver<R = string, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-export type HumanNameResolver<R = string, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-export type HumanHomePlanetResolver<R = string | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-export type HumanHeightResolver<R = number | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
+export type HumanIdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type HumanNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type HumanHomePlanetResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type HumanHeightResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface HumanHeightArgs {
   unit?: LengthUnit | null;
 }
 
-export type HumanMassResolver<R = number | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-export type HumanFriendsResolver<R = Character[] | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-export type HumanFriendsConnectionResolver<R = FriendsConnection, Parent = Human, Context = any> = Resolver<
+export type HumanMassResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type HumanFriendsResolver<R = Character[] | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type HumanFriendsConnectionResolver<R = FriendsConnection, Parent = any, Context = any> = Resolver<
   R,
   Parent,
   Context
@@ -345,44 +321,44 @@ export interface HumanFriendsConnectionArgs {
   after?: string | null;
 }
 
-export type HumanAppearsInResolver<R = Episode[], Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-export type HumanStarshipsResolver<R = Starship[] | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
+export type HumanAppearsInResolver<R = Episode[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type HumanStarshipsResolver<R = Starship[] | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 
-export interface StarshipResolvers<Context = any, Parent = Starship> {
-  id?: StarshipIdResolver<string, Parent, Context> /** The ID of the starship */;
-  name?: StarshipNameResolver<string, Parent, Context> /** The name of the starship */;
-  length?: StarshipLengthResolver<number | null, Parent, Context> /** Length of the starship, along the longest axis */;
+export interface StarshipResolvers<Context = any> {
+  id?: StarshipIdResolver<string, any, Context> /** The ID of the starship */;
+  name?: StarshipNameResolver<string, any, Context> /** The name of the starship */;
+  length?: StarshipLengthResolver<number | null, any, Context> /** Length of the starship, along the longest axis */;
 }
 
-export type StarshipIdResolver<R = string, Parent = Starship, Context = any> = Resolver<R, Parent, Context>;
-export type StarshipNameResolver<R = string, Parent = Starship, Context = any> = Resolver<R, Parent, Context>;
-export type StarshipLengthResolver<R = number | null, Parent = Starship, Context = any> = Resolver<R, Parent, Context>;
+export type StarshipIdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type StarshipNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type StarshipLengthResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface StarshipLengthArgs {
   unit?: LengthUnit | null;
 }
 
 /** An autonomous mechanical character in the Star Wars universe */
-export interface DroidResolvers<Context = any, Parent = Droid> {
-  id?: DroidIdResolver<string, Parent, Context> /** The ID of the droid */;
-  name?: DroidNameResolver<string, Parent, Context> /** What others call this droid */;
+export interface DroidResolvers<Context = any> {
+  id?: DroidIdResolver<string, any, Context> /** The ID of the droid */;
+  name?: DroidNameResolver<string, any, Context> /** What others call this droid */;
   friends?: DroidFriendsResolver<
     Character[] | null,
-    Parent,
+    any,
     Context
   > /** This droid's friends, or an empty list if they have none */;
   friendsConnection?: DroidFriendsConnectionResolver<
     FriendsConnection,
-    Parent,
+    any,
     Context
   > /** The friends of the droid exposed as a connection with edges */;
-  appearsIn?: DroidAppearsInResolver<Episode[], Parent, Context> /** The movies this droid appears in */;
-  primaryFunction?: DroidPrimaryFunctionResolver<string | null, Parent, Context> /** This droid's primary function */;
+  appearsIn?: DroidAppearsInResolver<Episode[], any, Context> /** The movies this droid appears in */;
+  primaryFunction?: DroidPrimaryFunctionResolver<string | null, any, Context> /** This droid's primary function */;
 }
 
-export type DroidIdResolver<R = string, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-export type DroidNameResolver<R = string, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-export type DroidFriendsResolver<R = Character[] | null, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-export type DroidFriendsConnectionResolver<R = FriendsConnection, Parent = Droid, Context = any> = Resolver<
+export type DroidIdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type DroidNameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type DroidFriendsResolver<R = Character[] | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type DroidFriendsConnectionResolver<R = FriendsConnection, Parent = any, Context = any> = Resolver<
   R,
   Parent,
   Context
@@ -392,22 +368,14 @@ export interface DroidFriendsConnectionArgs {
   after?: string | null;
 }
 
-export type DroidAppearsInResolver<R = Episode[], Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-export type DroidPrimaryFunctionResolver<R = string | null, Parent = Droid, Context = any> = Resolver<
-  R,
-  Parent,
-  Context
->;
+export type DroidAppearsInResolver<R = Episode[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
+export type DroidPrimaryFunctionResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 /** The mutation type, represents all updates we can make to our data */
-export interface MutationResolvers<Context = any, Parent = Mutation> {
-  createReview?: MutationCreateReviewResolver<Review | null, Parent, Context>;
+export interface MutationResolvers<Context = any> {
+  createReview?: MutationCreateReviewResolver<Review | null, any, Context>;
 }
 
-export type MutationCreateReviewResolver<R = Review | null, Parent = Mutation, Context = any> = Resolver<
-  R,
-  Parent,
-  Context
->;
+export type MutationCreateReviewResolver<R = Review | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 export interface MutationCreateReviewArgs {
   episode?: Episode | null;
   review: ReviewInput;
@@ -578,11 +546,11 @@ export type HeroParentTypeDependentFieldDroidInlineFragment = {
 };
 
 export type HeroParentTypeDependentField_Friends = {
-  __typename?: HeroParentTypeDependentField__HumanInlineFragment['__typename'];
+  __typename?: HeroParentTypeDependentField_HumanInlineFragment['__typename'];
   name: string;
-} & (HeroParentTypeDependentField__HumanInlineFragment);
+} & (HeroParentTypeDependentField_HumanInlineFragment);
 
-export type HeroParentTypeDependentField__HumanInlineFragment = {
+export type HeroParentTypeDependentField_HumanInlineFragment = {
   __typename?: 'Human';
   height?: number | null;
 };

--- a/dev-test/star-wars/types.skipSchema.ts
+++ b/dev-test/star-wars/types.skipSchema.ts
@@ -204,11 +204,11 @@ export namespace HeroParentTypeDependentField {
   };
 
   export type _Friends = {
-    __typename?: __HumanInlineFragment['__typename'];
+    __typename?: _HumanInlineFragment['__typename'];
     name: string;
-  } & (__HumanInlineFragment);
+  } & (_HumanInlineFragment);
 
-  export type __HumanInlineFragment = {
+  export type _HumanInlineFragment = {
     __typename?: 'Human';
     height?: number | null;
   };

--- a/dev-test/star-wars/types.ts
+++ b/dev-test/star-wars/types.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -22,10 +22,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 };
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
 
 /** A character from the Star Wars universe */
 export interface Character {
@@ -166,27 +162,22 @@ export type SearchResult = Human | Droid | Starship;
 
 /** The query type, represents all of the entry points into our object graph */
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    hero?: HeroResolver<Character | null, Parent, Context>;
-    reviews?: ReviewsResolver<(Review | null)[] | null, Parent, Context>;
-    search?: SearchResolver<(SearchResult | null)[] | null, Parent, Context>;
-    character?: CharacterResolver<Character | null, Parent, Context>;
-    droid?: DroidResolver<Droid | null, Parent, Context>;
-    human?: HumanResolver<Human | null, Parent, Context>;
-    starship?: StarshipResolver<Starship | null, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    hero?: HeroResolver<Character | null, any, Context>;
+    reviews?: ReviewsResolver<(Review | null)[] | null, any, Context>;
+    search?: SearchResolver<(SearchResult | null)[] | null, any, Context>;
+    character?: CharacterResolver<Character | null, any, Context>;
+    droid?: DroidResolver<Droid | null, any, Context>;
+    human?: HumanResolver<Human | null, any, Context>;
+    starship?: StarshipResolver<Starship | null, any, Context>;
   }
 
-  export type HeroResolver<R = Character | null, Parent = Query, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    HeroArgs
-  >;
+  export type HeroResolver<R = Character | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HeroArgs>;
   export interface HeroArgs {
     episode?: Episode | null;
   }
 
-  export type ReviewsResolver<R = (Review | null)[] | null, Parent = Query, Context = any> = Resolver<
+  export type ReviewsResolver<R = (Review | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -196,7 +187,7 @@ export namespace QueryResolvers {
     episode: Episode;
   }
 
-  export type SearchResolver<R = (SearchResult | null)[] | null, Parent = Query, Context = any> = Resolver<
+  export type SearchResolver<R = (SearchResult | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -206,7 +197,7 @@ export namespace QueryResolvers {
     text?: string | null;
   }
 
-  export type CharacterResolver<R = Character | null, Parent = Query, Context = any> = Resolver<
+  export type CharacterResolver<R = Character | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -216,17 +207,17 @@ export namespace QueryResolvers {
     id: string;
   }
 
-  export type DroidResolver<R = Droid | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, DroidArgs>;
+  export type DroidResolver<R = Droid | null, Parent = any, Context = any> = Resolver<R, Parent, Context, DroidArgs>;
   export interface DroidArgs {
     id: string;
   }
 
-  export type HumanResolver<R = Human | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, HumanArgs>;
+  export type HumanResolver<R = Human | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HumanArgs>;
   export interface HumanArgs {
     id: string;
   }
 
-  export type StarshipResolver<R = Starship | null, Parent = Query, Context = any> = Resolver<
+  export type StarshipResolver<R = Starship | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -238,120 +229,111 @@ export namespace QueryResolvers {
 }
 /** A connection object for a character's friends */
 export namespace FriendsConnectionResolvers {
-  export interface Resolvers<Context = any, Parent = FriendsConnection> {
-    totalCount?: TotalCountResolver<number | null, Parent, Context> /** The total number of friends */;
+  export interface Resolvers<Context = any> {
+    totalCount?: TotalCountResolver<number | null, any, Context> /** The total number of friends */;
     edges?: EdgesResolver<
       (FriendsEdge | null)[] | null,
-      Parent,
+      any,
       Context
     > /** The edges for each of the character's friends. */;
     friends?: FriendsResolver<
       (Character | null)[] | null,
-      Parent,
+      any,
       Context
     > /** A list of the friends, as a convenience when edges are not needed. */;
-    pageInfo?: PageInfoResolver<PageInfo, Parent, Context> /** Information for paginating this connection */;
+    pageInfo?: PageInfoResolver<PageInfo, any, Context> /** Information for paginating this connection */;
   }
 
-  export type TotalCountResolver<R = number | null, Parent = FriendsConnection, Context = any> = Resolver<
+  export type TotalCountResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type EdgesResolver<R = (FriendsEdge | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type EdgesResolver<R = (FriendsEdge | null)[] | null, Parent = FriendsConnection, Context = any> = Resolver<
+  export type FriendsResolver<R = (Character | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type FriendsResolver<R = (Character | null)[] | null, Parent = FriendsConnection, Context = any> = Resolver<
-    R,
-    Parent,
-    Context
-  >;
-  export type PageInfoResolver<R = PageInfo, Parent = FriendsConnection, Context = any> = Resolver<R, Parent, Context>;
+  export type PageInfoResolver<R = PageInfo, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** An edge object for a character's friends */
 export namespace FriendsEdgeResolvers {
-  export interface Resolvers<Context = any, Parent = FriendsEdge> {
-    cursor?: CursorResolver<string, Parent, Context> /** A cursor used for pagination */;
-    node?: NodeResolver<Character | null, Parent, Context> /** The character represented by this friendship edge */;
+  export interface Resolvers<Context = any> {
+    cursor?: CursorResolver<string, any, Context> /** A cursor used for pagination */;
+    node?: NodeResolver<Character | null, any, Context> /** The character represented by this friendship edge */;
   }
 
-  export type CursorResolver<R = string, Parent = FriendsEdge, Context = any> = Resolver<R, Parent, Context>;
-  export type NodeResolver<R = Character | null, Parent = FriendsEdge, Context = any> = Resolver<R, Parent, Context>;
+  export type CursorResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NodeResolver<R = Character | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Information for paginating this connection */
 export namespace PageInfoResolvers {
-  export interface Resolvers<Context = any, Parent = PageInfo> {
-    startCursor?: StartCursorResolver<string | null, Parent, Context>;
-    endCursor?: EndCursorResolver<string | null, Parent, Context>;
-    hasNextPage?: HasNextPageResolver<boolean, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    startCursor?: StartCursorResolver<string | null, any, Context>;
+    endCursor?: EndCursorResolver<string | null, any, Context>;
+    hasNextPage?: HasNextPageResolver<boolean, any, Context>;
   }
 
-  export type StartCursorResolver<R = string | null, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
-  export type EndCursorResolver<R = string | null, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
-  export type HasNextPageResolver<R = boolean, Parent = PageInfo, Context = any> = Resolver<R, Parent, Context>;
+  export type StartCursorResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type EndCursorResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HasNextPageResolver<R = boolean, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** Represents a review for a movie */
 export namespace ReviewResolvers {
-  export interface Resolvers<Context = any, Parent = Review> {
-    stars?: StarsResolver<number, Parent, Context> /** The number of stars this review gave, 1-5 */;
-    commentary?: CommentaryResolver<string | null, Parent, Context> /** Comment about the movie */;
+  export interface Resolvers<Context = any> {
+    stars?: StarsResolver<number, any, Context> /** The number of stars this review gave, 1-5 */;
+    commentary?: CommentaryResolver<string | null, any, Context> /** Comment about the movie */;
   }
 
-  export type StarsResolver<R = number, Parent = Review, Context = any> = Resolver<R, Parent, Context>;
-  export type CommentaryResolver<R = string | null, Parent = Review, Context = any> = Resolver<R, Parent, Context>;
+  export type StarsResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type CommentaryResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** A humanoid creature from the Star Wars universe */
 export namespace HumanResolvers {
-  export interface Resolvers<Context = any, Parent = Human> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the human */;
-    name?: NameResolver<string, Parent, Context> /** What this human calls themselves */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the human */;
+    name?: NameResolver<string, any, Context> /** What this human calls themselves */;
     homePlanet?: HomePlanetResolver<
       string | null,
-      Parent,
+      any,
       Context
     > /** The home planet of the human, or null if unknown */;
-    height?: HeightResolver<number | null, Parent, Context> /** Height in the preferred unit, default is meters */;
-    mass?: MassResolver<number | null, Parent, Context> /** Mass in kilograms, or null if unknown */;
+    height?: HeightResolver<number | null, any, Context> /** Height in the preferred unit, default is meters */;
+    mass?: MassResolver<number | null, any, Context> /** Mass in kilograms, or null if unknown */;
     friends?: FriendsResolver<
       (Character | null)[] | null,
-      Parent,
+      any,
       Context
     > /** This human's friends, or an empty list if they have none */;
     friendsConnection?: FriendsConnectionResolver<
       FriendsConnection,
-      Parent,
+      any,
       Context
     > /** The friends of the human exposed as a connection with edges */;
-    appearsIn?: AppearsInResolver<(Episode | null)[], Parent, Context> /** The movies this human appears in */;
+    appearsIn?: AppearsInResolver<(Episode | null)[], any, Context> /** The movies this human appears in */;
     starships?: StarshipsResolver<
       (Starship | null)[] | null,
-      Parent,
+      any,
       Context
     > /** A list of starships this person has piloted, or an empty list if none */;
   }
 
-  export type IdResolver<R = string, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type HomePlanetResolver<R = string | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type HeightResolver<R = number | null, Parent = Human, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    HeightArgs
-  >;
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HomePlanetResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type HeightResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context, HeightArgs>;
   export interface HeightArgs {
     unit?: LengthUnit | null;
   }
 
-  export type MassResolver<R = number | null, Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type FriendsResolver<R = (Character | null)[] | null, Parent = Human, Context = any> = Resolver<
+  export type MassResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FriendsResolver<R = (Character | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type FriendsConnectionResolver<R = FriendsConnection, Parent = Human, Context = any> = Resolver<
+  export type FriendsConnectionResolver<R = FriendsConnection, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -362,8 +344,8 @@ export namespace HumanResolvers {
     after?: string | null;
   }
 
-  export type AppearsInResolver<R = (Episode | null)[], Parent = Human, Context = any> = Resolver<R, Parent, Context>;
-  export type StarshipsResolver<R = (Starship | null)[] | null, Parent = Human, Context = any> = Resolver<
+  export type AppearsInResolver<R = (Episode | null)[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type StarshipsResolver<R = (Starship | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
@@ -371,51 +353,46 @@ export namespace HumanResolvers {
 }
 
 export namespace StarshipResolvers {
-  export interface Resolvers<Context = any, Parent = Starship> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the starship */;
-    name?: NameResolver<string, Parent, Context> /** The name of the starship */;
-    length?: LengthResolver<number | null, Parent, Context> /** Length of the starship, along the longest axis */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the starship */;
+    name?: NameResolver<string, any, Context> /** The name of the starship */;
+    length?: LengthResolver<number | null, any, Context> /** Length of the starship, along the longest axis */;
   }
 
-  export type IdResolver<R = string, Parent = Starship, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Starship, Context = any> = Resolver<R, Parent, Context>;
-  export type LengthResolver<R = number | null, Parent = Starship, Context = any> = Resolver<
-    R,
-    Parent,
-    Context,
-    LengthArgs
-  >;
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type LengthResolver<R = number | null, Parent = any, Context = any> = Resolver<R, Parent, Context, LengthArgs>;
   export interface LengthArgs {
     unit?: LengthUnit | null;
   }
 }
 /** An autonomous mechanical character in the Star Wars universe */
 export namespace DroidResolvers {
-  export interface Resolvers<Context = any, Parent = Droid> {
-    id?: IdResolver<string, Parent, Context> /** The ID of the droid */;
-    name?: NameResolver<string, Parent, Context> /** What others call this droid */;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<string, any, Context> /** The ID of the droid */;
+    name?: NameResolver<string, any, Context> /** What others call this droid */;
     friends?: FriendsResolver<
       (Character | null)[] | null,
-      Parent,
+      any,
       Context
     > /** This droid's friends, or an empty list if they have none */;
     friendsConnection?: FriendsConnectionResolver<
       FriendsConnection,
-      Parent,
+      any,
       Context
     > /** The friends of the droid exposed as a connection with edges */;
-    appearsIn?: AppearsInResolver<(Episode | null)[], Parent, Context> /** The movies this droid appears in */;
-    primaryFunction?: PrimaryFunctionResolver<string | null, Parent, Context> /** This droid's primary function */;
+    appearsIn?: AppearsInResolver<(Episode | null)[], any, Context> /** The movies this droid appears in */;
+    primaryFunction?: PrimaryFunctionResolver<string | null, any, Context> /** This droid's primary function */;
   }
 
-  export type IdResolver<R = string, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-  export type FriendsResolver<R = (Character | null)[] | null, Parent = Droid, Context = any> = Resolver<
+  export type IdResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type FriendsResolver<R = (Character | null)[] | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type FriendsConnectionResolver<R = FriendsConnection, Parent = Droid, Context = any> = Resolver<
+  export type FriendsConnectionResolver<R = FriendsConnection, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -426,16 +403,16 @@ export namespace DroidResolvers {
     after?: string | null;
   }
 
-  export type AppearsInResolver<R = (Episode | null)[], Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
-  export type PrimaryFunctionResolver<R = string | null, Parent = Droid, Context = any> = Resolver<R, Parent, Context>;
+  export type AppearsInResolver<R = (Episode | null)[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type PrimaryFunctionResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }
 /** The mutation type, represents all updates we can make to our data */
 export namespace MutationResolvers {
-  export interface Resolvers<Context = any, Parent = Mutation> {
-    createReview?: CreateReviewResolver<Review | null, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    createReview?: CreateReviewResolver<Review | null, any, Context>;
   }
 
-  export type CreateReviewResolver<R = Review | null, Parent = Mutation, Context = any> = Resolver<
+  export type CreateReviewResolver<R = Review | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -627,11 +604,11 @@ export namespace HeroParentTypeDependentField {
   };
 
   export type _Friends = {
-    __typename?: __HumanInlineFragment['__typename'];
+    __typename?: _HumanInlineFragment['__typename'];
     name: string;
-  } & (__HumanInlineFragment);
+  } & (_HumanInlineFragment);
 
-  export type __HumanInlineFragment = {
+  export type _HumanInlineFragment = {
     __typename?: 'Human';
     height?: number | null;
   };

--- a/dev-test/test-schema/typings.avoidOptionals.ts
+++ b/dev-test/test-schema/typings.avoidOptionals.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -23,10 +23,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
   ): R | Result | Promise<R | Result>;
 };
 
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
-
 export interface Query {
   allUsers: (User | null)[];
   userById: User | null;
@@ -42,13 +38,13 @@ export interface UserByIdQueryArgs {
 }
 
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    allUsers?: AllUsersResolver<(User | null)[], Parent, Context>;
-    userById?: UserByIdResolver<User | null, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    allUsers?: AllUsersResolver<(User | null)[], any, Context>;
+    userById?: UserByIdResolver<User | null, any, Context>;
   }
 
-  export type AllUsersResolver<R = (User | null)[], Parent = Query, Context = any> = Resolver<R, Parent, Context>;
-  export type UserByIdResolver<R = User | null, Parent = Query, Context = any> = Resolver<
+  export type AllUsersResolver<R = (User | null)[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type UserByIdResolver<R = User | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -60,13 +56,13 @@ export namespace QueryResolvers {
 }
 
 export namespace UserResolvers {
-  export interface Resolvers<Context = any, Parent = User> {
-    id?: IdResolver<number, Parent, Context>;
-    name?: NameResolver<string, Parent, Context>;
-    email?: EmailResolver<string, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<number, any, Context>;
+    name?: NameResolver<string, any, Context>;
+    email?: EmailResolver<string, any, Context>;
   }
 
-  export type IdResolver<R = number, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type EmailResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type EmailResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }

--- a/dev-test/test-schema/typings.immutableTypes.ts
+++ b/dev-test/test-schema/typings.immutableTypes.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -23,10 +23,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
   ): R | Result | Promise<R | Result>;
 };
 
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
-
 export interface Query {
   readonly allUsers: ReadonlyArray<User | null>;
   readonly userById?: User | null;
@@ -42,17 +38,17 @@ export interface UserByIdQueryArgs {
 }
 
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    allUsers?: AllUsersResolver<ReadonlyArray<User | null>, Parent, Context>;
-    userById?: UserByIdResolver<User | null, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    allUsers?: AllUsersResolver<ReadonlyArray<User | null>, any, Context>;
+    userById?: UserByIdResolver<User | null, any, Context>;
   }
 
-  export type AllUsersResolver<R = ReadonlyArray<User | null>, Parent = Query, Context = any> = Resolver<
+  export type AllUsersResolver<R = ReadonlyArray<User | null>, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context
   >;
-  export type UserByIdResolver<R = User | null, Parent = Query, Context = any> = Resolver<
+  export type UserByIdResolver<R = User | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -64,13 +60,13 @@ export namespace QueryResolvers {
 }
 
 export namespace UserResolvers {
-  export interface Resolvers<Context = any, Parent = User> {
-    id?: IdResolver<number, Parent, Context>;
-    name?: NameResolver<string, Parent, Context>;
-    email?: EmailResolver<string, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<number, any, Context>;
+    name?: NameResolver<string, any, Context>;
+    email?: EmailResolver<string, any, Context>;
   }
 
-  export type IdResolver<R = number, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type EmailResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type EmailResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }

--- a/dev-test/test-schema/typings.ts
+++ b/dev-test/test-schema/typings.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -23,10 +23,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
   ): R | Result | Promise<R | Result>;
 };
 
-export type Resolver<Result, Parent = any, Context = any, Args = any> =
-  | QueryResolver<Result, Parent, Context, Args>
-  | SubscriptionResolver<Result, Parent, Context, Args>;
-
 export interface Query {
   allUsers: (User | null)[];
   userById?: User | null;
@@ -42,13 +38,13 @@ export interface UserByIdQueryArgs {
 }
 
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any, Parent = Query> {
-    allUsers?: AllUsersResolver<(User | null)[], Parent, Context>;
-    userById?: UserByIdResolver<User | null, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    allUsers?: AllUsersResolver<(User | null)[], any, Context>;
+    userById?: UserByIdResolver<User | null, any, Context>;
   }
 
-  export type AllUsersResolver<R = (User | null)[], Parent = Query, Context = any> = Resolver<R, Parent, Context>;
-  export type UserByIdResolver<R = User | null, Parent = Query, Context = any> = Resolver<
+  export type AllUsersResolver<R = (User | null)[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type UserByIdResolver<R = User | null, Parent = any, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -60,13 +56,13 @@ export namespace QueryResolvers {
 }
 
 export namespace UserResolvers {
-  export interface Resolvers<Context = any, Parent = User> {
-    id?: IdResolver<number, Parent, Context>;
-    name?: NameResolver<string, Parent, Context>;
-    email?: EmailResolver<string, Parent, Context>;
+  export interface Resolvers<Context = any> {
+    id?: IdResolver<number, any, Context>;
+    name?: NameResolver<string, any, Context>;
+    email?: EmailResolver<string, any, Context>;
   }
 
-  export type IdResolver<R = number, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-  export type EmailResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type EmailResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
 }

--- a/packages/graphql-codegen-compiler/src/flatten-types.ts
+++ b/packages/graphql-codegen-compiler/src/flatten-types.ts
@@ -73,20 +73,24 @@ export function flattenSelectionSet(selectionSet: SelectionSetItem[], result: Fl
 
 export function flattenTypes(document: Document): FlattenDocument {
   return {
-    operations: document.operations.map<FlattenOperation>((operation: Operation): FlattenOperation => {
-      return {
-        isFlatten: true,
-        ...operation,
-        innerModels: flattenSelectionSet(operation.selectionSet)
-      } as FlattenOperation;
-    }),
-    fragments: document.fragments.map<FlattenFragment>((fragment: Fragment): FlattenFragment => {
-      return {
-        isFlatten: true,
-        ...fragment,
-        innerModels: flattenSelectionSet(fragment.selectionSet)
-      } as FlattenFragment;
-    }),
+    operations: document.operations.map<FlattenOperation>(
+      (operation: Operation): FlattenOperation => {
+        return {
+          isFlatten: true,
+          ...operation,
+          innerModels: flattenSelectionSet(operation.selectionSet)
+        } as FlattenOperation;
+      }
+    ),
+    fragments: document.fragments.map<FlattenFragment>(
+      (fragment: Fragment): FlattenFragment => {
+        return {
+          isFlatten: true,
+          ...fragment,
+          innerModels: flattenSelectionSet(fragment.selectionSet)
+        } as FlattenFragment;
+      }
+    ),
     hasOperations: document.hasOperations,
     hasFragments: document.hasFragments
   };

--- a/packages/graphql-codegen-core/src/schema/resolve-type-indicators.ts
+++ b/packages/graphql-codegen-core/src/schema/resolve-type-indicators.ts
@@ -5,9 +5,7 @@ import {
   GraphQLNamedType,
   GraphQLObjectType,
   GraphQLScalarType,
-  GraphQLType,
-  GraphQLUnionType,
-  isLeafType
+  GraphQLUnionType
 } from 'graphql';
 
 export interface NamedTypeIndicators {

--- a/packages/graphql-codegen-core/src/schema/resolve-type.ts
+++ b/packages/graphql-codegen-core/src/schema/resolve-type.ts
@@ -27,6 +27,22 @@ export function isArray(type: GraphQLOutputType | GraphQLInputType): boolean {
 }
 
 export function dimensionOfArray(type: GraphQLOutputType | GraphQLInputType): number {
+  const result = _dimensionOfArray(type);
+
+  if (typeof result === 'undefined') {
+    // tslint:disable
+    console.log('wrong type', { ...type });
+    console.log('as string', String(type));
+    console.log('inspect', type.inspect());
+    console.log('json', type.toJSON());
+    console.log('is array', isArray(type));
+    console.log('characters', Array.from(String(type)));
+  }
+
+  return result;
+}
+
+export function _dimensionOfArray(type: GraphQLOutputType | GraphQLInputType): number {
   if (isArray(type)) {
     let dimension = 0;
     const characters = Array.from(String(type));

--- a/packages/graphql-codegen-core/src/schema/resolve-type.ts
+++ b/packages/graphql-codegen-core/src/schema/resolve-type.ts
@@ -27,22 +27,6 @@ export function isArray(type: GraphQLOutputType | GraphQLInputType): boolean {
 }
 
 export function dimensionOfArray(type: GraphQLOutputType | GraphQLInputType): number {
-  const result = _dimensionOfArray(type);
-
-  if (typeof result === 'undefined') {
-    // tslint:disable
-    console.log('wrong type', { ...type });
-    console.log('as string', String(type));
-    console.log('inspect', type.inspect());
-    console.log('json', type.toJSON());
-    console.log('is array', isArray(type));
-    console.log('characters', Array.from(String(type)));
-  }
-
-  return result;
-}
-
-export function _dimensionOfArray(type: GraphQLOutputType | GraphQLInputType): number {
   if (isArray(type)) {
     let dimension = 0;
     const characters = Array.from(String(type));

--- a/packages/graphql-codegen-core/src/schema/transform-interface.ts
+++ b/packages/graphql-codegen-core/src/schema/transform-interface.ts
@@ -8,7 +8,7 @@ import { getImplementingTypes } from './implementing-types';
 export function transformInterface(schema: GraphQLSchema, gqlInterface: GraphQLInterfaceType): Interface {
   debugLog(`[transformInterface] transformed interface ${gqlInterface.name}`);
 
-  const resolvedFields = resolveFields(schema, gqlInterface.getFields());
+  const resolvedFields = resolveFields(schema, gqlInterface.getFields(), gqlInterface);
   const directives = getDirectives(schema, gqlInterface);
   const implementingTypes = getImplementingTypes(gqlInterface.name, schema);
 

--- a/packages/graphql-codegen-core/src/schema/transform-object.ts
+++ b/packages/graphql-codegen-core/src/schema/transform-object.ts
@@ -9,7 +9,7 @@ export function transformGraphQLObject(
   object: GraphQLObjectType | GraphQLInputObjectType
 ): Type {
   debugLog(`[transformGraphQLObject] transforming type ${object.name}`);
-  const resolvedFields = resolveFields(schema, (object as any).getFields());
+  const resolvedFields = resolveFields(schema, (object as any).getFields(), object);
   const resolvedInterfaces = object instanceof GraphQLObjectType ? object.getInterfaces().map(inf => inf.name) : [];
   const directives = getDirectives(schema, object);
 

--- a/packages/graphql-codegen-core/src/types.ts
+++ b/packages/graphql-codegen-core/src/types.ts
@@ -39,6 +39,9 @@ export interface Field extends AstNode {
   isUnion: boolean;
   isInputType: boolean;
   isEnum: boolean;
+  isMutation: boolean;
+  isSubscription: boolean;
+  isQuery: boolean;
 }
 
 export interface Type extends AstNode {

--- a/packages/graphql-codegen-core/src/types.ts
+++ b/packages/graphql-codegen-core/src/types.ts
@@ -5,6 +5,17 @@ export interface AstNode {
   usesDirectives: boolean;
 }
 
+export type FieldType =
+  | 'Interface'
+  | 'InputType'
+  | 'Type'
+  | 'Query'
+  | 'Mutation'
+  | 'Subscription'
+  | 'Enum'
+  | 'Scalar'
+  | 'Union';
+
 export interface Argument extends AstNode {
   raw: string;
   name: string;
@@ -27,6 +38,7 @@ export interface Field extends AstNode {
   description: string;
   arguments: Argument[];
   type: string;
+  fieldType: FieldType;
   raw: string;
   isArray: boolean;
   dimensionOfArray: number;
@@ -39,9 +51,6 @@ export interface Field extends AstNode {
   isUnion: boolean;
   isInputType: boolean;
   isEnum: boolean;
-  isMutation: boolean;
-  isSubscription: boolean;
-  isQuery: boolean;
 }
 
 export interface Type extends AstNode {

--- a/packages/templates/typescript/src/helpers/get-field-resolver.ts
+++ b/packages/templates/typescript/src/helpers/get-field-resolver.ts
@@ -11,7 +11,7 @@ export function getFieldResolver(type, options) {
 
   let resolver: string;
 
-  if (type.isSubscription) {
+  if (type.fieldType === 'Subscription') {
     resolver = 'SubscriptionResolver';
   } else {
     resolver = 'Resolver';

--- a/packages/templates/typescript/src/helpers/get-field-resolver.ts
+++ b/packages/templates/typescript/src/helpers/get-field-resolver.ts
@@ -9,10 +9,18 @@ export function getFieldResolver(type, options) {
 
   let result;
 
-  if (type.hasArguments && !config.noNamespaces) {
-    result = `Resolver<R, Parent, Context, ${pascalCase(type.name)}Args>`;
+  let resolver: string;
+
+  if (type.isSubscription) {
+    resolver = 'SubscriptionResolver';
   } else {
-    result = `Resolver<R, Parent, Context>`;
+    resolver = 'Resolver';
+  }
+
+  if (type.hasArguments && !config.noNamespaces) {
+    result = `${resolver}<R, Parent, Context, ${pascalCase(type.name)}Args>`;
+  } else {
+    result = `${resolver}<R, Parent, Context>`;
   }
 
   return new SafeString(result);

--- a/packages/templates/typescript/src/resolver.handlebars
+++ b/packages/templates/typescript/src/resolver.handlebars
@@ -2,14 +2,14 @@
 {{#unless @root.config.noNamespaces}}
 export namespace {{ toPascalCase name }}Resolvers {
 {{/unless}}
-  export interface {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Resolvers<Context = any, Parent = {{ toPascalCase name}}> {
+  export interface {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Resolvers<Context = any> {
     {{#each fields}}
-    {{ name }}?: {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<{{convertedType this}}, Parent, Context>; {{ toComment description }}
+    {{ name }}?: {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<{{ convertedType this}}, any, Context>; {{ toComment description }}
     {{/each}}
   }
 
   {{#each fields}}
-  export type {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{convertedType this}}, Parent = {{toPascalCase ../name}}, Context = any> = {{ getFieldResolver this }};
+  export type {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{ convertedType this}}, Parent = any, Context = any> = {{ getFieldResolver this }};
 
   {{~# if hasArguments }}
 

--- a/packages/templates/typescript/src/schema.handlebars
+++ b/packages/templates/typescript/src/schema.handlebars
@@ -2,7 +2,7 @@
 {{#if types}}
 import { GraphQLResolveInfo } from 'graphql';
 
-export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+export type Resolver<Result, Parent = any, Context = any, Args = any> = (
   parent?: Parent,
   args?: Args,
   context?: Context,
@@ -23,9 +23,6 @@ export type SubscriptionResolver<Result, Parent = any, Context = any, Args = any
     info?: GraphQLResolveInfo
   ): R | Result | Promise<R | Result>;
 }
-
-export type Resolver<Result, Parent = any, Context = any, Args = any> = 
-  QueryResolver<Result, Parent, Context, Args> | SubscriptionResolver<Result, Parent, Context, Args>;
 
 {{/if}}
 {{/ifCond}}

--- a/packages/templates/typescript/src/utils/get-result-type.ts
+++ b/packages/templates/typescript/src/utils/get-result-type.ts
@@ -10,19 +10,25 @@ export function getResultType(type, options) {
   if (type.isArray) {
     let result = realType;
 
-    if (type.isNullableArray && !config.noNamespaces) {
-      result = useImmutable ? [realType, 'null'].join(' | ') : `(${[realType, 'null'].join(' | ')})`;
-    }
-    if (useImmutable) {
-      result = `${new Array(type.dimensionOfArray + 1).join('ReadonlyArray<')}${result}${new Array(
-        type.dimensionOfArray + 1
-      ).join('>')}`;
-    } else {
-      result = `${result}${new Array(type.dimensionOfArray + 1).join('[]')}`;
-    }
+    try {
+      if (type.isNullableArray && !config.noNamespaces) {
+        result = useImmutable ? [realType, 'null'].join(' | ') : `(${[realType, 'null'].join(' | ')})`;
+      }
+      if (useImmutable) {
+        result = `${new Array(type.dimensionOfArray + 1).join('ReadonlyArray<')}${result}${new Array(
+          type.dimensionOfArray + 1
+        ).join('>')}`;
+      } else {
+        result = `${result}${new Array(type.dimensionOfArray + 1).join('[]')}`;
+      }
 
-    if (!type.isRequired) {
-      result = [result, 'null'].join(' | ');
+      if (!type.isRequired) {
+        result = [result, 'null'].join(' | ');
+      }
+    } catch (e) {
+      // tslint:disable-next-line
+      console.log('type', { ...type });
+      throw e;
     }
 
     return result;

--- a/packages/templates/typescript/src/utils/get-result-type.ts
+++ b/packages/templates/typescript/src/utils/get-result-type.ts
@@ -11,15 +11,15 @@ export function getResultType(type, options) {
     let result = realType;
 
     try {
+      const dimension = (type.dimensionOfArray || -1) + 1;
+
       if (type.isNullableArray && !config.noNamespaces) {
         result = useImmutable ? [realType, 'null'].join(' | ') : `(${[realType, 'null'].join(' | ')})`;
       }
       if (useImmutable) {
-        result = `${new Array(type.dimensionOfArray + 1).join('ReadonlyArray<')}${result}${new Array(
-          type.dimensionOfArray + 1
-        ).join('>')}`;
+        result = `${new Array(dimension).join('ReadonlyArray<')}${result}${new Array(dimension).join('>')}`;
       } else {
-        result = `${result}${new Array(type.dimensionOfArray + 1).join('[]')}`;
+        result = `${result}${new Array(dimension).join('[]')}`;
       }
 
       if (!type.isRequired) {
@@ -28,6 +28,8 @@ export function getResultType(type, options) {
     } catch (e) {
       // tslint:disable-next-line
       console.log('type', { ...type });
+      // tslint:disable-next-line
+      console.log('type.dimensionOfArray', type.dimensionOfArray);
       throw e;
     }
 

--- a/packages/templates/typescript/src/utils/get-result-type.ts
+++ b/packages/templates/typescript/src/utils/get-result-type.ts
@@ -2,35 +2,29 @@ import { pascalCase } from 'change-case';
 
 export function getResultType(type, options) {
   const baseType = type.type;
+  const underscorePrefix = type.type.match(/^[\_]+/) || '';
   const config = options.data.root.config || {};
   const realType =
-    options.data.root.primitivesMap[baseType] || `${config.interfacePrefix || ''}${pascalCase(baseType)}`;
+    options.data.root.primitivesMap[baseType] ||
+    `${config.interfacePrefix || ''}${underscorePrefix + pascalCase(baseType)}`;
   const useImmutable = !!config.immutableTypes;
 
   if (type.isArray) {
     let result = realType;
 
-    try {
-      const dimension = type.dimensionOfArray + 1;
+    const dimension = type.dimensionOfArray + 1;
 
-      if (type.isNullableArray && !config.noNamespaces) {
-        result = useImmutable ? [realType, 'null'].join(' | ') : `(${[realType, 'null'].join(' | ')})`;
-      }
-      if (useImmutable) {
-        result = `${new Array(dimension).join('ReadonlyArray<')}${result}${new Array(dimension).join('>')}`;
-      } else {
-        result = `${result}${new Array(dimension).join('[]')}`;
-      }
+    if (type.isNullableArray && !config.noNamespaces) {
+      result = useImmutable ? [realType, 'null'].join(' | ') : `(${[realType, 'null'].join(' | ')})`;
+    }
+    if (useImmutable) {
+      result = `${new Array(dimension).join('ReadonlyArray<')}${result}${new Array(dimension).join('>')}`;
+    } else {
+      result = `${result}${new Array(dimension).join('[]')}`;
+    }
 
-      if (!type.isRequired) {
-        result = [result, 'null'].join(' | ');
-      }
-    } catch (e) {
-      // tslint:disable-next-line
-      console.log('type', { ...type });
-      // tslint:disable-next-line
-      console.log('type.dimensionOfArray', type.dimensionOfArray);
-      throw e;
+    if (!type.isRequired) {
+      result = [result, 'null'].join(' | ');
     }
 
     return result;

--- a/packages/templates/typescript/src/utils/get-result-type.ts
+++ b/packages/templates/typescript/src/utils/get-result-type.ts
@@ -11,7 +11,7 @@ export function getResultType(type, options) {
     let result = realType;
 
     try {
-      const dimension = (type.dimensionOfArray || -1) + 1;
+      const dimension = type.dimensionOfArray + 1;
 
       if (type.isNullableArray && !config.noNamespaces) {
         result = useImmutable ? [realType, 'null'].join(' | ') : `(${[realType, 'null'].join(' | ')})`;

--- a/packages/templates/typescript/tests/resolvers.spec.ts
+++ b/packages/templates/typescript/tests/resolvers.spec.ts
@@ -37,7 +37,7 @@ describe('Resolvers', () => {
     expect(content).toBeSimilarStringTo(`
     import { GraphQLResolveInfo } from 'graphql';
 
-    export type QueryResolver<Result, Parent = any, Context = any, Args = any> = (
+    export type Resolver<Result, Parent = any, Context = any, Args = any> = (
       parent?: Parent,
       args?: Args,
       context?: Context,
@@ -58,10 +58,6 @@ describe('Resolvers', () => {
         info?: GraphQLResolveInfo
       ): R | Result | Promise<R | Result>;
     }
-    
-    export type Resolver<Result, Parent = any, Context = any, Args = any> = 
-      QueryResolver<Result, Parent, Context, Args> | SubscriptionResolver<Result, Parent, Context, Args>;
-    
       `);
   });
 
@@ -182,6 +178,42 @@ describe('Resolvers', () => {
 
     expect(content).not.toBeSimilarStringTo(`
         export namespace QueryResolvers {
+      `);
+  });
+
+  it('should handle subscription', async () => {
+    const { context } = compileAndBuildContext(`
+        type Subscription {
+          fieldTest: String 
+        }
+        
+        schema {
+          subscription: Subscription
+        }
+      `);
+
+    const compiled = await compileTemplate(
+      {
+        ...config
+      },
+      context
+    );
+
+    const content = compiled[0].content;
+
+    expect(content).not.toBeSimilarStringTo(`
+      export namespace SubscriptionResolvers {
+        export interface Resolvers<Context = any> {
+          fieldTest?: FieldTestResolver<string | null, any, Context>;
+        }
+
+        export type FieldTestResolver<R = string | null, Parent = any, Context = any> = SubscriptionResolver<R, Parent, Context, FieldTestArgs>;
+        
+        export interface FieldTestArgs {
+          last: number;
+          sort?: string | null;
+        }
+      }
       `);
   });
 

--- a/packages/templates/typescript/tests/resolvers.spec.ts
+++ b/packages/templates/typescript/tests/resolvers.spec.ts
@@ -82,8 +82,8 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
         export namespace QueryResolvers {
-          export interface Resolvers<Context = any, Parent = Query> {
-            fieldTest?: FieldTestResolver<string | null, Parent, Context>;
+          export interface Resolvers<Context = any> {
+            fieldTest?: FieldTestResolver<string | null, any, Context>;
           }
         `);
   });
@@ -105,10 +105,10 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
         export namespace QueryResolvers {
-          export interface Resolvers<Context = any, Parent = Query> {
-            fieldTest?: FieldTestResolver<string | null, Parent, Context>;
+          export interface Resolvers<Context = any> {
+            fieldTest?: FieldTestResolver<string | null, any, Context>;
           }
-        export type FieldTestResolver<R = string | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+        export type FieldTestResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
         }
       `);
   });
@@ -130,11 +130,11 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
         export namespace QueryResolvers {
-          export interface Resolvers<Context = any, Parent = Query> {
-            fieldTest?: FieldTestResolver<string | null, Parent, Context>;
+          export interface Resolvers<Context = any> {
+            fieldTest?: FieldTestResolver<string | null, any, Context>;
           }
     
-          export type FieldTestResolver<R = string | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, FieldTestArgs>;
+          export type FieldTestResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context, FieldTestArgs>;
           
           export interface FieldTestArgs {
             last: number;
@@ -209,11 +209,11 @@ describe('Resolvers', () => {
     const content = compiled[0].content;
 
     expect(content).toBeSimilarStringTo(`
-        export interface QueryResolvers<Context = any, Parent = Query> {
-          fieldTest?: QueryFieldTestResolver<string | null, Parent, Context>;
+        export interface QueryResolvers<Context = any> {
+          fieldTest?: QueryFieldTestResolver<string | null, any, Context>;
         }
 
-        export type QueryFieldTestResolver<R = string | null, Parent = Query, Context = any> = Resolver<R, Parent, Context>;
+        export type QueryFieldTestResolver<R = string | null, Parent = any, Context = any> = Resolver<R, Parent, Context>;
       `);
   });
 
@@ -242,7 +242,7 @@ describe('Resolvers', () => {
     const content = compiled[0].content;
 
     expect(content).toBeSimilarStringTo(`
-      export type SnakeCaseRootQueryResolver<R = SnakeCaseResult | null, Parent = Query, Context = any> = Resolver<R, Parent, Context, SnakeCaseRootQueryArgs>;
+      export type SnakeCaseRootQueryResolver<R = SnakeCaseResult | null, Parent = any, Context = any> = Resolver<R, Parent, Context, SnakeCaseRootQueryArgs>;
       `);
     expect(content).toBeSimilarStringTo(`
       export interface SnakeCaseRootQueryArgs {


### PR DESCRIPTION
If end user decide to put something there it should be able to do it

Fixes #462 
Fixes #466
https://github.com/dotansimha/graphql-code-generator/issues/153#issuecomment-410647014
https://github.com/dotansimha/graphql-code-generator/pull/444#discussion_r207878190

- [x] check the output in ✈️ 🇫🇷 
- [x] check the output in 🎰 🇩🇪 