### PR TITLE
Add flow output options for exact objects and read only types

### DIFF
--- a/packages/plugins/flow-documents/package.json
+++ b/packages/plugins/flow-documents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphql-codegen-flow-documents",
-  "version": "0.16.1",
-  "description": "GraphQL Code Generator plugin for generating Flow types for GraphQL documents (query/mutation/subscription/fragment)",
+  "version": "0.17.0",
+  "description": "GraphQL Code Generator plugin for generating Flow types for GraphQL docuemnts (query/mutation/subscription/fragment)",
   "repository": "git@github.com:dotansimha/graphql-code-generator.git",
   "license": "MIT",
   "scripts": {

--- a/packages/plugins/flow-documents/src/index.ts
+++ b/packages/plugins/flow-documents/src/index.ts
@@ -1,5 +1,4 @@
 import { PluginFunction, DocumentFile } from 'graphql-codegen-core';
-import { OutputOptions } from 'graphql-codegen-flow';
 import { visit, concatAST, GraphQLSchema } from 'graphql';
 import { FlowDocumentsVisitor } from './visitor';
 
@@ -8,7 +7,8 @@ export interface FlowDocumentsPluginConfig {
   skipTypename?: boolean;
   namingConvention?: string;
   typesPrefix?: string;
-  outputOptions?: OutputOptions;
+  useFlowExactObjects?: boolean;
+  useFlowReadOnlyTypes?: boolean;
 }
 
 export type ScalarsMap = { [name: string]: string };

--- a/packages/plugins/flow-documents/src/selection-set-to-object.ts
+++ b/packages/plugins/flow-documents/src/selection-set-to-object.ts
@@ -107,10 +107,8 @@ export class SelectionSetToObject {
     }
 
     const { selections } = this._selectionSet;
-    const useFlowExactObject: boolean =
-      this._visitorInstance.parsedConfig.outputOptions.indexOf('useFlowExactObjects') > -1;
-    const useFlowReadOnlyTypes: boolean =
-      this._visitorInstance.parsedConfig.outputOptions.indexOf('useFlowReadOnlyTypes') > -1;
+    const useFlowExactObject: boolean = this._visitorInstance.parsedConfig.useFlowExactObjects;
+    const useFlowReadOnlyTypes: boolean = this._visitorInstance.parsedConfig.useFlowReadOnlyTypes;
 
     for (const selection of selections) {
       switch (selection.kind) {

--- a/packages/plugins/flow-documents/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow-documents/tests/flow-documents.spec.ts
@@ -678,7 +678,7 @@ describe('Flow Documents Plugin', () => {
       const result = visit(ast, {
         leave: new FlowDocumentsVisitor(schema, {
           skipTypename: true,
-          outputOptions: ['useFlowExactObjects']
+          useFlowExactObjects: true
         })
       });
 
@@ -705,7 +705,7 @@ describe('Flow Documents Plugin', () => {
       const result = visit(ast, {
         leave: new FlowDocumentsVisitor(schema, {
           skipTypename: true,
-          outputOptions: ['useFlowReadOnlyTypes']
+          useFlowReadOnlyTypes: true
         })
       });
 

--- a/packages/plugins/flow-resolvers/src/index.ts
+++ b/packages/plugins/flow-resolvers/src/index.ts
@@ -1,4 +1,4 @@
-import { ScalarsMap, OutputOptions } from 'graphql-codegen-flow';
+import { ScalarsMap } from 'graphql-codegen-flow';
 import { DocumentFile, PluginFunction } from 'graphql-codegen-core';
 import { isScalarType, parse, printSchema, visit, GraphQLSchema } from 'graphql';
 import { FlowResolversVisitor } from './visitor';
@@ -9,7 +9,8 @@ export interface FlowResolversPluginConfig {
   scalars?: ScalarsMap;
   namingConvention?: string;
   typesPrefix?: string;
-  outputOptions?: OutputOptions;
+  useFlowExactObjects?: boolean;
+  useFlowReadOnlyTypes?: boolean;
 }
 
 export const plugin: PluginFunction<FlowResolversPluginConfig> = (

--- a/packages/plugins/flow/src/index.ts
+++ b/packages/plugins/flow/src/index.ts
@@ -9,14 +9,14 @@ export * from './visitor';
 
 export type ScalarsMap = { [name: string]: string };
 export type EnumValuesMap = { [key: string]: string };
-export type OutputOptions = Array<'useFlowExactObjects' | 'useFlowReadOnlyTypes'>;
 
 export interface FlowPluginConfig {
   scalars?: ScalarsMap;
   enumValues?: EnumValuesMap;
   namingConvention?: string;
   typesPrefix?: string;
-  outputOptions?: OutputOptions;
+  useFlowExactObjects?: boolean;
+  useFlowReadOnlyTypes?: boolean;
 }
 
 export const plugin: PluginFunction<FlowPluginConfig> = (

--- a/packages/plugins/flow/src/utils.ts
+++ b/packages/plugins/flow/src/utils.ts
@@ -10,7 +10,7 @@ import {
   GraphQLList,
   isListType
 } from 'graphql';
-import { OutputOptions } from './index';
+import { FlowPluginConfig } from './index';
 
 export function block(array) {
   return array && array.length !== 0 ? '{\n' + array.join('\n') + '\n}' : '';
@@ -36,10 +36,10 @@ export class DeclarationBlock {
   _content = null;
   _block = null;
   _nameGenerics = null;
-  _outputOptions = null;
+  _config = null;
 
-  constructor(outputOptions: OutputOptions) {
-    this._outputOptions = outputOptions;
+  constructor(config: FlowPluginConfig) {
+    this._config = config;
   }
 
   export(exp = true): DeclarationBlock {
@@ -91,8 +91,8 @@ export class DeclarationBlock {
   }
 
   public get string(): string {
-    const useFlowExactObject: boolean = this._outputOptions.indexOf('useFlowExactObjects') > -1;
-    const useFlowReadOnlyTypes: boolean = this._outputOptions.indexOf('useFlowReadOnlyTypes') > -1;
+    const useFlowExactObject: boolean = this._config.useFlowExactObjects || false;
+    const useFlowReadOnlyTypes: boolean = this._config.useFlowReadOnlyTypes || false;
     const block: string = this._block && useFlowReadOnlyTypes ? this.getFlowReadOnlyTypeBlock() : this._block;
     let result = '';
 

--- a/packages/plugins/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/tests/flow.spec.ts
@@ -687,7 +687,7 @@ describe('Flow Plugin', () => {
         }`);
       const result = visit(ast, {
         leave: new FlowVisitor({
-          outputOptions: ['useFlowExactObjects']
+          useFlowExactObjects: true
         })
       });
 
@@ -708,7 +708,7 @@ describe('Flow Plugin', () => {
         }`);
       const result = visit(ast, {
         leave: new FlowVisitor({
-          outputOptions: ['useFlowReadOnlyTypes']
+          useFlowReadOnlyTypes: true
         })
       });
 


### PR DESCRIPTION
### Motivation
we've missed 2 flow features https://flow.org/en/docs/types/objects/#toc-exact-object-types and https://flow.org/en/docs/types/utilities/#toc-readonly. this PR adds the support of both based on new `config` settings called `useFlowExctObjects` and `useFlowReadOnlyTypes`.

### setup
extend your `codegen.yml`:
```
generates:
 <path to your output file>:
    plugins:
      - flow
    config:
      useFlowExactObjects: true
      useFlowReadOnlyTypes: true
```



# expected output on schema types
### enabled `useFlowExactObjects`
instead of:
```
interface MyInterface {
  foo: String
  bar: String!
}
```

you'll get:
```
interface MyInterface {|
  foo: String
  bar: String!
|}
```

### enabled `useFlowReadOnlyTypes`
instead of:
```
interface MyInterface {
  foo: String
  bar: String!
}
```

you'll get:
```
interface MyInterface {
  +foo: String
  +bar: String!
}
```



# expected output on document types
### enabled `useFlowExactObjects`
instead of:
```
export type CurrentUserQuery = { me: ?($Pick<User, { id: * }> & (($Pick<User, { username: * }> & { profile: ?$Pick<Profile, { age: * }> }))) };
```

you'll get:
```
export type CurrentUserQuery = {| me: ?($Pick<User, {| id: *, username: *, role: * |}> & {| profile: ?$Pick<Profile, {| age: * |}> |}) |};
```

### enabled `useFlowReadOnlyTypes`
instead of:
```
export type CurrentUserQuery = { me: ?($Pick<User, { id: * }> & (($Pick<User, { username: * }> & { profile: ?$Pick<Profile, { age: * }> }))) };
```

you'll get:
```
export type CurrentUserQuery = { +me: ?($Pick<User, { +id: *, +username: *, +role: * }> & { +profile: ?$Pick<Profile, { +age: * }> }) };
```