### PR TITLE
Fix validating queries against schema bug

### DIFF
--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -264,7 +264,7 @@ export const executeWithOptions = async (options: CLIOptions): Promise<FileOutpu
     if (Array.isArray(documentSourcesResult) && documentSourcesResult.length > 0) {
       const graphQLErrors = documentSourcesResult as ReadonlyArray<GraphQLError>;
       for (const graphQLError of graphQLErrors) {
-        logger.error(`${graphQLError.path}: ${graphQLError.message}`);
+        logger.error(graphQLError.message);
       }
       cliError('Found errors when validating queries against schema');
     }

--- a/packages/graphql-codegen-cli/src/loaders/documents/document-loader.ts
+++ b/packages/graphql-codegen-cli/src/loaders/documents/document-loader.ts
@@ -32,13 +32,19 @@ export const loadDocumentsSources = (
   const loadResults = filePaths
     .map(filePath => {
       const fileContent = loadFileContent(filePath);
+      if (!fileContent) {
+        return {
+          fileContent,
+          errors: []
+        };
+      }
       const errors = validate(schema, fileContent);
       return {
         fileContent,
         errors
       };
     })
-    .filter(content => content);
+    .filter(content => content.fileContent);
 
   const errors = loadResults.map(r => r.errors).reduce((soFar, current) => soFar.concat(current), []);
   return errors.length > 0 ? errors : concatAST(loadResults.map(r => r.fileContent));


### PR DESCRIPTION
Hi! PR #513 was a WIP but got merged :) Here is a fix for the error that arises when loading documents sources without a gql tag. I also filtered out the validation rule `NoUnusedFragments` because as of now it seems that we don't compile the template literals which will not include external fragments declared in other variables