### PR TITLE
ignore invalid directive error during validation

### DIFF
--- a/packages/graphql-codegen-cli/src/loaders/documents/document-loader.ts
+++ b/packages/graphql-codegen-cli/src/loaders/documents/document-loader.ts
@@ -32,6 +32,8 @@ export interface LoadDocumentError {
   readonly errors: ReadonlyArray<GraphQLError>;
 }
 
+const IGNORED_VALIDATION_ERRORS = ['Unknown fragment', 'Unknown directive'];
+
 export const loadDocumentsSources = (
   schema: GraphQLSchema,
   filePaths: string[]
@@ -42,8 +44,11 @@ export const loadDocumentsSources = (
   const errors: ReadonlyArray<LoadDocumentError> = loadResults
     .map(result => ({
       filePath: result.filePath,
-      errors: validate(schema, result.content, effectiveRules).filter(e => e.message.indexOf('Unknown fragment') === -1)
+      errors: validate(schema, result.content, effectiveRules).filter(
+        e => !IGNORED_VALIDATION_ERRORS.find(ignoredErr => e.message.indexOf(ignoredErr) > -1)
+      )
     }))
     .filter(r => r.errors.length > 0);
+
   return errors.length > 0 ? errors : concatAST(loadResults.map(r => r.content));
 };

--- a/packages/graphql-codegen-cli/tests/load-documents-sources.spec.ts
+++ b/packages/graphql-codegen-cli/tests/load-documents-sources.spec.ts
@@ -17,6 +17,13 @@ describe('loadDocumentsSources', () => {
     expect(result['kind']).toBe('Document');
   });
 
+  it('should not throw an exception in case of invalid directive', () => {
+    const documentPath = join(__dirname, './test-documents/invalid-directive.graphql');
+    const result = loadDocumentsSources(schema, [documentPath]);
+    expect(Array.isArray(result)).toBeFalsy();
+    expect(result['kind']).toBe('Document');
+  });
+
   it('should return an error array when document is invalid', () => {
     const documentPath = join(__dirname, './test-documents/invalid-fields.graphql');
     const result = loadDocumentsSources(schema, [documentPath]);
@@ -40,7 +47,7 @@ describe('loadDocumentsSources', () => {
     expect(errors[0].errors[0].message).toContain('Cannot query field "fieldD" on type "Query"');
   });
 
-  it.only('should not return an error array when one file references fragment in other file', () => {
+  it('should not return an error array when one file references fragment in other file', () => {
     const documentPath1 = join(__dirname, './test-documents/my-fragment.ts');
     const documentPath2 = join(__dirname, './test-documents/query-with-my-fragment.ts');
     const result = loadDocumentsSources(schema, [documentPath1, documentPath2]);

--- a/packages/graphql-codegen-cli/tests/test-documents/invalid-directive.graphql
+++ b/packages/graphql-codegen-cli/tests/test-documents/invalid-directive.graphql
@@ -1,0 +1,6 @@
+query myQuery {
+    fieldA
+    fieldB @client {
+        fieldC
+    }
+}


### PR DESCRIPTION
To support client-side only directives, such as `@client`. 