### PR TITLE
resolvers: generic type for parent

### DIFF
--- a/dev-test/test-schema/resolvers-types.ts
+++ b/dev-test/test-schema/resolvers-types.ts
@@ -66,14 +66,14 @@ export interface UserByIdQueryArgs {
 // ====================================================
 
 export namespace QueryResolvers {
-  export interface Resolvers<Context = any> {
-    allUsers?: AllUsersResolver<(User | null)[], any, Context>;
+  export interface Resolvers<Context = any, TypeParent = never> {
+    allUsers?: AllUsersResolver<(User | null)[], TypeParent, Context>;
 
-    userById?: UserByIdResolver<User | null, any, Context>;
+    userById?: UserByIdResolver<User | null, TypeParent, Context>;
   }
 
-  export type AllUsersResolver<R = (User | null)[], Parent = any, Context = any> = Resolver<R, Parent, Context>;
-  export type UserByIdResolver<R = User | null, Parent = any, Context = any> = Resolver<
+  export type AllUsersResolver<R = (User | null)[], Parent = never, Context = any> = Resolver<R, Parent, Context>;
+  export type UserByIdResolver<R = User | null, Parent = never, Context = any> = Resolver<
     R,
     Parent,
     Context,
@@ -85,15 +85,15 @@ export namespace QueryResolvers {
 }
 
 export namespace UserResolvers {
-  export interface Resolvers<Context = any> {
-    id?: IdResolver<number, any, Context>;
+  export interface Resolvers<Context = any, TypeParent = User> {
+    id?: IdResolver<number, TypeParent, Context>;
 
-    name?: NameResolver<string, any, Context>;
+    name?: NameResolver<string, TypeParent, Context>;
 
-    email?: EmailResolver<string, any, Context>;
+    email?: EmailResolver<string, TypeParent, Context>;
   }
 
-  export type IdResolver<R = number, Parent = any, Context = any> = Resolver<R, Parent, Context>;
-  export type NameResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
-  export type EmailResolver<R = string, Parent = any, Context = any> = Resolver<R, Parent, Context>;
+  export type IdResolver<R = number, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type NameResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+  export type EmailResolver<R = string, Parent = User, Context = any> = Resolver<R, Parent, Context>;
 }

--- a/packages/templates/typescript-resolvers/src/config.ts
+++ b/packages/templates/typescript-resolvers/src/config.ts
@@ -3,9 +3,11 @@ import typescriptConfig from 'graphql-codegen-typescript-template';
 import * as resolver from './resolver.handlebars';
 import * as beforeSchema from './before-schema.handlebars';
 import * as afterSchema from './after-schema.handlebars';
+import { getParentType } from './helpers/parent-type';
 
 typescriptConfig.templates['resolver'] = resolver;
 typescriptConfig.templates['schema'] = `${beforeSchema}${typescriptConfig.templates['schema']}${afterSchema}`;
+typescriptConfig.customHelpers.getParentType = getParentType;
 typescriptConfig.outFile = 'resolvers-types.ts';
 
 export { typescriptConfig as config };

--- a/packages/templates/typescript-resolvers/src/helpers/parent-type.ts
+++ b/packages/templates/typescript-resolvers/src/helpers/parent-type.ts
@@ -1,0 +1,22 @@
+import { Type, toPascalCase } from 'graphql-codegen-core';
+import { GraphQLSchema, GraphQLObjectType } from 'graphql';
+
+function getRootTypeNames(schema: GraphQLSchema): string[] {
+  const query = ((schema.getQueryType() || {}) as GraphQLObjectType).name;
+  const mutation = ((schema.getMutationType() || {}) as GraphQLObjectType).name;
+  const subscription = ((schema.getSubscriptionType() || {}) as GraphQLObjectType).name;
+
+  return [query, mutation, subscription];
+}
+
+function isRootType(type: Type, schema: GraphQLSchema) {
+  return getRootTypeNames(schema).includes(type.name);
+}
+
+export function getParentType(type: Type, options: Handlebars.HelperOptions) {
+  const config = options.data.root.config || {};
+  const schema: GraphQLSchema = options.data.root.rawSchema;
+  const name = `${config.interfacePrefix || ''}${toPascalCase(type.name)}`;
+
+  return isRootType(type, schema) ? 'never' : name;
+}

--- a/packages/templates/typescript-resolvers/src/resolver.handlebars
+++ b/packages/templates/typescript-resolvers/src/resolver.handlebars
@@ -2,15 +2,15 @@
 {{#unless @root.config.noNamespaces}}
 export namespace {{ toPascalCase name }}Resolvers {
 {{/unless}}
-  export interface {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Resolvers<Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}any{{/if}}> {
+  export interface {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Resolvers<Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}any{{/if}}, TypeParent = {{ getParentType this }}> {
     {{#each fields}}
     {{ toComment description }}
-    {{ name }}?: {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<{{ convertedType this}}, any, Context>;
+    {{ name }}?: {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<{{ convertedType this }}, TypeParent, Context>;
     {{/each}}
   }
 
   {{#each fields}}
-  export type {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{ convertedType this}}, Parent = any, Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}any{{/if}}> = {{ getFieldResolver this ../this }};
+  export type {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{ convertedType this }}, Parent = {{ getParentType ../this }}, Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}any{{/if}}> = {{ getFieldResolver this ../this }};
 
   {{~# if hasArguments }}
 


### PR DESCRIPTION
Uses `never` on root types
Otherwise uses parent's type as default