### PR TITLE
[typescript-resolvers] do not apply generic to interfaces and unions

### DIFF
--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -71,10 +71,10 @@ export interface IResolvers<Context = {{{ getContext }}}> {
     {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}}<Context>;
   {{/each}}
   {{#each interfaces}}
-    {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}}<Context>;
+    {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}};
   {{/each}}
   {{#each unions}}
-    {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}}<Context>;
+    {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}};
   {{/each}}
   {{#each scalars}}
     {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: GraphQLScalarType;


### PR DESCRIPTION
the resolve-type template does not produce a generic interface, so applying a generic to these in #1130 causes a compile error

https://github.com/dotansimha/graphql-code-generator/blob/498958e7a0ad3fc3b8f863db667dc0d5e2bdc73a/packages/plugins/typescript-resolvers/src/resolve-type.handlebars#L5-L7