### PR TITLE
Allow subscription resolver to return a promise

### DIFF
--- a/dev-test/test-schema/resolvers-types.ts
+++ b/dev-test/test-schema/resolvers-types.ts
@@ -14,7 +14,7 @@ export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
     args: Args,
     context: Context,
     info: GraphQLResolveInfo
-  ): AsyncIterator<R | Result>;
+  ): AsyncIterator<R | Result> | Promise<AsyncIterator<R | Result>>;
   resolve?<R = Result, P = Parent>(
     parent: P,
     args: Args,

--- a/packages/templates/typescript-resolvers/README.md
+++ b/packages/templates/typescript-resolvers/README.md
@@ -46,7 +46,7 @@ export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
     args: Args,
     context: Context,
     info: GraphQLResolveInfo
-  ): AsyncIterator<R | Result>;
+  ): AsyncIterator<R | Result> | Promise<AsyncIterator<R | Result>>;
   resolve?<R = Result, P = Parent>(
     parent: P,
     args: Args,

--- a/packages/templates/typescript-resolvers/src/before-schema.handlebars
+++ b/packages/templates/typescript-resolvers/src/before-schema.handlebars
@@ -13,7 +13,7 @@ export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
     args: Args,
     context: Context,
     info: GraphQLResolveInfo
-  ): AsyncIterator<R | Result>;
+  ): AsyncIterator<R | Result> | Promise<AsyncIterator<R | Result>>;
   resolve?<R = Result, P = Parent>(
     parent: P,
     args: Args,

--- a/packages/templates/typescript-resolvers/tests/resolvers.spec.ts
+++ b/packages/templates/typescript-resolvers/tests/resolvers.spec.ts
@@ -50,7 +50,7 @@ describe('Resolvers', () => {
         args: Args,
         context: Context,
         info: GraphQLResolveInfo
-      ): AsyncIterator<R | Result>;
+      ): AsyncIterator<R | Result> | Promise<AsyncIterator<R | Result>>;
       resolve?<R = Result, P = Parent>(
         parent: P,
         args: Args,


### PR DESCRIPTION
Explicitly to match this use:

https://github.com/graphql-boilerplates/typescript-graphql-server/blob/master/advanced/src/resolvers/Subscription.ts#L6

which is here defined to return a promise:
https://github.com/graphql-boilerplates/typescript-graphql-server/blob/master/advanced/src/generated/prisma.ts#L32