### PR TITLE
[DO NOT MERGE]fix(core): make __typename required when used

### DIFF
--- a/packages/graphql-codegen-core/src/operations/transform-fragment-document.ts
+++ b/packages/graphql-codegen-core/src/operations/transform-fragment-document.ts
@@ -5,7 +5,11 @@ import { debugLog } from '../debugging';
 import { print } from 'graphql/language/printer';
 import { getDirectives } from '../utils/get-directives';
 
-export function transformFragment(schema: GraphQLSchema, fragment: FragmentDefinitionNode, overrideName?: string | null): Fragment {
+export function transformFragment(
+  schema: GraphQLSchema,
+  fragment: FragmentDefinitionNode,
+  overrideName?: string | null
+): Fragment {
   debugLog(
     `[transformFragment] transforming fragment ${fragment.name.value} on type ${fragment.typeCondition.name.value}`
   );

--- a/packages/graphql-codegen-core/src/types.ts
+++ b/packages/graphql-codegen-core/src/types.ts
@@ -113,6 +113,10 @@ export interface SchemaTemplateContext extends AstNode {
   rawSchema: GraphQLSchema;
 }
 
+export interface SelectionSet {
+  hasTypename: boolean;
+  items: SelectionSetItem[];
+}
 export interface SelectionSetItem extends AstNode {
   isFragmentSpread: boolean;
   isInlineFragment: boolean;

--- a/packages/templates/typescript-mongodb/src/helpers/entity-fields.ts
+++ b/packages/templates/typescript-mongodb/src/helpers/entity-fields.ts
@@ -34,7 +34,7 @@ function buildFieldDef(type: string, field: Field, options: Handlebars.HelperOpt
     },
     options,
     true
-  );
+  ).type;
 }
 
 function convertToInterfaceDefinition(type: Type | Interface, obj: FieldsResult, root = true): string {

--- a/packages/templates/typescript/src/documents.handlebars
+++ b/packages/templates/typescript/src/documents.handlebars
@@ -3,27 +3,24 @@
 {{#unless @root.config.noNamespaces}}
 export namespace {{ toPascalCase name }} {
 {{/unless}}
-  export type {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Variables = {
-  {{#each variables}}
-    {{#if @root.config.immutableTypes }}readonly {{/if}}{{ name }}{{ getOptionals this }}: {{ convertedType this }};
-  {{/each}}
-  }
+export type {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Variables = {
+{{#each variables}}
+{{#if @root.config.immutableTypes }}readonly {{/if}}{{ name }}{{ getOptionals this }}: {{ convertedType this }};
+{{/each}}
+}
 
-  export type {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}{{ toPascalCase operationType }} ={{#if hasFields}} {
-    {{#if @root.config.immutableTypes }}readonly {{/if}}__typename?: "{{ toPascalCase operationType }}";
-    {{> selectionSet fields=fields prefix=name }}
-  }{{/if}}{{> fragments this=this prefix=name }}
-  {{#each innerModels }}
+export type {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}{{ toPascalCase operationType }} ={{#if
+hasFields}} {
+{{#if @root.config.immutableTypes }}readonly {{/if}}__typename?: "{{ toPascalCase operationType }}";
+{{> selectionSet fields=fields prefix=name }}
+}{{/if}}{{> fragments this=this prefix=name }}
+{{#each innerModels }}
 
-  export type {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ toPascalCase modelType }} ={{#if hasFields}} {
-  {{#unless hasInlineFragments}}
-    {{#if @root.config.immutableTypes }}readonly {{/if}}__typename?: "{{ schemaBaseType }}";
-  {{else}}
-    {{#if @root.config.immutableTypes }}readonly {{/if}}__typename?: {{#each inlineFragments}}{{#if @root.config.noNamespaces}}{{ toPascalCase ../../name }}{{/if}}{{onType}}["__typename"]{{#unless @last}} | {{/unless}}{{/each}};
-  {{/unless}}
-    {{> selectionSet fields=fields prefix=../name }}
-  }{{/if}}{{> fragments this=this prefix=../name }}
-  {{/each}}
+export type {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ toPascalCase modelType }} ={{#if
+hasFields}} {
+{{> selectionSet fields=fields prefix=../name }}
+}{{/if}}{{> fragments this=this prefix=../name }}
+{{/each}}
 {{#unless @root.config.noNamespaces}}
 }
 {{/unless}}
@@ -33,23 +30,18 @@ export namespace {{ toPascalCase name }} {
 {{#unless @root.config.noNamespaces}}
 export namespace {{ toPascalCase name }} {
 {{/unless}}
-  export type {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Fragment ={{#if hasFields}} {
-    {{#if @root.config.immutableTypes }}readonly {{/if}}__typename?: "{{ onType }}";
-    {{> selectionSet fields=fields prefix=name }}
-  }{{/if}}{{> fragments this=this prefix=name }}
-  {{#each innerModels }}
+export type {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Fragment ={{#if hasFields}} {
+{{#if @root.config.immutableTypes }}readonly {{/if}}__typename: "{{ onType }}";
+{{> selectionSet fields=fields prefix=name }}
+}{{/if}}{{> fragments this=this prefix=name }}
+{{#each innerModels }}
 
-  export type {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ toPascalCase modelType }} ={{#if hasFields}} {
-  {{#unless hasInlineFragments}}
-    {{#if @root.config.immutableTypes }}readonly {{/if}}__typename?: "{{ schemaBaseType }}";
-  {{else}}
-    {{#if @root.config.immutableTypes }}readonly {{/if}}__typename?: {{#each inlineFragments}}{{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{onType}}["__typename"]{{#unless @last}} | {{/unless}}{{/each}};
-  {{/unless}}
-    {{> selectionSet fields=fields prefix=../name }}
-  }{{/if}}{{> fragments this=this prefix=../name}}
-  {{/each}}
+export type {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ toPascalCase modelType }} ={{#if
+hasFields}} {
+{{> selectionSet fields=fields prefix=../name }}
+}{{/if}}{{> fragments this=this prefix=../name}}
+{{/each}}
 {{#unless @root.config.noNamespaces}}
 }
 {{/unless}}
 {{/each}}
-

--- a/packages/templates/typescript/src/helpers/get-type.ts
+++ b/packages/templates/typescript/src/helpers/get-type.ts
@@ -9,5 +9,9 @@ export function getType(type: Field, options: Handlebars.HelperOptions) {
 
   const result = getResultType(type, options);
 
-  return new SafeString(result);
+  if (result.isQuoted) {
+    return new SafeString(`"${result.type}"`);
+  }
+
+  return new SafeString(result.type);
 }


### PR DESCRIPTION
Yet another hotfix (ﾟ∀。)

This PR is for fixing #700

The goal for this PR is to make `__typename` required when actually used in a document.

Summary of this PR:

1. `__typename` field in a trivial Field will be required when a selection has `__typename` field, otherwise, no `__typename` field will be generated in the selection field.
2. `__typename` on a union field, will not generate `__typename` on the union, but will *always* generate on each inline fragment
3. `__typename` on spread fragment is now *always* required.

The way to achieve above behavior is somewhat inappropriate I think. Thus I put `[DO NOT MERGE]` on the title and call this `hotfix`. I just want things working at first.

About `2.` and `3.`, they do not really check `__typename` is used in the query or not. Because I found it is hard to do such check. I do so because it is a conventional use case for union and fragments. We should find a proper way to handle this.