### PR TITLE
Restore `locations` field in introspection query

### DIFF
--- a/packages/graphql-codegen-cli/src/loaders/schema/introspection-from-url.ts
+++ b/packages/graphql-codegen-cli/src/loaders/schema/introspection-from-url.ts
@@ -49,7 +49,7 @@ export class IntrospectionFromUrlLoader implements SchemaLoader {
         {
           url: url,
           json: {
-            query: introspectionQuery.replace('locations', '')
+            query: introspectionQuery
           },
           headers: extraHeaders
         },


### PR DESCRIPTION
Fix for #556 

Not sure where things were left in the discussion, but so far I haven't found any explanation for the `replace` call that removes `locations`, and as things stand I'm unable to use this library. Furthermore, neither of the other `introspection-from-` files seem to have a similar transformation. 

