### PR TITLE
fix: same behaviour when generating nullable types with/without noNamespaces

### DIFF
--- a/packages/plugins/typescript-client/tests/typescript-client.spec.ts
+++ b/packages/plugins/typescript-client/tests/typescript-client.spec.ts
@@ -494,7 +494,7 @@ describe('TypeScript Client', () => {
   
     export type MyFeedQuery = {
       __typename?: "Query";
-      feed: Maybe<MyFeedFeed[]>;
+      feed: Maybe<(Maybe<MyFeedFeed>)[]>;
     }
   
     export type MyFeedFeed = {
@@ -696,7 +696,7 @@ describe('TypeScript Client', () => {
     }
     export type MyFeedQuery = {
       __typename?: "Query";
-      feed: Maybe<MyFeedFeed[]>;
+      feed: Maybe<(Maybe<MyFeedFeed>)[]>;
     }
     export type MyFeedFeed = {
       __typename?: "Entry";

--- a/packages/plugins/typescript-common/src/helpers.ts
+++ b/packages/plugins/typescript-common/src/helpers.ts
@@ -69,7 +69,7 @@ export function getFieldType(field: Field, realType: string, options: Handlebars
 
     const dimension = field.dimensionOfArray + 1;
 
-    if (field.isNullableArray && !config.noNamespaces) {
+    if (field.isNullableArray) {
       result = useImmutable ? useMaybe(realType) : `(${useMaybe(realType)})`;
     }
 

--- a/packages/plugins/typescript-common/tests/typescript-common.spec.ts
+++ b/packages/plugins/typescript-common/tests/typescript-common.spec.ts
@@ -496,6 +496,30 @@ describe('TypeScript Common', () => {
         }
       `);
     });
+    it('Should generate input type fields correctly when noNamespaces is true', async () => {
+      const content = await plugin(
+        schema,
+        [],
+        {
+          noNamespaces: true
+        },
+        {
+          outputFile: 'graphql.ts'
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`
+        export interface T {
+          f1?: Maybe<string>; 
+          f2: number; 
+          f3?: Maybe<(Maybe<string>)[]>; 
+          f4: (Maybe<string>)[]; 
+          f5: string[]; 
+          f6?: Maybe<string[]>; 
+          f7?: number;
+        }
+      `);
+    });
 
     it('Should generate input type fields correctly when immutableTypes is set', async () => {
       const content = await plugin(


### PR DESCRIPTION
Related: #1223 