### PR TITLE
Added CLI flag to shallow error on schema validation

### DIFF
--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -88,7 +88,7 @@ export const initCLI = (args: any): CLIOptions => {
   return (commander as any) as CLIOptions;
 };
 
-export const cliError = (err: any) => {
+export const cliError = (err: any, exitOnError = true) => {
   let msg: string;
 
   if (err instanceof Error) {
@@ -100,7 +100,10 @@ export const cliError = (err: any) => {
   }
 
   getLogger().error(msg);
-  process.exit(1);
+
+  if (exitOnError) {
+    process.exit(1);
+  }
 
   return;
 };
@@ -368,7 +371,7 @@ export const executeWithOptions = async (options: CLIOptions & { [key: string]: 
         }
       }
 
-      cliError(`Found ${errorCount} errors when validating your GraphQL documents against schema!`);
+      cliError(`Found ${errorCount} errors when validating your GraphQL documents against schema!`, !options.watch);
     }
 
     const transformedDocuments = transformDocument(graphQlSchema, documentSourcesResult as DocumentNode);


### PR DESCRIPTION
This PR adds optional CLI flag `--shallow-error` useful for `watch` mode. 
At the moment codegen will terminate the watch process if the error will be found on schema validation and the developer needs to restart watcher if he made a mistake in the schema or some query/mutation.

With `--shallow-error` flag process will output the error but also, will keep watcher alive giving an ability to fix a mistake without restarting the process. 