### PR TITLE
V2: importable context type. {} as default context and also instead of every `never`

### DIFF
--- a/packages/plugins/typescript-resolvers/src/context.ts
+++ b/packages/plugins/typescript-resolvers/src/context.ts
@@ -1,6 +1,6 @@
 export function importContext(options: Handlebars.HelperOptions): string {
   const config = options.data.root.config || {};
-  const contextType: string | undefined = config.contextType || {};
+  const contextType: string | undefined = config.contextType;
 
   if (typeof contextType !== 'string') {
     return '';
@@ -17,7 +17,7 @@ export function importContext(options: Handlebars.HelperOptions): string {
 
 export function getContext(options: Handlebars.HelperOptions): string {
   const config = options.data.root.config || {};
-  const contextType: string | undefined = config.contextType || {};
+  const contextType: string | undefined = config.contextType;
 
   if (typeof contextType !== 'string') {
     return '{}';

--- a/packages/plugins/typescript-resolvers/src/context.ts
+++ b/packages/plugins/typescript-resolvers/src/context.ts
@@ -1,0 +1,33 @@
+export function importContext(options: Handlebars.HelperOptions): string {
+  const config = options.data.root.config || {};
+  const contextType: string | undefined = config.contextType || {};
+
+  if (typeof contextType !== 'string') {
+    return '';
+  }
+
+  if (contextType.indexOf('#') === -1) {
+    return contextType;
+  }
+
+  const [path, type] = contextType.split('#');
+
+  return `import { ${type} } from '${path}';`;
+}
+
+export function getContext(options: Handlebars.HelperOptions): string {
+  const config = options.data.root.config || {};
+  const contextType: string | undefined = config.contextType || {};
+
+  if (typeof contextType !== 'string') {
+    return '{}';
+  }
+
+  if (contextType.indexOf('#') === -1) {
+    return contextType;
+  }
+
+  const [, type] = contextType.split('#');
+
+  return type;
+}

--- a/packages/plugins/typescript-resolvers/src/context.ts
+++ b/packages/plugins/typescript-resolvers/src/context.ts
@@ -1,3 +1,5 @@
+import { parseMapper } from './mappers';
+
 export function importContext(options: Handlebars.HelperOptions): string {
   const config = options.data.root.config || {};
   const contextType: string | undefined = config.contextType;
@@ -6,13 +8,13 @@ export function importContext(options: Handlebars.HelperOptions): string {
     return '';
   }
 
-  if (contextType.indexOf('#') === -1) {
-    return contextType;
+  const mapper = parseMapper(contextType);
+
+  if (!mapper.isExternal) {
+    return mapper.type;
   }
 
-  const [path, type] = contextType.split('#');
-
-  return `import { ${type} } from '${path}';`;
+  return `import { ${mapper.type} } from '${mapper.source}';`;
 }
 
 export function getContext(options: Handlebars.HelperOptions): string {
@@ -23,11 +25,7 @@ export function getContext(options: Handlebars.HelperOptions): string {
     return '{}';
   }
 
-  if (contextType.indexOf('#') === -1) {
-    return contextType;
-  }
+  const mapper = parseMapper(contextType);
 
-  const [, type] = contextType.split('#');
-
-  return type;
+  return mapper.type;
 }

--- a/packages/plugins/typescript-resolvers/src/index.ts
+++ b/packages/plugins/typescript-resolvers/src/index.ts
@@ -7,6 +7,7 @@ import * as resolver from './resolver.handlebars';
 import { getFieldResolverName, getFieldResolver, getFieldType } from './helpers';
 import { pickMapper } from './mappers';
 import { importMappers } from './import-mappers';
+import { importContext, getContext } from './context';
 import { getParentType } from './parent-type';
 
 export interface TypeScriptServerResolversConfig extends TypeScriptCommonConfig {
@@ -28,6 +29,8 @@ export const plugin: PluginFunction<TypeScriptServerResolversConfig> = async (
   Handlebars.registerHelper('getParentType', getParentType(convert));
   Handlebars.registerHelper('getFieldType', getFieldType(convert));
   Handlebars.registerHelper('importMappers', importMappers);
+  Handlebars.registerHelper('importContext', importContext);
+  Handlebars.registerHelper('getContext', getContext);
 
   return Handlebars.compile(rootTemplate)(templateContext);
 };

--- a/packages/plugins/typescript-resolvers/src/mappers.ts
+++ b/packages/plugins/typescript-resolvers/src/mappers.ts
@@ -12,7 +12,7 @@ function isExternal(value: string) {
   return value.includes('#');
 }
 
-function parseMapper(mapper: string): Mapper {
+export function parseMapper(mapper: string): Mapper {
   if (isExternal(mapper)) {
     const [source, type] = mapper.split('#');
     return {

--- a/packages/plugins/typescript-resolvers/src/parent-type.ts
+++ b/packages/plugins/typescript-resolvers/src/parent-type.ts
@@ -20,5 +20,5 @@ export const getParentType = convert => (type: Type, options: Handlebars.HelperO
   const mapper = pickMapper(type.name, config.mappers || {});
   const name = mapper ? mapper.type : `${config.interfacePrefix || ''}${convert(type.name)}`;
 
-  return isRootType(type, schema) ? 'never' : name;
+  return isRootType(type, schema) ? '{}' : name;
 };

--- a/packages/plugins/typescript-resolvers/src/resolver.handlebars
+++ b/packages/plugins/typescript-resolvers/src/resolver.handlebars
@@ -2,16 +2,16 @@
 {{#unless @root.config.noNamespaces}}
 export namespace {{ convert name }}Resolvers {
 {{/unless}}
-  export interface {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Resolvers<Context = {{{ getContext }}}, TypeParent = {{ getParentType this }}> {
+  export interface {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Resolvers<Context = {{{ getContext }}}, TypeParent = {{{ getParentType this }}}> {
     {{#each fields}}
     {{ toComment description }}
-    {{ name }}?: {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<{{ getFieldType this }}, TypeParent, Context>;
+    {{ name }}?: {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<{{{ getFieldType this }}}, TypeParent, Context>;
     {{/each}}
   }
 
   {{#each fields}}
 
-  export type {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{ getFieldType this }}, Parent = {{ getParentType ../this }}, Context = {{{ getContext }}}> = {{ getFieldResolver this ../this }};
+  export type {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{{ getFieldType this }}}, Parent = {{{ getParentType ../this }}}, Context = {{{ getContext }}}> = {{ getFieldResolver this ../this }};
 
   {{~# if hasArguments }}
 

--- a/packages/plugins/typescript-resolvers/src/resolver.handlebars
+++ b/packages/plugins/typescript-resolvers/src/resolver.handlebars
@@ -2,7 +2,7 @@
 {{#unless @root.config.noNamespaces}}
 export namespace {{ convert name }}Resolvers {
 {{/unless}}
-  export interface {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Resolvers<Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}{}{{/if}}, TypeParent = {{ getParentType this }}> {
+  export interface {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Resolvers<Context = {{{ getContext }}}, TypeParent = {{ getParentType this }}> {
     {{#each fields}}
     {{ toComment description }}
     {{ name }}?: {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<{{ getFieldType this }}, TypeParent, Context>;
@@ -11,7 +11,7 @@ export namespace {{ convert name }}Resolvers {
 
   {{#each fields}}
 
-  export type {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{ getFieldType this }}, Parent = {{ getParentType ../this }}, Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}{}{{/if}}> = {{ getFieldResolver this ../this }};
+  export type {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{ getFieldType this }}, Parent = {{ getParentType ../this }}, Context = {{{ getContext }}}> = {{ getFieldResolver this ../this }};
 
   {{~# if hasArguments }}
 

--- a/packages/plugins/typescript-resolvers/src/resolver.handlebars
+++ b/packages/plugins/typescript-resolvers/src/resolver.handlebars
@@ -2,7 +2,7 @@
 {{#unless @root.config.noNamespaces}}
 export namespace {{ convert name }}Resolvers {
 {{/unless}}
-  export interface {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Resolvers<Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}any{{/if}}, TypeParent = {{ getParentType this }}> {
+  export interface {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Resolvers<Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}{}{{/if}}, TypeParent = {{ getParentType this }}> {
     {{#each fields}}
     {{ toComment description }}
     {{ name }}?: {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<{{ getFieldType this }}, TypeParent, Context>;
@@ -11,7 +11,7 @@ export namespace {{ convert name }}Resolvers {
 
   {{#each fields}}
 
-  export type {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{ getFieldType this }}, Parent = {{ getParentType ../this }}, Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}any{{/if}}> = {{ getFieldResolver this ../this }};
+  export type {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{ getFieldType this }}, Parent = {{ getParentType ../this }}, Context = {{#if @root.config.contextType}}{{@root.config.contextType}}{{else}}{}{{/if}}> = {{ getFieldResolver this ../this }};
 
   {{~# if hasArguments }}
 

--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -1,7 +1,7 @@
 import { GraphQLResolveInfo } from 'graphql';
 {{{ importMappers types }}}
 
-export type Resolver<Result, Parent = any, Context = {}, Args = never> = (
+export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
   parent: Parent,
   args: Args,
   context: Context,
@@ -23,7 +23,7 @@ export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
   ): R | Result | Promise<R | Result>;
 }
 
-export type SubscriptionResolver<Result, Parent = any, Context = {}, Args = never> =
+export type SubscriptionResolver<Result, Parent = {}, Context = {}, Args = {}> =
   | ((...args: any[]) => ISubscriptionResolverObject<Result, Parent, Context, Args>)
   | ISubscriptionResolverObject<Result, Parent, Context, Args>;
 

--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -1,7 +1,7 @@
 import { GraphQLResolveInfo } from 'graphql';
 {{{ importMappers types }}}
 
-export type Resolver<Result, Parent = any, Context = any, Args = never> = (
+export type Resolver<Result, Parent = any, Context = {}, Args = never> = (
   parent: Parent,
   args: Args,
   context: Context,
@@ -23,7 +23,7 @@ export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
   ): R | Result | Promise<R | Result>;
 }
 
-export type SubscriptionResolver<Result, Parent = any, Context = any, Args = never> =
+export type SubscriptionResolver<Result, Parent = any, Context = {}, Args = never> =
   | ((...args: any[]) => ISubscriptionResolverObject<Result, Parent, Context, Args>)
   | ISubscriptionResolverObject<Result, Parent, Context, Args>;
 

--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -1,6 +1,8 @@
 import { GraphQLResolveInfo } from 'graphql';
 {{{ importMappers types }}}
 
+{{{ importContext }}}
+
 export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
   parent: Parent,
   args: Args,

--- a/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
@@ -24,7 +24,7 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`import { GraphQLResolveInfo } from 'graphql';`);
     expect(content).toBeSimilarStringTo(`
-    export type Resolver<Result, Parent = any, Context = any, Args = never> = (
+    export type Resolver<Result, Parent = any, Context = {}, Args = never> = (
       parent: Parent,
       args: Args,
       context: Context,
@@ -46,7 +46,7 @@ describe('Resolvers', () => {
       ): R | Result | Promise<R | Result>;
     }
     
-    export type SubscriptionResolver<Result, Parent = any, Context = any, Args = never> =
+    export type SubscriptionResolver<Result, Parent = any, Context = {}, Args = never> =
       | ((...args: any[]) => ISubscriptionResolverObject<Result, Parent, Context, Args>)
       | ISubscriptionResolverObject<Result, Parent, Context, Args>;
     `);
@@ -57,7 +57,7 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
         export namespace QueryResolvers {
-          export interface Resolvers<Context = any, TypeParent = never> {
+          export interface Resolvers<Context = {}, TypeParent = never> {
             fieldTest?: FieldTestResolver<string | null, TypeParent, Context>;
           }
         `);
@@ -68,10 +68,10 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
         export namespace QueryResolvers {
-          export interface Resolvers<Context = any, TypeParent = never> {
+          export interface Resolvers<Context = {}, TypeParent = never> {
             fieldTest?: FieldTestResolver<string | null, TypeParent, Context>;
           }
-          export type FieldTestResolver<R = string | null, Parent = never, Context = any> = Resolver<R, Parent, Context>;
+          export type FieldTestResolver<R = string | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
         }
       `);
   });
@@ -93,11 +93,11 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
         export namespace QueryResolvers {
-          export interface Resolvers<Context = any, TypeParent = never> {
+          export interface Resolvers<Context = {}, TypeParent = never> {
             fieldTest?: FieldTestResolver<string | null, TypeParent, Context>;
           }
     
-          export type FieldTestResolver<R = string | null, Parent = never, Context = any> = Resolver<R, Parent, Context, FieldTestArgs>;
+          export type FieldTestResolver<R = string | null, Parent = never, Context = {}> = Resolver<R, Parent, Context, FieldTestArgs>;
           
           export interface FieldTestArgs {
             last: number;
@@ -124,11 +124,11 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
       export namespace SubscriptionResolvers {
-        export interface Resolvers<Context = any, TypeParent = never> {
+        export interface Resolvers<Context = {}, TypeParent = never> {
           fieldTest?: FieldTestResolver<string | null, TypeParent, Context>;
         }
 
-        export type FieldTestResolver<R = string | null, Parent = never, Context = any> = SubscriptionResolver<R, Parent, Context>;
+        export type FieldTestResolver<R = string | null, Parent = never, Context = {}> = SubscriptionResolver<R, Parent, Context>;
       }
       `);
   });
@@ -149,11 +149,11 @@ describe('Resolvers', () => {
     const content = await plugin(testSchema, [], { noNamespaces: true });
 
     expect(content).toBeSimilarStringTo(`
-        export interface QueryResolvers<Context = any, TypeParent = never> {
+        export interface QueryResolvers<Context = {}, TypeParent = never> {
           fieldTest?: QueryFieldTestResolver<string | null, TypeParent, Context>;
         }
 
-        export type QueryFieldTestResolver<R = string | null, Parent = never, Context = any> = Resolver<R, Parent, Context>;
+        export type QueryFieldTestResolver<R = string | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
       `);
   });
 
@@ -206,7 +206,7 @@ describe('Resolvers', () => {
     const content = await plugin(testSchema, [], {});
 
     expect(content).toBeSimilarStringTo(`
-      export type SnakeCaseRootQueryResolver<R = SnakeCaseResult | null, Parent = never, Context = any> = Resolver<R, Parent, Context, SnakeCaseRootQueryArgs>;
+      export type SnakeCaseRootQueryResolver<R = SnakeCaseResult | null, Parent = never, Context = {}> = Resolver<R, Parent, Context, SnakeCaseRootQueryArgs>;
       `);
     expect(content).toBeSimilarStringTo(`
       export interface SnakeCaseRootQueryArgs {
@@ -256,35 +256,35 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
       export namespace QueryResolvers {
-        export interface Resolvers<Context = any, TypeParent = never> {
+        export interface Resolvers<Context = {}, TypeParent = never> {
           post?: PostResolver<Post | null, TypeParent, Context>;
         }
   
-        export type PostResolver<R = Post | null, Parent = never, Context = any> = Resolver<R, Parent, Context>;
+        export type PostResolver<R = Post | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
       }
     `);
 
     expect(content).toBeSimilarStringTo(`
       export namespace PostResolvers {
-        export interface Resolvers<Context = any, TypeParent = Post> {
+        export interface Resolvers<Context = {}, TypeParent = Post> {
           id?: IdResolver<string | null, TypeParent, Context>;
           author?: AuthorResolver<User | null, TypeParent, Context>;
         }
 
-        export type IdResolver<R = string | null, Parent = Post, Context = any> = Resolver<R, Parent, Context>;
-        export type AuthorResolver<R = User | null, Parent = Post, Context = any> = Resolver<R, Parent, Context>;
+        export type IdResolver<R = string | null, Parent = Post, Context = {}> = Resolver<R, Parent, Context>;
+        export type AuthorResolver<R = User | null, Parent = Post, Context = {}> = Resolver<R, Parent, Context>;
       }
     `);
 
     expect(content).toBeSimilarStringTo(`
       export namespace UserResolvers {
-        export interface Resolvers<Context = any, TypeParent = User> {
+        export interface Resolvers<Context = {}, TypeParent = User> {
           id?: IdResolver<string | null, TypeParent, Context>;
           name?: NameResolver<string | null, TypeParent, Context>;
         }
 
-        export type IdResolver<R = string | null, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-        export type NameResolver<R = string | null, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+        export type IdResolver<R = string | null, Parent = User, Context = {}> = Resolver<R, Parent, Context>;
+        export type NameResolver<R = string | null, Parent = User, Context = {}> = Resolver<R, Parent, Context>;
       }
     `);
   });
@@ -315,31 +315,31 @@ describe('Resolvers', () => {
     const content = await plugin(testSchema, [], { noNamespaces: true });
 
     expect(content).toBeSimilarStringTo(`
-      export interface QueryResolvers<Context = any, TypeParent = never> {
+      export interface QueryResolvers<Context = {}, TypeParent = never> {
         post?: QueryPostResolver<Post | null, TypeParent, Context>;
       }
 
-      export type QueryPostResolver<R = Post | null, Parent = never, Context = any> = Resolver<R, Parent, Context>;
+      export type QueryPostResolver<R = Post | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
     `);
 
     expect(content).toBeSimilarStringTo(`
-      export interface PostResolvers<Context = any, TypeParent = Post> {
+      export interface PostResolvers<Context = {}, TypeParent = Post> {
         id?: PostIdResolver<string | null, TypeParent, Context>;
         author?: PostAuthorResolver<User | null, TypeParent, Context>;
       }
 
-      export type PostIdResolver<R = string | null, Parent = Post, Context = any> = Resolver<R, Parent, Context>;
-      export type PostAuthorResolver<R = User | null, Parent = Post, Context = any> = Resolver<R, Parent, Context>;
+      export type PostIdResolver<R = string | null, Parent = Post, Context = {}> = Resolver<R, Parent, Context>;
+      export type PostAuthorResolver<R = User | null, Parent = Post, Context = {}> = Resolver<R, Parent, Context>;
     `);
 
     expect(content).toBeSimilarStringTo(`
-      export interface UserResolvers<Context = any, TypeParent = User> {
+      export interface UserResolvers<Context = {}, TypeParent = User> {
         id?: UserIdResolver<string | null, TypeParent, Context>;
         name?: UserNameResolver<string | null, TypeParent, Context>;
       }
 
-      export type UserIdResolver<R = string | null, Parent = User, Context = any> = Resolver<R, Parent, Context>;
-      export type UserNameResolver<R = string | null, Parent = User, Context = any> = Resolver<R, Parent, Context>;
+      export type UserIdResolver<R = string | null, Parent = User, Context = {}> = Resolver<R, Parent, Context>;
+      export type UserNameResolver<R = string | null, Parent = User, Context = {}> = Resolver<R, Parent, Context>;
     `);
   });
 
@@ -390,24 +390,24 @@ describe('Resolvers', () => {
     // should check field's result and match it with provided parents
     expect(content).toBeSimilarStringTo(`
       export namespace QueryResolvers {
-        export interface Resolvers<Context = any, TypeParent = never> {
+        export interface Resolvers<Context = {}, TypeParent = never> {
           post?: PostResolver<PostParent | null, TypeParent, Context>;
         }
 
-        export type PostResolver<R = PostParent | null, Parent = never, Context = any> = Resolver<R, Parent, Context>;
+        export type PostResolver<R = PostParent | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
       }
     `);
 
     // should check if type has a defined parent and use it as TypeParent
     expect(content).toBeSimilarStringTo(`
       export namespace PostResolvers {
-        export interface Resolvers<Context = any, TypeParent = PostParent> {
+        export interface Resolvers<Context = {}, TypeParent = PostParent> {
           id?: IdResolver<string | null, TypeParent, Context>;
           author?: AuthorResolver<UserParent | null, TypeParent, Context>;
         }
 
-        export type IdResolver<R = string | null, Parent = PostParent, Context = any> = Resolver<R, Parent, Context>;
-        export type AuthorResolver<R = UserParent | null, Parent = PostParent, Context = any> = Resolver<R, Parent, Context>;
+        export type IdResolver<R = string | null, Parent = PostParent, Context = {}> = Resolver<R, Parent, Context>;
+        export type AuthorResolver<R = UserParent | null, Parent = PostParent, Context = {}> = Resolver<R, Parent, Context>;
       }
     `);
 
@@ -415,15 +415,15 @@ describe('Resolvers', () => {
     // should match field's result with provided parent type
     expect(content).toBeSimilarStringTo(`
       export namespace UserResolvers {
-        export interface Resolvers<Context = any, TypeParent = UserParent> {
+        export interface Resolvers<Context = {}, TypeParent = UserParent> {
           id?: IdResolver<string | null, TypeParent, Context>;
           name?: NameResolver<string | null, TypeParent, Context>;
           post?: PostResolver<PostParent | null, TypeParent, Context>;
         }
 
-        export type IdResolver<R = string | null, Parent = UserParent, Context = any> = Resolver<R, Parent, Context>;
-        export type NameResolver<R = string | null, Parent = UserParent, Context = any> = Resolver<R, Parent, Context>;
-        export type PostResolver<R = PostParent | null, Parent = UserParent, Context = any> = Resolver<R, Parent, Context>;
+        export type IdResolver<R = string | null, Parent = UserParent, Context = {}> = Resolver<R, Parent, Context>;
+        export type NameResolver<R = string | null, Parent = UserParent, Context = {}> = Resolver<R, Parent, Context>;
+        export type PostResolver<R = PostParent | null, Parent = UserParent, Context = {}> = Resolver<R, Parent, Context>;
       }
     `);
   });
@@ -455,22 +455,22 @@ describe('Resolvers', () => {
     // should check field's result and match it with provided parents
     expect(content).toBeSimilarStringTo(`
       export namespace QueryResolvers {
-        export interface Resolvers<Context = any, TypeParent = never> {
+        export interface Resolvers<Context = {}, TypeParent = never> {
           post?: PostResolver<Post | null, TypeParent, Context>;
         }
 
-        export type PostResolver<R = Post | null, Parent = never, Context = any> = Resolver<R, Parent, Context>;
+        export type PostResolver<R = Post | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
       }
     `);
 
     // should check if type has a defined parent and use it as TypeParent
     expect(content).toBeSimilarStringTo(`
       export namespace PostResolvers {
-        export interface Resolvers<Context = any, TypeParent = Post> {
+        export interface Resolvers<Context = {}, TypeParent = Post> {
           id?: IdResolver<string | null, TypeParent, Context>;
         }
 
-        export type IdResolver<R = string | null, Parent = Post, Context = any> = Resolver<R, Parent, Context>;
+        export type IdResolver<R = string | null, Parent = Post, Context = {}> = Resolver<R, Parent, Context>;
       }
     `);
   });
@@ -493,11 +493,11 @@ describe('Resolvers', () => {
     });
 
     expect(content).toBeSimilarStringTo(`
-      export interface QueryResolvers<Context = any, TypeParent = never> {
+      export interface QueryResolvers<Context = {}, TypeParent = never> {
         fieldTest?: QueryFieldTestResolver<string | null, TypeParent, Context>;
       }
     
-      export type QueryFieldTestResolver<R = string | null, Parent = never, Context = any> = Resolver<R, Parent, Context, QueryFieldTestArgs>;
+      export type QueryFieldTestResolver<R = string | null, Parent = never, Context = {}> = Resolver<R, Parent, Context, QueryFieldTestArgs>;
           
       export interface QueryFieldTestArgs {
         last: number;

--- a/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
@@ -24,7 +24,7 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`import { GraphQLResolveInfo } from 'graphql';`);
     expect(content).toBeSimilarStringTo(`
-    export type Resolver<Result, Parent = any, Context = {}, Args = never> = (
+    export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
       parent: Parent,
       args: Args,
       context: Context,
@@ -46,7 +46,7 @@ describe('Resolvers', () => {
       ): R | Result | Promise<R | Result>;
     }
     
-    export type SubscriptionResolver<Result, Parent = any, Context = {}, Args = never> =
+    export type SubscriptionResolver<Result, Parent = {}, Context = {}, Args = {}> =
       | ((...args: any[]) => ISubscriptionResolverObject<Result, Parent, Context, Args>)
       | ISubscriptionResolverObject<Result, Parent, Context, Args>;
     `);
@@ -57,7 +57,7 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
         export namespace QueryResolvers {
-          export interface Resolvers<Context = {}, TypeParent = never> {
+          export interface Resolvers<Context = {}, TypeParent = {}> {
             fieldTest?: FieldTestResolver<string | null, TypeParent, Context>;
           }
         `);
@@ -68,10 +68,10 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
         export namespace QueryResolvers {
-          export interface Resolvers<Context = {}, TypeParent = never> {
+          export interface Resolvers<Context = {}, TypeParent = {}> {
             fieldTest?: FieldTestResolver<string | null, TypeParent, Context>;
           }
-          export type FieldTestResolver<R = string | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
+          export type FieldTestResolver<R = string | null, Parent = {}, Context = {}> = Resolver<R, Parent, Context>;
         }
       `);
   });
@@ -93,11 +93,11 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
         export namespace QueryResolvers {
-          export interface Resolvers<Context = {}, TypeParent = never> {
+          export interface Resolvers<Context = {}, TypeParent = {}> {
             fieldTest?: FieldTestResolver<string | null, TypeParent, Context>;
           }
     
-          export type FieldTestResolver<R = string | null, Parent = never, Context = {}> = Resolver<R, Parent, Context, FieldTestArgs>;
+          export type FieldTestResolver<R = string | null, Parent = {}, Context = {}> = Resolver<R, Parent, Context, FieldTestArgs>;
           
           export interface FieldTestArgs {
             last: number;
@@ -124,11 +124,11 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
       export namespace SubscriptionResolvers {
-        export interface Resolvers<Context = {}, TypeParent = never> {
+        export interface Resolvers<Context = {}, TypeParent = {}> {
           fieldTest?: FieldTestResolver<string | null, TypeParent, Context>;
         }
 
-        export type FieldTestResolver<R = string | null, Parent = never, Context = {}> = SubscriptionResolver<R, Parent, Context>;
+        export type FieldTestResolver<R = string | null, Parent = {}, Context = {}> = SubscriptionResolver<R, Parent, Context>;
       }
       `);
   });
@@ -149,11 +149,11 @@ describe('Resolvers', () => {
     const content = await plugin(testSchema, [], { noNamespaces: true });
 
     expect(content).toBeSimilarStringTo(`
-        export interface QueryResolvers<Context = {}, TypeParent = never> {
+        export interface QueryResolvers<Context = {}, TypeParent = {}> {
           fieldTest?: QueryFieldTestResolver<string | null, TypeParent, Context>;
         }
 
-        export type QueryFieldTestResolver<R = string | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
+        export type QueryFieldTestResolver<R = string | null, Parent = {}, Context = {}> = Resolver<R, Parent, Context>;
       `);
   });
 
@@ -173,11 +173,11 @@ describe('Resolvers', () => {
     const content = await plugin(testSchema, [], { contextType: 'MyContext' });
 
     expect(content).toBeSimilarStringTo(`
-        export interface Resolvers<Context = MyContext, TypeParent = never> {
+        export interface Resolvers<Context = MyContext, TypeParent = {}> {
           fieldTest?: FieldTestResolver<string | null, TypeParent, Context>;
         }
 
-        export type FieldTestResolver<R = string | null, Parent = never, Context = MyContext> = Resolver<R, Parent, Context>;
+        export type FieldTestResolver<R = string | null, Parent = {}, Context = MyContext> = Resolver<R, Parent, Context>;
       `);
   });
 
@@ -206,7 +206,7 @@ describe('Resolvers', () => {
     const content = await plugin(testSchema, [], {});
 
     expect(content).toBeSimilarStringTo(`
-      export type SnakeCaseRootQueryResolver<R = SnakeCaseResult | null, Parent = never, Context = {}> = Resolver<R, Parent, Context, SnakeCaseRootQueryArgs>;
+      export type SnakeCaseRootQueryResolver<R = SnakeCaseResult | null, Parent = {}, Context = {}> = Resolver<R, Parent, Context, SnakeCaseRootQueryArgs>;
       `);
     expect(content).toBeSimilarStringTo(`
       export interface SnakeCaseRootQueryArgs {
@@ -256,11 +256,11 @@ describe('Resolvers', () => {
 
     expect(content).toBeSimilarStringTo(`
       export namespace QueryResolvers {
-        export interface Resolvers<Context = {}, TypeParent = never> {
+        export interface Resolvers<Context = {}, TypeParent = {}> {
           post?: PostResolver<Post | null, TypeParent, Context>;
         }
   
-        export type PostResolver<R = Post | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
+        export type PostResolver<R = Post | null, Parent = {}, Context = {}> = Resolver<R, Parent, Context>;
       }
     `);
 
@@ -315,11 +315,11 @@ describe('Resolvers', () => {
     const content = await plugin(testSchema, [], { noNamespaces: true });
 
     expect(content).toBeSimilarStringTo(`
-      export interface QueryResolvers<Context = {}, TypeParent = never> {
+      export interface QueryResolvers<Context = {}, TypeParent = {}> {
         post?: QueryPostResolver<Post | null, TypeParent, Context>;
       }
 
-      export type QueryPostResolver<R = Post | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
+      export type QueryPostResolver<R = Post | null, Parent = {}, Context = {}> = Resolver<R, Parent, Context>;
     `);
 
     expect(content).toBeSimilarStringTo(`
@@ -390,11 +390,11 @@ describe('Resolvers', () => {
     // should check field's result and match it with provided parents
     expect(content).toBeSimilarStringTo(`
       export namespace QueryResolvers {
-        export interface Resolvers<Context = {}, TypeParent = never> {
+        export interface Resolvers<Context = {}, TypeParent = {}> {
           post?: PostResolver<PostParent | null, TypeParent, Context>;
         }
 
-        export type PostResolver<R = PostParent | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
+        export type PostResolver<R = PostParent | null, Parent = {}, Context = {}> = Resolver<R, Parent, Context>;
       }
     `);
 
@@ -455,11 +455,11 @@ describe('Resolvers', () => {
     // should check field's result and match it with provided parents
     expect(content).toBeSimilarStringTo(`
       export namespace QueryResolvers {
-        export interface Resolvers<Context = {}, TypeParent = never> {
+        export interface Resolvers<Context = {}, TypeParent = {}> {
           post?: PostResolver<Post | null, TypeParent, Context>;
         }
 
-        export type PostResolver<R = Post | null, Parent = never, Context = {}> = Resolver<R, Parent, Context>;
+        export type PostResolver<R = Post | null, Parent = {}, Context = {}> = Resolver<R, Parent, Context>;
       }
     `);
 
@@ -493,11 +493,11 @@ describe('Resolvers', () => {
     });
 
     expect(content).toBeSimilarStringTo(`
-      export interface QueryResolvers<Context = {}, TypeParent = never> {
+      export interface QueryResolvers<Context = {}, TypeParent = {}> {
         fieldTest?: QueryFieldTestResolver<string | null, TypeParent, Context>;
       }
     
-      export type QueryFieldTestResolver<R = string | null, Parent = never, Context = {}> = Resolver<R, Parent, Context, QueryFieldTestArgs>;
+      export type QueryFieldTestResolver<R = string | null, Parent = {}, Context = {}> = Resolver<R, Parent, Context, QueryFieldTestArgs>;
           
       export interface QueryFieldTestArgs {
         last: number;

--- a/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
@@ -181,6 +181,34 @@ describe('Resolvers', () => {
       `);
   });
 
+  it('should override custom context with type from a module', async () => {
+    const testSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          fieldTest: String 
+        }
+        
+        schema {
+          query: Query
+        }
+      `
+    });
+
+    const content = await plugin(testSchema, [], { contextType: './path/to/types#MyContext' });
+
+    expect(content).toBeSimilarStringTo(`
+        import { MyContext } from './path/to/types';
+      `);
+
+    expect(content).toBeSimilarStringTo(`
+        export interface Resolvers<Context = MyContext, TypeParent = {}> {
+          fieldTest?: FieldTestResolver<string | null, TypeParent, Context>;
+        }
+
+        export type FieldTestResolver<R = string | null, Parent = {}, Context = MyContext> = Resolver<R, Parent, Context>;
+      `);
+  });
+
   it('should handle snake case and convert it to pascal case', async () => {
     const testSchema = makeExecutableSchema({
       typeDefs: `

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,10 +162,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
   integrity sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==
 
-"@types/node@10.12.5":
-  version "10.12.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.5.tgz#7e7ea1a9b34d2c8d704cb0b755dffbcda34741ad"
-  integrity sha512-GzdHjq3t3eGLMv92Al90Iq+EoLL+86mPfQhuglbBFO7HiLdC/rkt+zrzJJumAiBF6nsrBWhou22rPW663AAyFw==
+"@types/node@10.12.6":
+  version "10.12.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.6.tgz#7fc213c1b811c90fc9a3edb6206742b95d697678"
+  integrity sha512-+ZWB5Ec1iki99xQFzBlivlKxSZQ+fuUKBott8StBOnLN4dWbRHlgdg1XknpW6g0tweniN5DcOqA64CJyOUPSAw==
 
 "@types/pify@3.0.2":
   version "3.0.2"
@@ -2315,19 +2315,6 @@ execa@^0.8.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
-  integrity sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -3075,13 +3062,13 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-husky@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-1.1.3.tgz#3ccfdb4d7332896bf7cd0e618c6fb8be09d9de4b"
-  integrity sha512-6uc48B/A2Mqi65yeg37d/TPcTb0bZ1GTkMYOM0nXLOPuPaTRhXCeee80/noOrbavWd12x72Tusja7GJ5rzvV6g==
+husky@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.1.4.tgz#92f61383527d2571e9586234e5864356bfaceaa9"
+  integrity sha512-cZjGpS7qsaBSo3fOMUuR7erQloX3l5XzL1v/RkIqU6zrQImDdU70z5Re9fGDp7+kbYlM2EtS4aYMlahBeiCUGw==
   dependencies:
     cosmiconfig "^5.0.6"
-    execa "^0.9.0"
+    execa "^1.0.0"
     find-up "^3.0.0"
     get-stdin "^6.0.0"
     is-ci "^1.2.1"


### PR DESCRIPTION
`never` is hard to work with when you mock things...

`{}` as default context makes sense because with `any` we won't get any ts warnings, it's more strict (breaking).
`{}` for empty arguments also makes sense since GraphQL provides an empty object when there's no arguments.