### PR TITLE
Support for the "# import" syntax

### DIFF
--- a/dev-test/test-schema/schema-with-imports.graphql
+++ b/dev-test/test-schema/schema-with-imports.graphql
@@ -1,0 +1,9 @@
+# import User from './schema.graphql'
+
+type Query {
+  allUsers: [User]!
+  userById(id: Int!): User
+
+  # Generates a new answer for the guessing game
+  answer: [Int!]!
+}

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -80,6 +80,7 @@
     "glob": "7.1.2",
     "graphql-codegen-compiler": "0.10.7",
     "graphql-codegen-core": "0.10.7",
+    "graphql-import": "0.6.0",
     "is-glob": "4.0.0",
     "is-valid-path": "0.1.1",
     "mkdirp": "0.5.1",

--- a/packages/graphql-codegen-cli/tests/cli.spec.ts
+++ b/packages/graphql-codegen-cli/tests/cli.spec.ts
@@ -19,6 +19,24 @@ describe('executeWithOptions', () => {
     expect(result.length).toBe(1);
   });
 
+  it('execute the correct results when using schema with graphql file', async () => {
+    const result = await executeWithOptions({
+      schema: '../../dev-test/test-schema/schema.graphql',
+      template: 'ts'
+    });
+
+    expect(result.length).toBe(1);
+  });
+
+  it('execute the correct results when using schema with graphql file and imports', async () => {
+    const result = await executeWithOptions({
+      schema: '../../dev-test/test-schema/schema-with-imports.graphql',
+      template: 'ts'
+    });
+
+    expect(result.length).toBe(1);
+  });
+
   it('execute the correct results when using custom config file', async () => {
     const result = await executeWithOptions({
       schema: '../../dev-test/githunt/schema.json',
@@ -90,6 +108,6 @@ describe('executeWithOptions', () => {
       require: ['../tests/dummy-require.js']
     });
     expect(result.length).toBe(1);
-    expect(global.dummyWasLoaded).toBe(true);
+    expect(global['dummyWasLoaded']).toBe(true);
   });
 });

--- a/packages/graphql-codegen-cli/tests/schema-from-typedefs.spec.ts
+++ b/packages/graphql-codegen-cli/tests/schema-from-typedefs.spec.ts
@@ -10,4 +10,14 @@ describe('schema from typedefs', () => {
     expect(built.getTypeMap()['User']).toBeDefined();
     expect(built.getTypeMap()['Query']).toBeDefined();
   });
+
+  it('should work with import notations', () => {
+    const schemaPath = './tests/test-files/schema-dir/query.graphql';
+    const handler = new SchemaFromTypedefs();
+    const canHandle = handler.canHandle(schemaPath);
+    expect(canHandle).toBeTruthy();
+    const built = handler.handle(schemaPath, {});
+    expect(built.getTypeMap()['User']).toBeDefined();
+    expect(built.getTypeMap()['Query']).toBeDefined();
+  });
 });

--- a/packages/graphql-codegen-cli/tests/test-files/schema-dir/query.graphql
+++ b/packages/graphql-codegen-cli/tests/test-files/schema-dir/query.graphql
@@ -1,3 +1,5 @@
+# import User from './user.graphql'
+
 type Query {
   user: User
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2534,6 +2534,12 @@ graphql-codegen-typescript-template-multiple@0.9.4:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/graphql-codegen-typescript-template-multiple/-/graphql-codegen-typescript-template-multiple-0.9.4.tgz#d0a6faa18547b726c3246b8fbca256abeb6c68ec"
 
+graphql-import@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/graphql-import/-/graphql-import-0.6.0.tgz#c00cb8a269ceea263e062922c8c81a2272d1ffcb"
+  dependencies:
+    lodash "^4.17.4"
+
 graphql-tag@2.9.2:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.9.2.tgz#2f60a5a981375f430bf1e6e95992427dc18af686"


### PR DESCRIPTION
[GraphQL Yoga](https://github.com/prismagraphql/graphql-yoga) uses [`graphql-import`](https://github.com/prismagraphql/graphql-import) that allows for using the following syntax: 

```graphql
# import B from "b.graphql"

type A {
  # test 1
  first: String
  second: Float
  b: B
}
```

This PR adds support for that syntax.

Thanks for this amazing package @dotansimha 👍 