### PR TITLE
Add react-apollo-hooks code generation

### DIFF
--- a/docs/plugins/typescript-react-apollo.md
+++ b/docs/plugins/typescript-react-apollo.md
@@ -44,3 +44,15 @@ Or if you prefer:
 ```tsx
   const withTestData = Test.HOC(...);
 ```
+
+## Configuration
+
+#### `withHooks` (default value: `false`)
+
+This will cause the codegen to add React **Hooks** implementations, to be used in conjunction with [`react-apollo-hooks`](https://github.com/trojanowski/react-apollo-hooks). The generated code will wrap base `useQuery` and `useMutation` hooks with TypeScript typings.
+
+You can use the generated hook in your Functional Component like this:
+
+```tsx
+  const { data, loading, error } = Test.useQuery(...);
+```

--- a/packages/plugins/typescript-react-apollo/src/index.ts
+++ b/packages/plugins/typescript-react-apollo/src/index.ts
@@ -11,6 +11,7 @@ export interface TypeScriptReactApolloConfig extends TypeScriptCommonConfig {
   noGraphqlTag?: boolean;
   noNamespaces?: boolean;
   noHOC?: boolean;
+  withHooks?: boolean;
 }
 
 export const plugin: PluginFunction<TypeScriptReactApolloConfig> = async (

--- a/packages/plugins/typescript-react-apollo/src/root.handlebars
+++ b/packages/plugins/typescript-react-apollo/src/root.handlebars
@@ -2,6 +2,14 @@
 import * as ReactApollo from 'react-apollo';
 import * as React from 'react';
 
+{{#if @root.config.withHooks}}
+import { 
+    useQuery as useApolloQuery, 
+    useMutation as useApolloMutation,
+    QueryHookOptions,
+    MutationHookOptions 
+} from 'react-apollo-hooks';
+{{/if}}
 {{#unless @root.config.noGraphqlTag}}
 import gql from 'graphql-tag';
 {{/unless}}
@@ -43,6 +51,17 @@ export namespace {{convert name 'typeNames' }} {
         );
     };
     {{/unless}}
+    {{#if @root.config.withHooks}}
+    export function use{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType 'typeNames'}}(baseOptions?: {{convert operationType 'typeNames'}}HookOptions<
+            {{#ifCond operationType '===' 'mutation'}}{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType 'typeNames'}},
+            {{/ifCond}}{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables
+        >) {
+        return useApollo{{convert operationType 'typeNames'}}<
+            {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType 'typeNames'}},
+            {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables
+        >({{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Document, baseOptions);
+    };
+    {{/if}}
     {{#unless @root.config.noNamespaces}}
 }
     {{/unless}}


### PR DESCRIPTION
## Summary
With this PR, i'd like to add generators for [`react-apollo-hooks`](https://github.com/trojanowski/react-apollo-hooks), following [official React Hooks release](https://reactjs.org/blog/2019/02/06/react-v16.8.0.html).

Hooks generation is behind a config flag (`withHooks`) and by default is disabled.

Example code generated:
```tsx
// ...
// Current HOC
export function AddUserMutationHOC<TProps, TChildProps = any>(
  operationOptions:
    | ReactApollo.OperationOption<
        TProps,
        AddUserMutationMutation,
        AddUserMutationVariables,
        AddUserMutationProps<TChildProps>
      >
    | undefined
) {
  return ReactApollo.graphql<
    TProps,
    AddUserMutationMutation,
    AddUserMutationVariables,
    AddUserMutationProps<TChildProps>
  >(AddUserMutationDocument, operationOptions);
}
// Hooks (*new*)
export function useAddUserMutationMutation(
  baseOptions?: MutationHookOptions<
    AddUserMutationMutation,
    AddUserMutationVariables
  >
) {
  return useApolloMutation<AddUserMutationMutation, AddUserMutationVariables>(
    AddUserMutationDocument,
    baseOptions
  );
}
```

## Motivation
Even if react hooks are not officially supported by `react-apollo` library, there are [many](https://github.com/apollographql/react-apollo/iss…) [discussions](https://github.com/trojanowski/react-apollo-hooks/issues/40) around integrating them. Furthermore, current implementation by @trojanowski seems like a perfect way to start using them right now.

## Why not another plugin?
All the typings are shared, providing Hooks is just an addition (like *HOCs*). Generation is optional due to `withHooks` flag, so it should play well with current usage.

Let me know if there's something I should change, or if you'd prefer a different approach. 