### PR TITLE
[Flow Resolvers] fix type imports

### DIFF
--- a/packages/plugins/flow-resolvers/src/index.ts
+++ b/packages/plugins/flow-resolvers/src/index.ts
@@ -16,13 +16,13 @@ export const plugin: PluginFunction<FlowResolversPluginConfig> = (
   documents: DocumentFile[],
   config: FlowResolversPluginConfig
 ) => {
-  const imports = ['GraphQLResolveInfo'];
+  const imports = ['type GraphQLResolveInfo'];
   const hasScalars = Object.values(schema.getTypeMap())
     .filter(t => t.astNode)
     .some(isScalarType);
 
   if (hasScalars) {
-    imports.push('GraphQLScalarTypeConfig');
+    imports.push('type GraphQLScalarTypeConfig');
   }
 
   const result = `

--- a/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
@@ -85,13 +85,13 @@ describe('Flow Resolvers Plugin', () => {
   it('Should generate the correct imports when schema has scalars', () => {
     const result = plugin(makeExecutableSchema({ typeDefs: `scalar MyScalar` }), [], {}, { outputFile: '' });
 
-    expect(result).toBeSimilarStringTo(`import { GraphQLResolveInfo, GraphQLScalarTypeConfig } from 'graphql';`);
+    expect(result).toBeSimilarStringTo(`import { type GraphQLResolveInfo, type GraphQLScalarTypeConfig } from 'graphql';`);
   });
 
   it('Should generate the correct imports when schema has no scalars', () => {
     const result = plugin(makeExecutableSchema({ typeDefs: `type MyType { f: String }` }), [], {}, { outputFile: '' });
 
-    expect(result).not.toBeSimilarStringTo(`import { GraphQLResolveInfo, GraphQLScalarTypeConfig } from 'graphql';`);
+    expect(result).not.toBeSimilarStringTo(`import { type GraphQLResolveInfo, type GraphQLScalarTypeConfig } from 'graphql';`);
   });
 
   it('Should generate basic type resolvers with mapping', () => {


### PR DESCRIPTION
Both `GraphQLResolveInfo` and `GraphQLScalarTypeConfig` are types in `graphql` package flow import and should be imported via `import { type ... }` or flow lints will complain.

This pull request fixes this behaviour. I've intentionally put `type` specificator to both of them, in case we will need import some real entry from `graphql` package once.