### PR TITLE
Fix getLogger(...).warning is not a function

### DIFF
--- a/packages/graphql-codegen-cli/src/utils/watcher.ts
+++ b/packages/graphql-codegen-cli/src/utils/watcher.ts
@@ -33,7 +33,7 @@ export const createWatcher = (options: CLIOptions, onNext: (result: FileOutput[]
 
     const { warning, watch, relative_path = '' } = await client.command(['watch-project', process.cwd()]);
     if (warning) {
-      getLogger().warning(warning);
+      getLogger().warn(warning);
     }
 
     const { clock } = await client.command(['clock', watch]);


### PR DESCRIPTION
Running `gql-gen -w` would result in the following crash.
```
error: graphql_codegen_core_1.getLogger(...).warning is not a function
```
This issue is from this line: 

https://github.com/dotansimha/graphql-code-generator/blob/master/packages/graphql-codegen-cli/src/utils/watcher.ts#L36


The warning I was getting was an Access denied error, which won't happen for everyone, which might be why this is kinda a hard issue to find. Simple fix though!