### PR TITLE
Fix for schema merging 

### DIFF
--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -26,7 +26,8 @@ import { IntrospectionFromUrlLoader } from './loaders/schema/introspection-from-
 import { SchemaFromTypedefs } from './loaders/schema/schema-from-typedefs';
 import { SchemaFromExport } from './loaders/schema/schema-from-export';
 import { CLIOptions } from './cli-options';
-import { mergeSchemas } from 'graphql-tools';
+import { mergeGraphQLSchemas } from '@graphql-modules/epoxy';
+import { makeExecutableSchema } from 'graphql-tools';
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
@@ -312,9 +313,11 @@ export const executeWithOptions = async (options: CLIOptions): Promise<FileOutpu
       }
     }
 
-    const graphQlSchema = mergeSchemas({
-      schemas: await Promise.all(schemas)
-    });
+    const allSchemas = await Promise.all(schemas);
+    const graphQlSchema =
+      allSchemas.length === 1
+        ? allSchemas[0]
+        : makeExecutableSchema({ typeDefs: mergeGraphQLSchemas(allSchemas), allowUndefinedInResolve: true });
 
     if (process.env.VERBOSE !== undefined) {
       getLogger().info(`GraphQL Schema is: `, graphQlSchema);

--- a/packages/scripts/codegen-templates-scripts/webpack.config.js
+++ b/packages/scripts/codegen-templates-scripts/webpack.config.js
@@ -10,7 +10,10 @@ module.exports = {
   },
   mode: 'production',
   target: 'node',
-  externals: [nodeExternals(), 'graphql'],
+  optimization: {
+    minimize: false
+  },
+  externals: [nodeExternals(), 'graphql', 'graphql-codegen-core', 'graphql-codegen-compiler', 'graphql-tag', 'lodash'],
   resolve: {
     mainFields: ['browser', 'main', 'module'],
     extensions: ['.ts', '.tsx', '.js', '.jsx'],

--- a/packages/templates/typescript-mongodb/tests/ts-mongo.spec.ts
+++ b/packages/templates/typescript-mongodb/tests/ts-mongo.spec.ts
@@ -48,7 +48,7 @@ describe('Types', () => {
     }
   };
 
-  it.only('should resolve type and fields correctly', async () => {
+  it('should resolve type and fields correctly', async () => {
     const { context } = compileAndBuildContext(`
         type User @entity(additionalFields: [
           { path: "nonSchemaField", type: "string" }


### PR DESCRIPTION
`mergeSchemas` from `graphql-tools` removes directives because it's based on AST, so it broke the MongoDB template because the directives were stripped.

We prefer to use `@graphql-modules/epoxy` for it ;)