### PR TITLE
Allow js files to be required for template config

### DIFF
--- a/dev-test/config/gql-gen.js
+++ b/dev-test/config/gql-gen.js
@@ -1,0 +1,5 @@
+module.exports = {
+  generatorConfig: {
+    printTime: true
+  }
+};

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -73,7 +73,7 @@ export const initCLI = (args: any): CLIOptions => {
       'Language/platform name templates, or a name of NPM modules that `export default` GqlGenConfig object'
     )
     .option('-p, --project <project-path>', 'Project path(s) to scan for custom template files')
-    .option('--config <json-file>', 'Codegen configuration file, defaults to: ./gql-gen.json')
+    .option('--config <js/json-file>', 'Codegen configuration file, defaults to: ./gql-gen.json')
     .option('-m, --skip-schema', 'Generates only client side documents, without server side schema types')
     .option('-c, --skip-documents', 'Generates only server side schema types, without client side documents')
     .option('-o, --out <path>', 'Output file(s) path', String, './')
@@ -199,8 +199,13 @@ export const executeWithOptions = async (options: CLIOptions & { [key: string]: 
 
   if (fs.existsSync(configPath)) {
     getLogger().info(`Loading config file from: ${configPath}`);
-    config = JSON.parse(fs.readFileSync(configPath).toString()) as GqlGenConfig;
-    debugLog(`[executeWithOptions] Got project config JSON: ${JSON.stringify(config)}`);
+    const configFromExport = require(configPath);
+    config = (configFromExport.default || configFromExport.config || configFromExport) as GqlGenConfig;
+    try {
+      debugLog(`[executeWithOptions] Got project config JSON: ${JSON.stringify(config)}`);
+    } catch (e) {
+      debugLog(`[executeWithOptions] Got project config file: ${configPath}`);
+    }
   }
 
   if (project && project !== '') {

--- a/packages/graphql-codegen-cli/tests/cli.spec.ts
+++ b/packages/graphql-codegen-cli/tests/cli.spec.ts
@@ -95,6 +95,16 @@ describe('executeWithOptions', () => {
     expect(result[0].content).toMatch('Generated in');
   });
 
+  it('execute the correct results when using custom config js file', async () => {
+    const result = await executeWithOptions({
+      schema: '../../dev-test/githunt/schema.json',
+      template: 'ts',
+      config: '../../dev-test/config/gql-gen.js'
+    });
+
+    expect(result[0].content).toMatch('Generated in');
+  });
+
   it('execute the correct results when using schema export as object', async () => {
     const result = await executeWithOptions({
       schema: '../../dev-test/test-schema/schema-object.js',


### PR DESCRIPTION
Found this to be useful if you want to import the enum mappings from external files:

`gql-gen.js`:
```ts
import enumMappings from '../../constants/enumMappings';

export default {
  generatorConfig: {
    printTime: true,
    resolvers: false,
    enums: enumMappings
  }
};
```
