### PR TITLE
Enum source casing

### DIFF
--- a/docs/plugins/typescript-common.md
+++ b/docs/plugins/typescript-common.md
@@ -27,6 +27,10 @@ You can override the naming conversion by pointing to a specific function in a m
 
 This will effect all the name conversions of the module.
 
+#### `disableEnumNamingConvention` (default value: `false`)
+
+Set this option to `true` to make enum values follow the naming convention of the source, as opposed to being converted to the `namingConvention` specified above.
+
 #### `scalars`
 
 Will map scalars to the predefined types.

--- a/packages/plugins/typescript-common/src/enum.handlebars
+++ b/packages/plugins/typescript-common/src/enum.handlebars
@@ -4,7 +4,7 @@ export type {{@root.config.interfacePrefix}}{{ convert name }} = {{#each values 
 {{else}}
 export {{#if @root.config.constEnums }}const {{/if}}enum {{@root.config.interfacePrefix}}{{ convert name }} {
 {{#each values }}
-  {{ convert value }} = {{{ getEnumValue ../name value }}},
+  {{ convertEnumValue value }} = {{{ getEnumValue ../name value }}},
 {{/each}}
 }
 {{/if}}

--- a/packages/plugins/typescript-common/src/index.ts
+++ b/packages/plugins/typescript-common/src/index.ts
@@ -13,6 +13,7 @@ export * from './helpers';
 
 export interface TypeScriptCommonConfig {
   namingConvention?: string;
+  disableEnumNamingConvention?: boolean;
   avoidOptionals?: boolean;
   constEnums?: boolean;
   enumsAsTypes?: boolean;
@@ -45,12 +46,19 @@ export function initCommonTemplate(hbs, schema, config) {
 
     return baseConvertFn(str);
   };
+  const convertEnumValue = (str: string): string => {
+    if (config.disableEnumNamingConvention) {
+      return str;
+    }
+    return convert(str);
+  };
   hbs.registerPartial('enum', enumTemplate);
   hbs.registerPartial('type', type);
   hbs.registerHelper('blockComment', helpers.blockComment);
   hbs.registerHelper('blockCommentIf', helpers.blockCommentIf);
   hbs.registerHelper('toComment', helpers.toComment);
   hbs.registerHelper('convert', convert);
+  hbs.registerHelper('convertEnumValue', convertEnumValue);
   hbs.registerHelper('getOptionals', getOptionals);
   hbs.registerHelper('getEnumValue', getEnumValue);
   hbs.registerHelper('convertedType', getType(convert));

--- a/packages/plugins/typescript-common/tests/typescript-common.spec.ts
+++ b/packages/plugins/typescript-common/tests/typescript-common.spec.ts
@@ -91,6 +91,17 @@ describe('TypeScript Common', () => {
       `);
     });
 
+    it('Should generate enum values matching source casing with disableEnumNamingConvention', async () => {
+      const content = await plugin(schema, [], { disableEnumNamingConvention: true });
+
+      expect(content).toBeSimilarStringTo(`
+        export enum A {
+          ONE = "ONE",
+          TWO = "TWO",
+        }
+      `);
+    });
+
     it('Should generate enums as types with enumsAsTypes', async () => {
       const content = await plugin(schema, [], { enumsAsTypes: true });
 
@@ -162,12 +173,12 @@ describe('TypeScript Common', () => {
 
       expect(content).toBeSimilarStringTo(`
         export interface T {
-          f1?: string | null; 
-          f2: number; 
-          f3?: (string | null)[] | null; 
-          f4: (string | null)[]; 
-          f5: string[]; 
-          f6?: string[] | null; 
+          f1?: string | null;
+          f2: number;
+          f3?: (string | null)[] | null;
+          f4: (string | null)[];
+          f5: string[];
+          f6?: string[] | null;
         }
       `);
     });
@@ -177,8 +188,8 @@ describe('TypeScript Common', () => {
 
       expect(content).toBeSimilarStringTo(`
         export interface T {
-          readonly f1?: string | null; 
-          readonly f2: number; 
+          readonly f1?: string | null;
+          readonly f2: number;
           readonly f3?: ReadonlyArray<string | null> | null;
           readonly f4: ReadonlyArray<string | null>;
           readonly f5: ReadonlyArray<string>;
@@ -190,10 +201,10 @@ describe('TypeScript Common', () => {
     it('Should generate input type description', async () => {
       const content = await plugin(
         buildSchema(`
-      # inputTypeDesc 
+      # inputTypeDesc
       input T {
         f: String!
-      }  
+      }
       `),
         [],
         {}
@@ -202,7 +213,7 @@ describe('TypeScript Common', () => {
       expect(content).toBeSimilarStringTo(`
         /** inputTypeDesc */
         export interface T {
-          f: string; 
+          f: string;
         }
       `);
     });
@@ -212,12 +223,12 @@ describe('TypeScript Common', () => {
 
       expect(content).toBeSimilarStringTo(`
       export interface PreT {
-        f1?: string | null; 
-        f2: number; 
-        f3?: (string | null)[] | null; 
-        f4: (string | null)[]; 
-        f5: string[]; 
-        f6?: string[] | null; 
+        f1?: string | null;
+        f2: number;
+        f3?: (string | null)[] | null;
+        f4: (string | null)[];
+        f5: string[];
+        f6?: string[] | null;
       }
       `);
     });
@@ -227,12 +238,12 @@ describe('TypeScript Common', () => {
 
       expect(content).toBeSimilarStringTo(`
       export interface T {
-        f1?: boop | null; 
-        f2: number; 
-        f3?: (boop | null)[] | null; 
-        f4: (boop | null)[]; 
-        f5: boop[]; 
-        f6?: boop[] | null; 
+        f1?: boop | null;
+        f2: number;
+        f3?: (boop | null)[] | null;
+        f4: (boop | null)[];
+        f5: boop[];
+        f6?: boop[] | null;
       }
       `);
     });
@@ -245,7 +256,7 @@ describe('TypeScript Common', () => {
         type Query {
           fieldTest: [Date]
         }
-        
+
         scalar Date
       `),
         [],
@@ -263,7 +274,7 @@ describe('TypeScript Common', () => {
         type Query {
           fieldTest: [Date]
         }
-        
+
         scalar Date
       `),
         [],


### PR DESCRIPTION
- added the new `disableEnumNamingConvention` option to allow existing case to be carried over from the SDL enum to TypeScript in a non-breaking way
- added a test for the new option
- added the new option to the markdown file

It looks like some VS Code whitespace auto-trimming made it into one of the commits as well. Sorry about that!