### PR TITLE
Mappers (in typescript-resolvers template)

### DIFF
--- a/packages/templates/typescript-mongodb/package.json
+++ b/packages/templates/typescript-mongodb/package.json
@@ -16,7 +16,8 @@
     "graphql-codegen-core": "0.12.6"
   },
   "dependencies": {
-    "lodash": "4.17.11"
+    "lodash": "4.17.11",
+    "graphql-codegen-typescript-template": "0.12.6"
   },
   "main": "./dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/templates/typescript-mongodb/src/helpers/entity-fields.ts
+++ b/packages/templates/typescript-mongodb/src/helpers/entity-fields.ts
@@ -1,6 +1,6 @@
 import { Field, Interface, Type } from 'graphql-codegen-core';
 import { set } from 'lodash';
-import { getResultType } from '../../../typescript/src/utils/get-result-type';
+import { convertedType } from 'graphql-codegen-typescript-template';
 
 // Directives fields
 const ID_DIRECTIVE = 'id';
@@ -27,7 +27,7 @@ function appendField(obj: object, field: string, value: string, mapDirectiveValu
 type FieldsResult = { [name: string]: string | FieldsResult };
 
 function buildFieldDef(type: string, field: Field, options: Handlebars.HelperOptions): string {
-  return getResultType(
+  return convertedType(
     {
       ...field,
       type

--- a/packages/templates/typescript-resolvers/package.json
+++ b/packages/templates/typescript-resolvers/package.json
@@ -9,8 +9,10 @@
     "pretest": "yarn build",
     "test": "codegen-templates-scripts test"
   },
+  "dependencies": {
+    "graphql-codegen-typescript-template": "0.12.6"
+  },
   "devDependencies": {
-    "graphql-codegen-typescript-template": "0.12.6",
     "codegen-templates-scripts": "0.12.6",
     "graphql-codegen-core": "0.12.6",
     "graphql-codegen-compiler": "0.12.6",

--- a/packages/templates/typescript-resolvers/src/after-schema.handlebars
+++ b/packages/templates/typescript-resolvers/src/after-schema.handlebars
@@ -1,4 +1,5 @@
 {{{ blockCommentIf 'Resolvers' types }}}
+
 {{#each types}}
 {{~> resolver }}
 {{/each}}

--- a/packages/templates/typescript-resolvers/src/before-schema.handlebars
+++ b/packages/templates/typescript-resolvers/src/before-schema.handlebars
@@ -25,3 +25,6 @@ export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
 export type SubscriptionResolver<Result, Parent = any, Context = any, Args = never> =
   | ((...args: any[]) => ISubscriptionResolverObject<Result, Parent, Context, Args>)
   | ISubscriptionResolverObject<Result, Parent, Context, Args>;
+
+
+{{{ importMappers types }}}

--- a/packages/templates/typescript-resolvers/src/config.ts
+++ b/packages/templates/typescript-resolvers/src/config.ts
@@ -5,11 +5,13 @@ import * as beforeSchema from './before-schema.handlebars';
 import * as afterSchema from './after-schema.handlebars';
 import { getParentType } from './helpers/parent-type';
 import { getFieldType } from './helpers/field-type';
+import { importMappers } from './helpers/import-mappers';
 
 typescriptConfig.templates['resolver'] = resolver;
 typescriptConfig.templates['schema'] = `${beforeSchema}${typescriptConfig.templates['schema']}${afterSchema}`;
 typescriptConfig.customHelpers.getParentType = getParentType;
 typescriptConfig.customHelpers.getFieldType = getFieldType;
+typescriptConfig.customHelpers.importMappers = importMappers;
 typescriptConfig.outFile = 'resolvers-types.ts';
 
 export { typescriptConfig as config };

--- a/packages/templates/typescript-resolvers/src/config.ts
+++ b/packages/templates/typescript-resolvers/src/config.ts
@@ -4,10 +4,12 @@ import * as resolver from './resolver.handlebars';
 import * as beforeSchema from './before-schema.handlebars';
 import * as afterSchema from './after-schema.handlebars';
 import { getParentType } from './helpers/parent-type';
+import { getFieldType } from './helpers/field-type';
 
 typescriptConfig.templates['resolver'] = resolver;
 typescriptConfig.templates['schema'] = `${beforeSchema}${typescriptConfig.templates['schema']}${afterSchema}`;
 typescriptConfig.customHelpers.getParentType = getParentType;
+typescriptConfig.customHelpers.getFieldType = getFieldType;
 typescriptConfig.outFile = 'resolvers-types.ts';
 
 export { typescriptConfig as config };

--- a/packages/templates/typescript-resolvers/src/helpers/field-type.ts
+++ b/packages/templates/typescript-resolvers/src/helpers/field-type.ts
@@ -1,0 +1,11 @@
+import { Field } from 'graphql-codegen-core';
+import { convertedType, getFieldType as fieldType } from 'graphql-codegen-typescript-template';
+import { pickMapper } from './mappers';
+
+export function getFieldType(field: Field, options: Handlebars.HelperOptions) {
+  const config = options.data.root.config || {};
+  const mapper = pickMapper(field.type, config.mappers || {});
+  const type: string = mapper ? fieldType(field, mapper.type, options) : convertedType(field, options);
+
+  return type;
+}

--- a/packages/templates/typescript-resolvers/src/helpers/import-mappers.ts
+++ b/packages/templates/typescript-resolvers/src/helpers/import-mappers.ts
@@ -1,0 +1,41 @@
+import { Type } from 'graphql-codegen-core';
+import { pickMapper } from './mappers';
+
+interface Modules {
+  [path: string]: string[];
+}
+
+export function importMappers(types: Type[], options: Handlebars.HelperOptions) {
+  const config = options.data.root.config || {};
+  const mappers = config.mappers || {};
+  const modules: Modules = {};
+  const availableTypes = types.map(t => t.name);
+
+  for (const type in mappers) {
+    if (mappers.hasOwnProperty(type)) {
+      const mapper = pickMapper(type, mappers);
+
+      // checks if mapper comes from a module
+      // and if is used
+      if (mapper && mapper.isExternal && availableTypes.includes(type)) {
+        const path = mapper.source;
+        if (!modules[path]) {
+          modules[path] = [];
+        }
+
+        // checks for duplicates
+        if (!modules[path].includes(mapper.type)) {
+          modules[path].push(mapper.type);
+        }
+      }
+    }
+  }
+
+  const imports: string[] = Object.keys(modules).map(
+    path => `
+      import { ${modules[path].join(', ')} } from '${path}';
+    `
+  );
+
+  return imports.join('\n');
+}

--- a/packages/templates/typescript-resolvers/src/helpers/mappers.ts
+++ b/packages/templates/typescript-resolvers/src/helpers/mappers.ts
@@ -1,0 +1,39 @@
+export interface ParentsMap {
+  [key: string]: string;
+}
+
+export interface Mapper {
+  isExternal: boolean;
+  type: string;
+  source?: string;
+}
+
+function isExternal(value: string) {
+  return value.includes('#');
+}
+
+function parseMapper(mapper: string): Mapper {
+  if (isExternal(mapper)) {
+    const [source, type] = mapper.split('#');
+    return {
+      isExternal: true,
+      source,
+      type
+    };
+  }
+
+  return {
+    isExternal: false,
+    type: mapper
+  };
+}
+
+export function pickMapper(name: string, map: ParentsMap): Mapper | undefined {
+  const mapper = map[name];
+
+  if (!mapper) {
+    return undefined;
+  }
+
+  return parseMapper(mapper);
+}

--- a/packages/templates/typescript-resolvers/src/helpers/parent-type.ts
+++ b/packages/templates/typescript-resolvers/src/helpers/parent-type.ts
@@ -1,5 +1,6 @@
 import { Type, toPascalCase } from 'graphql-codegen-core';
 import { GraphQLSchema, GraphQLObjectType } from 'graphql';
+import { pickMapper } from './mappers';
 
 function getRootTypeNames(schema: GraphQLSchema): string[] {
   const query = ((schema.getQueryType() || {}) as GraphQLObjectType).name;
@@ -16,7 +17,8 @@ function isRootType(type: Type, schema: GraphQLSchema) {
 export function getParentType(type: Type, options: Handlebars.HelperOptions) {
   const config = options.data.root.config || {};
   const schema: GraphQLSchema = options.data.root.rawSchema;
-  const name = `${config.interfacePrefix || ''}${toPascalCase(type.name)}`;
+  const mapper = pickMapper(type.name, config.mappers || {});
+  const name = mapper ? mapper.type : `${config.interfacePrefix || ''}${toPascalCase(type.name)}`;
 
   return isRootType(type, schema) ? 'never' : name;
 }

--- a/packages/templates/typescript-resolvers/src/resolver.handlebars
+++ b/packages/templates/typescript-resolvers/src/resolver.handlebars
@@ -5,12 +5,13 @@ export namespace {{ toPascalCase name }}Resolvers {
   export interface {{#if @root.config.noNamespaces}}{{ toPascalCase name }}{{/if}}Resolvers<Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}any{{/if}}, TypeParent = {{ getParentType this }}> {
     {{#each fields}}
     {{ toComment description }}
-    {{ name }}?: {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<{{ convertedType this }}, TypeParent, Context>;
+    {{ name }}?: {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<{{ getFieldType this }}, TypeParent, Context>;
     {{/each}}
   }
 
   {{#each fields}}
-  export type {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{ convertedType this }}, Parent = {{ getParentType ../this }}, Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}any{{/if}}> = {{ getFieldResolver this ../this }};
+
+  export type {{#if @root.config.noNamespaces}}{{ toPascalCase ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{ getFieldType this }}, Parent = {{ getParentType ../this }}, Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}any{{/if}}> = {{ getFieldResolver this ../this }};
 
   {{~# if hasArguments }}
 

--- a/packages/templates/typescript-resolvers/tests/resolvers.spec.ts
+++ b/packages/templates/typescript-resolvers/tests/resolvers.spec.ts
@@ -471,9 +471,9 @@ describe('Resolvers', () => {
 
     // import parents
     // merge duplicates into single module
-    // expect(content).toBeSimilarStringTo(`
-    //   import { UserParent, PostParent } from './interfaces';
-    // `);
+    expect(content).toBeSimilarStringTo(`
+      import { UserParent, PostParent } from './interfaces';
+    `);
 
     // should check field's result and match it with provided parents
     expect(content).toBeSimilarStringTo(`

--- a/packages/templates/typescript-resolvers/tests/resolvers.spec.ts
+++ b/packages/templates/typescript-resolvers/tests/resolvers.spec.ts
@@ -455,11 +455,13 @@ describe('Resolvers', () => {
     const compiled = await compileTemplate(
       {
         ...config,
-        parentTypes: {
-          // it means that User type expects UserParent to be a parent
-          User: './interfaces#UserParent',
-          // it means that Post type expects UserParent to be a parent
-          Post: './interfaces#PostParent'
+        config: {
+          mappers: {
+            // it means that User type expects UserParent to be a parent
+            User: './interfaces#UserParent',
+            // it means that Post type expects UserParent to be a parent
+            Post: './interfaces#PostParent'
+          }
         }
       } as any,
       context
@@ -467,49 +469,49 @@ describe('Resolvers', () => {
 
     const content = compiled[0].content;
 
-    // TODO: import parents
-    // TODO: merge duplicates into single module
-    expect(content).toBeSimilarStringTo(`
-      import { UserParent, PostParent } from './interfaces';
-    `);
+    // import parents
+    // merge duplicates into single module
+    // expect(content).toBeSimilarStringTo(`
+    //   import { UserParent, PostParent } from './interfaces';
+    // `);
 
-    // TODO: should check field's result and match it with provided parents
+    // should check field's result and match it with provided parents
     expect(content).toBeSimilarStringTo(`
       export namespace QueryResolvers {
         export interface Resolvers<Context = any, TypeParent = never> {
-          post?: PostResolver<UserParent, TypeParent, Context>;
+          post?: PostResolver<PostParent | null, TypeParent, Context>;
         }
-  
-        export type PostResolver<R = UserParent, Parent = never, Context = any> = Resolver<R, Parent, Context>;
+
+        export type PostResolver<R = PostParent | null, Parent = never, Context = any> = Resolver<R, Parent, Context>;
       }
     `);
 
-    // TODO: should check if type has a defined parent and use it as TypeParent
+    // should check if type has a defined parent and use it as TypeParent
     expect(content).toBeSimilarStringTo(`
       export namespace PostResolvers {
+        export interface Resolvers<Context = any, TypeParent = PostParent> {
+          id?: IdResolver<string | null, TypeParent, Context>;
+          author?: AuthorResolver<UserParent | null, TypeParent, Context>;
+        }
+
+        export type IdResolver<R = string | null, Parent = PostParent, Context = any> = Resolver<R, Parent, Context>;
+        export type AuthorResolver<R = UserParent | null, Parent = PostParent, Context = any> = Resolver<R, Parent, Context>;
+      }
+    `);
+
+    // should check if type has a defined parent and use it as TypeParent
+    // should match field's result with provided parent type
+    expect(content).toBeSimilarStringTo(`
+      export namespace UserResolvers {
         export interface Resolvers<Context = any, TypeParent = UserParent> {
           id?: IdResolver<string | null, TypeParent, Context>;
-          author?: AuthorResolver<User | null, TypeParent, Context>;
+          name?: NameResolver<string | null, TypeParent, Context>;
+          post?: PostResolver<PostParent | null, TypeParent, Context>;
         }
 
         export type IdResolver<R = string | null, Parent = UserParent, Context = any> = Resolver<R, Parent, Context>;
-        export type AuthorResolver<R = User | null, Parent = UserParent, Context = any> = Resolver<R, Parent, Context>;
-      }
-    `);
-
-    // TODO: should check if type has a defined parent and use it as TypeParent
-    // TODO: should match field's result with provided parent type
-    expect(content).toBeSimilarStringTo(`
-      export namespace UserResolvers {
-        export interface Resolvers<Context = any, TypeParent = User> {
-          id?: IdResolver<string | null, TypeParent, Context>;
-          name?: NameResolver<string | null, TypeParent, Context>;
-          post?: PostResolver<PostParent, TypeParent, Context>;
-        }
-
-        export type IdResolver<R = string | null, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-        export type NameResolver<R = string | null, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-        export type NameResolver<R = PostParent, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+        export type NameResolver<R = string | null, Parent = UserParent, Context = any> = Resolver<R, Parent, Context>;
+        export type PostResolver<R = PostParent | null, Parent = UserParent, Context = any> = Resolver<R, Parent, Context>;
       }
     `);
   });

--- a/packages/templates/typescript-resolvers/tests/resolvers.spec.ts
+++ b/packages/templates/typescript-resolvers/tests/resolvers.spec.ts
@@ -424,4 +424,93 @@ describe('Resolvers', () => {
       export type UserNameResolver<R = string | null, Parent = User, Context = any> = Resolver<R, Parent, Context>;
     `);
   });
+
+  it('should accept a map of parent types', async () => {
+    const { context } = compileAndBuildContext(`
+        type Query {
+          post: Post
+        }
+
+        type Post {
+          id: String
+          author: User
+        }
+
+        type User {
+          id: String
+          name: String
+          post: Post
+        }
+        
+        schema {
+          query: Query
+        }
+      `);
+
+    // type UserParent = string;
+    // interface PostParent {
+    //   id: string;
+    //   author: string;
+    // }
+    const compiled = await compileTemplate(
+      {
+        ...config,
+        parentTypes: {
+          // it means that User type expects UserParent to be a parent
+          User: './interfaces#UserParent',
+          // it means that Post type expects UserParent to be a parent
+          Post: './interfaces#PostParent'
+        }
+      } as any,
+      context
+    );
+
+    const content = compiled[0].content;
+
+    // TODO: import parents
+    // TODO: merge duplicates into single module
+    expect(content).toBeSimilarStringTo(`
+      import { UserParent, PostParent } from './interfaces';
+    `);
+
+    // TODO: should check field's result and match it with provided parents
+    expect(content).toBeSimilarStringTo(`
+      export namespace QueryResolvers {
+        export interface Resolvers<Context = any, TypeParent = never> {
+          post?: PostResolver<UserParent, TypeParent, Context>;
+        }
+  
+        export type PostResolver<R = UserParent, Parent = never, Context = any> = Resolver<R, Parent, Context>;
+      }
+    `);
+
+    // TODO: should check if type has a defined parent and use it as TypeParent
+    expect(content).toBeSimilarStringTo(`
+      export namespace PostResolvers {
+        export interface Resolvers<Context = any, TypeParent = UserParent> {
+          id?: IdResolver<string | null, TypeParent, Context>;
+          author?: AuthorResolver<User | null, TypeParent, Context>;
+        }
+
+        export type IdResolver<R = string | null, Parent = UserParent, Context = any> = Resolver<R, Parent, Context>;
+        export type AuthorResolver<R = User | null, Parent = UserParent, Context = any> = Resolver<R, Parent, Context>;
+      }
+    `);
+
+    // TODO: should check if type has a defined parent and use it as TypeParent
+    // TODO: should match field's result with provided parent type
+    expect(content).toBeSimilarStringTo(`
+      export namespace UserResolvers {
+        export interface Resolvers<Context = any, TypeParent = User> {
+          id?: IdResolver<string | null, TypeParent, Context>;
+          name?: NameResolver<string | null, TypeParent, Context>;
+          post?: PostResolver<PostParent, TypeParent, Context>;
+        }
+
+        export type IdResolver<R = string | null, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+        export type NameResolver<R = string | null, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+        export type NameResolver<R = PostParent, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+      }
+    `);
+  });
 });

--- a/packages/templates/typescript/src/helpers/get-type.ts
+++ b/packages/templates/typescript/src/helpers/get-type.ts
@@ -1,5 +1,5 @@
 import { SafeString } from 'handlebars';
-import { getResultType } from '../utils/get-result-type';
+import { convertedType } from '../utils/get-result-type';
 import { Field } from 'graphql-codegen-core';
 
 export function getType(type: Field, options: Handlebars.HelperOptions) {
@@ -7,7 +7,7 @@ export function getType(type: Field, options: Handlebars.HelperOptions) {
     return '';
   }
 
-  const result = getResultType(type, options);
+  const result = convertedType(type, options);
 
   return new SafeString(result);
 }

--- a/packages/templates/typescript/src/index.ts
+++ b/packages/templates/typescript/src/index.ts
@@ -1,3 +1,4 @@
 import { config } from './config';
+export { convertedType, getFieldType } from './utils/get-result-type';
 
 export default config;


### PR DESCRIPTION
```js
{
  mappers: {
    User: './interfaces#UserParent',
    Post: 'string' // or even 'Post'
  }
}
```

I think tests show exactly what we want to achieve.