### PR TITLE
feature: named clients and custom providedIn

### DIFF
--- a/packages/templates/apollo-angular/src/components.handlebars
+++ b/packages/templates/apollo-angular/src/components.handlebars
@@ -6,15 +6,21 @@ import * as Apollo from 'apollo-angular';
 import gql from 'graphql-tag';
 {{/unless}}
 
+{{#if @root.config.providedIn}}
+{{{ @root.config.providedIn.import }}}
+{{/if}}
+
 {{#each fragments}}
     {{{generateFragment this}}}
 {{/each}}
 
 {{#each operations}}
     @Injectable({
-        providedIn: 'root'
+        providedIn: {{{ providedIn }}}
     })
     export class {{ toPascalCase name }}GQL extends Apollo.{{toPascalCase operationType}}<{{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}{{ toPascalCase operationType }}, {{ toPascalCase name }}{{#unless @root.config.noNamespaces}}.{{/unless}}Variables> {
         document: any = {{{ gql this }}}
+        
+        {{#if @root.config.namedClient}}client = '{{{@root.config.namedClient}}}';{{/if}}
     }
 {{/each}}

--- a/packages/templates/apollo-angular/src/config.ts
+++ b/packages/templates/apollo-angular/src/config.ts
@@ -3,9 +3,11 @@ import typescriptConfig from 'graphql-codegen-typescript-template';
 import * as components from './components.handlebars';
 import { gql } from './helpers/gql';
 import { generateFragment } from './helpers/generate-fragment';
+import { providedIn } from './helpers/provided-in';
 
 typescriptConfig.templates['documents'] += components;
 typescriptConfig.customHelpers.gql = gql;
 typescriptConfig.customHelpers.generateFragment = generateFragment;
+typescriptConfig.customHelpers.providedIn = providedIn;
 
 export { typescriptConfig as config };

--- a/packages/templates/apollo-angular/src/helpers/provided-in.ts
+++ b/packages/templates/apollo-angular/src/helpers/provided-in.ts
@@ -1,0 +1,5 @@
+export function providedIn(options: any): string {
+  const config = options.data.root.config || {};
+
+  return config.providedIn ? config.providedIn.ref : `'root'`; // Important to return it with in quotes
+}

--- a/packages/templates/apollo-angular/tests/components.spec.ts
+++ b/packages/templates/apollo-angular/tests/components.spec.ts
@@ -294,4 +294,78 @@ describe('Components', () => {
       \`;
     `);
   });
+
+  it('should handle named client', async () => {
+    const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
+    const context = schemaToTemplateContext(schema);
+
+    const documents = gql`
+      query MyFeed {
+        feed {
+          id
+        }
+      }
+    `;
+
+    const transformedDocument = transformDocument(schema, documents);
+    const compiled = await compileTemplate(
+      { ...config, config: { noNamespaces: true, namedClient: 'custom' } },
+      context,
+      [transformedDocument],
+      { generateSchema: false }
+    );
+    const content = compiled[0].content;
+
+    expect(content).toBeSimilarStringTo(`
+      document: any = gql\` query MyFeed {
+          feed {
+            id
+          }
+        }
+      \`
+      
+      client = 'custom';
+    `);
+  });
+
+  it('should handle providedIn', async () => {
+    const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));
+    const context = schemaToTemplateContext(schema);
+
+    const documents = gql`
+      query MyFeed {
+        feed {
+          id
+        }
+      }
+    `;
+
+    const providedIn = {
+      import: `import { UsersModule } from './users.modules';`,
+      ref: 'UsersModule'
+    };
+
+    const transformedDocument = transformDocument(schema, documents);
+    const compiled = await compileTemplate(
+      {
+        ...config,
+        config: {
+          noNamespaces: true,
+          providedIn
+        }
+      },
+      context,
+      [transformedDocument],
+      { generateSchema: false }
+    );
+    const content = compiled[0].content;
+
+    expect(content).toBeSimilarStringTo(providedIn.import);
+
+    expect(content).toBeSimilarStringTo(`
+      @Injectable({
+        providedIn: ${providedIn.ref}
+      })
+    `);
+  });
 });


### PR DESCRIPTION
With that we can use it in ✈️ 

It also opens up for lazy loaded + tree-shakable providers