### PR TITLE
Fix IResolvers index signature

### DIFF
--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -177,7 +177,7 @@ export type IResolvers<TContext = {}> = {
     QueryRoot?: QueryRootResolvers.Resolvers<TContext>;
     User?: UserResolvers.Resolvers<TContext>;
     SubscriptionRoot?: SubscriptionRootResolvers.Resolvers<TContext>;
-} & { [typeName: string] : never };
+} & { [typeName: string] : { [ fieldName: string ]: ( Resolver<any, any, TContext, any> | SubscriptionResolver<any, any, TContext, any> ) } };
 
 export type IDirectiveResolvers<Result> = {
     skip?: SkipDirectiveResolver<Result>;

--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -171,8 +171,6 @@ export interface DeprecatedDirectiveArgs {
   reason?: string;
 }
 
-
-
 export type IResolvers<TContext = {}> = {
     QueryRoot?: QueryRootResolvers.Resolvers<TContext>;
     User?: UserResolvers.Resolvers<TContext>;

--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -79,10 +79,10 @@ export type IResolvers<TContext = {{{ getContext }}}> = {
   {{#each scalars}}
     {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: GraphQLScalarType;
   {{/each}}
-} & { [typeName: string] : never };
+} &  & { [typeName: string] : { [ fieldName: string ]: ( Resolver<any, any, TContext, any> | SubscriptionResolver<any, any, {{{ getContext }}}, any> ) } }
 
 export type IDirectiveResolvers<Result> = {
   {{#each definedDirectives}}
     {{ name }}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}DirectiveResolver<Result>;
   {{/each}}
-} & { [directiveName: string] : never };
+} & { [directiveName: string] : DirectiveResolverFn<any, any, {{{ getContext }}}> };

--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -79,7 +79,7 @@ export type IResolvers<TContext = {{{ getContext }}}> = {
   {{#each scalars}}
     {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: GraphQLScalarType;
   {{/each}}
-} &  & { [typeName: string] : { [ fieldName: string ]: ( Resolver<any, any, TContext, any> | SubscriptionResolver<any, any, TContext, any> ) } }
+} &  & { [typeName: string] : { [ fieldName: string ]: ( Resolver<any, any, TContext, any> | SubscriptionResolver<any, any, TContext, any> ) } };
 
 export type IDirectiveResolvers<Result> = {
   {{#each definedDirectives}}

--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -79,10 +79,10 @@ export type IResolvers<TContext = {{{ getContext }}}> = {
   {{#each scalars}}
     {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: GraphQLScalarType;
   {{/each}}
-} &  & { [typeName: string] : { [ fieldName: string ]: ( Resolver<any, any, TContext, any> | SubscriptionResolver<any, any, {{{ getContext }}}, any> ) } }
+} &  & { [typeName: string] : { [ fieldName: string ]: ( Resolver<any, any, TContext, any> | SubscriptionResolver<any, any, TContext, any> ) } }
 
 export type IDirectiveResolvers<Result> = {
   {{#each definedDirectives}}
     {{ name }}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}DirectiveResolver<Result>;
   {{/each}}
-} & { [directiveName: string] : DirectiveResolverFn<any, any, {{{ getContext }}}> };
+} & { [directiveName: string] : DirectiveResolverFn<any, any, TContext> };

--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -81,7 +81,7 @@ export type IResolvers<TContext = {{{ getContext }}}> = {
   {{/each}}
 } & { [typeName: string] : { [ fieldName: string ]: ( Resolver<any, any, TContext, any> | SubscriptionResolver<any, any, TContext, any> ) } };
 
-export type IDirectiveResolvers<Result> = {
+export type IDirectiveResolvers<Result, TContext = {{{ getContext }}}> = {
   {{#each definedDirectives}}
     {{ name }}{{#unless @root.config.strict}}?{{/unless}}: {{ convert name 'typeNames'}}DirectiveResolver<Result>;
   {{/each}}

--- a/packages/plugins/typescript-resolvers/src/root.handlebars
+++ b/packages/plugins/typescript-resolvers/src/root.handlebars
@@ -79,7 +79,7 @@ export type IResolvers<TContext = {{{ getContext }}}> = {
   {{#each scalars}}
     {{ convert name 'typeNames'}}{{#unless @root.config.strict}}?{{/unless}}: GraphQLScalarType;
   {{/each}}
-} &  & { [typeName: string] : { [ fieldName: string ]: ( Resolver<any, any, TContext, any> | SubscriptionResolver<any, any, TContext, any> ) } };
+} & { [typeName: string] : { [ fieldName: string ]: ( Resolver<any, any, TContext, any> | SubscriptionResolver<any, any, TContext, any> ) } };
 
 export type IDirectiveResolvers<Result> = {
   {{#each definedDirectives}}

--- a/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
@@ -1241,7 +1241,7 @@ describe('Resolvers', () => {
     `);
 
     expect(content).toBeSimilarStringTo(`
-      export type IDirectiveResolvers<Result> = {
+      export type IDirectiveResolvers<Result, TContext = {}> = {
         modify?: ModifyDirectiveResolver<Result>;
         skip?: SkipDirectiveResolver<Result>;
         include?: IncludeDirectiveResolver<Result>;

--- a/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/typescript-resolvers.spec.ts
@@ -1237,7 +1237,7 @@ describe('Resolvers', () => {
         Node?: NodeResolvers;
         PostOrUser?: PostOrUserResolvers;
         Date?: GraphQLScalarType;
-      } & { [typeName: string] : never };
+      } & { [typeName: string] : { [ fieldName: string ]: ( Resolver<any, any, TContext, any> | SubscriptionResolver<any, any, TContext, any> ) } };
     `);
 
     expect(content).toBeSimilarStringTo(`
@@ -1246,7 +1246,7 @@ describe('Resolvers', () => {
         skip?: SkipDirectiveResolver<Result>;
         include?: IncludeDirectiveResolver<Result>;
         deprecated?: DeprecatedDirectiveResolver<Result>;
-      } & { [directiveName: string] : never };
+      } & { [directiveName: string] : DirectiveResolverFn<any, any, TContext> };
     `);
   });
 


### PR DESCRIPTION
- Make `IResolvers` and `IDirectiveResolvers` are extendable with generic resolvers instead of restricting new resolvers by `never`.