### PR TITLE
Support `strict` code output

### DIFF
--- a/packages/plugins/typescript-resolvers/src/index.ts
+++ b/packages/plugins/typescript-resolvers/src/index.ts
@@ -13,6 +13,7 @@ import { importContext, getContext } from './context';
 import { getParentType, getParentTypes } from './parent-type';
 
 export interface TypeScriptServerResolversConfig extends TypeScriptCommonConfig {
+  strict?: boolean;
   noNamespaces?: boolean;
   contextType?: string;
   mappers?: { [name: string]: string };

--- a/packages/plugins/typescript-resolvers/src/resolver.handlebars
+++ b/packages/plugins/typescript-resolvers/src/resolver.handlebars
@@ -5,7 +5,7 @@ export namespace {{ convert name 'typeNames'}}Resolvers {
   export interface {{#if @root.config.noNamespaces}}{{ convert name 'typeNames'}}{{/if}}Resolvers<Context = {{{ getContext }}}, TypeParent = {{{ getParentType this }}}> {
     {{#each fields}}
     {{ toComment description }}
-    {{ name }}?: {{#if @root.config.noNamespaces}}{{ convert ../name 'typeNames'}}{{/if}}{{ getFieldResolverName name }}<{{{ getFieldType this }}}, TypeParent, Context>;
+    {{ name }}{{#unless @root.config.strict}}?{{/unless}}: {{#if @root.config.noNamespaces}}{{ convert ../name 'typeNames'}}{{/if}}{{ getFieldResolverName name }}<{{{ getFieldType this }}}, TypeParent, Context>;
     {{/each}}
   }
 
@@ -24,7 +24,7 @@ export namespace {{ convert name 'typeNames'}}Resolvers {
 
   {{/if}}
   {{/each}}
-  
+
 {{#unless @root.config.noNamespaces}}
 }
 {{/unless}}

--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -68,21 +68,21 @@ export type DirectiveResolverFn<TResult, TArgs = {}, TContext = {}> = (
 
 export interface IResolvers<Context = {{{ getContext }}}> {
   {{#each types}}
-    {{ convert name 'typeNames'}}?: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}}<Context>;
+    {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}}<Context>;
   {{/each}}
   {{#each interfaces}}
-    {{ convert name 'typeNames'}}?: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}}<Context>;
+    {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}}<Context>;
   {{/each}}
   {{#each unions}}
-    {{ convert name 'typeNames'}}?: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}}<Context>;
+    {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}Resolvers{{#unless @root.config.noNamespaces}}.Resolvers{{/unless}}<Context>;
   {{/each}}
   {{#each scalars}}
-    {{ convert name 'typeNames'}}?: GraphQLScalarType;
+    {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: GraphQLScalarType;
   {{/each}}
 }
 
 export interface IDirectiveResolvers<Result> {
   {{#each definedDirectives}}
-    {{ name }}?: {{ convert name 'typeNames'}}DirectiveResolver<Result>;
+    {{ name }}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}DirectiveResolver<Result>;
   {{/each}}
 }

--- a/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
@@ -1252,7 +1252,7 @@ describe('Resolvers', () => {
         type User {
           postId: String
           post: Post
-        } 
+        }
 
         type UserPost {
           id: String
@@ -1261,7 +1261,7 @@ describe('Resolvers', () => {
         type Post {
           id: String
         }
-        
+
         schema {
           query: Query
         }
@@ -1293,6 +1293,24 @@ describe('Resolvers', () => {
       }
 
       export type UserPost_IdResolver<R = Maybe<string>, Parent = UserPost, Context = {}> = Resolver<R, Parent, Context>;
+    `);
+  });
+
+  it('should output strict resolvers', async () => {
+    const content = await plugin(
+      schema,
+      [],
+      { strict: true },
+      {
+        outputFile: 'graphql.ts'
+      }
+    );
+
+    expect(content).toBeSimilarStringTo(`
+      export namespace QueryResolvers {
+        export interface Resolvers<Context = {}, TypeParent = {}> {
+          fieldTest: FieldTestResolver<Maybe<string>, TypeParent, Context>;
+        }
     `);
   });
 });


### PR DESCRIPTION
I want my resolvers to be type-safe, this will make it a little extra work to write them out completely but at least it won't fail at runtime. FWIW, I have a way that would work to automatically reduce the types when the property is of the correct type for GraphQL to automatically use as a resolver (example below, could be tidied up and easily generated based on the import).

```ts
interface Bar {
    test: string
    another: number
}

interface Foo <T> {
    test: T extends Record<'test', string>
    ? never
    : () => string
}

export type KnownKeys<T> = ({ [K in keyof T]-?: T[K] extends never ? never : K })[keyof T];
export type Strip<T> = Pick<T, KnownKeys<T>>;

const foo: Strip<Foo<Bar>> = {}
```

Edit: What is the existing reasoning for having all the properties be optional?

Edit 2: Working in the playground but not in my editor, trying to refine the subtraction type now.

Edit 3: I have it working with these types!

```ts
export type ResolverCheck <T, K extends string | number | symbol, R extends Resolver<any, any, any, any>> = T extends Record<K, R | ReturnType<R>> ? never : R;
export type KnownKeys<T> = ({ [K in keyof T]-?: T[K] extends never ? never : K })[keyof T];
export type Strip<T> = Pick<T, KnownKeys<T>>;
```

Just need to use `ResolverCheck<TypeParent, 'prop', Resolver>` and it can automatically be stripped from the type later using `Strip`.