### PR TITLE
Flow plugin improvements  

### DIFF
--- a/packages/plugins/flow-resolvers/src/index.ts
+++ b/packages/plugins/flow-resolvers/src/index.ts
@@ -26,7 +26,7 @@ export const plugin: PluginFunction<FlowResolversPluginConfig> = (
   }
 
   const result = `
-import { ${imports.join(', ')} } from 'graphql/type';
+import { ${imports.join(', ')} } from 'graphql';
 
 export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
   parent?: Parent,
@@ -36,17 +36,17 @@ export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
 ) => Promise<Result> | Result;
 
 export type SubscriptionSubscribeFn<Result, Parent, Context, Args> = (
-  parent: Parent,
-  args: Args,
-  context: Context,
-  info: GraphQLResolveInfo
+  parent?: Parent,
+  args?: Args,
+  context?: Context,
+  info?: GraphQLResolveInfo
 ) => AsyncIterator<Result> | Promise<AsyncIterator<Result>>;
 
 export type SubscriptionResolveFn<Result, Parent, Context, Args> = (
-  parent: Parent,
-  args: Args,
-  context: Context,
-  info: GraphQLResolveInfo
+  parent?: Parent,
+  args?: Args,
+  context?: Context,
+  info?: GraphQLResolveInfo
 ) => Result | Promise<Result>;
 
 export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
@@ -77,9 +77,9 @@ export type DirectiveResolverFn<TResult, TArgs = {}, TContext = {}> = (
 
   const printedSchema = printSchema(schema);
   const astNode = parse(printedSchema);
-  const visitorResult = visit(astNode, {
-    leave: new FlowResolversVisitor(config, schema)
-  });
+  const visitor = new FlowResolversVisitor(config, schema);
+  const visitorResult = visit(astNode, { leave: visitor });
+  const rootResolver = visitor.rootResolver;
 
-  return result + '\n' + visitorResult.definitions.filter(d => typeof d === 'string').join('\n');
+  return [result, ...visitorResult.definitions.filter(d => typeof d === 'string'), rootResolver].join('\n');
 };

--- a/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
@@ -1,7 +1,6 @@
 import 'graphql-codegen-core/dist/testing';
 import { makeExecutableSchema } from 'graphql-tools';
 import { plugin } from '../src';
-import { typeDefs } from '../../../graphql-codegen-cli/tests/test-files/schema-dir/schema';
 
 describe('Flow Resolvers Plugin', () => {
   const schema = makeExecutableSchema({
@@ -86,15 +85,13 @@ describe('Flow Resolvers Plugin', () => {
   it('Should generate the correct imports when schema has scalars', () => {
     const result = plugin(makeExecutableSchema({ typeDefs: `scalar MyScalar` }), [], {}, { outputFile: '' });
 
-    expect(result).toBeSimilarStringTo(`import { GraphQLResolveInfo, GraphQLScalarTypeConfig } from 'graphql/type';`);
+    expect(result).toBeSimilarStringTo(`import { GraphQLResolveInfo, GraphQLScalarTypeConfig } from 'graphql';`);
   });
 
   it('Should generate the correct imports when schema has no scalars', () => {
     const result = plugin(makeExecutableSchema({ typeDefs: `type MyType { f: String }` }), [], {}, { outputFile: '' });
 
-    expect(result).not.toBeSimilarStringTo(
-      `import { GraphQLResolveInfo, GraphQLScalarTypeConfig } from 'graphql/type';`
-    );
+    expect(result).not.toBeSimilarStringTo(`import { GraphQLResolveInfo, GraphQLScalarTypeConfig } from 'graphql';`);
   });
 
   it('Should generate basic type resolvers with mapping', () => {


### PR DESCRIPTION
- [x] fixed flow imports (use `graphql` instead of `graphql/type`)
- [x] added root resolver
- [x] change resolvers arguments to be optional
- [ ] fix parent type of `Query`, `Mutation` and `Subscription` resolvers (should be `any`) 
- [ ] implement `react-apollo` flow plugin
  