### PR TITLE
Make graphqlTagPluck to extract documents from files

### DIFF
--- a/packages/graphql-codegen-cli/src/loaders/documents/documents-from-glob.ts
+++ b/packages/graphql-codegen-cli/src/loaders/documents/documents-from-glob.ts
@@ -41,7 +41,7 @@ export class DocumentsFromGlob implements DocumentLoader {
         return parse(new Source(fileContent, filePath));
       }
 
-      const foundDoc = extractDocumentStringFromCodeFile(fileContent);
+      const foundDoc = extractDocumentStringFromCodeFile(new Source(fileContent, filePath));
 
       if (foundDoc) {
         return parse(new Source(foundDoc, filePath));

--- a/packages/graphql-codegen-cli/src/utils/document-finder.ts
+++ b/packages/graphql-codegen-cli/src/utils/document-finder.ts
@@ -1,14 +1,15 @@
 import { parse } from 'graphql-codegen-core';
+import { Source } from 'graphql';
 import gqlPluck from 'graphql-tag-pluck';
 
-export const extractDocumentStringFromCodeFile = (fileContent: string): string | void => {
+export function extractDocumentStringFromCodeFile(source: Source): string | void {
   try {
-    const parsed = parse(fileContent);
+    const parsed = parse(source.body);
 
     if (parsed) {
-      return fileContent;
+      return source.body;
     }
   } catch (e) {
-    return gqlPluck.fromCodeString.sync(fileContent) || null;
+    return gqlPluck.fromFile.sync(source.name) || null;
   }
-};
+}

--- a/packages/graphql-codegen-cli/tests/codegen.spec.ts
+++ b/packages/graphql-codegen-cli/tests/codegen.spec.ts
@@ -292,6 +292,19 @@ describe('Codegen Executor', () => {
       expect(result[0].content).toContain('MyQuery');
       expect(result[0].filename).toEqual('out1.ts');
     });
+
+    it('should handle TypeScript features', async () => {
+      const result = await executeCodegen({
+        schema: ['./tests/test-documents/schema.graphql'],
+        documents: ['./tests/test-documents/ts-features-with-query.ts'],
+        generates: {
+          'out1.ts': ['typescript-common', 'typescript-client']
+        }
+      });
+
+      expect(result[0].content).toContain('MyQuery');
+      expect(result[0].filename).toEqual('out1.ts');
+    });
   });
 
   describe('Plugin Configuration', () => {

--- a/packages/graphql-codegen-cli/tests/document-finder.spec.ts
+++ b/packages/graphql-codegen-cli/tests/document-finder.spec.ts
@@ -5,8 +5,9 @@ import { extractDocumentStringFromCodeFile } from '../src/utils/document-finder'
 
 describe('extractDocumentStringFromCodeFile', () => {
   function extract(fileName: string) {
-    const fileContent = fs.readFileSync(`./tests/test-files/${fileName}`).toString();
-    const doc = extractDocumentStringFromCodeFile(fileContent);
+    const filepath = `./tests/test-files/${fileName}`;
+    const fileContent = fs.readFileSync(filepath).toString();
+    const doc = extractDocumentStringFromCodeFile(new Source(fileContent, filepath));
 
     if (doc) {
       expect(tryParse(doc)).not.toThrow();

--- a/packages/graphql-codegen-cli/tests/test-documents/ts-features-with-query.ts
+++ b/packages/graphql-codegen-cli/tests/test-documents/ts-features-with-query.ts
@@ -1,0 +1,19 @@
+import gql from 'graphql-tag';
+
+interface ModuleWithProviders {
+  ngModule: string;
+}
+
+export class FooModule {
+  static forRoot() {
+    return <ModuleWithProviders>{
+      ngModule: 'foo'
+    };
+  }
+}
+
+export const query = gql`
+  query myQuery {
+    fieldA
+  }
+`;


### PR DESCRIPTION
Because loading documents fails on some typescript features if we use `gqlPluck.fromCodeString`

After https://github.com/DAB0mB/graphql-tag-pluck/pull/8 gets fixed we can switch back to use code as a string.