### PR TITLE
[New Template] Generate `module` definition for `.graphql` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,15 @@ If you develop a **client-side with TypeScript, Angular and GraphQL**, you can u
 
 ## Available Templates:
 
-| Language                  | Purpose                                                        | Package Name & Docs                                                                                |
-| ------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| TypeScript                | Generate server-side TypeScript types, and client-side typings | [`graphql-codegen-typescript-template`](./packages/templates/typescript)                           |
-| MongoDB TypeScript Models | Generate server-side TypeScript types, with MongoDB models     | [`graphql-codegen-typescript-mongodb-template`](./packages/templates/typescript-mongodb)           |
-| Apollo Angular            | Generate TypeScript types, and Apollo Angular Services         | [`graphql-codegen-apollo-angular-template`](./packages/templates/apollo-angular)                   |
-| React Apollo Typescript   | Generate TypeScript types, and React Apollo Components         | [`graphql-codegen-typescript-react-apollo-template`](./packages/templates/typescript-react-apollo) |
-| XSD                       | Generate XSD file                                              | [`graphql-xsd`](https://www.npmjs.com/package/graphql-xsd)                                         |
-| Introspection             | Generate Introspection file                                    | [`graphql-codegen-introspection-template`](./packages/templates/introspection)                     |
+| Language                                | Purpose                                                        | Package Name & Docs                                                                                         |
+| --------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| TypeScript                              | Generate server-side TypeScript types, and client-side typings | [`graphql-codegen-typescript-template`](./packages/templates/typescript)                                    |
+| MongoDB TypeScript Models               | Generate server-side TypeScript types, with MongoDB models     | [`graphql-codegen-typescript-mongodb-template`](./packages/templates/typescript-mongodb)                    |
+| Apollo Angular                          | Generate TypeScript types, and Apollo Angular Services         | [`graphql-codegen-apollo-angular-template`](./packages/templates/apollo-angular)                            |
+| React Apollo Typescript                 | Generate TypeScript types, and React Apollo Components         | [`graphql-codegen-typescript-react-apollo-template`](./packages/templates/typescript-react-apollo)          |
+| XSD                                     | Generate XSD file                                              | [`graphql-xsd`](https://www.npmjs.com/package/graphql-xsd)                                                  |
+| Introspection                           | Generate Introspection file                                    | [`graphql-codegen-introspection-template`](./packages/templates/introspection)                              |
+| TypeScript modules for `.graphql` files | Generates `declare module` for `.graphql` files                | [`graphql-codegen-graphql-files-typescript-modules`](./packages/templates/graphql-files-typescript-modules) |
 
 If you are looking for the **Flow** / **Swift** generators, please note that we will implement it soon again, but you can use `0.5.5` from NPM.
 
@@ -110,7 +111,7 @@ Allowed flags:
 | -h,--header         | String   | Header to add to the introspection HTTP request when using remote endpoint                                                                                                                                                                                                               |
 | -t,--template       | String   | Template name, for example: "typescript" (not required when using `--project`)                                                                                                                                                                                                           |
 | -p,--project        | String   | Project directory with templates (refer to "Custom Templates" section)                                                                                                                                                                                                                   |
-| --config            | String   | Path to project config JSON file (refer to "Custom Templates" section), defaults to `gql-gen.json`                                                                                                                                                                                        |
+| --config            | String   | Path to project config JSON file (refer to "Custom Templates" section), defaults to `gql-gen.json`                                                                                                                                                                                       |
 | -o,--out            | String   | Path for output file/directory. When using single-file generator specify filename, and when using multiple-files generator specify a directory                                                                                                                                           |
 | -m,--skip-schema    | void     | If specified, server side schema won't be generated through the template (enums won't omit)                                                                                                                                                                                              |
 | -c,--skip-documents | void     | If specified, client side documents won't be generated through the template                                                                                                                                                                                                              |

--- a/dev-test/generate-all.sh
+++ b/dev-test/generate-all.sh
@@ -4,6 +4,8 @@ node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescr
 CODEGEN_AVOID_OPTIONALS=true node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescript-template --schema ./dev-test/test-schema/schema.json --out ./dev-test/test-schema/typings.avoidOptionals.ts
 CODEGEN_IMMUTABLE_TYPES=true node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescript-template --schema ./dev-test/test-schema/schema.json --out ./dev-test/test-schema/typings.immutableTypes.ts
 
+node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-graphql-files-typescript-modules --schema ./dev-test/githunt/schema.json --out ./dev-test/githunt/graphql-declared-modules.d.ts "./dev-test/githunt/**/*.graphql"
+
 node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescript-template --schema ./dev-test/githunt/schema.json --out ./dev-test/githunt/types.ts "./dev-test/githunt/**/*.graphql"
 CODEGEN_ENUMS_AS_TYPES=true node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescript-template --schema ./dev-test/githunt/schema.json --out ./dev-test/githunt/types.d.ts "./dev-test/githunt/**/*.graphql"
 CODEGEN_AVOID_OPTIONALS=true node packages/graphql-codegen-cli/dist/cli.js --template graphql-codegen-typescript-template --schema ./dev-test/githunt/schema.json --out ./dev-test/githunt/types.avoidOptionals.ts "./dev-test/githunt/**/*.graphql"

--- a/dev-test/githunt/graphql-declared-modules.d.ts
+++ b/dev-test/githunt/graphql-declared-modules.d.ts
@@ -1,0 +1,98 @@
+declare module '*/dev-test/githunt/comment-added.subscription.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+
+  export { onCommentAdded };
+
+  export default defaultDocument;
+}
+
+declare module '*/dev-test/githunt/comment.query.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+
+  export { Comment };
+
+  export default defaultDocument;
+}
+
+declare module '*/dev-test/githunt/current-user.query.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+
+  export { CurrentUserForProfile };
+
+  export default defaultDocument;
+}
+
+declare module '*/dev-test/githunt/feed.query.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+
+  export { Feed };
+
+  export default defaultDocument;
+}
+
+declare module '*/dev-test/githunt/new-entry.mutation.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+
+  export { submitRepository };
+
+  export default defaultDocument;
+}
+
+declare module '*/dev-test/githunt/submit-comment.mutation.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+
+  export { submitComment };
+
+  export default defaultDocument;
+}
+
+declare module '*/dev-test/githunt/vote.mutation.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+
+  export { vote };
+
+  export default defaultDocument;
+}
+
+declare module '*/dev-test/githunt/comments-page-comment.fragment.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+
+  export {};
+
+  export default defaultDocument;
+}
+
+declare module '*/dev-test/githunt/feed-entry.fragment.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+
+  export {};
+
+  export default defaultDocument;
+}
+
+declare module '*/dev-test/githunt/repo-info.fragment.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+
+  export {};
+
+  export default defaultDocument;
+}
+
+declare module '*/dev-test/githunt/vote-buttons.fragment.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+
+  export {};
+
+  export default defaultDocument;
+}

--- a/dev-test/githunt/graphql-declared-modules.d.ts
+++ b/dev-test/githunt/graphql-declared-modules.d.ts
@@ -1,5 +1,5 @@
 /*tslint:disable*/
-declare module '*/dev-test/githunt/comment-added.subscription.graphql' {
+declare module '*/comment-added.subscription.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
   const onCommentAdded: DocumentNode;
@@ -9,7 +9,7 @@ declare module '*/dev-test/githunt/comment-added.subscription.graphql' {
   export default defaultDocument;
 }
 
-declare module '*/dev-test/githunt/comment.query.graphql' {
+declare module '*/comment.query.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
   const Comment: DocumentNode;
@@ -19,7 +19,7 @@ declare module '*/dev-test/githunt/comment.query.graphql' {
   export default defaultDocument;
 }
 
-declare module '*/dev-test/githunt/current-user.query.graphql' {
+declare module '*/current-user.query.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
   const CurrentUserForProfile: DocumentNode;
@@ -29,7 +29,7 @@ declare module '*/dev-test/githunt/current-user.query.graphql' {
   export default defaultDocument;
 }
 
-declare module '*/dev-test/githunt/feed.query.graphql' {
+declare module '*/feed.query.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
   const Feed: DocumentNode;
@@ -39,7 +39,7 @@ declare module '*/dev-test/githunt/feed.query.graphql' {
   export default defaultDocument;
 }
 
-declare module '*/dev-test/githunt/new-entry.mutation.graphql' {
+declare module '*/new-entry.mutation.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
   const submitRepository: DocumentNode;
@@ -49,7 +49,7 @@ declare module '*/dev-test/githunt/new-entry.mutation.graphql' {
   export default defaultDocument;
 }
 
-declare module '*/dev-test/githunt/submit-comment.mutation.graphql' {
+declare module '*/submit-comment.mutation.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
   const submitComment: DocumentNode;
@@ -59,7 +59,7 @@ declare module '*/dev-test/githunt/submit-comment.mutation.graphql' {
   export default defaultDocument;
 }
 
-declare module '*/dev-test/githunt/vote.mutation.graphql' {
+declare module '*/vote.mutation.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
   const vote: DocumentNode;
@@ -69,7 +69,7 @@ declare module '*/dev-test/githunt/vote.mutation.graphql' {
   export default defaultDocument;
 }
 
-declare module '*/dev-test/githunt/comments-page-comment.fragment.graphql' {
+declare module '*/comments-page-comment.fragment.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
 
@@ -78,7 +78,7 @@ declare module '*/dev-test/githunt/comments-page-comment.fragment.graphql' {
   export default defaultDocument;
 }
 
-declare module '*/dev-test/githunt/feed-entry.fragment.graphql' {
+declare module '*/feed-entry.fragment.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
 
@@ -87,7 +87,7 @@ declare module '*/dev-test/githunt/feed-entry.fragment.graphql' {
   export default defaultDocument;
 }
 
-declare module '*/dev-test/githunt/repo-info.fragment.graphql' {
+declare module '*/repo-info.fragment.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
 
@@ -96,7 +96,7 @@ declare module '*/dev-test/githunt/repo-info.fragment.graphql' {
   export default defaultDocument;
 }
 
-declare module '*/dev-test/githunt/vote-buttons.fragment.graphql' {
+declare module '*/vote-buttons.fragment.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
 

--- a/dev-test/githunt/graphql-declared-modules.d.ts
+++ b/dev-test/githunt/graphql-declared-modules.d.ts
@@ -1,6 +1,8 @@
+/*tslint:disable*/
 declare module '*/dev-test/githunt/comment-added.subscription.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
+  const onCommentAdded: DocumentNode;
 
   export { onCommentAdded };
 
@@ -10,6 +12,7 @@ declare module '*/dev-test/githunt/comment-added.subscription.graphql' {
 declare module '*/dev-test/githunt/comment.query.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
+  const Comment: DocumentNode;
 
   export { Comment };
 
@@ -19,6 +22,7 @@ declare module '*/dev-test/githunt/comment.query.graphql' {
 declare module '*/dev-test/githunt/current-user.query.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
+  const CurrentUserForProfile: DocumentNode;
 
   export { CurrentUserForProfile };
 
@@ -28,6 +32,7 @@ declare module '*/dev-test/githunt/current-user.query.graphql' {
 declare module '*/dev-test/githunt/feed.query.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
+  const Feed: DocumentNode;
 
   export { Feed };
 
@@ -37,6 +42,7 @@ declare module '*/dev-test/githunt/feed.query.graphql' {
 declare module '*/dev-test/githunt/new-entry.mutation.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
+  const submitRepository: DocumentNode;
 
   export { submitRepository };
 
@@ -46,6 +52,7 @@ declare module '*/dev-test/githunt/new-entry.mutation.graphql' {
 declare module '*/dev-test/githunt/submit-comment.mutation.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
+  const submitComment: DocumentNode;
 
   export { submitComment };
 
@@ -55,6 +62,7 @@ declare module '*/dev-test/githunt/submit-comment.mutation.graphql' {
 declare module '*/dev-test/githunt/vote.mutation.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
+  const vote: DocumentNode;
 
   export { vote };
 

--- a/packages/graphql-codegen-cli/src/loaders/documents/document-loader.ts
+++ b/packages/graphql-codegen-cli/src/loaders/documents/document-loader.ts
@@ -1,5 +1,4 @@
-import { validate, GraphQLSchema, GraphQLError, specifiedRules } from 'graphql';
-import { DocumentNode, Source, parse, concatAST } from 'graphql-codegen-core';
+import { DocumentNode, Source, parse, DocumentFile } from 'graphql-codegen-core';
 import * as fs from 'fs';
 import * as path from 'path';
 import { extractDocumentStringFromCodeFile } from '../../utils/document-finder';
@@ -25,30 +24,6 @@ export const loadFileContent = (filePath: string): DocumentNode | null => {
   }
 };
 
-const effectiveRules = specifiedRules.filter((f: Function) => f.name !== 'NoUnusedFragments');
-
-export interface LoadDocumentError {
-  readonly filePath: string;
-  readonly errors: ReadonlyArray<GraphQLError>;
-}
-
-const IGNORED_VALIDATION_ERRORS = ['Unknown fragment', 'Unknown directive'];
-
-export const loadDocumentsSources = (
-  schema: GraphQLSchema,
-  filePaths: string[]
-): DocumentNode | ReadonlyArray<LoadDocumentError> => {
-  const loadResults = filePaths
-    .map(filePath => ({ filePath, content: loadFileContent(filePath) }))
-    .filter(result => result.content);
-  const errors: ReadonlyArray<LoadDocumentError> = loadResults
-    .map(result => ({
-      filePath: result.filePath,
-      errors: validate(schema, result.content, effectiveRules).filter(
-        e => !IGNORED_VALIDATION_ERRORS.find(ignoredErr => e.message.indexOf(ignoredErr) > -1)
-      )
-    }))
-    .filter(r => r.errors.length > 0);
-
-  return errors.length > 0 ? errors : concatAST(loadResults.map(r => r.content));
+export const loadDocumentsSources = (filePaths: string[]): DocumentFile[] => {
+  return filePaths.map(filePath => ({ filePath, content: loadFileContent(filePath) })).filter(result => result.content);
 };

--- a/packages/graphql-codegen-cli/src/loaders/documents/validate-documents.ts
+++ b/packages/graphql-codegen-cli/src/loaders/documents/validate-documents.ts
@@ -1,0 +1,24 @@
+import { validate, GraphQLSchema, GraphQLError, specifiedRules } from 'graphql';
+import { DocumentFile } from 'graphql-codegen-core';
+
+const effectiveRules = specifiedRules.filter((f: Function) => f.name !== 'NoUnusedFragments');
+
+export interface LoadDocumentError {
+  readonly filePath: string;
+  readonly errors: ReadonlyArray<GraphQLError>;
+}
+
+const IGNORED_VALIDATION_ERRORS = ['Unknown fragment', 'Unknown directive'];
+
+export const validateGraphQlDocuments = (
+  schema: GraphQLSchema,
+  documentFiles: DocumentFile[]
+): ReadonlyArray<LoadDocumentError> =>
+  documentFiles
+    .map(result => ({
+      filePath: result.filePath,
+      errors: validate(schema, result.content, effectiveRules).filter(
+        e => !IGNORED_VALIDATION_ERRORS.find(ignoredErr => e.message.indexOf(ignoredErr) > -1)
+      )
+    }))
+    .filter(r => r.errors.length > 0);

--- a/packages/graphql-codegen-cli/tests/load-documents-sources.spec.ts
+++ b/packages/graphql-codegen-cli/tests/load-documents-sources.spec.ts
@@ -2,7 +2,7 @@ import { makeExecutableSchema } from 'graphql-tools';
 import { join } from 'path';
 import { readFileSync } from 'fs';
 import { loadDocumentsSources } from '../src/loaders/documents/document-loader';
-import { LoadDocumentError, validateGraphQlDocuments } from '../src/loaders/documents/validate-documents';
+import { validateGraphQlDocuments } from '../src/loaders/documents/validate-documents';
 import { GraphQLError } from 'graphql';
 
 describe('loadDocumentsSources', () => {

--- a/packages/graphql-codegen-compiler/src/build-files-array.ts
+++ b/packages/graphql-codegen-compiler/src/build-files-array.ts
@@ -1,0 +1,32 @@
+import { Document, TemplateDocumentFileReference } from 'graphql-codegen-core';
+import { AstNode } from '../../graphql-codegen-core/dist/types';
+import { resolve, extname, basename } from 'path';
+
+function getFileAttrs(
+  filePath: string
+): { cwd: string; relative: string; absolute: string; filename: string; extension: string } {
+  const cwd = process.cwd();
+
+  return {
+    cwd,
+    relative: filePath,
+    absolute: resolve(filePath),
+    filename: basename(filePath),
+    extension: extname(filePath)
+  };
+}
+
+export function buildFilesArray(parsedDocument: Document): TemplateDocumentFileReference[] {
+  const filesMap: { [filename: string]: AstNode[] } = {};
+  const relevantOperations = [...parsedDocument.operations, ...parsedDocument.fragments].filter(o => o.originalFile);
+
+  for (const operation of relevantOperations) {
+    if (!filesMap[operation.originalFile]) {
+      filesMap[operation.originalFile] = [];
+    }
+
+    filesMap[operation.originalFile].push(operation);
+  }
+
+  return Object.keys(filesMap).map(filename => ({ documents: filesMap[filename], ...getFileAttrs(filename) }));
+}

--- a/packages/graphql-codegen-compiler/src/compile.ts
+++ b/packages/graphql-codegen-compiler/src/compile.ts
@@ -17,6 +17,7 @@ import { flattenTypes } from './flatten-types';
 import { generateMultipleFiles } from './generate-multiple-files';
 import { generateSingleFile } from './generate-single-file';
 import { cleanTemplateComments } from './clean-template';
+import { buildFilesArray } from './build-files-array';
 
 export const DEFAULT_SETTINGS: Settings = {
   generateSchema: true,
@@ -47,6 +48,7 @@ export async function compileTemplate(
     mergedDocuments = {
       fragments: [],
       operations: [],
+      documentsFiles: [],
       hasFragments: false,
       hasOperations: false
     };
@@ -65,6 +67,8 @@ export async function compileTemplate(
       },
       { hasFragments: false, hasOperations: false, operations: [], fragments: [] } as Document
     );
+
+    mergedDocuments.documentsFiles = buildFilesArray(mergedDocuments);
 
     debugLog(
       `[compileTemplate] all documents merged into single document, total of ${

--- a/packages/graphql-codegen-compiler/src/compile.ts
+++ b/packages/graphql-codegen-compiler/src/compile.ts
@@ -18,6 +18,7 @@ import { generateMultipleFiles } from './generate-multiple-files';
 import { generateSingleFile } from './generate-single-file';
 import { cleanTemplateComments } from './clean-template';
 import { buildFilesArray } from './build-files-array';
+import { TemplateDocumentFileReference } from 'graphql-codegen-core';
 
 export const DEFAULT_SETTINGS: Settings = {
   generateSchema: true,
@@ -41,6 +42,7 @@ export async function compileTemplate(
 
   const executionSettings = Object.assign(DEFAULT_SETTINGS, settings);
   let mergedDocuments: Document;
+  let documentsFiles: TemplateDocumentFileReference[];
 
   if (!executionSettings.generateDocuments) {
     debugLog(`[compileTemplate] generateDocuments is false, ignoring documents...`);
@@ -48,10 +50,10 @@ export async function compileTemplate(
     mergedDocuments = {
       fragments: [],
       operations: [],
-      documentsFiles: [],
       hasFragments: false,
       hasOperations: false
     };
+    documentsFiles = [];
   } else {
     mergedDocuments = documents.reduce(
       (previousValue: Document, item: Document): Document => {
@@ -68,13 +70,13 @@ export async function compileTemplate(
       { hasFragments: false, hasOperations: false, operations: [], fragments: [] } as Document
     );
 
-    mergedDocuments.documentsFiles = buildFilesArray(mergedDocuments);
-
     debugLog(
       `[compileTemplate] all documents merged into single document, total of ${
         mergedDocuments.operations.length
       } operations and ${mergedDocuments.fragments.length} fragments`
     );
+
+    documentsFiles = buildFilesArray(mergedDocuments);
 
     if (!isExternalProcessingFunction && (config as GeneratorConfig).flattenTypes) {
       debugLog(`[compileTemplate] flattenTypes is true, flattening all selection sets from all documents...`);
@@ -136,7 +138,8 @@ export async function compileTemplate(
         executionSettings,
         config,
         templateContext,
-        mergedDocuments
+        mergedDocuments,
+        documentsFiles
       );
     } else if (config.inputType === EInputType.MULTIPLE_FILES || config.inputType === EInputType.PROJECT) {
       if (config.inputType === EInputType.MULTIPLE_FILES) {
@@ -165,7 +168,14 @@ export async function compileTemplate(
 
       debugLog(`[compileTemplate] Templates names: `, Object.keys(compiledTemplates));
 
-      return generateMultipleFiles(compiledTemplates, executionSettings, config, templateContext, mergedDocuments);
+      return generateMultipleFiles(
+        compiledTemplates,
+        executionSettings,
+        config,
+        templateContext,
+        mergedDocuments,
+        documentsFiles
+      );
     } else {
       throw new Error(`Invalid inputType specified: ${config.inputType}!`);
     }

--- a/packages/graphql-codegen-compiler/src/generate-multiple-files.ts
+++ b/packages/graphql-codegen-compiler/src/generate-multiple-files.ts
@@ -1,5 +1,5 @@
 import { MultiFileTemplates } from './types';
-import { GeneratorConfig, Settings, FileOutput } from 'graphql-codegen-core';
+import { GeneratorConfig, Settings, FileOutput, TemplateDocumentFileReference } from 'graphql-codegen-core';
 import {
   Enum,
   Fragment,
@@ -320,7 +320,8 @@ export function generateMultipleFiles(
   executionSettings: Settings,
   config: GeneratorConfig,
   templateContext: SchemaTemplateContext,
-  documents: Document
+  documents: Document,
+  documentsFiles: TemplateDocumentFileReference[] = []
 ): FileOutput[] {
   debugLog(`[generateMultipleFiles] Compiling multiple files...`);
   const result: FileOutput[] = [];
@@ -344,6 +345,7 @@ export function generateMultipleFiles(
           schemaContext,
           documents,
           {
+            documentsFiles,
             config: config.config,
             primitives: config.primitives,
             currentTime: moment().format()
@@ -365,6 +367,7 @@ export function generateMultipleFiles(
             schemaContext,
             documents,
             {
+              documentsFiles,
               config: config.config,
               currentTime: moment().format()
             },

--- a/packages/graphql-codegen-compiler/src/generate-single-file.ts
+++ b/packages/graphql-codegen-compiler/src/generate-single-file.ts
@@ -1,5 +1,12 @@
 import { prepareSchemaForDocumentsOnly } from './prepare-documents-only';
-import { Settings, FileOutput, SchemaTemplateContext, Document, debugLog } from 'graphql-codegen-core';
+import {
+  Settings,
+  FileOutput,
+  SchemaTemplateContext,
+  Document,
+  debugLog,
+  TemplateDocumentFileReference
+} from 'graphql-codegen-core';
 import { GeneratorConfig } from 'graphql-codegen-core';
 import * as moment from 'moment';
 
@@ -8,7 +15,8 @@ export function generateSingleFile(
   executionSettings: Settings,
   config: GeneratorConfig,
   templateContext: SchemaTemplateContext,
-  documents: Document
+  documents: Document,
+  documentsFiles: TemplateDocumentFileReference[] = []
 ): FileOutput[] {
   debugLog(`[generateSingleFile] Compiling single file to: ${config.outFile}`);
 
@@ -16,6 +24,7 @@ export function generateSingleFile(
     {
       filename: config.outFile,
       content: compiledIndexTemplate({
+        documentsFiles,
         config: config.config,
         primitives: config.primitives,
         currentTime: moment().format(),

--- a/packages/graphql-codegen-core/src/index.ts
+++ b/packages/graphql-codegen-core/src/index.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export { schemaToTemplateContext } from './schema/schema-to-template-context';
-export { transformDocument } from './operations/transform-document';
+export { transformDocument, transformDocumentsFiles } from './operations/transform-document';
 export { validateIntrospection, introspectionToGraphQLSchema } from './utils/introspection-to-schema';
 export { parse } from './utils/parse';
 export * from './types';

--- a/packages/graphql-codegen-core/src/schema/transform-fields.ts
+++ b/packages/graphql-codegen-core/src/schema/transform-fields.ts
@@ -69,9 +69,10 @@ function toFieldType(schema: GraphQLSchema, type: GraphQLNamedType): FieldType {
     Union: () => type instanceof GraphQLUnionType,
     InputType: () => type instanceof GraphQLInputObjectType,
     Enum: () => type instanceof GraphQLEnumType,
-    Query: () => schema.getQueryType() && schema.getQueryType().name === type.name,
-    Mutation: () => schema.getMutationType() && schema.getMutationType().name === type.name,
-    Subscription: () => schema.getSubscriptionType() && schema.getSubscriptionType().name === type.name
+    Query: () => schema.getQueryType() && (schema.getQueryType() as GraphQLObjectType).name === type.name,
+    Mutation: () => schema.getMutationType() && (schema.getMutationType() as GraphQLObjectType).name === type.name,
+    Subscription: () =>
+      schema.getSubscriptionType() && (schema.getSubscriptionType() as GraphQLObjectType).name === type.name
   };
 
   return Object.keys(typeMap).find(fieldType => typeMap[fieldType]()) as FieldType;

--- a/packages/graphql-codegen-core/src/types.ts
+++ b/packages/graphql-codegen-core/src/types.ts
@@ -182,6 +182,7 @@ export interface Fragment extends AstNode {
   hasFragmentsSpread: boolean;
   hasInlineFragments: boolean;
   hasFields: boolean;
+  originalFile?: string;
 }
 
 export interface Operation extends AstNode {
@@ -200,6 +201,7 @@ export interface Operation extends AstNode {
   hasFragmentsSpread: boolean;
   hasInlineFragments: boolean;
   hasFields: boolean;
+  originalFile?: string;
 }
 
 export interface Variable {
@@ -298,6 +300,11 @@ export type CustomProcessingFunction = (
   mergedDocuments: Document,
   settings: any
 ) => FileOutput[] | Promise<FileOutput[]>;
+
+export interface DocumentFile {
+  filePath: string;
+  content: DocumentNode;
+}
 
 export function isCustomProcessingFunction(
   config: GeneratorConfig | CustomProcessingFunction

--- a/packages/graphql-codegen-core/src/types.ts
+++ b/packages/graphql-codegen-core/src/types.ts
@@ -234,7 +234,6 @@ export interface Document {
   operations: Operation[];
   hasFragments: boolean;
   hasOperations: boolean;
-  documentsFiles?: TemplateDocumentFileReference[];
 }
 
 export type DirectiveUseMap = { [key: string]: any };

--- a/packages/graphql-codegen-core/src/types.ts
+++ b/packages/graphql-codegen-core/src/types.ts
@@ -220,11 +220,21 @@ export interface Variable {
   isEnum: boolean;
 }
 
+export interface TemplateDocumentFileReference {
+  relative: string;
+  absolute: string;
+  cwd: string;
+  filename: string;
+  extension: string;
+  documents: AstNode[];
+}
+
 export interface Document {
   fragments: Fragment[];
   operations: Operation[];
   hasFragments: boolean;
   hasOperations: boolean;
+  documentsFiles?: TemplateDocumentFileReference[];
 }
 
 export type DirectiveUseMap = { [key: string]: any };

--- a/packages/scripts/codegen-templates-scripts/cli/codegen-templates-scripts-init.js
+++ b/packages/scripts/codegen-templates-scripts/cli/codegen-templates-scripts-init.js
@@ -29,8 +29,8 @@ copyfiles(
     content.devDependencies[pack.name] = pack.version;
     content.devDependencies['graphql-codegen-core'] = pack.version;
     content.devDependencies['graphql-codegen-compiler'] = pack.version;
-    content.devDependencies['graphql'] = '0.13.2';
-    content.devDependencies['@types/graphql'] = '0.13.0';
+    content.devDependencies['graphql'] = '14.0.2';
+    content.devDependencies['@types/graphql'] = '14.0.3';
     fs.writeFileSync(packageFilePath, JSON.stringify(content, null, 2));
   }
 );

--- a/packages/templates/graphql-files-typescript-modules/.gitignore
+++ b/packages/templates/graphql-files-typescript-modules/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+dist
+temp
+yarn-error.log

--- a/packages/templates/graphql-files-typescript-modules/.npmignore
+++ b/packages/templates/graphql-files-typescript-modules/.npmignore
@@ -1,0 +1,4 @@
+src
+node_modules
+tests
+!dist

--- a/packages/templates/graphql-files-typescript-modules/README.md
+++ b/packages/templates/graphql-files-typescript-modules/README.md
@@ -1,0 +1,52 @@
+## `graphql-codegen-graphql-files-typescript-modules`
+
+This template generates TypeScript typings for `.graphql` files containing GraphQL documents, and you can later consume it using [`graphql-tag/loader`](https://github.com/apollographql/graphql-tag#webpack-preprocessing-with-graphql-tagloader), and get type-check and type-safty for your imports. That also means that now when you will import from `.graphql` files, your IDE will provide auto-complete.
+
+This template also handles `.graphql` files containing multiple GraphQL documents, and name the imports according to the operation name.
+
+> Note: Fragments are not generated with named imports, only as defualt imports, due to `graphql-tag/loader` behavior.
+
+### How to use?
+
+Just like any other GraphQL-Code-Generator template, install this template from Npm:
+
+```
+yarn add graphql @types/graphql graphql-code-generator graphql-codegen-graphql-files-typescript-modules
+```
+
+Then, run the codegen, specify the template, your schema (required for documents validation), and specify your `.graphql` files path:
+
+```
+gql-gen --template graphql-codegen-graphql-files-typescript-modules --schema "schema.json" --out src/modules-declarations.d.ts "./src/**/*.graphql"
+```
+
+> Make sure to output the file into a directory that included in your TypeScript project, this way TypeScript will pick it up as declaration file. No need to import the generated file, because TypeScript does it automatically for you.
+
+### Requirements
+
+To use this template, make sure you are using [`graphql-tag/loader`](https://github.com/apollographql/graphql-tag#webpack-preprocessing-with-graphql-tagloader) with Webpack, and make sure to install `@types/graphql` package in your project.
+
+### Examples
+
+For example, if you have a query called `MyQuery` in `my-query.graphql`, this template will generate the following code:
+
+```typescript
+declare module '*/my-query.graphql' {
+  import { DocumentNode } from 'graphql';
+  const MyQuery: DocumentNode;
+
+  export { MyQuery };
+
+  export default defaultDocument;
+}
+```
+
+Later, in your code, you can use default import, or named imports:
+
+```ts
+import myQuery from './my-query.graphql';
+
+// OR
+
+import { myQuery } from './my-query.graphql';
+```

--- a/packages/templates/graphql-files-typescript-modules/package.json
+++ b/packages/templates/graphql-files-typescript-modules/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "graphql-codegen-graphql-files-typescript-modules",
+  "version": "0.12.6",
+  "description": "",
+  "license": "MIT",
+  "scripts": {
+    "prepublishOnly": "yarn build",
+    "build": "codegen-templates-scripts build",
+    "pretest": "yarn build",
+    "test": ""
+  },
+  "devDependencies": {
+    "codegen-templates-scripts": "0.12.6",
+    "graphql-codegen-core": "0.12.6",
+    "graphql-codegen-compiler": "0.12.6",
+    "graphql": "14.0.2",
+    "@types/graphql": "14.0.3"
+  },
+  "main": "./dist/index.js",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "enableTsDiagnostics": false
+      }
+    },
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
+  }
+}

--- a/packages/templates/graphql-files-typescript-modules/src/config.ts
+++ b/packages/templates/graphql-files-typescript-modules/src/config.ts
@@ -8,9 +8,6 @@ export const config: GeneratorConfig = {
     index
   },
   flattenTypes: true,
-  customHelpers: {
-    filenameToModuleName: (filePath: string) => (filePath.charAt(0) === '.' ? `*${filePath.substr(1)}` : filePath)
-  },
   primitives: {
     // Declare your primitives map (GraphQL built-in types to your language types)
     String: 'string',

--- a/packages/templates/graphql-files-typescript-modules/src/config.ts
+++ b/packages/templates/graphql-files-typescript-modules/src/config.ts
@@ -1,0 +1,23 @@
+import * as index from './template.handlebars';
+import { EInputType, GeneratorConfig } from 'graphql-codegen-core';
+
+export const config: GeneratorConfig = {
+  inputType: EInputType.SINGLE_FILE, // The type of the templates input (and output): either one file or multiple files
+  templates: {
+    // declare here your templates and partials
+    index
+  },
+  flattenTypes: true,
+  customHelpers: {
+    filenameToModuleName: (filePath: string) => (filePath.charAt(0) === '.' ? `*${filePath.substr(1)}` : filePath)
+  },
+  primitives: {
+    // Declare your primitives map (GraphQL built-in types to your language types)
+    String: 'string',
+    Int: 'number',
+    Float: 'number',
+    Boolean: 'boolean',
+    ID: 'string'
+  },
+  outFile: 'graphql-modules-declaration.d.ts' // default output file name
+};

--- a/packages/templates/graphql-files-typescript-modules/src/index.ts
+++ b/packages/templates/graphql-files-typescript-modules/src/index.ts
@@ -1,0 +1,3 @@
+import { config } from './config';
+
+export default config;

--- a/packages/templates/graphql-files-typescript-modules/src/polyfills.d.ts
+++ b/packages/templates/graphql-files-typescript-modules/src/polyfills.d.ts
@@ -1,0 +1,4 @@
+declare module '*.handlebars' {
+  const content: string;
+  export = content;
+}

--- a/packages/templates/graphql-files-typescript-modules/src/template.handlebars
+++ b/packages/templates/graphql-files-typescript-modules/src/template.handlebars
@@ -3,7 +3,7 @@
 // Generated in {{ currentTime }}
 {{/if}}
 {{#each documentsFiles}} 
-declare module '{{filenameToModuleName relative}}' {
+declare module '*/{{ filename }}' {
     import { DocumentNode } from 'graphql';
     const defaultDocument: DocumentNode;
     {{#each documents}}{{#if operationType}}const {{ name }}: DocumentNode;{{/if}}{{/each}}

--- a/packages/templates/graphql-files-typescript-modules/src/template.handlebars
+++ b/packages/templates/graphql-files-typescript-modules/src/template.handlebars
@@ -1,0 +1,16 @@
+{{#if config.printTime }}
+// Generated in {{ currentTime }}
+{{/if}}
+{{#each documentsFiles}} 
+declare module '{{filenameToModuleName relative}}' {
+    import { DocumentNode } from 'graphql';
+    const defaultDocument: DocumentNode;
+    
+    export {
+      {{#each documents}}{{#if operationType}}{{ name }},{{/if}}{{/each}}
+    };
+
+    export default defaultDocument;
+}
+
+{{/each}}

--- a/packages/templates/graphql-files-typescript-modules/src/template.handlebars
+++ b/packages/templates/graphql-files-typescript-modules/src/template.handlebars
@@ -1,3 +1,4 @@
+/*tslint:disable*/
 {{#if config.printTime }}
 // Generated in {{ currentTime }}
 {{/if}}
@@ -5,6 +6,7 @@
 declare module '{{filenameToModuleName relative}}' {
     import { DocumentNode } from 'graphql';
     const defaultDocument: DocumentNode;
+    {{#each documents}}{{#if operationType}}const {{ name }}: DocumentNode;{{/if}}{{/each}}
     
     export {
       {{#each documents}}{{#if operationType}}{{ name }},{{/if}}{{/each}}

--- a/packages/templates/graphql-files-typescript-modules/tsconfig.json
+++ b/packages/templates/graphql-files-typescript-modules/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "target": "es5",
+    "lib": ["es6", "esnext", "es2015"],
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "./dist/",
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "exclude": ["node_modules", "tests", "dist"]
+}


### PR DESCRIPTION
The goal is to generate something like that:

Given a file `./src/my-query.graphql`, it will generate:

```
declare module './src/my-query.graphql' {
  const doc: DocumentNode;
  export default doc;
}
```

And support all use cases of [`graphql-tag/loader`](https://github.com/apollographql/graphql-tag#webpack-preprocessing-with-graphql-tagloader), to make sure that imports from `.graphql` files on client-side are strongly-typed now

Tasks:
- [x] Separate document error validations from handling.
- [x] Added `originalFile` to the each found document.
- [x] Removing gql documents concatation.
- [x] Add `documentsFiles` to `context` to get list of files, and then iterate list of documents from that file.
- [x] Add Handlebars helper that parses the `originalFile` into easy-to-use variables (such as, the relative path to `cwd`, absolute path, file extension...).
- [x] Create new template
- [x] Add README to template
- [x] Update root README