### PR TITLE
suppress warnings from apollo-tools when making schema from typedefs

### DIFF
--- a/packages/graphql-codegen-cli/src/loaders/schema/schema-from-typedefs.ts
+++ b/packages/graphql-codegen-cli/src/loaders/schema/schema-from-typedefs.ts
@@ -48,7 +48,8 @@ export class SchemaFromTypedefs implements SchemaLoader {
     return makeExecutableSchema({
       typeDefs,
       allowUndefinedInResolve: true,
-      resolvers: {}
+      resolvers: {},
+      resolverValidationOptions: { requireResolversForResolveType: false }
     });
   }
 }


### PR DESCRIPTION
I get a ton of warnings like this due to using a lot of graphql interfaces. This warning doesn't apply here because we don't deal with resolvers. This patch turns it off.

```
Type "Node" is missing a "resolveType" resolver. Pass false into "resolverValidationOptions.requireResolversForResolveType" to disable this warning.
```