### PR TITLE
Fix documentation links

### DIFF
--- a/packages/templates/INPUT_TYPE_PROJECT.md
+++ b/packages/templates/INPUT_TYPE_PROJECT.md
@@ -21,7 +21,7 @@ To start using GraphQL code generator with custom templates, install the CLI mod
 
 > The purpose of this file to to tell the GraphQL code generate if you want to flatten selection set, and specify your environment's scalars transformation, for example: `String` from GraphQL is `string` in TypeScript.
 
-> To understand what `primitives` and `flattenTypes` are doing behind the scenes, [refer to this README](../scripts/handlebars-templates-scripts/README.md#flattentypes)
+> To understand what `primitives` and `flattenTypes` are doing behind the scenes, [refer to this README](../scripts/codegen-templates-scripts/README.md#flattentypes)
 
 Now create a simple template file with this special structure: `{file-prefix}.{file-extension}.{required-context}.gqlgen`, for example: `hoc.js.all.gqlgen`, and use any custom template, for example:
 
@@ -33,7 +33,7 @@ Now create a simple template file with this special structure: `{file-prefix}.{f
 
 This file will compile by the generator as Handlebars template, with the `all` context, and the result file name will be `hoc.js`.
 
-To see a full list of available contexts, [refer to this README](../scripts/handlebars-templates-scripts/README.md#templates)
+To see a full list of available contexts, [refer to this README](../scripts/codegen-templates-scripts/README.md#templates)
 
 Next, run the generator from the CLI, but use `project` flag (instead of `template`), and specify the base path for you templates (the generator will look for the following file extensions: `template`, `tmpl`, `gqlgen`, `handlebars`):
 
@@ -41,6 +41,6 @@ Next, run the generator from the CLI, but use `project` flag (instead of `templa
 
 #### tips, tricks, and gotchas
 
-**Any subdirectory structure will be maintained in the output.** When using the `eachImport` helper, note that the import `file` is just the filename, so you'll have to [handle relative paths yourself](https://github.com/micimize/graphql-to-io-ts/blob/master/src/helpers/relative-import.js).
+**Any subdirectory structure will be maintained in the output.** When using the `eachImport` helper, note that the import `file` is just the filename, so you'll have to [handle relative paths yourself](https://github.com/micimize/graphql-to-io-ts/blob/225fe92b4c37dbb674d31ea0deccdd5fe050d2b3/helpers/relative-import.js).
 
 **All templates in your template directory will be registered with `registerPartial(filename.split('.').reverse()[1], template)`, so `ts.type.gqlgen` becomes the partial `type`.** This means you can easily use `{{> type }}` in `ts.inputType.gqlgen`, but also means that multiple templates using the same context might clobber eachother in the partial registry. If this is a problem, simply make a seperate partial with a unique name like `prefixPartial.handlebars`.


### PR DESCRIPTION
Links to `codegen-templates-scripts` were incorrectly `handlebars-templates-scripts`.

Also, a link to an external repo was pointing to a file that has since been deleted.