### PR TITLE
Make sure it can load a schema as a string

### DIFF
--- a/packages/graphql-codegen-cli/src/load.ts
+++ b/packages/graphql-codegen-cli/src/load.ts
@@ -28,9 +28,9 @@ const documentsHandlers = [new DocumentFromString(), new DocumentsFromGlob()];
 const schemaHandlers = [
   new IntrospectionFromUrlLoader(),
   new IntrospectionFromFileLoader(),
-  new SchemaFromString(),
   new SchemaFromTypedefs(),
-  new SchemaFromExport()
+  new SchemaFromExport(),
+  new SchemaFromString()
 ];
 
 export const loadSchema = async (

--- a/packages/graphql-codegen-cli/src/load.ts
+++ b/packages/graphql-codegen-cli/src/load.ts
@@ -28,9 +28,9 @@ const documentsHandlers = [new DocumentFromString(), new DocumentsFromGlob()];
 const schemaHandlers = [
   new IntrospectionFromUrlLoader(),
   new IntrospectionFromFileLoader(),
+  new SchemaFromString(),
   new SchemaFromTypedefs(),
-  new SchemaFromExport(),
-  new SchemaFromString()
+  new SchemaFromExport()
 ];
 
 export const loadSchema = async (

--- a/packages/graphql-codegen-cli/src/loaders/schema/schema-from-string.ts
+++ b/packages/graphql-codegen-cli/src/loaders/schema/schema-from-string.ts
@@ -1,11 +1,11 @@
 import { Types } from 'graphql-codegen-core';
 import { SchemaLoader } from './schema-loader';
-import isValidPath = require('is-valid-path');
 import { parse, DocumentNode } from 'graphql';
+import isGlob = require('is-glob');
 
 export class SchemaFromString implements SchemaLoader {
   canHandle(str: string): boolean {
-    if (isValidPath(str)) {
+    if (isGlob(str) || /\.[a-z0-9]+$/i.test(str)) {
       return false;
     }
 

--- a/packages/graphql-codegen-cli/src/loaders/schema/schema-from-string.ts
+++ b/packages/graphql-codegen-cli/src/loaders/schema/schema-from-string.ts
@@ -4,6 +4,11 @@ import { parse, DocumentNode } from 'graphql';
 
 export class SchemaFromString implements SchemaLoader {
   canHandle(str: string): boolean {
+    // XXX: is-valid-path or is-glob treat SDL as a valid path
+    // (`scalar Date` for example)
+    // this why checking the extension is fast enough
+    // and prevent from parsing the string in order to find out
+    // if the string is a SDL
     if (/\.[a-z0-9]+$/i.test(str)) {
       return false;
     }

--- a/packages/graphql-codegen-cli/src/loaders/schema/schema-from-string.ts
+++ b/packages/graphql-codegen-cli/src/loaders/schema/schema-from-string.ts
@@ -1,11 +1,10 @@
 import { Types } from 'graphql-codegen-core';
 import { SchemaLoader } from './schema-loader';
 import { parse, DocumentNode } from 'graphql';
-import isGlob = require('is-glob');
 
 export class SchemaFromString implements SchemaLoader {
   canHandle(str: string): boolean {
-    if (isGlob(str) || /\.[a-z0-9]+$/i.test(str)) {
+    if (/\.[a-z0-9]+$/i.test(str)) {
       return false;
     }
 

--- a/packages/graphql-codegen-cli/tests/schema-from-string.spec.ts
+++ b/packages/graphql-codegen-cli/tests/schema-from-string.spec.ts
@@ -1,0 +1,21 @@
+import { SchemaFromString } from '../src/loaders/schema/schema-from-string';
+
+describe('Schema From String', () => {
+  const instance = new SchemaFromString();
+
+  it('should not load the schema when an input is a file', async () => {
+    const paths = ['./file.js', 'file.js', './dir/*.js'];
+
+    for (const input of paths) {
+      expect(instance.canHandle(input)).toEqual(false);
+    }
+  });
+
+  it('should load the schema when an input is a string and not a filepath or glob', async () => {
+    expect(
+      instance.canHandle(`
+        scalar DateTime
+      `)
+    ).toEqual(true);
+  });
+});


### PR DESCRIPTION
`isValidPath` says that pretty much any string is a valid path... So I decided to check whether it's a glob path or has an alphanumeric extension.