### PR TITLE
Fix fragment/document conflict in React template

### DIFF
--- a/packages/templates/apollo-angular/tests/components.spec.ts
+++ b/packages/templates/apollo-angular/tests/components.spec.ts
@@ -13,15 +13,6 @@ import config from '../dist';
 import * as fs from 'fs';
 import { DocumentNode, extendSchema } from 'graphql';
 
-const compileAndBuildContext = (typeDefs: string): { context: SchemaTemplateContext; schema: GraphQLSchema } => {
-  const schema = makeExecutableSchema({ typeDefs, resolvers: {}, allowUndefinedInResolve: true });
-
-  return {
-    schema,
-    context: schemaToTemplateContext(schema)
-  };
-};
-
 describe('Components', () => {
   it('should generate Component', async () => {
     const schema = introspectionToGraphQLSchema(JSON.parse(fs.readFileSync('./tests/files/schema.json').toString()));

--- a/packages/templates/typescript-react-apollo/src/components.handlebars
+++ b/packages/templates/typescript-react-apollo/src/components.handlebars
@@ -5,9 +5,10 @@ import * as React from 'react';
 import gql from 'graphql-tag';
 {{/unless}}
 
-
+{{ blockCommentIf 'Fragments' fragments }}
 {{{generateFragments fragments}}}
 
+{{ blockCommentIf 'Components' operations }}
 {{#each operations }}
     {{#unless @root.config.noNamespaces}}
 export namespace {{toPascalCase name}} {

--- a/packages/templates/typescript-react-apollo/src/helpers/generate-fragments.ts
+++ b/packages/templates/typescript-react-apollo/src/helpers/generate-fragments.ts
@@ -9,7 +9,7 @@ export function generateFragments(fragments: Fragment[], options: Handlebars.Hel
   if (!fragments) {
     return '';
   }
-  const graph = new DepGraph({ circular: true });
+  const graph = new DepGraph<Fragment>({ circular: true });
   fragments.forEach(fragment => {
     graph.addNode(fragment.name, fragment);
   });
@@ -36,12 +36,12 @@ export function generateFragments(fragments: Fragment[], options: Handlebars.Hel
       // Because all of them will have same namespace FooBar
       if (config.noNamespaces) {
         return `
-          export const ${pascalCasedFragmentName}Document = ${gql(fragment, options)};
+          export const ${pascalCasedFragmentName}FragmentDoc = ${gql(fragment, options)};
         `;
       } else {
         return `
           export namespace ${pascalCasedFragmentName} {
-            export const Document = ${gql(fragment, options)};
+            export const FragmentDoc = ${gql(fragment, options)};
           }
         `;
       }

--- a/packages/templates/typescript-react-apollo/src/helpers/to-fragment-name.ts
+++ b/packages/templates/typescript-react-apollo/src/helpers/to-fragment-name.ts
@@ -3,8 +3,8 @@ import { pascalCase } from 'change-case';
 export function toFragmentName(fragmentName: string, options: Handlebars.HelperOptions): string {
   const config = options.data.root.config || {};
   if (config.noNamespaces) {
-    return pascalCase(`${fragmentName}Document`);
+    return pascalCase(`${fragmentName}FragmentDoc`);
   } else {
-    return pascalCase(`${fragmentName}`) + '.Document';
+    return pascalCase(fragmentName) + '.FragmentDoc';
   }
 }


### PR DESCRIPTION
I used `FragmentDoc` suffix for fragments and left `Document` for other operations.

I don't think there's a person uses those fragments directly but if so this is a breaking change.

Fixes #702