### PR TITLE
Introduce a template for apollo-angular

### DIFF
--- a/packages/templates/typescript-apollo-angular/.gitignore
+++ b/packages/templates/typescript-apollo-angular/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+dist
+temp
+yarn-error.log

--- a/packages/templates/typescript-apollo-angular/.npmignore
+++ b/packages/templates/typescript-apollo-angular/.npmignore
@@ -1,0 +1,4 @@
+src
+node_modules
+tests
+!dist

--- a/packages/templates/typescript-apollo-angular/.npmrc
+++ b/packages/templates/typescript-apollo-angular/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true

--- a/packages/templates/typescript-apollo-angular/README.md
+++ b/packages/templates/typescript-apollo-angular/README.md
@@ -6,7 +6,7 @@ This template is extended version of TypeScript template, so the configuration i
 - Example Input
 
 ```graphql
-query Feed {
+query MyFeed {
   feed {
     id
     commentCount
@@ -17,7 +17,7 @@ query Feed {
 - Example Usage
 
 ```ts
-import { FeedQuery } from './graphql';
+import { MyFeedGQL } from './graphql';
 
 @Component({
   selector: 'feed',
@@ -31,8 +31,16 @@ import { FeedQuery } from './graphql';
 export class FeedComponent {
   feed: Observable<any>;
 
-  constructor(feedQuery: FeedQuery) {
-    this.feed = feedQuery.watch().valueChanges.pipe(map(result => result.data.feed));
+  constructor(feedGQL: MyFeedGQL) {
+    this.feed = feedGQL.watch().valueChanges.pipe(map(result => result.data.feed));
   }
 }
 ```
+
+## Generator Config
+
+This generator supports custom config and output behavior. Use to following flags/environment variables to modify your output as you wish:
+
+### `noGraphqlTag` (or `CODEGEN_NO_GRAPHQL_TAG`, default value: `false`)
+
+This will cause the codegen to output parsed documents and not use a literal tag of `graphql-tag` package.

--- a/packages/templates/typescript-apollo-angular/README.md
+++ b/packages/templates/typescript-apollo-angular/README.md
@@ -1,0 +1,38 @@
+# TypeScript Apollo Angular Template
+
+This template generates Apollo services (`Query`, `Mutation`, `Subscription`) with TypeScript typings.
+This template is extended version of TypeScript template, so the configuration is same with `graphql-codegen-typescript-template`.
+
+- Example Input
+
+```graphql
+query Feed {
+  feed {
+    id
+    commentCount
+  }
+}
+```
+
+- Example Usage
+
+```ts
+import { FeedQuery } from './graphql';
+
+@Component({
+  selector: 'feed',
+  template: `
+    <h1>Feed:</h1>
+    <ul>
+      <li *ngFor="let item of feed | async"> {{item.id}} </li>
+    </ul>
+  `
+})
+export class FeedComponent {
+  feed: Observable<any>;
+
+  constructor(feedQuery: FeedQuery) {
+    this.feed = feedQuery.watch().valueChanges.pipe(map(result => result.data.feed));
+  }
+}
+```

--- a/packages/templates/typescript-apollo-angular/package.json
+++ b/packages/templates/typescript-apollo-angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "graphql-codegen-typescript-apollo-angular-template",
+  "name": "graphql-codegen-apollo-angular-template",
   "version": "0.10.7",
   "description": "",
   "license": "MIT",

--- a/packages/templates/typescript-apollo-angular/package.json
+++ b/packages/templates/typescript-apollo-angular/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "graphql-codegen-typescript-apollo-angular-template",
+  "version": "0.10.7",
+  "description": "",
+  "license": "MIT",
+  "scripts": {
+    "prepublishOnly": "yarn build",
+    "build": "codegen-templates-scripts build",
+    "pretest": "yarn build",
+    "test": "codegen-templates-scripts test"
+  },
+  "devDependencies": {
+    "@types/graphql": "0.13.4",
+    "codegen-templates-scripts": "0.10.7",
+    "graphql": "0.13.2",
+    "graphql-codegen-compiler": "0.10.7",
+    "graphql-codegen-core": "0.10.7"
+  },
+  "main": "./dist/index.js",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "enableTsDiagnostics": false
+      }
+    },
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
+  },
+  "dependencies": {
+    "graphql-codegen-typescript-template": "0.10.7"
+  }
+}

--- a/packages/templates/typescript-apollo-angular/src/components.handlebars
+++ b/packages/templates/typescript-apollo-angular/src/components.handlebars
@@ -11,6 +11,6 @@ import gql from 'graphql-tag';
         providedIn: 'root'
     })
     export class {{ toPascalCase name }}GQL extends Apollo.{{toPascalCase operationType}}<{{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}{{ toPascalCase operationType }}, {{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}Variables> {
-        document = {{#unless @root.config.noGraphqlTag}}gql` {{ document }} `{{else}}{{{ gql document }}}{{/unless}}
+        document: any = {{#unless @root.config.noGraphqlTag}}gql` {{ document }} `{{else}}{{{ gql document }}}{{/unless}}
     }
 {{/each}}

--- a/packages/templates/typescript-apollo-angular/src/components.handlebars
+++ b/packages/templates/typescript-apollo-angular/src/components.handlebars
@@ -3,7 +3,7 @@ import * as Apollo from 'apollo-angular';
 import gql from 'graphql-tag';
 
 {{#each operations }}
-    export class {{ toPascalCase name }} extends Apollo.{{toPascalCase operationType}}<{{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}{{ toPascalCase operationType }}, {{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}Variables> {
+    export class {{ toPascalCase name }}GQL extends Apollo.{{toPascalCase operationType}}<{{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}{{ toPascalCase operationType }}, {{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}Variables> {
         document = gql` {{ document }} `
     }
 {{/each}}

--- a/packages/templates/typescript-apollo-angular/src/components.handlebars
+++ b/packages/templates/typescript-apollo-angular/src/components.handlebars
@@ -1,8 +1,13 @@
+import { Injectable } from '@angular/core';
+
 import * as Apollo from 'apollo-angular';
 
 import gql from 'graphql-tag';
 
 {{#each operations }}
+    @Injectable({
+        providedIn: 'root'
+    })
     export class {{ toPascalCase name }}GQL extends Apollo.{{toPascalCase operationType}}<{{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}{{ toPascalCase operationType }}, {{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}Variables> {
         document = gql` {{ document }} `
     }

--- a/packages/templates/typescript-apollo-angular/src/components.handlebars
+++ b/packages/templates/typescript-apollo-angular/src/components.handlebars
@@ -2,11 +2,15 @@ import { Injectable } from '@angular/core';
 
 import * as Apollo from 'apollo-angular';
 
+{{#unless @root.config.noGraphQLTag}}
+import gql from 'graphql-tag';
+{{/unless}}
+
 {{#each operations }}
     @Injectable({
         providedIn: 'root'
     })
     export class {{ toPascalCase name }}GQL extends Apollo.{{toPascalCase operationType}}<{{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}{{ toPascalCase operationType }}, {{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}Variables> {
-        document = {{{ gql document }}}
+        document = {{#unless @root.config.noGraphQLTag}}gql` {{ document }} `{{else}}{{{ gql document }}}{{/unless}}
     }
 {{/each}}

--- a/packages/templates/typescript-apollo-angular/src/components.handlebars
+++ b/packages/templates/typescript-apollo-angular/src/components.handlebars
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 
 import * as Apollo from 'apollo-angular';
 
-{{#unless @root.config.noGraphQLTag}}
+{{#unless @root.config.noGraphqlTag}}
 import gql from 'graphql-tag';
 {{/unless}}
 
@@ -11,6 +11,6 @@ import gql from 'graphql-tag';
         providedIn: 'root'
     })
     export class {{ toPascalCase name }}GQL extends Apollo.{{toPascalCase operationType}}<{{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}{{ toPascalCase operationType }}, {{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}Variables> {
-        document = {{#unless @root.config.noGraphQLTag}}gql` {{ document }} `{{else}}{{{ gql document }}}{{/unless}}
+        document = {{#unless @root.config.noGraphqlTag}}gql` {{ document }} `{{else}}{{{ gql document }}}{{/unless}}
     }
 {{/each}}

--- a/packages/templates/typescript-apollo-angular/src/components.handlebars
+++ b/packages/templates/typescript-apollo-angular/src/components.handlebars
@@ -2,13 +2,11 @@ import { Injectable } from '@angular/core';
 
 import * as Apollo from 'apollo-angular';
 
-import gql from 'graphql-tag';
-
 {{#each operations }}
     @Injectable({
         providedIn: 'root'
     })
     export class {{ toPascalCase name }}GQL extends Apollo.{{toPascalCase operationType}}<{{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}{{ toPascalCase operationType }}, {{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}Variables> {
-        document = gql` {{ document }} `
+        document = {{{ gql document }}}
     }
 {{/each}}

--- a/packages/templates/typescript-apollo-angular/src/components.handlebars
+++ b/packages/templates/typescript-apollo-angular/src/components.handlebars
@@ -1,0 +1,9 @@
+import * as Apollo from 'apollo-angular';
+
+import gql from 'graphql-tag';
+
+{{#each operations }}
+    export class {{ toPascalCase name }} extends Apollo.{{toPascalCase operationType}}<{{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}{{ toPascalCase operationType }}, {{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}Variables> {
+        document = gql` {{ document }} `
+    }
+{{/each}}

--- a/packages/templates/typescript-apollo-angular/src/config.ts
+++ b/packages/templates/typescript-apollo-angular/src/config.ts
@@ -1,0 +1,7 @@
+import typescriptConfig from 'graphql-codegen-typescript-template';
+
+import * as components from './components.handlebars';
+
+typescriptConfig.templates['documents'] += components;
+
+export { typescriptConfig as config };

--- a/packages/templates/typescript-apollo-angular/src/config.ts
+++ b/packages/templates/typescript-apollo-angular/src/config.ts
@@ -1,7 +1,9 @@
 import typescriptConfig from 'graphql-codegen-typescript-template';
 
 import * as components from './components.handlebars';
+import { gql } from './helpers/gql';
 
 typescriptConfig.templates['documents'] += components;
+typescriptConfig.customHelpers.gql = gql;
 
 export { typescriptConfig as config };

--- a/packages/templates/typescript-apollo-angular/src/helpers/gql.ts
+++ b/packages/templates/typescript-apollo-angular/src/helpers/gql.ts
@@ -1,0 +1,5 @@
+import gqlTag from 'graphql-tag';
+
+export function gql(document: string): string {
+  return JSON.stringify(gqlTag(document));
+}

--- a/packages/templates/typescript-apollo-angular/src/index.ts
+++ b/packages/templates/typescript-apollo-angular/src/index.ts
@@ -1,0 +1,3 @@
+import { config } from './config';
+
+export default config;

--- a/packages/templates/typescript-apollo-angular/src/polyfills.d.ts
+++ b/packages/templates/typescript-apollo-angular/src/polyfills.d.ts
@@ -1,0 +1,4 @@
+declare module '*.handlebars' {
+  const content: string;
+  export = content;
+}

--- a/packages/templates/typescript-apollo-angular/tests/components.spec.ts
+++ b/packages/templates/typescript-apollo-angular/tests/components.spec.ts
@@ -36,9 +36,6 @@ describe('Components', () => {
       import { Injectable } from '@angular/core';
     `);
     expect(content).toBeSimilarStringTo(`
-      import gql from 'graphql-tag';
-    `);
-    expect(content).toBeSimilarStringTo(`
       @Injectable({
         providedIn: 'root'
       })
@@ -114,4 +111,51 @@ describe('Components', () => {
       export class MyFeedGQL extends Apollo.Query<MyFeed.Query, MyFeed.Variables> {
     `);
   });
+
+  it('should use parsed document instead of graphql-tag', async () => {
+    const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
+    const context = schemaToTemplateContext(schema);
+
+    const documents = gql`
+      query MyFeed {
+        feed {
+          id
+          commentCount
+          repository {
+            full_name
+            html_url
+            owner {
+              avatar_url
+            }
+          }
+        }
+      }
+    `;
+
+    // location might be different so let's skip it
+    delete documents.loc;
+
+    const transformedDocument = transformDocument(schema, documents);
+    const compiled = await compileTemplate(
+      { ...config, config: { noNamespaces: true } },
+      context,
+      [transformedDocument],
+      { generateSchema: false }
+    );
+    // location might be different so let's remove it
+    const content = compiled[0].content.replace(/,"loc":{"start":\d+,"end":\d+}}\s+}/, '}');
+
+    expect(content).toBeSimilarStringTo(`
+      @Injectable({
+        providedIn: 'root'
+      })
+      export class MyFeedGQL extends Apollo.Query<MyFeedQuery, MyFeedVariables> {
+    `);
+
+    expect(content).toBeSimilarStringTo(`
+      document = ${JSON.stringify(documents)}
+    `);
+  });
 });
+
+// document = {"kind":"Document"

--- a/packages/templates/typescript-apollo-angular/tests/components.spec.ts
+++ b/packages/templates/typescript-apollo-angular/tests/components.spec.ts
@@ -36,7 +36,7 @@ describe('Components', () => {
       import gql from 'graphql-tag';
     `);
     expect(content).toBeSimilarStringTo(`
-      export class MyFeed extends Apollo.Query
+      export class MyFeedGQL extends Apollo.Query
     `);
   });
 
@@ -70,7 +70,7 @@ describe('Components', () => {
     const content = compiled[0].content;
 
     expect(content).toBeSimilarStringTo(`
-      export class MyFeed extends Apollo.Query<MyFeedQuery, MyFeedVariables> {
+      export class MyFeedGQL extends Apollo.Query<MyFeedQuery, MyFeedVariables> {
     `);
   });
 
@@ -99,7 +99,7 @@ describe('Components', () => {
     const content = compiled[0].content;
 
     expect(content).toBeSimilarStringTo(`
-      export class MyFeed extends Apollo.Query<MyFeed.Query, MyFeed.Variables> {
+      export class MyFeedGQL extends Apollo.Query<MyFeed.Query, MyFeed.Variables> {
     `);
   });
 });

--- a/packages/templates/typescript-apollo-angular/tests/components.spec.ts
+++ b/packages/templates/typescript-apollo-angular/tests/components.spec.ts
@@ -1,0 +1,105 @@
+import './custom-matchers';
+import { gql, introspectionToGraphQLSchema, schemaToTemplateContext, transformDocument } from 'graphql-codegen-core';
+import { compileTemplate } from 'graphql-codegen-compiler';
+import config from '../dist';
+import * as fs from 'fs';
+
+describe('Components', () => {
+  it('should generate Component', async () => {
+    const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
+    const context = schemaToTemplateContext(schema);
+
+    const documents = gql`
+      query MyFeed {
+        feed {
+          id
+          commentCount
+          repository {
+            full_name
+            html_url
+            owner {
+              avatar_url
+            }
+          }
+        }
+      }
+    `;
+
+    const transformedDocument = transformDocument(schema, documents);
+    const compiled = await compileTemplate(config, context, [transformedDocument], { generateSchema: false });
+    const content = compiled[0].content;
+
+    expect(content).toBeSimilarStringTo(`
+      import * as Apollo from 'apollo-angular';
+    `);
+    expect(content).toBeSimilarStringTo(`
+      import gql from 'graphql-tag';
+    `);
+    expect(content).toBeSimilarStringTo(`
+      export class MyFeed extends Apollo.Query
+    `);
+  });
+
+  it('should generate correct Component when noNamespaces enabled', async () => {
+    const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
+    const context = schemaToTemplateContext(schema);
+
+    const documents = gql`
+      query MyFeed {
+        feed {
+          id
+          commentCount
+          repository {
+            full_name
+            html_url
+            owner {
+              avatar_url
+            }
+          }
+        }
+      }
+    `;
+
+    const transformedDocument = transformDocument(schema, documents);
+    const compiled = await compileTemplate(
+      { ...config, config: { noNamespaces: true } },
+      context,
+      [transformedDocument],
+      { generateSchema: false }
+    );
+    const content = compiled[0].content;
+
+    expect(content).toBeSimilarStringTo(`
+      export class MyFeed extends Apollo.Query<MyFeedQuery, MyFeedVariables> {
+    `);
+  });
+
+  it('should generate correct Component when noNamespaces disabled', async () => {
+    const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
+    const context = schemaToTemplateContext(schema);
+
+    const documents = gql`
+      query MyFeed {
+        feed {
+          id
+          commentCount
+          repository {
+            full_name
+            html_url
+            owner {
+              avatar_url
+            }
+          }
+        }
+      }
+    `;
+
+    const transformedDocument = transformDocument(schema, documents);
+    const compiled = await compileTemplate(config, context, [transformedDocument], { generateSchema: false });
+    const content = compiled[0].content;
+
+    expect(content).toBeSimilarStringTo(`
+      export class MyFeed extends Apollo.Query<MyFeed.Query, MyFeed.Variables> {
+    `);
+  });
+});

--- a/packages/templates/typescript-apollo-angular/tests/components.spec.ts
+++ b/packages/templates/typescript-apollo-angular/tests/components.spec.ts
@@ -30,7 +30,7 @@ describe('Components', () => {
       {
         ...config,
         config: {
-          noGraphQLTag: true
+          noGraphqlTag: true
         }
       },
       context,
@@ -78,7 +78,7 @@ describe('Components', () => {
 
     const transformedDocument = transformDocument(schema, documents);
     const compiled = await compileTemplate(
-      { ...config, config: { noNamespaces: true, noGraphQLTag: true } },
+      { ...config, config: { noNamespaces: true, noGraphqlTag: true } },
       context,
       [transformedDocument],
       { generateSchema: false }
@@ -118,7 +118,7 @@ describe('Components', () => {
       {
         ...config,
         config: {
-          noGraphQLTag: true
+          noGraphqlTag: true
         }
       },
       context,
@@ -160,7 +160,7 @@ describe('Components', () => {
 
     const transformedDocument = transformDocument(schema, documents);
     const compiled = await compileTemplate(
-      { ...config, config: { noNamespaces: true, noGraphQLTag: true } },
+      { ...config, config: { noNamespaces: true, noGraphqlTag: true } },
       context,
       [transformedDocument],
       { generateSchema: false }
@@ -180,7 +180,7 @@ describe('Components', () => {
     `);
   });
 
-  it('should use graphql-tag when noGraphQLTag flag is disabled (by default)', async () => {
+  it('should use graphql-tag when noGraphqlTag flag is disabled (by default)', async () => {
     const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
     const context = schemaToTemplateContext(schema);
 

--- a/packages/templates/typescript-apollo-angular/tests/components.spec.ts
+++ b/packages/templates/typescript-apollo-angular/tests/components.spec.ts
@@ -33,9 +33,15 @@ describe('Components', () => {
       import * as Apollo from 'apollo-angular';
     `);
     expect(content).toBeSimilarStringTo(`
+      import { Injectable } from '@angular/core';
+    `);
+    expect(content).toBeSimilarStringTo(`
       import gql from 'graphql-tag';
     `);
     expect(content).toBeSimilarStringTo(`
+      @Injectable({
+        providedIn: 'root'
+      })
       export class MyFeedGQL extends Apollo.Query
     `);
   });
@@ -70,6 +76,9 @@ describe('Components', () => {
     const content = compiled[0].content;
 
     expect(content).toBeSimilarStringTo(`
+      @Injectable({
+        providedIn: 'root'
+      })
       export class MyFeedGQL extends Apollo.Query<MyFeedQuery, MyFeedVariables> {
     `);
   });
@@ -99,6 +108,9 @@ describe('Components', () => {
     const content = compiled[0].content;
 
     expect(content).toBeSimilarStringTo(`
+      @Injectable({
+        providedIn: 'root'
+      })
       export class MyFeedGQL extends Apollo.Query<MyFeed.Query, MyFeed.Variables> {
     `);
   });

--- a/packages/templates/typescript-apollo-angular/tests/components.spec.ts
+++ b/packages/templates/typescript-apollo-angular/tests/components.spec.ts
@@ -176,7 +176,7 @@ describe('Components', () => {
     `);
 
     expect(content).toBeSimilarStringTo(`
-      document = ${JSON.stringify(documents)}
+      document: any = ${JSON.stringify(documents)}
     `);
   });
 
@@ -221,7 +221,7 @@ describe('Components', () => {
     `);
 
     expect(content).toBeSimilarStringTo(`
-      document = gql\` query MyFeed {
+      document: any = gql\` query MyFeed {
     `);
   });
 });

--- a/packages/templates/typescript-apollo-angular/tests/custom-matchers.ts
+++ b/packages/templates/typescript-apollo-angular/tests/custom-matchers.ts
@@ -1,0 +1,45 @@
+import { oneLine } from 'common-tags';
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      /**
+       * Normalizes whitespace and performs string comparisons
+       */
+      toBeSimilarStringTo(expected: string): R;
+    }
+  }
+}
+
+function compareStrings(a: string, b: string): boolean {
+  return a.includes(b);
+}
+
+function toBeSimilarStringTo(received: string, argument: string) {
+  const strippedA = oneLine`${received}`.replace(/\s\s+/g, ' ');
+  const strippedB = oneLine`${argument}`.replace(/\s\s+/g, ' ');
+
+  if (compareStrings(strippedA, strippedB)) {
+    return {
+      message: () =>
+        `expected 
+ ${received}
+ not to be similar (strip-indent) string to
+ ${argument}`,
+      pass: true
+    };
+  } else {
+    return {
+      message: () =>
+        `expected 
+ ${received}
+ to be similar (strip-indent) string to
+ ${argument}`,
+      pass: false
+    };
+  }
+}
+
+expect.extend({
+  toBeSimilarStringTo
+});

--- a/packages/templates/typescript-apollo-angular/tests/files/schema.json
+++ b/packages/templates/typescript-apollo-angular/tests/files/schema.json
@@ -1,0 +1,1739 @@
+{
+  "__schema": {
+    "queryType": {
+      "name": "Query"
+    },
+    "mutationType": {
+      "name": "Mutation"
+    },
+    "subscriptionType": {
+      "name": "Subscription"
+    },
+    "types": [
+      {
+        "kind": "OBJECT",
+        "name": "Query",
+        "description": "",
+        "fields": [
+          {
+            "name": "feed",
+            "description": "A feed of repository submissions",
+            "args": [
+              {
+                "name": "type",
+                "description": "The sort order for the feed",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "FeedType",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "The number of items to skip, for pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": "The number of items to fetch starting from the offset, for pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Entry",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "entry",
+            "description": "A single entry",
+            "args": [
+              {
+                "name": "repoFullName",
+                "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Entry",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentUser",
+            "description": "Return the currently logged in user, or null if nobody is logged in",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "FeedType",
+        "description": "A list of options for the sort order of the feed",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "HOT",
+            "description": "Sort by a combination of freshness and score, using Reddit's algorithm",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NEW",
+            "description": "Newest entries first",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TOP",
+            "description": "Highest score entries first",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Int",
+        "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Entry",
+        "description": "Information about a GitHub repository submitted to GitHunt",
+        "fields": [
+          {
+            "name": "repository",
+            "description": "Information about the repository from GitHub",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Repository",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postedBy",
+            "description": "The GitHub user who submitted this entry",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "A timestamp of when the entry was submitted",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "score",
+            "description": "The score of this repository, upvotes - downvotes",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hotScore",
+            "description": "The hot score of this repository",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "comments",
+            "description": "Comments posted about this repository",
+            "args": [
+              {
+                "name": "limit",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Comment",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "commentCount",
+            "description": "The number of comments posted about this repository",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The SQL ID of this entry",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vote",
+            "description": "XXX to be changed",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Vote",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Repository",
+        "description": "A repository object from the GitHub API. This uses the exact field names returned by the\nGitHub API for simplicity, even though the convention for GraphQL is usually to camel case.",
+        "fields": [
+          {
+            "name": "name",
+            "description": "Just the name of the repository, e.g. GitHunt-API",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "full_name",
+            "description": "The full name of the repository with the username, e.g. apollostack/GitHunt-API",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the repository",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "html_url",
+            "description": "The link to the repository on GitHub",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stargazers_count",
+            "description": "The number of people who have starred this repository on GitHub",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "open_issues_count",
+            "description": "The number of open issues on this repository on GitHub",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner",
+            "description": "The owner of this repository on GitHub, e.g. apollostack",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "String",
+        "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "User",
+        "description": "A user object from the GitHub API. This uses the exact field names returned from the GitHub API.",
+        "fields": [
+          {
+            "name": "login",
+            "description": "The name of the user, e.g. apollostack",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "avatar_url",
+            "description": "The URL to a directly embeddable image for this user's avatar",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "html_url",
+            "description": "The URL of this user's GitHub page",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float",
+        "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Comment",
+        "description": "A comment about an entry, submitted by a user",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The SQL ID of this entry",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postedBy",
+            "description": "The GitHub user who posted the comment",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "A timestamp of when the comment was posted",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "content",
+            "description": "The text of the comment",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "repoName",
+            "description": "The repository which this comment is about",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Vote",
+        "description": "XXX to be removed",
+        "fields": [
+          {
+            "name": "vote_value",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Mutation",
+        "description": "",
+        "fields": [
+          {
+            "name": "submitRepository",
+            "description": "Submit a new repository, returns the new submission",
+            "args": [
+              {
+                "name": "repoFullName",
+                "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Entry",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vote",
+            "description": "Vote on a repository submission, returns the submission that was voted on",
+            "args": [
+              {
+                "name": "repoFullName",
+                "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "type",
+                "description": "The type of vote - UP, DOWN, or CANCEL",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "VoteType",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Entry",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "submitComment",
+            "description": "Comment on a repository, returns the new comment",
+            "args": [
+              {
+                "name": "repoFullName",
+                "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "commentContent",
+                "description": "The text content for the new comment",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Comment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "VoteType",
+        "description": "The type of vote to record, when submitting a vote",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "UP",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DOWN",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CANCEL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Subscription",
+        "description": "",
+        "fields": [
+          {
+            "name": "commentAdded",
+            "description": "Subscription fires on every comment added",
+            "args": [
+              {
+                "name": "repoFullName",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Comment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__Schema",
+        "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+        "fields": [
+          {
+            "name": "types",
+            "description": "A list of all types supported by this server.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "queryType",
+            "description": "The type that query operations will be rooted at.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mutationType",
+            "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "__Type",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subscriptionType",
+            "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "__Type",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "directives",
+            "description": "A list of all directives supported by this server.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Directive",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__Type",
+        "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+        "fields": [
+          {
+            "name": "kind",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "__TypeKind",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fields",
+            "description": null,
+            "args": [
+              {
+                "name": "includeDeprecated",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false"
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Field",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "interfaces",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "possibleTypes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "enumValues",
+            "description": null,
+            "args": [
+              {
+                "name": "includeDeprecated",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false"
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__EnumValue",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "inputFields",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__InputValue",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ofType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "__Type",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "__TypeKind",
+        "description": "An enum describing what kind of type a given `__Type` is.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "SCALAR",
+            "description": "Indicates this type is a scalar.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OBJECT",
+            "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INTERFACE",
+            "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNION",
+            "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ENUM",
+            "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INPUT_OBJECT",
+            "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LIST",
+            "description": "Indicates this type is a list. `ofType` is a valid field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NON_NULL",
+            "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Boolean",
+        "description": "The `Boolean` scalar type represents `true` or `false`.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__Field",
+        "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+        "fields": [
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "args",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isDeprecated",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deprecationReason",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__InputValue",
+        "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+        "fields": [
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "defaultValue",
+            "description": "A GraphQL-formatted string representing the default value for this input value.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__EnumValue",
+        "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+        "fields": [
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isDeprecated",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deprecationReason",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__Directive",
+        "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+        "fields": [
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "locations",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "__DirectiveLocation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "args",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "onOperation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `locations`."
+          },
+          {
+            "name": "onFragment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `locations`."
+          },
+          {
+            "name": "onField",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `locations`."
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "__DirectiveLocation",
+        "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "QUERY",
+            "description": "Location adjacent to a query operation.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MUTATION",
+            "description": "Location adjacent to a mutation operation.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUBSCRIPTION",
+            "description": "Location adjacent to a subscription operation.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FIELD",
+            "description": "Location adjacent to a field.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FRAGMENT_DEFINITION",
+            "description": "Location adjacent to a fragment definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FRAGMENT_SPREAD",
+            "description": "Location adjacent to a fragment spread.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INLINE_FRAGMENT",
+            "description": "Location adjacent to an inline fragment.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SCHEMA",
+            "description": "Location adjacent to a schema definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SCALAR",
+            "description": "Location adjacent to a scalar definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OBJECT",
+            "description": "Location adjacent to an object type definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FIELD_DEFINITION",
+            "description": "Location adjacent to a field definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ARGUMENT_DEFINITION",
+            "description": "Location adjacent to an argument definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INTERFACE",
+            "description": "Location adjacent to an interface definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNION",
+            "description": "Location adjacent to a union definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ENUM",
+            "description": "Location adjacent to an enum definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ENUM_VALUE",
+            "description": "Location adjacent to an enum value definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INPUT_OBJECT",
+            "description": "Location adjacent to an input object type definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INPUT_FIELD_DEFINITION",
+            "description": "Location adjacent to an input object field definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      }
+    ],
+    "directives": [
+      {
+        "name": "skip",
+        "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "args": [
+          {
+            "name": "if",
+            "description": "Skipped when true.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ]
+      },
+      {
+        "name": "include",
+        "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "args": [
+          {
+            "name": "if",
+            "description": "Included when true.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ]
+      },
+      {
+        "name": "deprecated",
+        "description": "Marks an element of a GraphQL schema as no longer supported.",
+        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
+        "args": [
+          {
+            "name": "reason",
+            "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": "\"No longer supported\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/templates/typescript-apollo-angular/tsconfig.json
+++ b/packages/templates/typescript-apollo-angular/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "target": "es5",
+    "lib": ["es6", "esnext", "es2015"],
+    "noImplicitAny": false,
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "./dist/"
+  },
+  "exclude": ["node_modules", "tests", "dist"]
+}


### PR DESCRIPTION
Uses https://github.com/apollographql/apollo-angular/pull/622

- [x] I used GQL suffix ~`Feed` conflicts with `Feed` namespace and `FeedQuery` with `FeedQuery` interface hmmmm (maybe different name based on `noNamespaces` or a unique prefix/suffix)~ 
- `noGraphQLTag` flag to use parsed object as a document (turned off by default, uses `graphql-tag`)

An example to play with:
https://codesandbox.io/s/github/kamilkisiela/apollo-angular-code-generator

Repository:
https://github.com/kamilkisiela/apollo-angular-code-generator