### PR TITLE
Support for reusing (importing) enums

### DIFF
--- a/docs/plugins/typescript-common.md
+++ b/docs/plugins/typescript-common.md
@@ -54,7 +54,9 @@ Will generate the declared enums as TypeScript types. This is useful if you can'
 
 #### `enums` (default value: `{}`)
 
-Use this feature to set custom values for your GraphQL enums.
+Use this feature to set custom values for your GraphQL enums, or to reuse an existing enum.
+
+##### Custom values:
 
 ```yaml
 # ...
@@ -67,6 +69,25 @@ generates:
         MyEnum:
           A: 'foo'
 ```
+
+##### Existing enum:
+
+```yaml
+# ...
+generates:
+  path/to/file.ts:
+    plugins:
+      - typescript-common
+    config:
+      enums:
+        MyEnum: ./path/to/enum#MyEnum
+```
+
+Note:
+
+- The file path is relative to the generated output file.
+- Another type named `MyEnumValueMap` will also be generated which allows you to map the GraphQL API enum values to internal values if needed.
+- This option supercedes `enumsAsTypes`
 
 #### `immutableTypes` (default value: `false`)
 

--- a/docs/plugins/typescript-common.md
+++ b/docs/plugins/typescript-common.md
@@ -54,7 +54,7 @@ Will generate the declared enums as TypeScript types. This is useful if you can'
 
 #### `enums` (default value: `{}`)
 
-Use this feature to set custom values for your GraphQL enums, or to reuse an existing enum.
+Use this feature to set custom values for your GraphQL enums, reuse an existing enum, or skip generation entirely.
 
 ##### Custom values:
 
@@ -87,7 +87,25 @@ Note:
 
 - The file path is relative to the generated output file.
 - Another type named `MyEnumValueMap` will also be generated which allows you to map the GraphQL API enum values to internal values if needed.
-- This option supercedes `enumsAsTypes`
+- This option supercedes `enumsAsTypes` for this enum.
+
+##### Skip generation:
+
+```yaml
+# ...
+generates:
+  path/to/file.ts:
+    plugins:
+      - typescript-common
+    config:
+      enums:
+        MyEnum: # empty
+```
+
+Note:
+
+- No `MyEnum` type will be generated at all, and you can use the `add` plugin to manually define or import it.
+- This option supercedes `enumsAsTypes` for this enum.
 
 #### `immutableTypes` (default value: `false`)
 

--- a/docs/plugins/typescript-common.md
+++ b/docs/plugins/typescript-common.md
@@ -52,9 +52,9 @@ This will cause the generator to avoid using TypeScript optionals (`?`), so the 
 
 Will generate the declared enums as TypeScript types. This is useful if you can't use `.ts` extension.
 
-#### `enumValues` (default value: `{}`)
+#### `enums` (default value: `{}`)
 
-Use this feature to set custom values for you GraphQL enums.
+Use this feature to set custom values for your GraphQL enums.
 
 ```yaml
 # ...
@@ -63,7 +63,7 @@ generates:
     plugins:
       - typescript-common
     config:
-      enumValues:
+      enums:
         MyEnum:
           A: 'foo'
 ```
@@ -71,7 +71,6 @@ generates:
 #### `immutableTypes` (default value: `false`)
 
 This will cause the codegen to output `readonly` properties and `ReadonlyArray`.
-
 
 #### `interfacePrefix` (default value: '')
 

--- a/packages/plugins/typescript-common/src/enum.handlebars
+++ b/packages/plugins/typescript-common/src/enum.handlebars
@@ -1,12 +1,14 @@
 {{{ toComment description }}}
 {{#with (importEnum name) }}
-  import {{#if type}}{ {{type}}{{#ifCond type "!=" (concat @root.config.interfacePrefix (convert name))}} as {{@root.config.interfacePrefix}}{{ convert name }}{{/ifCond}} }{{else}}{{@root.config.interfacePrefix}}{{ convert name }}{{/if}} from "{{file}}"
+  {{#if file}}
+    import {{#if type}}{ {{type}}{{#ifCond type "!=" (concat @root.config.interfacePrefix (convert name))}} as {{@root.config.interfacePrefix}}{{ convert name }}{{/ifCond}} }{{else}}{{@root.config.interfacePrefix}}{{ convert name }}{{/if}} from "{{file}}"
 
-  export type {{@root.config.interfacePrefix}}{{ convert (concat name "ValueMap")}} = {
-    {{#each ../values}}
-      {{{ value }}}: {{@root.config.interfacePrefix}}{{ convert ../name }},
-    {{/each}}
-  }
+    export type {{@root.config.interfacePrefix}}{{ convert (concat name "ValueMap")}} = {
+      {{#each ../values}}
+        {{{ value }}}: {{@root.config.interfacePrefix}}{{ convert ../name }},
+      {{/each}}
+    }
+  {{/if}}
 
 {{else}}
   {{#if @root.config.enumsAsTypes }}

--- a/packages/plugins/typescript-common/src/enum.handlebars
+++ b/packages/plugins/typescript-common/src/enum.handlebars
@@ -1,10 +1,21 @@
 {{{ toComment description }}}
-{{#if @root.config.enumsAsTypes }}
-export type {{@root.config.interfacePrefix}}{{ convert name }} = {{#each values }}{{{ getEnumValue ../name value }}}{{#unless @last}} | {{/unless}}{{/each}};
+{{#with (importEnum name) }}
+  import {{#if type}}{ {{type}}{{#ifCond type "!=" (concat @root.config.interfacePrefix (convert name))}} as {{@root.config.interfacePrefix}}{{ convert name }}{{/ifCond}} }{{else}}{{@root.config.interfacePrefix}}{{ convert name }}{{/if}} from "{{file}}"
+
+  export type {{@root.config.interfacePrefix}}{{ convert name}}ValueMap = {
+    {{#each ../values}}
+      {{{ value }}}: {{@root.config.interfacePrefix}}{{ convert ../name }},
+    {{/each}}
+  }
+
 {{else}}
-export {{#if @root.config.constEnums }}const {{/if}}enum {{@root.config.interfacePrefix}}{{ convert name }} {
-{{#each values }}
-  {{ convert value }} = {{{ getEnumValue ../name value }}},
-{{/each}}
-}
-{{/if}}
+  {{#if @root.config.enumsAsTypes }}
+  export type {{@root.config.interfacePrefix}}{{ convert name }} = {{#each values }}{{{ getEnumValue ../name value }}}{{#unless @last}} | {{/unless}}{{/each}};
+  {{else}}
+  export {{#if @root.config.constEnums }}const {{/if}}enum {{@root.config.interfacePrefix}}{{ convert name }} {
+  {{#each values }}
+    {{ convert value }} = {{{ getEnumValue ../name value }}},
+  {{/each}}
+  }
+  {{/if}}
+{{/with}}

--- a/packages/plugins/typescript-common/src/enum.handlebars
+++ b/packages/plugins/typescript-common/src/enum.handlebars
@@ -2,7 +2,7 @@
 {{#with (importEnum name) }}
   import {{#if type}}{ {{type}}{{#ifCond type "!=" (concat @root.config.interfacePrefix (convert name))}} as {{@root.config.interfacePrefix}}{{ convert name }}{{/ifCond}} }{{else}}{{@root.config.interfacePrefix}}{{ convert name }}{{/if}} from "{{file}}"
 
-  export type {{@root.config.interfacePrefix}}{{ convert name}}ValueMap = {
+  export type {{@root.config.interfacePrefix}}{{ convert (concat name "ValueMap")}} = {
     {{#each ../values}}
       {{{ value }}}: {{@root.config.interfacePrefix}}{{ convert ../name }},
     {{/each}}

--- a/packages/plugins/typescript-common/src/helpers.ts
+++ b/packages/plugins/typescript-common/src/helpers.ts
@@ -30,18 +30,26 @@ export function getScalarType(type: string, options: Handlebars.HelperOptions) {
 
 export function importEnum(name: string, options: Handlebars.HelperOptions) {
   const config = options.data.root.config || {};
-  if (!config.enums || typeof config.enums[name] !== 'string') {
-    return undefined;
+  const definition = config.enums && config.enums[name];
+
+  if (typeof definition === 'string') {
+    // filename specified with optional type name
+    const [file, type] = config.enums[name].split('#');
+    return { name, file, type };
   }
 
-  const [file, type] = config.enums[name].split('#');
+  if (typeof definition === 'object' && definition === null) {
+    // empty definition: don't generate anything
+    return {};
+  }
 
-  return { name, file, type };
+  // fall through to normal or value-mapped generation
+  return undefined;
 }
 
 export function getEnumValue(type: string, name: string, options: Handlebars.HelperOptions) {
   const config = options.data.root.config || {};
-  if (config.enums && type in config.enums && name in config.enums[type]) {
+  if (config.enums && config.enums[type] != null && name in config.enums[type]) {
     return config.enums[type][name];
   } else {
     return `"${name}"`;

--- a/packages/plugins/typescript-common/src/helpers.ts
+++ b/packages/plugins/typescript-common/src/helpers.ts
@@ -2,6 +2,12 @@ import { Field } from 'graphql-codegen-core';
 import { SafeString } from 'handlebars';
 import * as Handlebars from 'handlebars';
 
+export function concat(...args: string[]) {
+  args.pop(); // HBS options passed as last argument
+
+  return args.join('');
+}
+
 export function defineMaybe(options: Handlebars.HelperOptions): string {
   const config = options.data.root.config || {};
   const optionalType = config.optionalType || 'null';
@@ -20,6 +26,17 @@ export function getScalarType(type: string, options: Handlebars.HelperOptions) {
   } else {
     return 'any';
   }
+}
+
+export function importEnum(name: string, options: Handlebars.HelperOptions) {
+  const config = options.data.root.config || {};
+  if (!config.enums || typeof config.enums[name] !== 'string') {
+    return undefined;
+  }
+
+  const [file, type] = config.enums[name].split('#');
+
+  return { name, file, type };
 }
 
 export function getEnumValue(type: string, name: string, options: Handlebars.HelperOptions) {

--- a/packages/plugins/typescript-common/src/index.ts
+++ b/packages/plugins/typescript-common/src/index.ts
@@ -19,7 +19,7 @@ export interface TypeScriptCommonConfig {
   enumsAsTypes?: boolean;
   immutableTypes?: boolean;
   interfacePrefix?: string;
-  enums?: { [enumName: string]: { [valueName: string]: string } | string };
+  enums?: { [enumName: string]: { [valueName: string]: string } | string | null };
   scalars?: { [scalarName: string]: string };
 }
 

--- a/packages/plugins/typescript-common/src/index.ts
+++ b/packages/plugins/typescript-common/src/index.ts
@@ -7,7 +7,7 @@ import * as type from './type.handlebars';
 import * as rootTemplate from './root.handlebars';
 import * as Handlebars from 'handlebars';
 import { pascalCase } from 'change-case';
-import { getOptionals, getType, getEnumValue, getScalarType, defineMaybe } from './helpers';
+import { getOptionals, getType, getEnumValue, getScalarType, defineMaybe, importEnum, concat } from './helpers';
 
 export * from './helpers';
 
@@ -19,7 +19,7 @@ export interface TypeScriptCommonConfig {
   enumsAsTypes?: boolean;
   immutableTypes?: boolean;
   interfacePrefix?: string;
-  enums?: { [enumName: string]: { [valueName: string]: string } };
+  enums?: { [enumName: string]: { [valueName: string]: string } | string };
   scalars?: { [scalarName: string]: string };
 }
 
@@ -48,6 +48,7 @@ export function initCommonTemplate(hbs, schema, config) {
   };
   hbs.registerPartial('enum', enumTemplate);
   hbs.registerPartial('type', type);
+  hbs.registerHelper('concat', concat);
   hbs.registerHelper('defineMaybe', defineMaybe);
   hbs.registerHelper('blockComment', helpers.blockComment);
   hbs.registerHelper('blockCommentIf', helpers.blockCommentIf);
@@ -55,6 +56,7 @@ export function initCommonTemplate(hbs, schema, config) {
   hbs.registerHelper('convert', convert);
   hbs.registerHelper('getOptionals', getOptionals);
   hbs.registerHelper('getEnumValue', getEnumValue);
+  hbs.registerHelper('importEnum', importEnum);
   hbs.registerHelper('convertedType', getType(convert));
   hbs.registerHelper('toLowerCase', helpers.toLowerCase);
   hbs.registerHelper('toUpperCase', helpers.toUpperCase);

--- a/packages/plugins/typescript-common/tests/typescript-common.spec.ts
+++ b/packages/plugins/typescript-common/tests/typescript-common.spec.ts
@@ -370,6 +370,37 @@ describe('TypeScript Common', () => {
           }
         `);
       });
+
+      it('Should skip generation of an empty definition', async () => {
+        const content = await plugin(
+          schema,
+          [],
+          {
+            enums: {
+              A: null
+            }
+          },
+          {
+            outputFile: 'graphql.ts'
+          }
+        );
+
+        expect(content).not.toBeSimilarStringTo(`
+          import A from
+        `);
+
+        expect(content).not.toBeSimilarStringTo(`
+          import { A 
+        `);
+
+        expect(content).not.toBeSimilarStringTo(`
+          export enum A {"
+        `);
+
+        expect(content).not.toBeSimilarStringTo(`
+          export type AValueMap {"
+        `);
+      });
     });
 
     it('Should generate the correct description for enums', async () => {

--- a/packages/plugins/typescript-common/tests/typescript-common.spec.ts
+++ b/packages/plugins/typescript-common/tests/typescript-common.spec.ts
@@ -230,6 +230,148 @@ describe('TypeScript Common', () => {
         }`);
     });
 
+    describe('When imported', () => {
+      it('Should import the default export', async () => {
+        const content = await plugin(
+          schema,
+          [],
+          {
+            enums: {
+              A: 'some/path'
+            }
+          },
+          {
+            outputFile: 'graphql.ts'
+          }
+        );
+
+        expect(content).toBeSimilarStringTo(`
+          import A from "some/path"
+        `);
+      });
+
+      it('Should import a named export', async () => {
+        const content = await plugin(
+          schema,
+          [],
+          {
+            enums: {
+              A: 'some/path#A'
+            }
+          },
+          {
+            outputFile: 'graphql.ts'
+          }
+        );
+
+        expect(content).toBeSimilarStringTo(`
+          import { A } from "some/path"
+        `);
+      });
+
+      it('Should import an aliased named export', async () => {
+        const content = await plugin(
+          schema,
+          [],
+          {
+            enums: {
+              A: 'some/path#MyCustomA'
+            }
+          },
+          {
+            outputFile: 'graphql.ts'
+          }
+        );
+
+        expect(content).toBeSimilarStringTo(`
+          import { MyCustomA as A } from "some/path"
+        `);
+      });
+
+      it('Should import the default export with interfacePrefix', async () => {
+        const content = await plugin(
+          schema,
+          [],
+          {
+            interfacePrefix: 'Pref',
+            enums: {
+              A: 'some/path'
+            }
+          },
+          {
+            outputFile: 'graphql.ts'
+          }
+        );
+
+        expect(content).toBeSimilarStringTo(`
+          import PrefA from "some/path"
+        `);
+      });
+
+      it('Should import a named export with interfacePrefix', async () => {
+        const content = await plugin(
+          schema,
+          [],
+          {
+            interfacePrefix: 'Pref',
+            enums: {
+              A: 'some/path#A'
+            }
+          },
+          {
+            outputFile: 'graphql.ts'
+          }
+        );
+
+        expect(content).toBeSimilarStringTo(`
+          import { A as PrefA } from "some/path"
+        `);
+      });
+
+      it('Should import an aliased named export with interfacePrefix', async () => {
+        const content = await plugin(
+          schema,
+          [],
+          {
+            interfacePrefix: 'Pref',
+            enums: {
+              A: 'some/path#MyCustomA'
+            }
+          },
+          {
+            outputFile: 'graphql.ts'
+          }
+        );
+
+        expect(content).toBeSimilarStringTo(`
+          import { MyCustomA as PrefA } from "some/path"
+        `);
+      });
+
+      it('Should generate the value map with interfacePrefix', async () => {
+        const content = await plugin(
+          schema,
+          [],
+          {
+            interfacePrefix: 'Pref',
+            enums: {
+              A: 'some/path#MyCustomA'
+            }
+          },
+          {
+            outputFile: 'graphql.ts'
+          }
+        );
+
+        expect(content).toBeSimilarStringTo(`
+          export type PrefAValueMap = {
+            ONE: PrefA,
+            TWO: PrefA,
+          }
+        `);
+      });
+    });
+
     it('Should generate the correct description for enums', async () => {
       const content = await plugin(
         buildSchema(`


### PR DESCRIPTION
After logging #1134 I realized that it would be very useful to me to import existing enums in my codebase instead of generating new ones with custom, but similar values.  (See #678 for some problems with that approach.)

This PR allows specifying a string like `path/to/enums#MyCustomEnum` as the value for an enum definition in the config, which will then import the enum instead of generating another.  In order to still map to internal values (with Apollo or otherwise) a `AValueMap` type is also generated which assists in doing so.

### Example
```graphql
# schema.graphql
enum A {
  ONE
  TWO
}
```

```yaml
# codegen.yaml
generates:
  path/to/generated.ts:
    plugins:
      - typescript-common
    config:
      enums:
        A: path/to/enums#MyCustomEnum
```
```ts
// path/to/generated.ts
import { MyCustomEnum as A } from "path/to/enums";

export type AValueMap = {
  ONE: A,
  TWO: A
};
```
```ts
// your/resolvers.ts
import { MyCustomEnum } from "path/to/enums";
import { AValueMap } from "path/to/generated";

const aMap: AValueMap = {
  ONE: MyCustomEnum.First,
  TWO: MyCustomEnum.Second
};

export const resolvers = {
  Query: { ... },
  Mutation: { ... },
  A: aMap
};
```

Edit: Additionally, generation for a specific enum can be skipped entirely. This allows manual definition or import when combined with the `add` plugin.

### Example
```yaml
# codegen.yaml
generates:
  path/to/generated.ts:
    plugins:
      - typescript-common
    config:
      enums:
        A: #empty
```