### PR TITLE
Fix wrong operation option types generated by typescript-react-apollo template

### DIFF
--- a/packages/templates/typescript-react-apollo/src/hoc.handlebars
+++ b/packages/templates/typescript-react-apollo/src/hoc.handlebars
@@ -3,7 +3,7 @@
         {{#unless @root.config.noNamespaces}}
         export namespace {{toPascalCase name}} {
         {{/unless}}
-            export function {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}HOC<TProps = {}>(operationOptions: ReactApollo.OperationOption<TProps, {{toPascalCase operationType}}, Variables>){
+            export function {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}HOC<TProps = {}>(operationOptions: ReactApollo.OperationOption<TProps, {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}{{toPascalCase operationType}}, {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Variables>){
                 return ReactApollo.graphql<TProps, {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}{{toPascalCase operationType}}, {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Variables>(
                     {{#unless @root.config.noGraphqlTag}}gql` {{ document }} `{{else}}{{{ gql document }}}{{/unless}},
                     operationOptions


### PR DESCRIPTION
This PR fixes #526.