### PR TITLE
Fix mutation arguments transforms in flow plugin

### DIFF
--- a/packages/plugins/flow/src/variables-to-object.ts
+++ b/packages/plugins/flow/src/variables-to-object.ts
@@ -6,7 +6,11 @@ export class OperationVariablesToObject<
   Visitor extends BasicFlowVisitor,
   DefinitionType extends { name?: NameNode; variable?: VariableNode; type: TypeNode }
 > {
-  constructor(private _visitorInstance: Visitor, private _variablesNode: ReadonlyArray<DefinitionType>) {}
+  constructor(
+    private _visitorInstance: Visitor,
+    private _variablesNode: ReadonlyArray<DefinitionType>,
+    private _convertName: (name: any, addPrefix: boolean) => string
+  ) {}
 
   getName(node: DefinitionType): string {
     if (node.name) {
@@ -31,7 +35,9 @@ export class OperationVariablesToObject<
       .map(variable => {
         const baseType = typeof variable.type === 'string' ? variable.type : getBaseTypeNode(variable.type);
         const typeName = typeof baseType === 'string' ? baseType : baseType.name.value;
-        const typeValue = this._visitorInstance.scalars[typeName] ? this._visitorInstance.scalars[typeName] : typeName;
+        const typeValue = this._visitorInstance.scalars[typeName]
+          ? this._visitorInstance.scalars[typeName]
+          : this._convertName(typeName, true);
 
         return indent(
           `${this.getName(variable)}${variable.type.kind === Kind.NON_NULL_TYPE ? '' : '?'}: ${wrapAstTypeWithModifiers(

--- a/packages/plugins/flow/src/variables-to-object.ts
+++ b/packages/plugins/flow/src/variables-to-object.ts
@@ -6,11 +6,7 @@ export class OperationVariablesToObject<
   Visitor extends BasicFlowVisitor,
   DefinitionType extends { name?: NameNode; variable?: VariableNode; type: TypeNode }
 > {
-  constructor(
-    private _visitorInstance: Visitor,
-    private _variablesNode: ReadonlyArray<DefinitionType>,
-    private _convertName: (name: any, addPrefix: boolean) => string
-  ) {}
+  constructor(private _visitorInstance: Visitor, private _variablesNode: ReadonlyArray<DefinitionType>) {}
 
   getName(node: DefinitionType): string {
     if (node.name) {
@@ -37,7 +33,7 @@ export class OperationVariablesToObject<
         const typeName = typeof baseType === 'string' ? baseType : baseType.name.value;
         const typeValue = this._visitorInstance.scalars[typeName]
           ? this._visitorInstance.scalars[typeName]
-          : this._convertName(typeName, true);
+          : this._visitorInstance.convertName(typeName, true);
 
         return indent(
           `${this.getName(variable)}${variable.type.kind === Kind.NON_NULL_TYPE ? '' : '?'}: ${wrapAstTypeWithModifiers(

--- a/packages/plugins/flow/src/visitor.ts
+++ b/packages/plugins/flow/src/visitor.ts
@@ -49,9 +49,9 @@ export class FlowVisitor implements BasicFlowVisitor {
     };
   }
 
-  private _convertName(name: any, addPrefix = true): string {
+  private _convertName = (name: any, addPrefix = true): string => {
     return (addPrefix ? this._parsedConfig.typesPrefix : '') + this._parsedConfig.convert(name);
-  }
+  };
 
   get scalars(): ScalarsMap {
     return this._parsedConfig.scalars;
@@ -137,7 +137,8 @@ export class FlowVisitor implements BasicFlowVisitor {
       const name = original.name.value + this._convertName(field.name.value, false) + 'Args';
       const transformedArguments = new OperationVariablesToObject<FlowVisitor, InputValueDefinitionNode>(
         this,
-        field.arguments
+        field.arguments,
+        this._convertName
       );
 
       return new DeclarationBlock()

--- a/packages/plugins/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/tests/flow.spec.ts
@@ -293,6 +293,34 @@ describe('Flow Plugin', () => {
       validateFlow(result.definitions[0]);
       validateFlow(result.definitions[1]);
     });
+
+    it('Should add custom prefix for mutation arguments', () => {
+      const ast = parse(`input Input { name: String } type Mutation { foo(id: String, input: Input): String }`);
+      const result = visit(ast, {
+        leave: new FlowVisitor({ typesPrefix: 'T' })
+      });
+
+      expect(result.definitions[0]).toBeSimilarStringTo(`
+        export type TInput = {
+          name: ?string,
+        };
+      `);
+
+      expect(result.definitions[1]).toBeSimilarStringTo(`
+        export type TMutation = {
+          foo: ?string,
+        };
+
+
+        export type TMutationFooArgs = {
+          id?: ?string,
+          input?: ?TInput
+        };
+      `);
+
+      validateFlow(result.definitions[0]);
+      validateFlow(result.definitions[1]);
+    });
   });
 
   describe('Enum', () => {


### PR DESCRIPTION
**The problem:**

Transforming the snippet below with the `typesPrefix` flag generates wrong flow type for the `input` type. Notice how the `TMutationFooArgs.input` is referencing `Input` instead of `TInput`.
```GraphQL
input Input {
  name: String
}

type Mutation {
  foo(id: String, input: Input): String
}
```
```js
export type TInput = {
  name: ?string,
};

export type TMutation = {
  foo: ?string,
};

export type TMutationFooArgs = {
  id?: ?string,
  input?: ?Input
};
```

This PR fixes this bug by using the `_convertName` function in `OperationVariablesToObject`.
I have also added a test to cover this bug.