### PR TITLE
Add failing test for fragment validation

### DIFF
--- a/packages/graphql-codegen-cli/tests/load-documents-sources.spec.ts
+++ b/packages/graphql-codegen-cli/tests/load-documents-sources.spec.ts
@@ -39,4 +39,11 @@ describe('loadDocumentsSources', () => {
     expect(errors[0].errors[0] instanceof GraphQLError).toBeTruthy();
     expect(errors[0].errors[0].message).toContain('Cannot query field "fieldD" on type "Query"');
   });
+
+  it.only('should not return an error array when one file references fragment in other file', () => {
+    const documentPath1 = join(__dirname, './test-documents/my-fragment.ts');
+    const documentPath2 = join(__dirname, './test-documents/query-with-my-fragment.ts');
+    const result = loadDocumentsSources(schema, [documentPath1, documentPath2]);
+    expect(Array.isArray(result)).toBeFalsy();
+  });
 });

--- a/packages/graphql-codegen-cli/tests/test-documents/my-fragment.ts
+++ b/packages/graphql-codegen-cli/tests/test-documents/my-fragment.ts
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag';
+
+export const myFragment = gql`
+  fragment MyFragment on MyType {
+    fieldC
+  }
+`;

--- a/packages/graphql-codegen-cli/tests/test-documents/query-with-my-fragment.ts
+++ b/packages/graphql-codegen-cli/tests/test-documents/query-with-my-fragment.ts
@@ -1,0 +1,12 @@
+import gql from 'graphql-tag';
+import { myFragment } from './my-fragment';
+
+export const query = gql`
+  query myQuery {
+    fieldA
+    fieldB {
+      ...MyFragment
+    }
+  }
+  ${myFragment}
+`;


### PR DESCRIPTION
This shows a bug in the code added by PR #622. If we have a fragment thats lives in a different file, the validation will not work as it does not find the fragment.