### PR TITLE
Use core react-apollo-hooks implementation of subscription hooks by default

### DIFF
--- a/docs/plugins/typescript-react-apollo.md
+++ b/docs/plugins/typescript-react-apollo.md
@@ -73,10 +73,13 @@ Or if you are using `noNamespaces` option:
 
 #### `withSubscriptionHooks` (default value: `false`)
 
-This will cause the codegen to add React **Hooks** even for _Subscriptions_. Since they are not included in the `react-apollo-hooks` package, the option
-is separated.
+This will cause the codegen to add React **Hooks** for _Subscriptions_.
 
-In order to use this flag, you should add a `importUseSubscriptionFrom` option specifying the path (relative to generated file) where the `useSubscription` function and the `SubscriptionHookOptions<T, TVariables>` type may be found.
+> This feature requires a polyfill when using `react-apollo-hooks` versions prior to 0.4.1. See `importUseSubscriptionsFrom`.
+
+#### `importUseSubscriptionFrom`
+
+The polyfill can be defined by adding a `importUseSubscriptionFrom` option specifying the path (relative to generated file) where the `useSubscription` function and the `SubscriptionHookOptions<T, TVariables>` type may be found.
 
 For example if you have defined `useSubscription` in the `react-apollo-subscriptions.tsx` file, you can use:
 
@@ -86,8 +89,4 @@ withSubscriptionHooks: true
 importUseSubscriptionFrom: './react-apollo-subscriptions'
 ```
 
-> This feature is experimental. You can find an actual implementation [here](https://github.com/Urigo/WhatsApp-Clone-Client-React/blob/master/src/polyfills/react-apollo-hooks.ts) or from [this issue](https://github.com/trojanowski/react-apollo-hooks/pull/37) on `react-apollo-hooks`.
-
-#### `importUseSubscriptionFrom`
-
-See `withSubscriptionHooks`.
+> This option allows using the experimental useSubscription hooks when used with `react-apollo-hooks` with versions prior to 0.4.1. You can find an actual implementation [here](https://github.com/Urigo/WhatsApp-Clone-Client-React/blob/master/src/polyfills/react-apollo-hooks.ts) or from [this issue](https://github.com/trojanowski/react-apollo-hooks/pull/37) on `react-apollo-hooks`.

--- a/packages/plugins/typescript-react-apollo/src/helpers.ts
+++ b/packages/plugins/typescript-react-apollo/src/helpers.ts
@@ -9,7 +9,7 @@ export const propsType = convert => ({ name, operationType }: any, options: Hand
     return `
             Partial<
                 ReactApollo.MutateProps<
-                                        ${noNamespaces ? convert(name, 'typeNames') : ''}Mutation, 
+                                        ${noNamespaces ? convert(name, 'typeNames') : ''}Mutation,
                                         ${noNamespaces ? convert(name, 'typeNames') : ''}Variables
                                         >
                 >
@@ -18,7 +18,7 @@ export const propsType = convert => ({ name, operationType }: any, options: Hand
     return `
             Partial<
                 ReactApollo.DataProps<
-                                        ${noNamespaces ? convert(name, 'typeNames') : ''}${convert(operationType)}, 
+                                        ${noNamespaces ? convert(name, 'typeNames') : ''}${convert(operationType)},
                                         ${noNamespaces ? convert(name, 'typeNames') : ''}Variables
                                     >
                     >
@@ -122,6 +122,10 @@ export const shouldOutputHook = (operationType: string, options: Handlebars.Help
   return operationType !== 'subscription' || config.withSubscriptionHooks;
 };
 
-export const hooksNamespace = (operationType: string): string => {
-  return operationType === 'subscription' ? 'SubscriptionHooks' : 'ReactApolloHooks';
+export const hooksNamespace = (operationType: string, options: Handlebars.HelperOptions): string => {
+  const config = options.data.root.config || {};
+
+  return operationType === 'subscription' && config.importUseSubscriptionFrom
+    ? 'SubscriptionHooks'
+    : 'ReactApolloHooks';
 };

--- a/packages/plugins/typescript-react-apollo/src/index.ts
+++ b/packages/plugins/typescript-react-apollo/src/index.ts
@@ -48,10 +48,4 @@ export const validate: PluginValidateFn<any> = async (
   if (extname(outputFile) !== '.tsx') {
     throw new Error(`Plugin "react-apollo" requires extension to be ".tsx"!`);
   }
-
-  if (config.withSubscriptionHooks && !config.importUseSubscriptionFrom) {
-    throw new Error(
-      `Plugin "react-apollo" requires "importUseSubscriptionFrom" option if "withSubscriptionHooks" is enabled.`
-    );
-  }
 };

--- a/packages/plugins/typescript-react-apollo/src/root.handlebars
+++ b/packages/plugins/typescript-react-apollo/src/root.handlebars
@@ -6,7 +6,7 @@ import * as React from 'react';
 {{#if @root.config.withHooks}}
 import * as ReactApolloHooks from 'react-apollo-hooks';
 {{/if}}
-{{#if @root.config.withSubscriptionHooks}}
+{{#if @root.config.importUseSubscriptionFrom}}
 import * as SubscriptionHooks from '{{ @root.config.importUseSubscriptionFrom }}';
 {{/if}}
 {{#unless @root.config.noGraphqlTag}}
@@ -20,7 +20,7 @@ import gql from 'graphql-tag';
 {{#each operations }}
     {{#unless @root.config.noNamespaces}}
 export namespace {{convert name 'typeNames' }} {
-    {{/unless}}    
+    {{/unless}}
     export const {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Document = {{{ gql this }}};
     {{#unless @root.config.noComponents}}
      export class {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Component extends React.Component<Partial<ReactApollo.{{ convert operationType 'typeNames' }}Props<{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{ convert operationType 'typeNames' }}, {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables>>> {
@@ -39,9 +39,9 @@ export namespace {{convert name 'typeNames' }} {
     {{#ifCond operationType '===' 'mutation'}}
     export type {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}MutationFn = ReactApollo.MutationFn<{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType 'typeNames'}}, {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables>;
     {{/ifCond}}
-    export function {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}HOC<TProps, TChildProps = any>(operationOptions: 
+    export function {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}HOC<TProps, TChildProps = any>(operationOptions:
             ReactApollo.OperationOption<
-                TProps, 
+                TProps,
                 {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType 'typeNames'}},
                 {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables,
                 {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Props<TChildProps>

--- a/packages/plugins/typescript-react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript-react-apollo/tests/react-apollo.spec.ts
@@ -531,7 +531,7 @@ describe('Components', () => {
                 Variables
             >) {
           return ReactApolloHooks.useQuery<
-            Query, 
+            Query,
             Variables
           >(Document, baseOptions);
         };
@@ -543,7 +543,7 @@ describe('Components', () => {
                 Variables
             >) {
           return ReactApolloHooks.useMutation<
-            Mutation, 
+            Mutation,
             Variables
           >(Document, baseOptions);
         };
@@ -579,7 +579,7 @@ describe('Components', () => {
               ListenToCommentsVariables
             >) {
           return SubscriptionHooks.useSubscription<
-            ListenToCommentsSubscription, 
+            ListenToCommentsSubscription,
             ListenToCommentsVariables
           >(ListenToCommentsDocument, baseOptions);
         };
@@ -588,6 +588,43 @@ describe('Components', () => {
     expect(content).toBeSimilarStringTo(`
       import * as SubscriptionHooks from './addons/ras';
     `);
+  });
+
+  it('should generate Subscription Hooks if config is enabled without importUseSubscriptionFrom', async () => {
+    const documents = gql`
+      subscription ListenToComments($name: String) {
+        commentAdded(repoFullName: $name) {
+          id
+        }
+      }
+    `;
+
+    const content = await plugin(
+      schema,
+      [{ filePath: '', content: documents }],
+      {
+        noNamespaces: true,
+        withHooks: true,
+        withSubscriptionHooks: true
+      },
+      {
+        outputFile: 'graphql.tsx'
+      }
+    );
+
+    expect(content).toBeSimilarStringTo(`
+          export function useListenToComments(baseOptions?: ReactApolloHooks.SubscriptionHookOptions<
+              ListenToCommentsSubscription,
+              ListenToCommentsVariables
+            >) {
+          return ReactApolloHooks.useSubscription<
+            ListenToCommentsSubscription,
+            ListenToCommentsVariables
+          >(ListenToCommentsDocument, baseOptions);
+        };
+    `);
+
+    expect(content).not.toBeSimilarStringTo(`import * as SubscriptionHooks`);
   });
 
   it('should skip import React and ReactApollo if only hooks are used', async () => {


### PR DESCRIPTION
This removes the need for adding `importUseSubscriptionFrom` since react-apollo-hooks now ships with an official implementation.