### PR TITLE
Fix behavior of gqlImport option

### DIFF
--- a/docs/plugins/typescript-react-apollo.md
+++ b/docs/plugins/typescript-react-apollo.md
@@ -47,9 +47,10 @@ Or if you prefer:
 
 ## Configuration
 
-#### `gqlImport` (default value: `import gql from 'graphql-tag'`)
+#### `gqlImport` (default value: `graphql-tag`)
 
 Customize from which module will `gql` be imported from. This is useful if you want to use modules other than `graphql-tag`, e.g. `graphql.macro`. You can also control the imported GraphQL-parse function identifier e.g. `gatsby#graphql`, which will result in `import { graphql as gql } from 'gatsby'`.
+If you specify a value of this option as `false` GraphQL queries will be compiled to GraphQL AST at generate-time.
 
 #### `noHOC` (default value: `false`)
 

--- a/packages/plugins/typescript-react-apollo/src/helpers.ts
+++ b/packages/plugins/typescript-react-apollo/src/helpers.ts
@@ -138,7 +138,7 @@ export const getImports = (operationType: string, options: Handlebars.HelperOpti
   let imports = '';
   if (typeof config.gqlImport === 'undefined' || typeof config.gqlImport === 'string') {
     const gqlImport = parseImport(config.gqlImport || 'graphql-tag');
-    let imports = `
+    imports += `
       import ${
         gqlImport.propName ? `{ ${gqlImport.propName === 'gql' ? 'gql' : `${gqlImport.propName} as gql`} }` : 'gql'
       } from '${gqlImport.moduleName}';

--- a/packages/plugins/typescript-react-apollo/src/helpers.ts
+++ b/packages/plugins/typescript-react-apollo/src/helpers.ts
@@ -83,7 +83,11 @@ export const gql = convert => (operation: Operation, options: Handlebars.HelperO
     ${includeFragments(transformFragments(convert)(operation.document, options))}
   `;
 
-  return config.gqlImport ? JSON.stringify(gqlTag(doc)) : 'gql`' + doc + '`';
+  if (typeof config.gqlImport === 'boolean' && !config.gqlImport) {
+    return JSON.stringify(gqlTag(doc));
+  }
+
+  return 'gql`' + doc + '`';
 };
 
 function includeFragments(fragments: string[]): string {
@@ -131,12 +135,15 @@ export const hooksNamespace = (operationType: string): string => {
 
 export const getImports = (operationType: string, options: Handlebars.HelperOptions) => {
   const config = options.data.root.config || {};
-  const gqlImport = parseImport(config.gqlImport || 'graphql-tag');
-  let imports = `
-    import ${
-      gqlImport.propName ? `{ ${gqlImport.propName === 'gql' ? 'gql' : `${gqlImport.propName} as gql`} }` : 'gql'
-    } from '${gqlImport.moduleName}';
-  `;
+  let imports = '';
+  if (typeof config.gqlImport === 'undefined' || typeof config.gqlImport === 'string') {
+    const gqlImport = parseImport(config.gqlImport || 'graphql-tag');
+    let imports = `
+      import ${
+        gqlImport.propName ? `{ ${gqlImport.propName === 'gql' ? 'gql' : `${gqlImport.propName} as gql`} }` : 'gql'
+      } from '${gqlImport.moduleName}';
+    `;
+  }
   if (!config.noComponents) {
     imports += `import * as React from 'react';\n`;
   }


### PR DESCRIPTION
`gqlImport` option can be:
- `false` (GraphQL queries will be compiled to GraphQL AST without importing `gql` tag)
- `string` (Using custom `gql` tag modul)
- `undefined` (Using `import gql from 'graphql-tag'`)