### PR TITLE
Fix some logging messages not properly displaying the expected information

### DIFF
--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -194,9 +194,9 @@ export const executeWithOptions = async (options: CLIOptions): Promise<FileOutpu
   let config: GqlGenConfig = null;
 
   if (fs.existsSync(configPath)) {
-    getLogger().info('Loading config file from: ', configPath);
+    getLogger().info(`Loading config file from: ${configPath}`);
     config = JSON.parse(fs.readFileSync(configPath).toString()) as GqlGenConfig;
-    debugLog(`[executeWithOptions] Got project config JSON: `, config);
+    debugLog(`[executeWithOptions] Got project config JSON: ${JSON.stringify(config)}`);
   }
 
   if (project && project !== '') {

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -216,7 +216,7 @@ export const executeWithOptions = async (options: CLIOptions): Promise<FileOutpu
       if (fs.existsSync(resolvedPath)) {
         const requiredFile = require(resolvedPath);
 
-        if (requiredFile && requiredFile && typeof requiredFile === 'function') {
+        if (requiredFile && typeof requiredFile === 'function') {
           resolvedHelpers[helperName] = requiredFile;
         } else {
           throw new Error(`Custom template file ${resolvedPath} does not have a default export function!`);


### PR DESCRIPTION
Hello! While debugging gql-gen with a new template I was building, I found that some log messages were displaying empty strings instead of the values they were supposed to display. I fixed it locally in order to understand what was going on.
Please, consider if it could be appropriate to be merged upstream.