### PR TITLE
Custom naming convention (cont. #1092)

### DIFF
--- a/packages/plugins/typescript-apollo-angular/src/helpers/to-fragment-name.ts
+++ b/packages/plugins/typescript-apollo-angular/src/helpers/to-fragment-name.ts
@@ -1,3 +1,3 @@
 export const toFragmentName = convert => (fragmentName: string): string => {
-  return convert(`${fragmentName}Fragment`);
+  return convert(`${fragmentName}Fragment`, 'typeNames');
 };

--- a/packages/plugins/typescript-client/src/helpers.ts
+++ b/packages/plugins/typescript-client/src/helpers.ts
@@ -21,16 +21,16 @@ export function isPrimitiveType(type: Field, options: Handlebars.HelperOptions) 
 }
 
 function nameFragment(
-  convert: (str: string) => string,
+  convert: (str: string, kind: string) => string,
   prefix: string,
   fragment: SelectionSetFragmentSpread | SelectionSetInlineFragment,
   noNamespaces: boolean
 ) {
   if (isFragmentSpread(fragment)) {
-    return convert(fragment.fragmentName) + (noNamespaces ? '' : '.') + 'Fragment';
+    return convert(fragment.fragmentName, 'typeNames') + (noNamespaces ? '' : '.') + 'Fragment';
   }
 
-  return (noNamespaces ? convert(prefix) : '') + fragment.name;
+  return (noNamespaces ? convert(prefix, 'typeNames') : '') + fragment.name;
 }
 
 function isFragmentSpread(
@@ -106,7 +106,7 @@ export function convertedFieldType(convert) {
     const primitiveType = isPrimitiveType(field, options);
 
     if (shouldHavePrefix(field, options)) {
-      realType = convert(prefix);
+      realType = convert(prefix, 'typeNames');
 
       if (config.noNamespaces) {
         realType += field.type;
@@ -114,7 +114,7 @@ export function convertedFieldType(convert) {
     } else if (primitiveType) {
       realType = primitiveType;
     } else {
-      realType = convert(field.type);
+      realType = convert(field.type, 'typeNames');
     }
 
     return new SafeString(getFieldType(field, realType, options));

--- a/packages/plugins/typescript-client/src/root.handlebars
+++ b/packages/plugins/typescript-client/src/root.handlebars
@@ -2,25 +2,25 @@
 {{#each operations }}
 
 {{#unless @root.config.noNamespaces}}
-export namespace {{ convert name }} {
+export namespace {{ convert name 'typeNames' }} {
 {{/unless}}
-  export type {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Variables = {
+  export type {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables = {
   {{#each variables}}
     {{#if @root.config.immutableTypes }}readonly {{/if}}{{ name }}{{ getOptionals this }}: {{ convertedType this }};
   {{/each}}
   }
 
-  export type {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}{{ convert operationType }} ={{#if hasFields}} {
+  export type {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{ convert operationType 'typeNames' }} ={{#if hasFields}} {
     {{#if @root.config.immutableTypes }}readonly {{/if}}__typename?: "{{ convert operationType }}";
     {{> selectionSet fields=fields prefix=name }}
   }{{/if}}{{{ fragments this name ../fragments }}}
   {{#each innerModels }}
 
-  export type {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ convert modelType }} ={{#if hasFields}} {
+  export type {{#if @root.config.noNamespaces}}{{ convert ../name 'typeNames' }}{{/if}}{{ convert modelType 'typeNames' }} ={{#if hasFields}} {
   {{#unless hasInlineFragments}}
     {{#if @root.config.immutableTypes }}readonly {{/if}}__typename{{#unless hasTypename}}?{{/unless}}: "{{ schemaBaseType }}";
   {{else}}
-    {{#if @root.config.immutableTypes }}readonly {{/if}}__typename{{#unless hasTypename}}?{{/unless}}: {{#each inlineFragments}}{{#if @root.config.noNamespaces}}{{ convert ../../name }}{{/if}}{{name}}["__typename"]{{#unless @last}} | {{/unless}}{{/each}};
+    {{#if @root.config.immutableTypes }}readonly {{/if}}__typename{{#unless hasTypename}}?{{/unless}}: {{#each inlineFragments}}{{#if @root.config.noNamespaces}}{{ convert ../../name 'typeNames' }}{{/if}}{{name}}["__typename"]{{#unless @last}} | {{/unless}}{{/each}};
   {{/unless}}
     {{> selectionSet fields=fields prefix=../name }}
   }{{/if}} {{{ fragments this ../name ../../fragments }}}
@@ -32,19 +32,19 @@ export namespace {{ convert name }} {
 {{#each fragments }}
 
 {{#unless @root.config.noNamespaces}}
-export namespace {{ convert name }} {
+export namespace {{ convert name 'typeNames' }} {
 {{/unless}}
-  export type {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Fragment ={{#if hasFields}} {
+  export type {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Fragment ={{#if hasFields}} {
     {{#if @root.config.immutableTypes }}readonly {{/if}}__typename?: "{{ onType }}";
     {{> selectionSet fields=fields prefix=name }}
   }{{/if}}{{{ fragments this name ../fragments }}}
   {{#each innerModels }}
 
-  export type {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ convert modelType }} ={{#if hasFields}} {
+  export type {{#if @root.config.noNamespaces}}{{ convert ../name 'typeNames' }}{{/if}}{{ convert modelType 'typeNames' }} ={{#if hasFields}} {
   {{#unless hasInlineFragments}}
     {{#if @root.config.immutableTypes }}readonly {{/if}}__typename{{#unless hasTypename}}?{{/unless}}: "{{ schemaBaseType }}";
   {{else}}
-    {{#if @root.config.immutableTypes }}readonly {{/if}}__typename{{#unless hasTypename}}?{{/unless}}: {{#each inlineFragments}}{{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{name}}["__typename"]{{#unless @last}} | {{/unless}}{{/each}};
+    {{#if @root.config.immutableTypes }}readonly {{/if}}__typename{{#unless hasTypename}}?{{/unless}}: {{#each inlineFragments}}{{#if @root.config.noNamespaces}}{{ convert ../name 'typeNames' }}{{/if}}{{name}}["__typename"]{{#unless @last}} | {{/unless}}{{/each}};
   {{/unless}}
     {{> selectionSet fields=fields prefix=../name }}
   }{{/if}}{{{ fragments this ../name ../../fragments }}}

--- a/packages/plugins/typescript-common/src/enum.handlebars
+++ b/packages/plugins/typescript-common/src/enum.handlebars
@@ -1,10 +1,10 @@
 {{{ toComment description }}}
 {{#if @root.config.enumsAsTypes }}
-export type {{@root.config.interfacePrefix}}{{ convert name }} = {{#each values }}{{{ getEnumValue ../name value }}}{{#unless @last}} | {{/unless}}{{/each}};
+export type {{@root.config.interfacePrefix}}{{ convert name 'typeNames' }} = {{#each values }}{{{ getEnumValue ../name value }}}{{#unless @last}} | {{/unless}}{{/each}};
 {{else}}
-export {{#if @root.config.constEnums }}const {{/if}}enum {{@root.config.interfacePrefix}}{{ convert name }} {
+export {{#if @root.config.constEnums }}const {{/if}}enum {{@root.config.interfacePrefix}}{{ convert name 'typeNames' }} {
 {{#each values }}
-  {{ convert value }} = {{{ getEnumValue ../name value }}},
+  {{ convert value 'enumValues' }} = {{{ getEnumValue ../name value }}},
 {{/each}}
 }
 {{/if}}

--- a/packages/plugins/typescript-common/src/helpers.ts
+++ b/packages/plugins/typescript-common/src/helpers.ts
@@ -102,7 +102,7 @@ export function convertedType(type: Field, options: Handlebars.HelperOptions, co
   const config = options.data.root.config || {};
   const realType =
     options.data.root.primitives[baseType] ||
-    `${type.isScalar ? '' : config.interfacePrefix || ''}${skipConversion ? baseType : convert(baseType)}`;
+    `${type.isScalar ? '' : config.interfacePrefix || ''}${skipConversion ? baseType : convert(baseType, 'typeNames')}`;
 
   return getFieldType(type, realType, options);
 }

--- a/packages/plugins/typescript-common/src/index.ts
+++ b/packages/plugins/typescript-common/src/index.ts
@@ -6,13 +6,18 @@ import * as enumTemplate from './enum.handlebars';
 import * as type from './type.handlebars';
 import * as rootTemplate from './root.handlebars';
 import * as Handlebars from 'handlebars';
-import { pascalCase } from 'change-case';
 import { getOptionals, getType, getEnumValue, getScalarType, defineMaybe } from './helpers';
 
 export * from './helpers';
 
+export interface TypeScriptNamingConventionMap {
+  default?: string;
+  enumValues?: string;
+  typeNames?: string;
+}
+
 export interface TypeScriptCommonConfig {
-  namingConvention?: string;
+  namingConvention?: string | TypeScriptNamingConventionMap;
   avoidOptionals?: boolean;
   optionalType?: string;
   constEnums?: boolean;
@@ -31,10 +36,31 @@ export const DEFAULT_SCALARS = {
   ID: 'string'
 };
 
-export function initCommonTemplate(hbs, schema, config) {
+export function initCommonTemplate(hbs, schema, config: TypeScriptCommonConfig) {
   const scalars = { ...DEFAULT_SCALARS, ...(config.scalars || {}) };
-  const baseConvertFn = config.namingConvention ? resolveExternalModuleAndFn(config.namingConvention) : pascalCase;
-  const convert = (str: string): string => {
+  let namingConventionMap: TypeScriptNamingConventionMap;
+  if (config.namingConvention === 'undefined') {
+    namingConventionMap = {
+      default: 'change-case#pascalCase',
+      enumValues: 'change-case#pascalCase',
+      typeNames: 'change-case#pascalCase'
+    };
+  } else if (typeof config.namingConvention === 'string') {
+    namingConventionMap = {
+      default: config.namingConvention,
+      enumValues: config.namingConvention,
+      typeNames: config.namingConvention
+    };
+  } else {
+    namingConventionMap = {
+      default: config.namingConvention.default || 'change-case#pascalCase',
+      enumValues: config.namingConvention.enumValues || config.namingConvention.default || 'change-case#pascalCase',
+      typeNames: config.namingConvention.typeNames || config.namingConvention.default || 'change-case#pascalCase'
+    };
+  }
+  const convert = (str: string, kind: keyof TypeScriptNamingConventionMap = 'default'): string => {
+    const baseConvertFn =
+      namingConventionMap[kind] === 'keep' ? str => str : resolveExternalModuleAndFn(namingConventionMap[kind]);
     if (str.charAt(0) === '_') {
       const after = str.replace(
         /^(_*)(.*)/,

--- a/packages/plugins/typescript-common/src/index.ts
+++ b/packages/plugins/typescript-common/src/index.ts
@@ -36,10 +36,14 @@ export const DEFAULT_SCALARS = {
   ID: 'string'
 };
 
+function identity(str: any) {
+  return str;
+}
+
 export function initCommonTemplate(hbs, schema, config: TypeScriptCommonConfig) {
   const scalars = { ...DEFAULT_SCALARS, ...(config.scalars || {}) };
   let namingConventionMap: TypeScriptNamingConventionMap;
-  if (config.namingConvention === 'undefined') {
+  if (config.namingConvention === undefined) {
     namingConventionMap = {
       default: 'change-case#pascalCase',
       enumValues: 'change-case#pascalCase',
@@ -58,9 +62,14 @@ export function initCommonTemplate(hbs, schema, config: TypeScriptCommonConfig) 
       typeNames: config.namingConvention.typeNames || config.namingConvention.default || 'change-case#pascalCase'
     };
   }
-  const convert = (str: string, kind: keyof TypeScriptNamingConventionMap = 'default'): string => {
+  const convert = (str: string, kind?: keyof TypeScriptNamingConventionMap): string => {
+    const convention = namingConventionMap[kind || 'default'];
+
     const baseConvertFn =
-      namingConventionMap[kind] === 'keep' ? str => str : resolveExternalModuleAndFn(namingConventionMap[kind]);
+      convention === undefined || convention === 'keep'
+        ? identity
+        : resolveExternalModuleAndFn(namingConventionMap[kind]);
+
     if (str.charAt(0) === '_') {
       const after = str.replace(
         /^(_*)(.*)/,

--- a/packages/plugins/typescript-common/src/root.handlebars
+++ b/packages/plugins/typescript-common/src/root.handlebars
@@ -9,5 +9,5 @@
 {{#each scalars}}
 
 {{ toComment description }}
-{{#ifCond (convert name) "!==" (getScalarType name) }}export type {{ convert name }} = {{ getScalarType name }};{{/ifCond}}
+{{#ifCond (convert name 'typeNames' ) "!==" (getScalarType name) }}export type {{ convert name 'typeNames' }} = {{ getScalarType name }};{{/ifCond}}
 {{/each}}

--- a/packages/plugins/typescript-common/src/type.handlebars
+++ b/packages/plugins/typescript-common/src/type.handlebars
@@ -1,5 +1,5 @@
 {{ toComment description }}
-export interface {{@root.config.interfacePrefix}}{{ convert name }}{{#if hasInterfaces}} extends {{#each interfaces}}{{@root.config.interfacePrefix}}{{ convert this }}{{#unless @last}},{{/unless}}{{/each}}{{/if}} {
+export interface {{@root.config.interfacePrefix}}{{ convert name 'typeNames' }}{{#if hasInterfaces}} extends {{#each interfaces}}{{@root.config.interfacePrefix}}{{ convert this 'typeNames' }}{{#unless @last}},{{/unless}}{{/each}}{{/if}} {
 {{#each fields}}
   {{ toComment description }}
   {{#if @root.config.immutableTypes }}readonly {{/if}}{{ name }}{{ getOptionals this }}: {{ convertedType this }};

--- a/packages/plugins/typescript-react-apollo/src/helpers.ts
+++ b/packages/plugins/typescript-react-apollo/src/helpers.ts
@@ -9,8 +9,8 @@ export const propsType = convert => ({ name, operationType }: any, options: Hand
     return `
             Partial<
                 ReactApollo.MutateProps<
-                                        ${noNamespaces ? convert(name) : ''}Mutation, 
-                                        ${noNamespaces ? convert(name) : ''}Variables
+                                        ${noNamespaces ? convert(name, 'typeNames') : ''}Mutation, 
+                                        ${noNamespaces ? convert(name, 'typeNames') : ''}Variables
                                         >
                 >
         `;
@@ -18,8 +18,8 @@ export const propsType = convert => ({ name, operationType }: any, options: Hand
     return `
             Partial<
                 ReactApollo.DataProps<
-                                        ${noNamespaces ? convert(name) : ''}${convert(operationType)}, 
-                                        ${noNamespaces ? convert(name) : ''}Variables
+                                        ${noNamespaces ? convert(name, 'typeNames') : ''}${convert(operationType)}, 
+                                        ${noNamespaces ? convert(name, 'typeNames') : ''}Variables
                                     >
                     >
         `;
@@ -53,7 +53,7 @@ export const generateFragments = convert => (fragments: Fragment[], options: Han
     if (!cached) {
       cachedFragments[fragment.name] = fragment;
       const config = options.data.root.config || {};
-      const pascalCasedFragmentName = convert(fragment.name);
+      const pascalCasedFragmentName = convert(fragment.name, 'typeNames');
       // fooBar, FooBar and foo_bar may cause conflict due to the pascalCase.
       // Because all of them will have same namespace FooBar
       if (config.noNamespaces) {
@@ -111,8 +111,8 @@ export const toFragmentName = convert => (fragmentName: string, options: Handleb
   const config = options.data.root.config || {};
 
   if (config.noNamespaces) {
-    return convert(`${fragmentName}FragmentDoc`);
+    return convert(`${fragmentName}FragmentDoc`, 'typeNames');
   } else {
-    return convert(fragmentName) + '.FragmentDoc';
+    return convert(fragmentName, 'typeNames') + '.FragmentDoc';
   }
 };

--- a/packages/plugins/typescript-react-apollo/src/root.handlebars
+++ b/packages/plugins/typescript-react-apollo/src/root.handlebars
@@ -14,31 +14,31 @@ import gql from 'graphql-tag';
     {{#unless @root.config.noNamespaces}}
 export namespace {{convert name}} {
     {{/unless}}
-    export const {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Document = {{{ gql this }}};
-     export class {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Component extends React.Component<Partial<ReactApollo.{{ convert operationType }}Props<{{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}{{convert operationType}}, {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Variables>>> {
+    export const {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Document = {{{ gql this }}};
+     export class {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Component extends React.Component<Partial<ReactApollo.{{ convert operationType 'typeNames' }}Props<{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{ convert operationType 'typeNames' }}, {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables>>> {
         render(){
             return (
-                <ReactApollo.{{ convert operationType }}<{{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}{{convert operationType}}, {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Variables>
-                {{ toLowerCase operationType }}={ {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Document }
+                <ReactApollo.{{ convert operationType 'typeNames' }}<{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType}}, {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables>
+                {{ toLowerCase operationType }}={ {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Document }
                 {...(this as any)['props'] as any}
                 />
             );
         }
     }
     {{#unless @root.config.noHOC}}
-    export type {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Props<TChildProps = any> = {{{propsType this}}} & TChildProps;
+    export type {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Props<TChildProps = any> = {{{propsType this}}} & TChildProps;
     {{#ifCond operationType '===' 'mutation'}}
-    export type {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}MutationFn = ReactApollo.MutationFn<{{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}{{convert operationType}}, {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Variables>;
+    export type {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}MutationFn = ReactApollo.MutationFn<{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType}}, {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables>;
     {{/ifCond}}
-    export function {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}HOC<TProps, TChildProps = any>(operationOptions: 
+    export function {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}HOC<TProps, TChildProps = any>(operationOptions: 
             ReactApollo.OperationOption<
                 TProps, 
-                {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}{{convert operationType}},
-                {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Variables,
-                {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Props<TChildProps>
+                {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType}},
+                {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables,
+                {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Props<TChildProps>
             > | undefined){
-        return ReactApollo.graphql<TProps, {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}{{convert operationType}}, {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Variables, {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Props<TChildProps>>(
-            {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Document,
+        return ReactApollo.graphql<TProps, {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType 'typeNames' }}, {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables, {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Props<TChildProps>>(
+            {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Document,
             operationOptions
         );
     };

--- a/packages/plugins/typescript-resolvers/src/directive.handlebars
+++ b/packages/plugins/typescript-resolvers/src/directive.handlebars
@@ -1,9 +1,9 @@
 {{ toComment description }}
-export type {{ convert name }}DirectiveResolver<Result> = DirectiveResolverFn<Result, {{#if hasArguments}}{{ convert name }}DirectiveArgs{{else}}{}{{/if}}, {{{ getContext }}}>;
+export type {{ convert name 'typeNames' }}DirectiveResolver<Result> = DirectiveResolverFn<Result, {{#if hasArguments}}{{ convert name 'typeNames' }}DirectiveArgs{{else}}{}{{/if}}, {{{ getContext }}}>;
 
 {{~# if hasArguments }}
 
-export interface {{ convert name }}DirectiveArgs {
+export interface {{ convert name 'typeNames' }}DirectiveArgs {
 {{#each arguments}}
   {{ toComment description }}
   {{ name }}{{ getOptionals this }}: {{ convertedType this }};

--- a/packages/plugins/typescript-resolvers/src/helpers.ts
+++ b/packages/plugins/typescript-resolvers/src/helpers.ts
@@ -54,7 +54,7 @@ export const getFieldResolver = convert => (field: Field, type: Type, options: H
   const generics: string[] = ['R', 'Parent', 'Context'];
 
   if (field.hasArguments) {
-    const prefix = config.noNamespaces ? convert(type.name) : '';
+    const prefix = config.noNamespaces ? convert(type.name, 'typeNames') : '';
     generics.push(`${prefix}${convert(field.name)}Args`);
   }
 

--- a/packages/plugins/typescript-resolvers/src/resolve-type.handlebars
+++ b/packages/plugins/typescript-resolvers/src/resolve-type.handlebars
@@ -1,11 +1,11 @@
 {{ toComment description }}
 {{#unless @root.config.noNamespaces}}
-export namespace {{ convert name }}Resolvers {
+export namespace {{ convert name 'typeNames'}}Resolvers {
 {{/unless}}
-  export interface {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Resolvers {
-    __resolveType: {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}ResolveType;
+  export interface {{#if @root.config.noNamespaces}}{{ convert name 'typeNames'}}{{/if}}Resolvers {
+    __resolveType: {{#if @root.config.noNamespaces}}{{ convert name 'typeNames'}}{{/if}}ResolveType;
   }
-  export type {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}ResolveType<R = {{{ getTypenames this }}}, Parent = {{{ getParentTypes this }}}, Context = {{{ getContext }}}> = TypeResolveFn<R, Parent, Context>;
+  export type {{#if @root.config.noNamespaces}}{{ convert name 'typeNames'}}{{/if}}ResolveType<R = {{{ getTypenames this }}}, Parent = {{{ getParentTypes this }}}, Context = {{{ getContext }}}> = TypeResolveFn<R, Parent, Context>;
   
 {{#unless @root.config.noNamespaces}}
 }

--- a/packages/plugins/typescript-resolvers/src/resolver.handlebars
+++ b/packages/plugins/typescript-resolvers/src/resolver.handlebars
@@ -1,21 +1,21 @@
 {{ toComment description }}
 {{#unless @root.config.noNamespaces}}
-export namespace {{ convert name }}Resolvers {
+export namespace {{ convert name 'typeNames'}}Resolvers {
 {{/unless}}
-  export interface {{#if @root.config.noNamespaces}}{{ convert name }}{{/if}}Resolvers<Context = {{{ getContext }}}, TypeParent = {{{ getParentType this }}}> {
+  export interface {{#if @root.config.noNamespaces}}{{ convert name 'typeNames'}}{{/if}}Resolvers<Context = {{{ getContext }}}, TypeParent = {{{ getParentType this }}}> {
     {{#each fields}}
     {{ toComment description }}
-    {{ name }}?: {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<{{{ getFieldType this }}}, TypeParent, Context>;
+    {{ name }}?: {{#if @root.config.noNamespaces}}{{ convert ../name 'typeNames'}}{{/if}}{{ getFieldResolverName name }}<{{{ getFieldType this }}}, TypeParent, Context>;
     {{/each}}
   }
 
   {{#each fields}}
 
-  export type {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ getFieldResolverName name }}<R = {{{ getFieldType this }}}, Parent = {{{ getParentType ../this }}}, Context = {{{ getContext }}}> = {{ getFieldResolver this ../this }};
+  export type {{#if @root.config.noNamespaces}}{{ convert ../name 'typeNames'}}{{/if}}{{ getFieldResolverName name }}<R = {{{ getFieldType this }}}, Parent = {{{ getParentType ../this }}}, Context = {{{ getContext }}}> = {{ getFieldResolver this ../this }};
 
   {{~# if hasArguments }}
 
-  export interface {{#if @root.config.noNamespaces}}{{ convert ../name }}{{/if}}{{ convert name }}Args {
+  export interface {{#if @root.config.noNamespaces}}{{ convert ../name 'typeNames'}}{{/if}}{{ convert name 'typeNames'}}Args {
   {{#each arguments}}
     {{ toComment description }}
     {{ name }}{{ getOptionals this }}: {{ convertedType this }};

--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -68,21 +68,21 @@ export type DirectiveResolverFn<TResult, TArgs = {}, TContext = {}> = (
 
 export interface IResolvers {
   {{#each types}}
-    {{ convert name }}?: {{ convert name }}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}};
+    {{ convert name 'typeNames'}}?: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}};
   {{/each}}
   {{#each interfaces}}
-    {{ convert name }}?: {{ convert name }}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}};
+    {{ convert name 'typeNames'}}?: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}};
   {{/each}}
   {{#each unions}}
-    {{ convert name }}?: {{ convert name }}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}};
+    {{ convert name 'typeNames'}}?: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}};
   {{/each}}
   {{#each scalars}}
-    {{ convert name }}?: GraphQLScalarType;
+    {{ convert name 'typeNames'}}?: GraphQLScalarType;
   {{/each}}
 }
 
 export interface IDirectiveResolvers<Result> {
   {{#each definedDirectives}}
-    {{ name }}?: {{ convert name }}DirectiveResolver<Result>;
+    {{ name }}?: {{ convert name 'typeNames'}}DirectiveResolver<Result>;
   {{/each}}
 }

--- a/packages/plugins/typescript-resolvers/src/scalar.handlebars
+++ b/packages/plugins/typescript-resolvers/src/scalar.handlebars
@@ -1,3 +1,3 @@
-export interface {{name}}ScalarConfig extends GraphQLScalarTypeConfig<{{ convert name }}, any> {
+export interface {{name}}ScalarConfig extends GraphQLScalarTypeConfig<{{ convert name 'typeNames' }}, any> {
   name: '{{name}}'
 }

--- a/packages/plugins/typescript-server/src/root.handlebars
+++ b/packages/plugins/typescript-server/src/root.handlebars
@@ -16,7 +16,7 @@
 {{~#each types}}
   {{~#each fields}}
     {{~# if hasArguments }}
-export interface {{@root.config.interfacePrefix}}{{ convert name }}{{ convert ../name }}Args {
+export interface {{@root.config.interfacePrefix}}{{ convert name 'typeNames' }}{{ convert ../name 'typeNames' }}Args {
 {{#each arguments}}
   {{ toComment description }}
   {{ name }}{{ getOptionals this }}: {{ convertedType this }};
@@ -28,7 +28,7 @@ export interface {{@root.config.interfacePrefix}}{{ convert name }}{{ convert ..
 {{{ blockCommentIf 'Unions' unions }}}
 {{#each unions}}
 {{ toComment description }}
-export type {{@root.config.interfacePrefix}}{{ convert name }} = {{#each possibleTypes}}{{@root.config.interfacePrefix}}{{ convert this}}{{#unless @last}} | {{/unless}}{{/each}};
+export type {{@root.config.interfacePrefix}}{{ convert name 'typeNames' }} = {{#each possibleTypes}}{{@root.config.interfacePrefix}}{{ convert this 'typeNames' }}{{#unless @last}} | {{/unless}}{{/each}};
 
 {{/each}}
 {{#if @root.config.schemaNamespace ~}} } {{~/if}}


### PR DESCRIPTION
Introduces a minor fix on top of @ardatan's work in #1092. This fixes the `typescript-common` and `typescript-client` tests (which is all my team needs), but some are still failing in (at least) `typescript-react-apollo` and `typescript-apollo-angular`.

The issue appears to be that some plugins attempt to pass objects as the second parameter to the `convert` utility function in the form `{ name: "convert", hash: {}, data: { ... } }`. I was unable to track down where in the templates or helper functions this is taking place.

We need the capability to preserve enum names in the generated output (as in #969, but `0.15.0-alpha.3c84ac73` had other problems when we tried to use it) ASAP, so just let me know what needs work here.