### PR TITLE
fix(docs): fix link in templates readme

### DIFF
--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -4,7 +4,7 @@ If you with to write a custom template, you can either use one of the following 
 
 ## Write you own template package
 
-To write you own template package using Handlebars, you can use [`codegen-templates-scripts`](../scripts/handlebars-templates-scripts/README.md).
+To write you own template package using Handlebars, you can use [`codegen-templates-scripts`](../scripts/codegen-templates-scripts/README.md).
 
 ## Write your own output processor
 


### PR DESCRIPTION
The link in the readme was linking incorrectly :)