### PR TITLE
[DO NOT MERGE] fix(core): make nullable field in selection not be optional

### DIFF
--- a/packages/graphql-codegen-core/src/operations/build-selection-set.ts
+++ b/packages/graphql-codegen-core/src/operations/build-selection-set.ts
@@ -75,6 +75,7 @@ export function buildSelectionSet(
             type: resolvedType.name,
             raw: resolvedType.raw,
             isRequired: resolvedType.isRequired,
+            isSelected: true,
             isNullableArray: resolvedType.isNullableArray,
             isArray: resolvedType.isArray,
             dimensionOfArray: resolvedType.dimensionOfArray,

--- a/packages/graphql-codegen-core/src/schema/resolve-type.ts
+++ b/packages/graphql-codegen-core/src/schema/resolve-type.ts
@@ -5,6 +5,7 @@ export interface ResolvedType {
   raw: string;
   name: string;
   isRequired: boolean;
+  isSelected: boolean;
   isArray: boolean;
   isNullableArray: boolean;
   dimensionOfArray: number;
@@ -49,6 +50,7 @@ export function resolveType(type: GraphQLType): ResolvedType {
     name,
     raw: String(type),
     isRequired: isRequired(type),
+    isSelected: false,
     isArray: isArray(type),
     isNullableArray: isNullable(type),
     dimensionOfArray: dimensionOfArray(type)

--- a/packages/graphql-codegen-core/src/schema/transform-fields.ts
+++ b/packages/graphql-codegen-core/src/schema/transform-fields.ts
@@ -47,6 +47,7 @@ export function resolveFields(
         isArray: type.isArray,
         dimensionOfArray: type.dimensionOfArray,
         isRequired: type.isRequired,
+        isSelected: type.isSelected,
         hasArguments: resolvedArguments.length > 0,
         isEnum: indicators.isEnum,
         isScalar: indicators.isScalar,

--- a/packages/graphql-codegen-core/src/types.ts
+++ b/packages/graphql-codegen-core/src/types.ts
@@ -43,6 +43,7 @@ export interface Field extends AstNode {
   isArray: boolean;
   dimensionOfArray: number;
   isRequired: boolean;
+  isSelected: boolean;
   isNullableArray: boolean;
   hasArguments: boolean;
   isType: boolean;

--- a/packages/templates/typescript/src/helpers/get-optionals.ts
+++ b/packages/templates/typescript/src/helpers/get-optionals.ts
@@ -12,7 +12,7 @@ export function getOptionals(type: Field, options: Handlebars.HelperOptions) {
     return '';
   }
 
-  if (!type.isRequired) {
+  if (!type.isRequired && !type.isSelected) {
     return '?';
   }
 


### PR DESCRIPTION
This is a working hotfix for #699 to just make the issue gone.

Because I need to solve the issue to make things could continue first.

@dotansimha  I'm not sure if this fix is sane enough for #699. If this direction is acceptable, I'd go further to fix the tests and other stuff.

The goal of this PR is to differentiate a nullable field is in introspection or in a query.