### PR TITLE
Avoid escaping `prepend` lines (dotansimha/graphql-code-generator#484)

### DIFF
--- a/packages/templates/typescript/src/template.handlebars
+++ b/packages/templates/typescript/src/template.handlebars
@@ -3,7 +3,7 @@
 /** Generated in {{ currentTime }} */
 {{/if}}
 {{#each @root.config.prepend}}
-    {{this}}
+    {{{this}}}
 {{/each}}
 {{> schema }}
 {{> documents }}

--- a/packages/templates/typescript/tests/typescript.spec.ts
+++ b/packages/templates/typescript/tests/typescript.spec.ts
@@ -38,7 +38,7 @@ describe('TypeScript template', () => {
       {
         ...config,
         config: {
-          prepend: ['// Test']
+          prepend: ['// Test [="]']
         }
       } as GeneratorConfig,
       context
@@ -47,7 +47,7 @@ describe('TypeScript template', () => {
     const content = compiled[0].content;
 
     expect(content).toBeSimilarStringTo(`
-    // Test
+    // Test [="]
     `);
   });
 


### PR DESCRIPTION
Fixes #484.