### PR TITLE
[cli] fix handling gql-gen config

### DIFF
--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -239,6 +239,19 @@ export const executeWithOptions = async (options: CLIOptions): Promise<FileOutpu
     if (templateConfig.deprecationNote) {
       logger.warn(`Template ${template} is deprecated: ${templateConfig.deprecationNote}`);
     }
+
+    if (config) {
+      if ('flattenTypes' in config) {
+        templateConfig.flattenTypes = config.flattenTypes;
+      }
+
+      if ('primitives' in config) {
+        templateConfig.primitives = {
+          ...templateConfig.primitives,
+          ...config.primitives
+        };
+      }
+    }
   }
 
   const executeGeneration = async () => {

--- a/packages/graphql-codegen-compiler/src/generate-multiple-files.ts
+++ b/packages/graphql-codegen-compiler/src/generate-multiple-files.ts
@@ -345,7 +345,7 @@ export function generateMultipleFiles(
           documents,
           {
             config: config.config,
-            primitivesMap: config.primitives,
+            primitives: config.primitives,
             currentTime: moment().format()
           },
           config.filesExtension
@@ -366,8 +366,7 @@ export function generateMultipleFiles(
             documents,
             {
               config: config.config,
-              currentTime: moment().format(),
-              primitivesMap: config.primitives
+              currentTime: moment().format()
             },
             parsedTemplateName.fileExtension,
             parsedTemplateName.prefix

--- a/packages/graphql-codegen-compiler/src/generate-single-file.ts
+++ b/packages/graphql-codegen-compiler/src/generate-single-file.ts
@@ -17,7 +17,7 @@ export function generateSingleFile(
       filename: config.outFile,
       content: compiledIndexTemplate({
         config: config.config,
-        primitivesMap: config.primitives,
+        primitives: config.primitives,
         currentTime: moment().format(),
         ...(!executionSettings.generateSchema ? prepareSchemaForDocumentsOnly(templateContext) : templateContext),
         operations: documents.operations,

--- a/packages/templates/typescript/src/helpers/is-primitive-type.ts
+++ b/packages/templates/typescript/src/helpers/is-primitive-type.ts
@@ -1,4 +1,3 @@
 export function isPrimitiveType(type, options) {
-  // tslint:disable-next-line:no-console
-  return options.data.root.primitivesMap[type.type];
+  return options.data.root.primitives[type.type];
 }

--- a/packages/templates/typescript/src/utils/get-result-type.ts
+++ b/packages/templates/typescript/src/utils/get-result-type.ts
@@ -5,7 +5,7 @@ export function getResultType(type, options) {
   const underscorePrefix = type.type.match(/^[\_]+/) || '';
   const config = options.data.root.config || {};
   const realType =
-    options.data.root.primitivesMap[baseType] ||
+    options.data.root.primitives[baseType] ||
     `${type.isScalar ? '' : config.interfacePrefix || ''}${underscorePrefix + pascalCase(baseType)}`;
   const useImmutable = !!config.immutableTypes;
 

--- a/packages/templates/typescript/tests/resolvers.spec.ts
+++ b/packages/templates/typescript/tests/resolvers.spec.ts
@@ -282,4 +282,31 @@ describe('Resolvers', () => {
       }
     `);
   });
+
+  it('Should handle primitives option', async () => {
+    const { context } = compileAndBuildContext(`
+      type TestType {
+        id: ID!
+      }  
+    `);
+
+    const compiled = await compileTemplate(
+      {
+        ...config,
+        primitives: {
+          ...config.primitives,
+          ID: 'number'
+        }
+      },
+      context
+    );
+
+    const content = compiled[0].content;
+
+    expect(content).toBeSimilarStringTo(`
+      export interface TestType {
+        id: number;
+      }
+      `);
+  });
 });


### PR DESCRIPTION
CLI dismisses `primitives` and `flattenTypes` option in `gql-gen.json`.
This PR fixes this issue and also refactors by using `primitives` everywhere instead of `primitivesMap`.
Fixes #543 