### PR TITLE
[typescript-resolvers] Add Field Resolver name prefix

### DIFF
--- a/docs/plugins/typescript-resolvers.md
+++ b/docs/plugins/typescript-resolvers.md
@@ -239,3 +239,20 @@ export const resolvers: QueryResolvers.Resolvers = {
 ```
 
 Field resolvers will be modfied as well.
+
+## Field Resolver Name Prefix
+
+When using `noNamespace` option, you can add a prefix to field resolver name, in order to avoid conflicts in the schema.
+
+```yaml
+# ...
+generates:
+  path/to/file.ts:
+    config:
+      noNamespace: true
+      fieldResolverNamePrefix: Field
+    plugins:
+      - typescript-resolvers
+```
+
+And it will generate Field Resolver like `Post_IdResolver` instead of `PostIdResolver`

--- a/docs/plugins/typescript-resolvers.md
+++ b/docs/plugins/typescript-resolvers.md
@@ -242,7 +242,7 @@ Field resolvers will be modfied as well.
 
 ## Field Resolver Name Prefix
 
-When using `noNamespace` option, you can add a prefix to field resolver name, in order to avoid conflicts in the schema.
+When using `noNamespace` option, you can add a prefix to field resolver name, in order to avoid conflicts in the generated typescript declarations.
 
 ```yaml
 # ...
@@ -255,4 +255,4 @@ generates:
       - typescript-resolvers
 ```
 
-And it will generate Field Resolver like `Post_IdResolver` instead of `PostIdResolver`
+And it will generate Field Resolver like `PostFieldIdResolver` instead of `PostIdResolver`

--- a/packages/plugins/typescript-resolvers/src/helpers.ts
+++ b/packages/plugins/typescript-resolvers/src/helpers.ts
@@ -3,7 +3,6 @@ import { Field, Type, Interface, Union } from 'graphql-codegen-core';
 import { GraphQLSchema } from 'graphql';
 import { convertedType, getFieldType as fieldType } from 'graphql-codegen-typescript-common';
 import { pickMapper, useDefaultMapper } from './mappers';
-import { TypeScriptServerResolversConfig } from '.';
 
 export function importFromGraphQL(options: Handlebars.HelperOptions) {
   const imports: string[] = ['GraphQLResolveInfo'];

--- a/packages/plugins/typescript-resolvers/src/helpers.ts
+++ b/packages/plugins/typescript-resolvers/src/helpers.ts
@@ -3,6 +3,7 @@ import { Field, Type, Interface, Union } from 'graphql-codegen-core';
 import { GraphQLSchema } from 'graphql';
 import { convertedType, getFieldType as fieldType } from 'graphql-codegen-typescript-common';
 import { pickMapper, useDefaultMapper } from './mappers';
+import { TypeScriptServerResolversConfig } from '.';
 
 export function importFromGraphQL(options: Handlebars.HelperOptions) {
   const imports: string[] = ['GraphQLResolveInfo'];
@@ -30,8 +31,8 @@ export const getFieldType = convert => (field: Field, options: Handlebars.Helper
   return convertedType(field, options, convert);
 };
 
-export const getFieldResolverName = convert => (name: string) => {
-  return `${convert(name)}Resolver`;
+export const getFieldResolverName = (convert, config) => (name: string) => {
+  return `${config.fieldResolverNamePrefix || ''}${convert(name)}Resolver`;
 };
 
 export const getFieldResolver = convert => (field: Field, type: Type, options: Handlebars.HelperOptions) => {

--- a/packages/plugins/typescript-resolvers/src/index.ts
+++ b/packages/plugins/typescript-resolvers/src/index.ts
@@ -17,6 +17,7 @@ export interface TypeScriptServerResolversConfig extends TypeScriptCommonConfig 
   contextType?: string;
   mappers?: { [name: string]: string };
   defaultMapper?: string;
+  fieldResolverNamePrefix?: string;
 }
 
 export const plugin: PluginFunction<TypeScriptServerResolversConfig> = async (
@@ -29,7 +30,7 @@ export const plugin: PluginFunction<TypeScriptServerResolversConfig> = async (
   Handlebars.registerPartial('resolveType', resolveType);
   Handlebars.registerPartial('directive', directive);
   Handlebars.registerPartial('scalar', scalar);
-  Handlebars.registerHelper('getFieldResolverName', getFieldResolverName(convert));
+  Handlebars.registerHelper('getFieldResolverName', getFieldResolverName(convert, config));
   Handlebars.registerHelper('getFieldResolver', getFieldResolver(convert));
   Handlebars.registerHelper('getTypenames', getTypenames);
   Handlebars.registerHelper('getParentType', getParentType(convert));

--- a/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
@@ -1205,4 +1205,59 @@ describe('Resolvers', () => {
       }
     `);
   });
+
+  it('should insert Field Resolvers prefix if configured', async () => {
+    const testSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          user: User
+          post: UserPost
+        }
+
+        type User {
+          postId: String
+          post: Post
+        } 
+
+        type UserPost {
+          id: String
+        }
+
+        type Post {
+          id: String
+        }
+        
+        schema {
+          query: Query
+        }
+      `
+    });
+
+    const content = await plugin(
+      testSchema,
+      [],
+      { noNamespaces: true, fieldResolverNamePrefix: '_' },
+      {
+        outputFile: 'graphql.ts'
+      }
+    );
+
+    expect(content).toBeSimilarStringTo(`
+      export interface UserResolvers<Context = {}, TypeParent = User> {
+        postId?: User_PostIdResolver<Maybe<string>, TypeParent, Context>;
+        post?: User_PostResolver<Maybe<Post>, TypeParent, Context>;
+      }
+
+      export type User_PostIdResolver<R = Maybe<string>, Parent = User, Context = {}> = Resolver<R, Parent, Context>;
+      export type User_PostResolver<R = Maybe<Post>, Parent = User, Context = {}> = Resolver<R, Parent, Context>;
+    `);
+
+    expect(content).toBeSimilarStringTo(`
+      export interface UserPostResolvers<Context = {}, TypeParent = UserPost> {
+        id?: UserPost_IdResolver<Maybe<string>, TypeParent, Context>;
+      }
+
+      export type UserPost_IdResolver<R = Maybe<string>, Parent = UserPost, Context = {}> = Resolver<R, Parent, Context>;
+    `);
+  });
 });


### PR DESCRIPTION
With this PR, i propose a `fieldResolverNamePrefix` option for `typescript-resolvers` plugin, in order to avoid potential conflicts in name generation while using `noNamespace` option too.
I hope this implementation meets your code style & architecture, feel free to tell me if not.

See #1064 for use case.

I've added test & docs, however i'm not sure how to test it locally in my project. If you could suggest me how to link properly my modified version to my existing `package.json` (should I use `yarn link`? or maybe point `graphql-codegen-typescript-resolvers` to my github repo?) I'd be glad to test it more.