### PR TITLE
Some enhancements for hooks

### DIFF
--- a/docs/plugins/typescript-react-apollo.md
+++ b/docs/plugins/typescript-react-apollo.md
@@ -52,13 +52,13 @@ Or if you prefer:
 Customize from where will be `gql` imported. This is useful if you want to use eg. `graphql.macro` for inlining documents.
 Note that you need to write whole import line, eg. `import { gql } from 'graphql.macro'`.
 
-#### `noHOC` (default value: `false`)
+#### `withHOC` (default value: `true`)
 
-This will disable the higher order components generation.
+This will disable the higher order components generation by setting this option to `false`.
 
-#### `noComponents` (default value: `false`)
+#### `withComponents` (default value: `true`)
 
-This will cause the code generator to _omit_ React **Components**. So, in case you are just using _hooks_, you can disable the Components setting this option to `true`.
+This will cause the code generator to _omit_ React **Components**. So, in case you are just using _hooks_, you can disable the Components setting this option to `false`.
 
 #### `withHooks` (default value: `false`)
 
@@ -76,6 +76,4 @@ Or if you are using `noNamespaces` option:
   const { data, loading, error } = useTest(...);
 ```
 
-#### `withSubscriptionHooks` (default value: `false`)
-
-This will cause the codegen to add React **Hooks** even for _Subscriptions_. 
+You can specify alternative module that is exports `useQuery` `useMutation` and `useSubscription`. This is useful for further abstraction of some common tasks (eg. error handling). Filepath relative to generated file can be also specified. But if you provide only `true`, it will use `react-apollo-hooks` by default.

--- a/packages/plugins/typescript-react-apollo/src/helpers.ts
+++ b/packages/plugins/typescript-react-apollo/src/helpers.ts
@@ -117,12 +117,21 @@ export const toFragmentName = convert => (fragmentName: string, options: Handleb
   }
 };
 
-export const shouldOutputHook = (operationType: string, options: Handlebars.HelperOptions): boolean => {
-  const config = options.data.root.config || {};
-  return operationType !== 'subscription' || config.withSubscriptionHooks;
-};
-
 export const gqlImport = (operationType: string, options: Handlebars.HelperOptions): string => {
   const config = options.data.root.config || {};
-  return config.gqlImport || 'import gql from \'graphql-tag\'';
+  return config.gqlImport || "import gql from 'graphql-tag'";
+};
+
+export const getImports = (options: Handlebars.HelperOptions) => {
+  let imports = '';
+  const config = options.data.root.config || {};
+  if (config.withComponents) {
+    imports += `import * as React from 'react';`;
+  }
+  if (config.withComponents || config.withHOC) {
+    imports += `import * as ReactApollo from 'react-apollo';`;
+  }
+  if (config.withHooks) {
+    imports += typeof config.withHooks === 'string' ? config.withHooks : 'react-apollo-hooks';
+  }
 };

--- a/packages/plugins/typescript-react-apollo/src/helpers.ts
+++ b/packages/plugins/typescript-react-apollo/src/helpers.ts
@@ -83,7 +83,7 @@ export const gql = convert => (operation: Operation, options: Handlebars.HelperO
     ${includeFragments(transformFragments(convert)(operation.document, options))}
   `;
 
-  return config.noGraphqlTag ? JSON.stringify(gqlTag(doc)) : 'gql`' + doc + '`';
+  return config.gqlImport ? JSON.stringify(gqlTag(doc)) : 'gql`' + doc + '`';
 };
 
 function includeFragments(fragments: string[]): string {

--- a/packages/plugins/typescript-react-apollo/src/helpers.ts
+++ b/packages/plugins/typescript-react-apollo/src/helpers.ts
@@ -117,22 +117,32 @@ export const toFragmentName = convert => (fragmentName: string, options: Handleb
   }
 };
 
-export const gqlImport = (operationType: string, options: Handlebars.HelperOptions): string => {
-  const config = options.data.root.config || {};
-  return config.gqlImport || 'import gql from \'graphql-tag\'';
+export const parseImport = (importStr: string) => {
+  const [moduleName, propName] = importStr.split('#');
+  return {
+    moduleName,
+    propName
+  };
 };
 
-export const getImports = (options: Handlebars.HelperOptions) => {
-  let imports = '';
+export const getImports = (operationType: string, options: Handlebars.HelperOptions) => {
   const config = options.data.root.config || {};
+  const gqlImport = parseImport(config.gqlImport || 'graphql-tag');
+  let imports = `
+    import ${
+      gqlImport.propName ? `{ ${gqlImport.propName === 'gql' ? 'gql' : `${gqlImport.propName} as gql`} }` : 'gql'
+    } from '${gqlImport.moduleName}';
+  `;
   if (config.withComponents) {
-    imports += `import * as React from 'react';`;
+    imports += `import * as React from 'react';\n`;
   }
   if (config.withComponents || config.withHOC) {
-    imports += `import * as ReactApollo from 'react-apollo';`;
+    imports += `import * as ReactApollo from 'react-apollo';\n`;
   }
   if (config.withHooks) {
-    imports += typeof config.withHooks === 'string' ? config.withHooks : 'react-apollo-hooks';
+    imports += `import * as ReactApolloHooks from '${
+      typeof config.withHooks === 'string' ? config.withHooks : 'react-apollo-hooks'
+    }';\n`;
   }
   return imports;
 };

--- a/packages/plugins/typescript-react-apollo/src/index.ts
+++ b/packages/plugins/typescript-react-apollo/src/index.ts
@@ -8,7 +8,6 @@ import { generateFragments, gql, propsType, getImports } from './helpers';
 import { extname } from 'path';
 
 export interface TypeScriptReactApolloConfig extends TypeScriptCommonConfig {
-  noGraphqlTag?: boolean;
   noNamespaces?: boolean;
   withHOC?: boolean;
   withComponents?: boolean;

--- a/packages/plugins/typescript-react-apollo/src/index.ts
+++ b/packages/plugins/typescript-react-apollo/src/index.ts
@@ -4,7 +4,7 @@ import { flattenTypes } from 'graphql-codegen-plugin-helpers';
 import { GraphQLSchema } from 'graphql';
 import * as Handlebars from 'handlebars';
 import * as rootTemplate from './root.handlebars';
-import { generateFragments, gql, propsType, gqlImport } from './helpers';
+import { generateFragments, gql, propsType, getImports } from './helpers';
 import { extname } from 'path';
 
 export interface TypeScriptReactApolloConfig extends TypeScriptCommonConfig {
@@ -29,7 +29,7 @@ export const plugin: PluginFunction<TypeScriptReactApolloConfig> = async (
   Handlebars.registerHelper('generateFragments', generateFragments(convert));
   Handlebars.registerHelper('gql', gql(convert));
   Handlebars.registerHelper('propsType', propsType(convert));
-  Handlebars.registerHelper('gqlImport', gqlImport);
+  Handlebars.registerHelper('getImports', getImports);
 
   const hbsContext = {
     ...templateContext,

--- a/packages/plugins/typescript-react-apollo/src/index.ts
+++ b/packages/plugins/typescript-react-apollo/src/index.ts
@@ -4,31 +4,31 @@ import { flattenTypes } from 'graphql-codegen-plugin-helpers';
 import { GraphQLSchema } from 'graphql';
 import * as Handlebars from 'handlebars';
 import * as rootTemplate from './root.handlebars';
-import { generateFragments, gql, propsType, shouldOutputHook, gqlImport } from './helpers';
+import { generateFragments, gql, propsType, gqlImport } from './helpers';
 import { extname } from 'path';
 
 export interface TypeScriptReactApolloConfig extends TypeScriptCommonConfig {
   noGraphqlTag?: boolean;
   noNamespaces?: boolean;
-  noHOC?: boolean;
-  noComponents?: boolean;
-  withHooks?: boolean;
-  withSubscriptionHooks?: boolean;
+  withHOC?: boolean;
+  withComponents?: boolean;
+  withHooks?: boolean | string;
   gqlImport?: string;
 }
 
 export const plugin: PluginFunction<TypeScriptReactApolloConfig> = async (
   schema: GraphQLSchema,
   documents: DocumentFile[],
-  config: TypeScriptReactApolloConfig
+  config: TypeScriptReactApolloConfig = {}
 ): Promise<string> => {
+  config.withHOC = 'withHOC' in config ? config.withHOC : true;
+  config.withComponents = 'withComponents' in config ? config.withComponents : true;
   const { templateContext, convert } = initCommonTemplate(Handlebars, schema, config);
   const transformedDocuments = transformDocumentsFiles(schema, documents);
   const flattenDocuments = flattenTypes(transformedDocuments);
   Handlebars.registerHelper('generateFragments', generateFragments(convert));
   Handlebars.registerHelper('gql', gql(convert));
   Handlebars.registerHelper('propsType', propsType(convert));
-  Handlebars.registerHelper('shouldOutputHook', shouldOutputHook);
   Handlebars.registerHelper('gqlImport', gqlImport);
 
   const hbsContext = {

--- a/packages/plugins/typescript-react-apollo/src/root.handlebars
+++ b/packages/plugins/typescript-react-apollo/src/root.handlebars
@@ -1,11 +1,5 @@
 {{#ifCond operations.length '!==' 0}}
-{{#unless @root.config.noComponents}}
-import * as ReactApollo from 'react-apollo';
-import * as React from 'react';
-{{/unless}}
-{{#if @root.config.withHooks}}
-import * as ReactApolloHooks from 'react-apollo-hooks';
-{{/if}}
+{{{getImports}}}
 {{#unless @root.config.noGraphqlTag}}
 {{{gqlImport this}}};
 {{/unless}}
@@ -19,7 +13,7 @@ import * as ReactApolloHooks from 'react-apollo-hooks';
 export namespace {{convert name 'typeNames' }} {
     {{/unless}}    
     export const {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Document = {{{ gql this }}};
-    {{#unless @root.config.noComponents}}
+    {{#if @root.config.withComponents}}
      export class {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Component extends React.Component<Partial<ReactApollo.{{ convert operationType 'typeNames' }}Props<{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{ convert operationType 'typeNames' }}, {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables>>> {
         render(){
             return (
@@ -30,8 +24,8 @@ export namespace {{convert name 'typeNames' }} {
             );
         }
     }
-    {{/unless}}
-    {{#unless @root.config.noHOC}}
+    {{/if}}
+    {{#if @root.config.withHOC}}
     export type {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Props<TChildProps = any> = {{{propsType this}}} & TChildProps;
     {{#ifCond operationType '===' 'mutation'}}
     export type {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}MutationFn = ReactApollo.MutationFn<{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType 'typeNames'}}, {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables>;
@@ -48,9 +42,8 @@ export namespace {{convert name 'typeNames' }} {
             operationOptions
         );
     };
-    {{/unless}}
+    {{/if}}
     {{#if @root.config.withHooks}}
-    {{#if (shouldOutputHook operationType) }}
     export function use{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}(baseOptions?: ReactApolloHooks.{{convert operationType 'typeNames'}}HookOptions<
             {{#ifCond operationType '!==' 'query'}}{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}{{convert operationType 'typeNames'}},
             {{/ifCond}}{{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables
@@ -60,7 +53,6 @@ export namespace {{convert name 'typeNames' }} {
             {{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Variables
         >({{#if @root.config.noNamespaces}}{{ convert name 'typeNames' }}{{/if}}Document, baseOptions);
     };
-    {{/if}}
     {{/if}}
     {{#unless @root.config.noNamespaces}}
 }

--- a/packages/plugins/typescript-react-apollo/src/root.handlebars
+++ b/packages/plugins/typescript-react-apollo/src/root.handlebars
@@ -1,8 +1,5 @@
 {{#ifCond operations.length '!==' 0}}
-{{{getImports}}}
-{{#unless @root.config.noGraphqlTag}}
-{{{gqlImport this}}};
-{{/unless}}
+{{{getImports this}}}
 
 {{ blockCommentIf 'Fragments' fragments }}
 {{{generateFragments fragments}}}

--- a/packages/plugins/typescript-react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript-react-apollo/tests/react-apollo.spec.ts
@@ -571,7 +571,7 @@ describe('Components', () => {
     `);
   });
 
-  it('should generate Subscription Hooks if config is enabled', async () => {
+  it('should generate Subscription Hooks', async () => {
     const documents = gql`
       subscription ListenToComments($name: String) {
         commentAdded(repoFullName: $name) {
@@ -585,8 +585,7 @@ describe('Components', () => {
       [{ filePath: '', content: documents }],
       {
         noNamespaces: true,
-        withHooks: true,
-        withSubscriptionHooks: true,
+        withHooks: true
       },
       {
         outputFile: 'graphql.tsx'
@@ -628,8 +627,8 @@ describe('Components', () => {
       [{ filePath: '', content: documents }],
       {
         withHooks: true,
-        noHOC: true,
-        noComponents: true
+        withHOC: false,
+        withComponents: false
       },
       {
         outputFile: 'graphql.tsx'
@@ -642,6 +641,36 @@ describe('Components', () => {
 
     expect(content).not.toBeSimilarStringTo(`
       import * as React from 'react';
+    `);
+  });
+  it('should import ReactApolloHooks from hooksImportFrom config option', async () => {
+    const documents = gql`
+      query {
+        feed {
+          id
+          commentCount
+          repository {
+            full_name
+            html_url
+            owner {
+              avatar_url
+            }
+          }
+        }
+      }
+    `;
+
+    const content = await plugin(
+      schema,
+      [{ filePath: '', content: documents }],
+      { withHooks: 'custom-apollo-hooks' },
+      {
+        outputFile: 'graphql.tsx'
+      }
+    );
+
+    expect(content).toBeSimilarStringTo(`
+        import * as ReactApolloHooks from 'custom-apollo-hooks';
     `);
   });
 });

--- a/packages/plugins/typescript-react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript-react-apollo/tests/react-apollo.spec.ts
@@ -477,13 +477,13 @@ describe('Components', () => {
     const content = await plugin(
       schema,
       [{ filePath: '', content: documents }],
-      { gqlImport: 'import { gql } from graphql.macro' },
+      { gqlImport: 'graphql.macro#gql' },
       {
         outputFile: 'graphql.tsx'
       }
     );
 
-    expect(content).toContain(`import { gql } from graphql.macro;`);
+    expect(content).toContain(`import { gql } from 'graphql.macro';`);
   });
 
   it('should import ReactApolloHooks dependencies', async () => {


### PR DESCRIPTION
- Remove `withSubscriptionHooks`
- Use the same behaviour that @FredyC added in here but in a different way, I think we can uae same `withHooks` option to provide custom module for hooks.
- Fix missing `ReactApollo` import if `noComponents` is true, but `noHOC` is false.
- Change `noComponents` and `noHOC` to `withComponents` and `withHOC` which look more consistent with `withHooks`.
- Fixed invalid import syntax
- `gqlImport` is more consistent with other import syntaxes in codegen. `gqlImport: graphql.macro#gql`