### PR TITLE
Make types pascal cased

### DIFF
--- a/packages/templates/typescript/src/schema.handlebars
+++ b/packages/templates/typescript/src/schema.handlebars
@@ -63,7 +63,7 @@ export interface {{ toPascalCase name }}{{ toPascalCase ../name }}Args {
 {{/each}}
 {{#each unions}}
 {{ toComment description }}
-export type {{ name }} = {{#each possibleTypes}}{{this}}{{#unless @last}} | {{/unless}}{{/each}};
+export type {{ toPascalCase name }} = {{#each possibleTypes}}{{ toPascalCase this}}{{#unless @last}} | {{/unless}}{{/each}};
 
 {{/each}}
 {{#if @root.config.schemaNamespace ~}} } {{~/if}}

--- a/packages/templates/typescript/tests/typescript.spec.ts
+++ b/packages/templates/typescript/tests/typescript.spec.ts
@@ -558,6 +558,41 @@ describe('TypeScript template', () => {
       `);
     });
 
+    it('should transform correctly name of union', async () => {
+      const { context } = compileAndBuildContext(`
+        type Query {
+          fieldTest: [CBText]
+        }
+        union CBText = ABText | BBText
+        scalar ABText
+        scalar BBText
+      `);
+
+      const compiled = await compileTemplate(
+        {
+          ...config
+        } as GeneratorConfig,
+        context
+      );
+
+      const content = compiled[0].content;
+
+      expect(content).toBeSimilarStringTo(`
+        export type AbText = any;
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export type BbText = any;
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export interface Query {
+          fieldTest?: (CbText | null)[] | null;
+        }
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export type CbText = AbText | BbText;
+      `);
+    });
+
     it('should generate enums correctly', async () => {
       const { context } = compileAndBuildContext(`
         type Query {


### PR DESCRIPTION
The template doesn't currently Pascal case union types; this PR updates the schema handlebar to fix this.