### PR TITLE
Add Object.freeze to Flow enum types

### DIFF
--- a/packages/plugins/flow/src/utils.ts
+++ b/packages/plugins/flow/src/utils.ts
@@ -31,6 +31,7 @@ export class DeclarationBlock {
   _export = false;
   _name = null;
   _kind = null;
+  _methodName = null;
   _content = null;
   _block = null;
   _nameGenerics = null;
@@ -43,6 +44,12 @@ export class DeclarationBlock {
 
   asKind(kind): DeclarationBlock {
     this._kind = kind;
+
+    return this;
+  }
+
+  withMethodCall(methodName: string): DeclarationBlock {
+    this._methodName = methodName;
 
     return this;
   }
@@ -93,9 +100,15 @@ export class DeclarationBlock {
         result += this._content;
       }
 
-      result += `{
+      if (this._methodName) {
+        result += `${this._methodName}({
+${this._block}
+})`;
+      } else {
+        result += `{
 ${this._block}
 }`;
+      }
     } else if (this._content) {
       result += this._content;
     } else if (this._kind) {

--- a/packages/plugins/flow/src/visitor.ts
+++ b/packages/plugins/flow/src/visitor.ts
@@ -169,6 +169,7 @@ export class FlowVisitor implements BasicFlowVisitor {
       .export()
       .asKind('const')
       .withName(this.convertName(enumValuesName))
+      .withMethodCall('Object.freeze')
       .withBlock(
         node.values
           .map(enumOption =>

--- a/packages/plugins/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/tests/flow.spec.ts
@@ -102,11 +102,11 @@ describe('Flow Plugin', () => {
       }).definitions.join('\n');
 
       expect(result).toBeSimilarStringTo(`
-        export const myenumvalues = {
+        export const myenumvalues = Object.freeze({
           a: 'A',
           b: 'B',
           c: 'C'
-        };
+        });
     
         export type myenum = $Values<typeof myenumvalues>;
     
@@ -154,11 +154,11 @@ describe('Flow Plugin', () => {
       }).definitions.join('\n');
 
       expect(result).toBeSimilarStringTo(`
-      export const MyEnumValues = {
+      export const MyEnumValues = Object.freeze({
         A: 'A',
         B: 'B',
         C: 'C'
-      };
+      });
   
       export type MyEnum = $Values<typeof MyEnumValues>;
   
@@ -206,11 +206,11 @@ describe('Flow Plugin', () => {
       }).definitions.join('\n');
 
       expect(result).toBeSimilarStringTo(`
-      export const IMyEnumValues = {
+      export const IMyEnumValues = Object.freeze({
         IA: 'A',
         IB: 'B',
         IC: 'C'
-      };
+      });
   
       export type IMyEnum = $Values<typeof IMyEnumValues>;
   
@@ -331,11 +331,11 @@ describe('Flow Plugin', () => {
       });
 
       expect(result.definitions[0]).toBeSimilarStringTo(`
-        export const MyEnumValues = {
+        export const MyEnumValues = Object.freeze({
           A: 'A',
           B: 'B',
           C: 'C'
-        };
+        });
 
         export type MyEnum = $Values<typeof MyEnumValues>;
       `);
@@ -354,11 +354,11 @@ describe('Flow Plugin', () => {
       });
 
       expect(result.definitions[0]).toBeSimilarStringTo(`
-        export const MyEnumValues = {
+        export const MyEnumValues = Object.freeze({
           A: 'SomeValue',
           B: 'TEST',
           C: 'C'
-        };
+        });
 
         export type MyEnum = $Values<typeof MyEnumValues>;
       `);


### PR DESCRIPTION
The way GraphQL enums are currently handled is not sound.
The following schema type:
```graphql
enum Role {
  USER
  ADMIN
}
```
Is transformed into:
```js
export const RoleValues = {
  User: 'USER',
  Admin: 'ADMIN'
};
export type Role = $Values<typeof RoleValues>;
```
The problem is that the type of `Role = $Values<typeof RoleValues>` is inferred as `string` instead of a flow enum `'USER' | 'ADMIN'`.
To fix this, the `RoleValues` const should be wrapped in a `Object.freeze` call which locks the objects and restores correct flow enum type inference. [Try in Flow Playground](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBTAHgBzgJwBcwBjOAOwGdiAlOGDANQEMYBXDSsAXjAG9UYMAFVKGfAC4wAcmEBlAKI1pAGkFgAggBMAtgEtyU6RoAiAWQCSAOWmoAvgG50ocMPJkdOjOWKEAFnpcYiSEehRghHBgUHpYEX4YYHQMLOycEQCeOBiYuATEZFS09EysHFy8APIARgBWGCEAdFD4GBgAXhgAFAJCouJG8kqq6tr6hjKmljb2TiAo6Nh4RJnZSSU8YAAkqeUAPIRZGHBQ6yllnAB8TqiF1GDVzFpSyYm80gBCptIOYMDAYAAKgEgn44GwYFoHolmOQwOJ8ARGkA).
This PR fixes this behavior by freezing the generated enum map constant:
```js
export const RoleValues = Object.freeze({
  User: 'USER',
  Admin: 'ADMIN'
});
export type Role = $Values<typeof RoleValues>;
```