### PR TITLE
Obey .prettierignore file

### DIFF
--- a/packages/graphql-codegen-cli/src/utils/prettier.ts
+++ b/packages/graphql-codegen-cli/src/utils/prettier.ts
@@ -23,7 +23,13 @@ export async function prettify(filePath: string, content: string): Promise<strin
   try {
     const fileExtension = path.extname(filePath).slice(1) as keyof typeof EXTENSION_TO_PARSER;
     const parser = EXTENSION_TO_PARSER[fileExtension];
-    const config = await prettier.resolveConfig(process.cwd(), { useCache: true, editorconfig: true });
+    const { ignored } = await prettier.getFileInfo(filePath, { ignorePath: '.prettierignore' });
+
+    if (ignored) {
+      return content;
+    }
+
+    const config = await prettier.resolveConfig(filePath, { useCache: true, editorconfig: true });
 
     return prettier.format(content, {
       parser,


### PR DESCRIPTION
It was a little surprising when my team started experimenting with prettier and our generated typefiles changed. It would be nice to have some way to disable prettier, and rather than add another config option, I thought we could just use the existing `.prettierignore` file that prettier CLI supports.

This assumes that `.prettierignore` is in the current directory when executing gql-gen, but that's the same behavior as the prettier CLI, so it seemed OK to me.

I adapted this from Gitlab: https://gitlab.com/gitlab-org/gitlab-ce/blob/master/scripts/frontend/prettier.js#L90