### PR TITLE
Proposed quickfix for unknown fragment

### DIFF
--- a/packages/graphql-codegen-cli/src/loaders/documents/document-loader.ts
+++ b/packages/graphql-codegen-cli/src/loaders/documents/document-loader.ts
@@ -42,7 +42,7 @@ export const loadDocumentsSources = (
   const errors: ReadonlyArray<LoadDocumentError> = loadResults
     .map(result => ({
       filePath: result.filePath,
-      errors: validate(schema, result.content, effectiveRules)
+      errors: validate(schema, result.content, effectiveRules).filter(e => e.message.indexOf('Unknown fragment') === -1)
     }))
     .filter(r => r.errors.length > 0);
   return errors.length > 0 ? errors : concatAST(loadResults.map(r => r.content));

--- a/packages/graphql-codegen-cli/tests/load-documents-sources.spec.ts
+++ b/packages/graphql-codegen-cli/tests/load-documents-sources.spec.ts
@@ -39,4 +39,11 @@ describe('loadDocumentsSources', () => {
     expect(errors[0].errors[0] instanceof GraphQLError).toBeTruthy();
     expect(errors[0].errors[0].message).toContain('Cannot query field "fieldD" on type "Query"');
   });
+
+  it.only('should not return an error array when one file references fragment in other file', () => {
+    const documentPath1 = join(__dirname, './test-documents/my-fragment.ts');
+    const documentPath2 = join(__dirname, './test-documents/query-with-my-fragment.ts');
+    const result = loadDocumentsSources(schema, [documentPath1, documentPath2]);
+    expect(Array.isArray(result)).toBeFalsy();
+  });
 });

--- a/packages/graphql-codegen-cli/tests/test-documents/my-fragment.ts
+++ b/packages/graphql-codegen-cli/tests/test-documents/my-fragment.ts
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag';
+
+export const myFragment = gql`
+  fragment MyFragment on MyType {
+    fieldC
+  }
+`;

--- a/packages/graphql-codegen-cli/tests/test-documents/query-with-my-fragment.ts
+++ b/packages/graphql-codegen-cli/tests/test-documents/query-with-my-fragment.ts
@@ -1,0 +1,12 @@
+import gql from 'graphql-tag';
+import { myFragment } from './my-fragment';
+
+export const query = gql`
+  query myQuery {
+    fieldA
+    fieldB {
+      ...MyFragment
+    }
+  }
+  ${myFragment}
+`;


### PR DESCRIPTION
This is a quickfix for #624 to allow users to continue working. 

It will simply ignore errors with message "Unknown fragment". This way we can still get the filename of every other error.  I think only the case with misspelled fragment names in spreads where the fragment is imported from another file will be not be validated with this fix.

The proper fix would be to actually resolve all the fragments. 
