### PR TITLE
[react-apollo] do not html-escape documents

### DIFF
--- a/packages/templates/typescript-react-apollo/src/components.handlebars
+++ b/packages/templates/typescript-react-apollo/src/components.handlebars
@@ -19,7 +19,7 @@ import gql from 'graphql-tag';
             render(){
                 return (
                     <ReactApollo.{{ toPascalCase operationType }}<{{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}{{toPascalCase operationType}}, {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Variables>
-                    {{ toLowerCase operationType }}={ {{#unless @root.config.noGraphqlTag}}gql` {{ document }} `{{else}}{{{ gql document }}}{{/unless}} }
+                    {{ toLowerCase operationType }}={ {{#unless @root.config.noGraphqlTag}}gql` {{{ document }}} `{{else}}{{{ gql document }}}{{/unless}} }
                     {...this.props}
                     />
                 );

--- a/packages/templates/typescript-react-apollo/src/hoc.handlebars
+++ b/packages/templates/typescript-react-apollo/src/hoc.handlebars
@@ -5,7 +5,7 @@
         {{/unless}}
             export function {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}HOC<TProps = {}>(operationOptions: ReactApollo.OperationOption<TProps, {{toPascalCase operationType}}, Variables>){
                 return ReactApollo.graphql<TProps, {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}{{toPascalCase operationType}}, {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Variables>(
-                    {{#unless @root.config.noGraphqlTag}}gql` {{ document }} `{{else}}{{{ gql document }}}{{/unless}},
+                    {{#unless @root.config.noGraphqlTag}}gql` {{{ document }}} `{{else}}{{{ gql document }}}{{/unless}},
                     operationOptions
                 )
             };


### PR DESCRIPTION
Fixes #529 in `react-apollo`