### PR TITLE
Fix directive arguments transforms in flow-resolvers plugin

### DIFF
--- a/packages/plugins/flow-resolvers/src/visitor.ts
+++ b/packages/plugins/flow-resolvers/src/visitor.ts
@@ -51,7 +51,7 @@ export class FlowResolversVisitor implements BasicFlowVisitor {
     return this._parsedConfig.scalars;
   }
 
-  private _convertName(name: any, addPrefix = true): string {
+  convertName(name: any, addPrefix = true): string {
     return (addPrefix ? this._parsedConfig.typesPrefix : '') + this._parsedConfig.convert(name);
   }
 
@@ -67,7 +67,7 @@ export class FlowResolversVisitor implements BasicFlowVisitor {
 
   NamedType = (node: NamedTypeNode): string => {
     const asString = (node.name as any) as string;
-    const type = this._parsedConfig.scalars[asString] || this._convertName(asString);
+    const type = this._parsedConfig.scalars[asString] || this.convertName(asString);
 
     return `?${type}`;
   };
@@ -96,18 +96,18 @@ export class FlowResolversVisitor implements BasicFlowVisitor {
 
       return indent(
         `${node.name}?: ${isSubscriptionType ? 'SubscriptionResolver' : 'Resolver'}<${mappedType}, ParentType, Context${
-          hasArguments ? `, ${parentName + this._convertName(node.name, false) + 'Args'}` : ''
+          hasArguments ? `, ${parentName + this.convertName(node.name, false) + 'Args'}` : ''
         }>,`
       );
     };
   };
 
   ObjectTypeDefinition = (node: ObjectTypeDefinitionNode) => {
-    const name = this._convertName(node.name + 'Resolvers');
+    const name = this.convertName(node.name + 'Resolvers');
     const type =
       this._parsedConfig.mapping[node.name as any] ||
       this._parsedConfig.scalars[node.name as any] ||
-      this._convertName(node.name);
+      this.convertName(node.name);
     const block = new DeclarationBlock()
       .export()
       .asKind('interface')
@@ -118,7 +118,7 @@ export class FlowResolversVisitor implements BasicFlowVisitor {
   };
 
   UnionTypeDefinition = (node: UnionTypeDefinitionNode): string => {
-    const name = this._convertName(node.name + 'Resolvers');
+    const name = this.convertName(node.name + 'Resolvers');
     const possibleTypes = node.types
       .map(name => ((name as any) as string).replace('?', ''))
       .map(f => `'${f}'`)
@@ -132,17 +132,17 @@ export class FlowResolversVisitor implements BasicFlowVisitor {
   };
 
   ScalarTypeDefinition = (node: ScalarTypeDefinitionNode): string => {
-    const baseName = this._convertName(node.name);
+    const baseName = this.convertName(node.name);
 
     return new DeclarationBlock()
       .export()
       .asKind('type')
-      .withName(this._convertName(node.name + 'ScalarConfig'), ` extends GraphQLScalarTypeConfig<${baseName}, any>`)
+      .withName(this.convertName(node.name + 'ScalarConfig'), ` extends GraphQLScalarTypeConfig<${baseName}, any>`)
       .withBlock(indent(`name: '${node.name}'`)).string;
   };
 
   DirectiveDefinition = (node: DirectiveDefinitionNode): string => {
-    const directiveName = this._convertName(node.name + 'DirectiveResolver');
+    const directiveName = this.convertName(node.name + 'DirectiveResolver');
     const hasArguments = node.arguments && node.arguments.length > 0;
     const directiveArgs = hasArguments
       ? new OperationVariablesToObject<FlowResolversVisitor, InputValueDefinitionNode>(this, node.arguments).string
@@ -156,7 +156,7 @@ export class FlowResolversVisitor implements BasicFlowVisitor {
   };
 
   InterfaceTypeDefinition = (node: InterfaceTypeDefinitionNode): string => {
-    const name = this._convertName(node.name + 'Resolvers');
+    const name = this.convertName(node.name + 'Resolvers');
     const allTypesMap = this._schema.getTypeMap();
     const implementingTypes: string[] = [];
 

--- a/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
@@ -38,7 +38,7 @@ describe('Flow Resolvers Plugin', () => {
 
       scalar MyScalar
 
-      directive @myDirective(arg: String!, arg2: String!) on FIELD
+      directive @myDirective(arg: Int!, arg2: String!, arg3: Boolean!) on FIELD
   `
   });
 
@@ -46,8 +46,8 @@ describe('Flow Resolvers Plugin', () => {
     const result = plugin(schema, [], {}, { outputFile: '' });
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result> = DirectiveResolverFn<Result, {   arg?: ?string,
-      arg2?: ?string }, any>;
+    export type MyDirectiveDirectiveResolver<Result> = DirectiveResolverFn<Result, {   arg?: ?number,
+      arg2?: ?string, arg3?: ?boolean }, any>;
 
     export interface MyOtherTypeResolvers<Context = any, ParentType = MyOtherType> {
       bar?: Resolver<string, ParentType, Context>,
@@ -97,8 +97,8 @@ describe('Flow Resolvers Plugin', () => {
     );
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result> = DirectiveResolverFn<Result, {   arg?: ?string,
-      arg2?: ?string }, any>;
+    export type MyDirectiveDirectiveResolver<Result> = DirectiveResolverFn<Result, {   arg?: ?number,
+      arg2?: ?string, arg3?: ?boolean }, any>;
 
     export interface MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> {
       bar?: Resolver<string, ParentType, Context>,

--- a/packages/plugins/flow/src/visitor.ts
+++ b/packages/plugins/flow/src/visitor.ts
@@ -24,7 +24,10 @@ export const DEFAULT_SCALARS = {
   String: 'string',
   Boolean: 'boolean',
   Int: 'number',
-  Float: 'number'
+  Float: 'number',
+  string: 'string',
+  number: 'number',
+  boolean: 'boolean'
 };
 export interface ParsedConfig {
   scalars: ScalarsMap;


### PR DESCRIPTION
The visitors in flow-resovlers plugin weren't implementing the `convertName` method of the `BasicFlowVisitor` interface. Fixed that.

There was also a bug in `OperationVariablesToObject`:
When `typeof variable.type === 'string'` `variable.type` won't match the proper key from `DEFAULT_SCALARS` (it would be `string` instead of `String` or `number` instead of `Int`).
This happened only on directives parsing, in all other cases `typeof variable.type === 'object'`.
Fixed this by adding "mapped" default scalars `string, number, boolean` to `DEFAULT_SCALARS`.

This fixes the currently (master at https://github.com/dotansimha/graphql-code-generator/commit/7e3df340ff525f91e49d7ae349f0f1c982791b7f) broken tests in `flow-resolvers`. All tests in the monorepo should be green after merging.
