### PR TITLE
Remove subscription hook import

### DIFF
--- a/docs/plugins/typescript-react-apollo.md
+++ b/docs/plugins/typescript-react-apollo.md
@@ -73,21 +73,4 @@ Or if you are using `noNamespaces` option:
 
 #### `withSubscriptionHooks` (default value: `false`)
 
-This will cause the codegen to add React **Hooks** even for _Subscriptions_. Since they are not included in the `react-apollo-hooks` package, the option
-is separated.
-
-In order to use this flag, you should add a `importUseSubscriptionFrom` option specifying the path (relative to generated file) where the `useSubscription` function and the `SubscriptionHookOptions<T, TVariables>` type may be found.
-
-For example if you have defined `useSubscription` in the `react-apollo-subscriptions.tsx` file, you can use:
-
-```yaml
-withHooks: true
-withSubscriptionHooks: true
-importUseSubscriptionFrom: './react-apollo-subscriptions'
-```
-
-> This feature is experimental. You can find an actual implementation [here](https://github.com/Urigo/WhatsApp-Clone-Client-React/blob/master/src/polyfills/react-apollo-hooks.ts) or from [this issue](https://github.com/trojanowski/react-apollo-hooks/pull/37) on `react-apollo-hooks`.
-
-#### `importUseSubscriptionFrom`
-
-See `withSubscriptionHooks`.
+This will cause the codegen to add React **Hooks** even for _Subscriptions_. 

--- a/packages/plugins/typescript-react-apollo/src/helpers.ts
+++ b/packages/plugins/typescript-react-apollo/src/helpers.ts
@@ -121,7 +121,3 @@ export const shouldOutputHook = (operationType: string, options: Handlebars.Help
   const config = options.data.root.config || {};
   return operationType !== 'subscription' || config.withSubscriptionHooks;
 };
-
-export const hooksNamespace = (operationType: string): string => {
-  return operationType === 'subscription' ? 'SubscriptionHooks' : 'ReactApolloHooks';
-};

--- a/packages/plugins/typescript-react-apollo/src/index.ts
+++ b/packages/plugins/typescript-react-apollo/src/index.ts
@@ -4,7 +4,7 @@ import { flattenTypes } from 'graphql-codegen-plugin-helpers';
 import { GraphQLSchema } from 'graphql';
 import * as Handlebars from 'handlebars';
 import * as rootTemplate from './root.handlebars';
-import { generateFragments, gql, propsType, shouldOutputHook, hooksNamespace } from './helpers';
+import { generateFragments, gql, propsType, shouldOutputHook } from './helpers';
 import { extname } from 'path';
 
 export interface TypeScriptReactApolloConfig extends TypeScriptCommonConfig {
@@ -14,7 +14,6 @@ export interface TypeScriptReactApolloConfig extends TypeScriptCommonConfig {
   noComponents?: boolean;
   withHooks?: boolean;
   withSubscriptionHooks?: boolean;
-  importUseSubscriptionFrom?: string;
 }
 
 export const plugin: PluginFunction<TypeScriptReactApolloConfig> = async (
@@ -29,7 +28,6 @@ export const plugin: PluginFunction<TypeScriptReactApolloConfig> = async (
   Handlebars.registerHelper('gql', gql(convert));
   Handlebars.registerHelper('propsType', propsType(convert));
   Handlebars.registerHelper('shouldOutputHook', shouldOutputHook);
-  Handlebars.registerHelper('hooksNamespace', hooksNamespace);
 
   const hbsContext = {
     ...templateContext,
@@ -47,11 +45,5 @@ export const validate: PluginValidateFn<any> = async (
 ) => {
   if (extname(outputFile) !== '.tsx') {
     throw new Error(`Plugin "react-apollo" requires extension to be ".tsx"!`);
-  }
-
-  if (config.withSubscriptionHooks && !config.importUseSubscriptionFrom) {
-    throw new Error(
-      `Plugin "react-apollo" requires "importUseSubscriptionFrom" option if "withSubscriptionHooks" is enabled.`
-    );
   }
 };

--- a/packages/plugins/typescript-react-apollo/src/root.handlebars
+++ b/packages/plugins/typescript-react-apollo/src/root.handlebars
@@ -6,9 +6,6 @@ import * as React from 'react';
 {{#if @root.config.withHooks}}
 import * as ReactApolloHooks from 'react-apollo-hooks';
 {{/if}}
-{{#if @root.config.withSubscriptionHooks}}
-import * as SubscriptionHooks from '{{ @root.config.importUseSubscriptionFrom }}';
-{{/if}}
 {{#unless @root.config.noGraphqlTag}}
 import gql from 'graphql-tag';
 {{/unless}}
@@ -54,11 +51,11 @@ export namespace {{convert name 'typeNames' }} {
     {{/unless}}
     {{#if @root.config.withHooks}}
     {{#if (shouldOutputHook operationType) }}
-    export function use{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}(baseOptions?: {{hooksNamespace operationType}}.{{convert operationType 'typeNames'}}HookOptions<
+    export function use{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}(baseOptions?: ReactApolloHooks.{{convert operationType 'typeNames'}}HookOptions<
             {{#ifCond operationType '!==' 'query'}}{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType 'typeNames'}},
             {{/ifCond}}{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables
         >) {
-        return {{hooksNamespace operationType}}.use{{convert operationType 'typeNames'}}<
+        return ReactApolloHooks.use{{convert operationType 'typeNames'}}<
             {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType 'typeNames'}},
             {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables
         >({{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Document, baseOptions);

--- a/packages/plugins/typescript-react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript-react-apollo/tests/react-apollo.spec.ts
@@ -566,7 +566,6 @@ describe('Components', () => {
         noNamespaces: true,
         withHooks: true,
         withSubscriptionHooks: true,
-        importUseSubscriptionFrom: './addons/ras'
       },
       {
         outputFile: 'graphql.tsx'
@@ -574,19 +573,15 @@ describe('Components', () => {
     );
 
     expect(content).toBeSimilarStringTo(`
-          export function useListenToComments(baseOptions?: SubscriptionHooks.SubscriptionHookOptions<
+          export function useListenToComments(baseOptions?: ReactApolloHooks.SubscriptionHookOptions<
               ListenToCommentsSubscription,
               ListenToCommentsVariables
             >) {
-          return SubscriptionHooks.useSubscription<
+          return ReactApolloHooks.useSubscription<
             ListenToCommentsSubscription, 
             ListenToCommentsVariables
           >(ListenToCommentsDocument, baseOptions);
         };
-    `);
-
-    expect(content).toBeSimilarStringTo(`
-      import * as SubscriptionHooks from './addons/ras';
     `);
   });
 


### PR DESCRIPTION
Since `useSubscription` is [merged and released](https://github.com/trojanowski/react-apollo-hooks/pull/37), there is no need for a specific import.

It's also for consideration if `withSubscriptionHooks` is necessary. I don't feel that Subscriptions needs any special treatment really.