### PR TITLE
FIX: fixed bug with useFlowReadOnlyTypes on Enums

### DIFF
--- a/packages/plugins/flow/src/utils.ts
+++ b/packages/plugins/flow/src/utils.ts
@@ -93,7 +93,10 @@ export class DeclarationBlock {
   public get string(): string {
     const useFlowExactObject: boolean = this._config.useFlowExactObjects || false;
     const useFlowReadOnlyTypes: boolean = this._config.useFlowReadOnlyTypes || false;
-    const block: string = this._block && useFlowReadOnlyTypes ? this.getFlowReadOnlyTypeBlock() : this._block;
+    const block: string =
+      this._block && useFlowReadOnlyTypes && this._methodName !== 'Object.freeze'
+        ? this.getFlowReadOnlyTypeBlock()
+        : this._block;
     let result = '';
 
     if (this._export) {

--- a/packages/plugins/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/tests/flow.spec.ts
@@ -705,7 +705,14 @@ describe('Flow Plugin', () => {
         interface MyInterface {
           foo: String
           bar: String!
-        }`);
+        }
+
+        enum MyEnum {
+          A
+          B
+          C
+        }  
+      `);
       const result = visit(ast, {
         leave: new FlowVisitor({
           useFlowReadOnlyTypes: true
@@ -718,7 +725,19 @@ describe('Flow Plugin', () => {
           +bar: string,
         };
       `);
+
+      expect(result.definitions[1]).toBeSimilarStringTo(`
+        export const MyEnumValues = Object.freeze({
+          A: 'A',
+          B: 'B',
+          C: 'C'
+        });
+
+        export type MyEnum = $Values<typeof MyEnumValues>;
+      `);
+
       validateFlow(result.definitions[0]);
+      validateFlow(result.definitions[1]);
     });
   });
 });


### PR DESCRIPTION
just fixing a bug which occurred after introducing `useFlowReadOnlyTypes` on handling Enums.

### current output
```
export const MyEnumValues = Object.freeze({
  +A: 'A',
  +B: 'B',
  +C: 'C'
});
```

### fixed output
```
export const MyEnumValues = Object.freeze({
  A: 'A',
  B: 'B',
  C: 'C'
});
```