### PR TITLE
fix programmatic usage section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,12 @@ If you with to use this package as a library and execute it from your code, do t
 ```typescript
 import { generate } from 'graphql-code-generator';
 
-function doSomething() {
+async function doSomething() {
   const generatedFiles = await generate({
+    schema: 'http://127.0.0.1:3000/graphql',
     template: 'typescript',
-    url: 'http://127.0.0.1:3000/graphql',
-    out: process.cwd() + '/models/'
+    out: process.cwd() + '/models/',
+    args: ['./src/**/*.graphql']
   });
 }
 ```


### PR DESCRIPTION
I was having trouble when trying to use the programmatic approach shown in the readme, and I had to go into the type files to see what is accepted by `CLIOptions`.
Changes:
- I believe `url` is no longer used in favor of `schema`
- I added `args` to the example as the blob used in the CLI examples wasn't immediately clear as to how to use it
- Even though it isn't specific to this module, I added `async` in the case that a reader isn't yet familiar with async/await. This will remove the error of using `await` outside of an `async` function.