### PR TITLE
Add import for interfaces mappings

### DIFF
--- a/packages/plugins/typescript-resolvers/src/import-mappers.ts
+++ b/packages/plugins/typescript-resolvers/src/import-mappers.ts
@@ -1,4 +1,4 @@
-import { Type } from 'graphql-codegen-core';
+import { Type, Interface } from 'graphql-codegen-core';
 import { pickMapper, parseMapper } from './mappers';
 
 interface Modules {
@@ -10,12 +10,13 @@ function extractVariable(type: string) {
   return m ? m[0] : type;
 }
 
-export function importMappers(types: Type[], options: Handlebars.HelperOptions) {
+export function importMappers(types: Type[], interfaces: Interface[], options: Handlebars.HelperOptions) {
   const config = options.data.root.config || {};
   const mappers = config.mappers || {};
   const defaultMapper: string | undefined = config.defaultMapper;
   const modules: Modules = {};
   const availableTypes = types.map(t => t.name);
+  const availableInterfaces = interfaces.map(iface => iface.name);
 
   if (defaultMapper) {
     const mapper = parseMapper(defaultMapper);
@@ -31,7 +32,7 @@ export function importMappers(types: Type[], options: Handlebars.HelperOptions) 
 
       // checks if mapper comes from a module
       // and if is used
-      if (mapper && mapper.isExternal && availableTypes.includes(type)) {
+      if (mapper && mapper.isExternal && (availableTypes.includes(type) || availableInterfaces.includes(type))) {
         const path = mapper.source;
         const variable = extractVariable(mapper.type);
 

--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -1,6 +1,6 @@
 {{{ importFromGraphQL }}}
 
-{{{ importMappers types }}}
+{{{ importMappers types interfaces }}}
 
 {{{ importContext }}}
 

--- a/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
@@ -1382,3 +1382,52 @@ describe('Resolvers', () => {
     });
   });
 });
+
+describe('And Interfaces should be imported when used in mapping', () => {
+  const testSchema = makeExecutableSchema({
+    typeDefs: `
+      type Query {
+        post: Post
+      }
+
+      type Post {
+        id: String
+        author: User
+      }
+
+      interface User {
+        id: String
+        name: String
+        post: Post
+      }
+
+      schema {
+        query: Query
+      }
+    `
+  });
+
+  it('should import interface mapping', async () => {
+    const content = await plugin(
+      testSchema,
+      [],
+      {
+        mappers: {
+          // it means that User type expects UserParent to be a parent
+          User: './interfaces#UserParent',
+          // it means that Post type expects UserParent to be a parent
+          Post: './interfaces#PostParent'
+        }
+      },
+      {
+        outputFile: 'graphql.ts'
+      }
+    );
+
+    // import parents
+    // merge duplicates into single module
+    expect(content).toBeSimilarStringTo(`
+      import { UserParent, PostParent } from './interfaces';
+    `);
+  });
+});


### PR DESCRIPTION
Currently the mappers does not generate import statement for interfaces. This PR fixes it.
For example take a look at added test case.

The interfaces are good if you want to extend some other interface and use it as Type...