### PR TITLE
Refactor Scalars & Some other fixes

### DIFF
--- a/dev-test/githunt/flow.flow.js
+++ b/dev-test/githunt/flow.flow.js
@@ -1,29 +1,38 @@
 /* @flow */
 
+
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Comment = {
-  id: number,
+  id: $ElementType<Scalars, 'Int'>,
   postedBy: User,
-  createdAt: number,
-  content: string,
-  repoName: string,
+  createdAt: $ElementType<Scalars, 'Float'>,
+  content: $ElementType<Scalars, 'String'>,
+  repoName: $ElementType<Scalars, 'String'>,
 };
 
 export type Entry = {
   repository: Repository,
   postedBy: User,
-  createdAt: number,
-  score: number,
-  hotScore: number,
+  createdAt: $ElementType<Scalars, 'Float'>,
+  score: $ElementType<Scalars, 'Int'>,
+  hotScore: $ElementType<Scalars, 'Float'>,
   comments: Array<?Comment>,
-  commentCount: number,
-  id: number,
+  commentCount: $ElementType<Scalars, 'Int'>,
+  id: $ElementType<Scalars, 'Int'>,
   vote: Vote,
 };
 
 
 export type EntryCommentsArgs = {
-  limit?: ?number,
-  offset?: ?number
+  limit?: ?$ElementType<Scalars, 'Int'>,
+  offset?: ?$ElementType<Scalars, 'Int'>
 };
 
 export const FeedTypeValues = Object.freeze({
@@ -43,19 +52,19 @@ export type Mutation = {
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: string
+  repoFullName: $ElementType<Scalars, 'String'>
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: string,
+  repoFullName: $ElementType<Scalars, 'String'>,
   type: VoteType
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: $ElementType<Scalars, 'String'>,
+  commentContent: $ElementType<Scalars, 'String'>
 };
 
 export type Query = {
@@ -67,22 +76,22 @@ export type Query = {
 
 export type QueryFeedArgs = {
   type: FeedType,
-  offset?: ?number,
-  limit?: ?number
+  offset?: ?$ElementType<Scalars, 'Int'>,
+  limit?: ?$ElementType<Scalars, 'Int'>
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: string
+  repoFullName: $ElementType<Scalars, 'String'>
 };
 
 export type Repository = {
-  name: string,
-  full_name: string,
-  description?: ?string,
-  html_url: string,
-  stargazers_count: number,
-  open_issues_count?: ?number,
+  name: $ElementType<Scalars, 'String'>,
+  full_name: $ElementType<Scalars, 'String'>,
+  description?: ?$ElementType<Scalars, 'String'>,
+  html_url: $ElementType<Scalars, 'String'>,
+  stargazers_count: $ElementType<Scalars, 'Int'>,
+  open_issues_count?: ?$ElementType<Scalars, 'Int'>,
   owner?: ?User,
 };
 
@@ -92,17 +101,17 @@ export type Subscription = {
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: string
+  repoFullName: $ElementType<Scalars, 'String'>
 };
 
 export type User = {
-  login: string,
-  avatar_url: string,
-  html_url: string,
+  login: $ElementType<Scalars, 'String'>,
+  avatar_url: $ElementType<Scalars, 'String'>,
+  html_url: $ElementType<Scalars, 'String'>,
 };
 
 export type Vote = {
-  vote_value: number,
+  vote_value: $ElementType<Scalars, 'Int'>,
 };
 
 export const VoteTypeValues = Object.freeze({
@@ -116,16 +125,16 @@ export type VoteType = $Values<typeof VoteTypeValues>;
 type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
 export type OnCommentAddedSubscriptionVariables = {
-  repoFullName: string
+  repoFullName: $ElementType<Scalars, 'String'>
 };
 
 
 export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: ?({ __typename?: 'Comment' } & $Pick<Comment, { id: *, createdAt: *, content: * }> & { postedBy: ({ __typename?: 'User' } & $Pick<User, { login: *, html_url: * }>) }) });
 
 export type CommentQueryVariables = {
-  repoFullName: string,
-  limit?: ?number,
-  offset?: ?number
+  repoFullName: $ElementType<Scalars, 'String'>,
+  limit?: ?$ElementType<Scalars, 'Int'>,
+  offset?: ?$ElementType<Scalars, 'Int'>
 };
 
 
@@ -142,15 +151,15 @@ export type FeedEntryFragment = ({ __typename?: 'Entry' } & $Pick<Entry, { id: *
 
 export type FeedQueryVariables = {
   type: FeedType,
-  offset?: ?number,
-  limit?: ?number
+  offset?: ?$ElementType<Scalars, 'Int'>,
+  limit?: ?$ElementType<Scalars, 'Int'>
 };
 
 
 export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: ?({ __typename?: 'User' } & $Pick<User, { login: * }>), feed: ?Array<?({ __typename?: 'Entry' } & FeedEntryFragment)> });
 
 export type SubmitRepositoryMutationVariables = {
-  repoFullName: string
+  repoFullName: $ElementType<Scalars, 'String'>
 };
 
 
@@ -159,8 +168,8 @@ export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRe
 export type RepoInfoFragment = ({ __typename?: 'Entry' } & $Pick<Entry, { createdAt: * }> & { repository: ({ __typename?: 'Repository' } & $Pick<Repository, { description: *, stargazers_count: *, open_issues_count: * }>), postedBy: ({ __typename?: 'User' } & $Pick<User, { html_url: *, login: * }>) });
 
 export type SubmitCommentMutationVariables = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: $ElementType<Scalars, 'String'>,
+  commentContent: $ElementType<Scalars, 'String'>
 };
 
 
@@ -169,7 +178,7 @@ export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComme
 export type VoteButtonsFragment = ({ __typename?: 'Entry' } & $Pick<Entry, { score: * }> & { vote: ({ __typename?: 'Vote' } & $Pick<Vote, { vote_value: * }>) });
 
 export type VoteMutationVariables = {
-  repoFullName: string,
+  repoFullName: $ElementType<Scalars, 'String'>,
   type: VoteType
 };
 

--- a/dev-test/githunt/types.avoidOptionals.ts
+++ b/dev-test/githunt/types.avoidOptionals.ts
@@ -1,28 +1,36 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Comment = {
-  id: number,
+  id: Scalars['Int'],
   postedBy: User,
-  createdAt: number,
-  content: string,
-  repoName: string,
+  createdAt: Scalars['Float'],
+  content: Scalars['String'],
+  repoName: Scalars['String'],
 };
 
 export type Entry = {
   repository: Repository,
   postedBy: User,
-  createdAt: number,
-  score: number,
-  hotScore: number,
+  createdAt: Scalars['Float'],
+  score: Scalars['Int'],
+  hotScore: Scalars['Float'],
   comments: Array<Maybe<Comment>>,
-  commentCount: number,
-  id: number,
+  commentCount: Scalars['Int'],
+  id: Scalars['Int'],
   vote: Vote,
 };
 
 
 export type EntryCommentsArgs = {
-  limit: Maybe<number>,
-  offset: Maybe<number>
+  limit: Maybe<Scalars['Int']>,
+  offset: Maybe<Scalars['Int']>
 };
 
 export enum FeedType {
@@ -39,19 +47,19 @@ export type Mutation = {
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 export type Query = {
@@ -63,22 +71,22 @@ export type Query = {
 
 export type QueryFeedArgs = {
   type: FeedType,
-  offset: Maybe<number>,
-  limit: Maybe<number>
+  offset: Maybe<Scalars['Int']>,
+  limit: Maybe<Scalars['Int']>
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type Repository = {
-  name: string,
-  full_name: string,
-  description: Maybe<string>,
-  html_url: string,
-  stargazers_count: number,
-  open_issues_count: Maybe<number>,
+  name: Scalars['String'],
+  full_name: Scalars['String'],
+  description: Maybe<Scalars['String']>,
+  html_url: Scalars['String'],
+  stargazers_count: Scalars['Int'],
+  open_issues_count: Maybe<Scalars['Int']>,
   owner: Maybe<User>,
 };
 
@@ -88,17 +96,17 @@ export type Subscription = {
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type User = {
-  login: string,
-  avatar_url: string,
-  html_url: string,
+  login: Scalars['String'],
+  avatar_url: Scalars['String'],
+  html_url: Scalars['String'],
 };
 
 export type Vote = {
-  vote_value: number,
+  vote_value: Scalars['Int'],
 };
 
 export enum VoteType {
@@ -107,16 +115,16 @@ export enum VoteType {
   Cancel = 'CANCEL'
 }
 export type OnCommentAddedSubscriptionVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
 
 export type CommentQueryVariables = {
-  repoFullName: string,
-  limit: Maybe<number>,
-  offset: Maybe<number>
+  repoFullName: Scalars['String'],
+  limit: Maybe<Scalars['Int']>,
+  offset: Maybe<Scalars['Int']>
 };
 
 
@@ -133,15 +141,15 @@ export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | '
 
 export type FeedQueryVariables = {
   type: FeedType,
-  offset: Maybe<number>,
-  limit: Maybe<number>
+  offset: Maybe<Scalars['Int']>,
+  limit: Maybe<Scalars['Int']>
 };
 
 
 export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
 
 export type SubmitRepositoryMutationVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
@@ -150,8 +158,8 @@ export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRe
 export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
 
 export type SubmitCommentMutationVariables = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 
@@ -160,7 +168,7 @@ export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComme
 export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
 
 export type VoteMutationVariables = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 

--- a/dev-test/githunt/types.d.ts
+++ b/dev-test/githunt/types.d.ts
@@ -1,28 +1,36 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Comment = {
-  id: number,
+  id: Scalars['Int'],
   postedBy: User,
-  createdAt: number,
-  content: string,
-  repoName: string,
+  createdAt: Scalars['Float'],
+  content: Scalars['String'],
+  repoName: Scalars['String'],
 };
 
 export type Entry = {
   repository: Repository,
   postedBy: User,
-  createdAt: number,
-  score: number,
-  hotScore: number,
+  createdAt: Scalars['Float'],
+  score: Scalars['Int'],
+  hotScore: Scalars['Float'],
   comments: Array<Maybe<Comment>>,
-  commentCount: number,
-  id: number,
+  commentCount: Scalars['Int'],
+  id: Scalars['Int'],
   vote: Vote,
 };
 
 
 export type EntryCommentsArgs = {
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 export type FeedType = 'HOT' | 'NEW' | 'TOP';
@@ -35,19 +43,19 @@ export type Mutation = {
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 export type Query = {
@@ -59,22 +67,22 @@ export type Query = {
 
 export type QueryFeedArgs = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type Repository = {
-  name: string,
-  full_name: string,
-  description?: Maybe<string>,
-  html_url: string,
-  stargazers_count: number,
-  open_issues_count?: Maybe<number>,
+  name: Scalars['String'],
+  full_name: Scalars['String'],
+  description?: Maybe<Scalars['String']>,
+  html_url: Scalars['String'],
+  stargazers_count: Scalars['Int'],
+  open_issues_count?: Maybe<Scalars['Int']>,
   owner?: Maybe<User>,
 };
 
@@ -84,31 +92,31 @@ export type Subscription = {
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type User = {
-  login: string,
-  avatar_url: string,
-  html_url: string,
+  login: Scalars['String'],
+  avatar_url: Scalars['String'],
+  html_url: Scalars['String'],
 };
 
 export type Vote = {
-  vote_value: number,
+  vote_value: Scalars['Int'],
 };
 
 export type VoteType = 'UP' | 'DOWN' | 'CANCEL';
 export type OnCommentAddedSubscriptionVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
 
 export type CommentQueryVariables = {
-  repoFullName: string,
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  repoFullName: Scalars['String'],
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 
@@ -125,15 +133,15 @@ export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | '
 
 export type FeedQueryVariables = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
 
 export type SubmitRepositoryMutationVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
@@ -142,8 +150,8 @@ export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRe
 export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
 
 export type SubmitCommentMutationVariables = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 
@@ -152,7 +160,7 @@ export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComme
 export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
 
 export type VoteMutationVariables = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 

--- a/dev-test/githunt/types.enumsAsTypes.ts
+++ b/dev-test/githunt/types.enumsAsTypes.ts
@@ -1,28 +1,36 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Comment = {
-  id: number,
+  id: Scalars['Int'],
   postedBy: User,
-  createdAt: number,
-  content: string,
-  repoName: string,
+  createdAt: Scalars['Float'],
+  content: Scalars['String'],
+  repoName: Scalars['String'],
 };
 
 export type Entry = {
   repository: Repository,
   postedBy: User,
-  createdAt: number,
-  score: number,
-  hotScore: number,
+  createdAt: Scalars['Float'],
+  score: Scalars['Int'],
+  hotScore: Scalars['Float'],
   comments: Array<Maybe<Comment>>,
-  commentCount: number,
-  id: number,
+  commentCount: Scalars['Int'],
+  id: Scalars['Int'],
   vote: Vote,
 };
 
 
 export type EntryCommentsArgs = {
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 export type FeedType = 'HOT' | 'NEW' | 'TOP';
@@ -35,19 +43,19 @@ export type Mutation = {
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 export type Query = {
@@ -59,22 +67,22 @@ export type Query = {
 
 export type QueryFeedArgs = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type Repository = {
-  name: string,
-  full_name: string,
-  description?: Maybe<string>,
-  html_url: string,
-  stargazers_count: number,
-  open_issues_count?: Maybe<number>,
+  name: Scalars['String'],
+  full_name: Scalars['String'],
+  description?: Maybe<Scalars['String']>,
+  html_url: Scalars['String'],
+  stargazers_count: Scalars['Int'],
+  open_issues_count?: Maybe<Scalars['Int']>,
   owner?: Maybe<User>,
 };
 
@@ -84,31 +92,31 @@ export type Subscription = {
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type User = {
-  login: string,
-  avatar_url: string,
-  html_url: string,
+  login: Scalars['String'],
+  avatar_url: Scalars['String'],
+  html_url: Scalars['String'],
 };
 
 export type Vote = {
-  vote_value: number,
+  vote_value: Scalars['Int'],
 };
 
 export type VoteType = 'UP' | 'DOWN' | 'CANCEL';
 export type OnCommentAddedSubscriptionVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
 
 export type CommentQueryVariables = {
-  repoFullName: string,
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  repoFullName: Scalars['String'],
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 
@@ -125,15 +133,15 @@ export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | '
 
 export type FeedQueryVariables = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
 
 export type SubmitRepositoryMutationVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
@@ -142,8 +150,8 @@ export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRe
 export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
 
 export type SubmitCommentMutationVariables = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 
@@ -152,7 +160,7 @@ export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComme
 export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
 
 export type VoteMutationVariables = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 

--- a/dev-test/githunt/types.immutableTypes.ts
+++ b/dev-test/githunt/types.immutableTypes.ts
@@ -1,28 +1,36 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Comment = {
-  readonly id: number,
+  readonly id: Scalars['Int'],
   readonly postedBy: User,
-  readonly createdAt: number,
-  readonly content: string,
-  readonly repoName: string,
+  readonly createdAt: Scalars['Float'],
+  readonly content: Scalars['String'],
+  readonly repoName: Scalars['String'],
 };
 
 export type Entry = {
   readonly repository: Repository,
   readonly postedBy: User,
-  readonly createdAt: number,
-  readonly score: number,
-  readonly hotScore: number,
+  readonly createdAt: Scalars['Float'],
+  readonly score: Scalars['Int'],
+  readonly hotScore: Scalars['Float'],
   readonly comments: ReadonlyArray<Maybe<Comment>>,
-  readonly commentCount: number,
-  readonly id: number,
+  readonly commentCount: Scalars['Int'],
+  readonly id: Scalars['Int'],
   readonly vote: Vote,
 };
 
 
 export type EntryCommentsArgs = {
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 export enum FeedType {
@@ -39,19 +47,19 @@ export type Mutation = {
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 export type Query = {
@@ -63,22 +71,22 @@ export type Query = {
 
 export type QueryFeedArgs = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type Repository = {
-  readonly name: string,
-  readonly full_name: string,
-  readonly description?: Maybe<string>,
-  readonly html_url: string,
-  readonly stargazers_count: number,
-  readonly open_issues_count?: Maybe<number>,
+  readonly name: Scalars['String'],
+  readonly full_name: Scalars['String'],
+  readonly description?: Maybe<Scalars['String']>,
+  readonly html_url: Scalars['String'],
+  readonly stargazers_count: Scalars['Int'],
+  readonly open_issues_count?: Maybe<Scalars['Int']>,
   readonly owner?: Maybe<User>,
 };
 
@@ -88,17 +96,17 @@ export type Subscription = {
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type User = {
-  readonly login: string,
-  readonly avatar_url: string,
-  readonly html_url: string,
+  readonly login: Scalars['String'],
+  readonly avatar_url: Scalars['String'],
+  readonly html_url: Scalars['String'],
 };
 
 export type Vote = {
-  readonly vote_value: number,
+  readonly vote_value: Scalars['Int'],
 };
 
 export enum VoteType {
@@ -107,16 +115,16 @@ export enum VoteType {
   Cancel = 'CANCEL'
 }
 export type OnCommentAddedSubscriptionVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type OnCommentAddedSubscription = ({ readonly __typename?: 'Subscription' } & { readonly commentAdded: Maybe<({ readonly __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { readonly postedBy: ({ readonly __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
 
 export type CommentQueryVariables = {
-  repoFullName: string,
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  repoFullName: Scalars['String'],
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 
@@ -133,15 +141,15 @@ export type FeedEntryFragment = ({ readonly __typename?: 'Entry' } & Pick<Entry,
 
 export type FeedQueryVariables = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type FeedQuery = ({ readonly __typename?: 'Query' } & { readonly currentUser: Maybe<({ readonly __typename?: 'User' } & Pick<User, 'login'>)>, readonly feed: Maybe<ReadonlyArray<Maybe<({ readonly __typename?: 'Entry' } & FeedEntryFragment)>>> });
 
 export type SubmitRepositoryMutationVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
@@ -150,8 +158,8 @@ export type SubmitRepositoryMutation = ({ readonly __typename?: 'Mutation' } & {
 export type RepoInfoFragment = ({ readonly __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { readonly repository: ({ readonly __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), readonly postedBy: ({ readonly __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
 
 export type SubmitCommentMutationVariables = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 
@@ -160,7 +168,7 @@ export type SubmitCommentMutation = ({ readonly __typename?: 'Mutation' } & { re
 export type VoteButtonsFragment = ({ readonly __typename?: 'Entry' } & Pick<Entry, 'score'> & { readonly vote: ({ readonly __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
 
 export type VoteMutationVariables = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -1,29 +1,37 @@
 // tslint:disable
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Comment = {
-  id: number,
+  id: Scalars['Int'],
   postedBy: User,
-  createdAt: number,
-  content: string,
-  repoName: string,
+  createdAt: Scalars['Float'],
+  content: Scalars['String'],
+  repoName: Scalars['String'],
 };
 
 export type Entry = {
   repository: Repository,
   postedBy: User,
-  createdAt: number,
-  score: number,
-  hotScore: number,
+  createdAt: Scalars['Float'],
+  score: Scalars['Int'],
+  hotScore: Scalars['Float'],
   comments: Array<Maybe<Comment>>,
-  commentCount: number,
-  id: number,
+  commentCount: Scalars['Int'],
+  id: Scalars['Int'],
   vote: Vote,
 };
 
 
 export type EntryCommentsArgs = {
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 export enum FeedType {
@@ -40,19 +48,19 @@ export type Mutation = {
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 export type Query = {
@@ -64,22 +72,22 @@ export type Query = {
 
 export type QueryFeedArgs = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type Repository = {
-  name: string,
-  full_name: string,
-  description?: Maybe<string>,
-  html_url: string,
-  stargazers_count: number,
-  open_issues_count?: Maybe<number>,
+  name: Scalars['String'],
+  full_name: Scalars['String'],
+  description?: Maybe<Scalars['String']>,
+  html_url: Scalars['String'],
+  stargazers_count: Scalars['Int'],
+  open_issues_count?: Maybe<Scalars['Int']>,
   owner?: Maybe<User>,
 };
 
@@ -89,17 +97,17 @@ export type Subscription = {
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type User = {
-  login: string,
-  avatar_url: string,
-  html_url: string,
+  login: Scalars['String'],
+  avatar_url: Scalars['String'],
+  html_url: Scalars['String'],
 };
 
 export type Vote = {
-  vote_value: number,
+  vote_value: Scalars['Int'],
 };
 
 export enum VoteType {
@@ -108,16 +116,16 @@ export enum VoteType {
   Cancel = 'CANCEL'
 }
 export type OnCommentAddedSubscriptionVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
 
 export type CommentQueryVariables = {
-  repoFullName: string,
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  repoFullName: Scalars['String'],
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 
@@ -134,15 +142,15 @@ export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | '
 
 export type FeedQueryVariables = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
 
 export type SubmitRepositoryMutationVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
@@ -151,8 +159,8 @@ export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRe
 export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
 
 export type SubmitCommentMutationVariables = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 
@@ -161,7 +169,7 @@ export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComme
 export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
 
 export type VoteMutationVariables = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -1,29 +1,37 @@
 // tslint:disable
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Comment = {
-  id: number,
+  id: Scalars['Int'],
   postedBy: User,
-  createdAt: number,
-  content: string,
-  repoName: string,
+  createdAt: Scalars['Float'],
+  content: Scalars['String'],
+  repoName: Scalars['String'],
 };
 
 export type Entry = {
   repository: Repository,
   postedBy: User,
-  createdAt: number,
-  score: number,
-  hotScore: number,
+  createdAt: Scalars['Float'],
+  score: Scalars['Int'],
+  hotScore: Scalars['Float'],
   comments: Array<Maybe<Comment>>,
-  commentCount: number,
-  id: number,
+  commentCount: Scalars['Int'],
+  id: Scalars['Int'],
   vote: Vote,
 };
 
 
 export type EntryCommentsArgs = {
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 export enum FeedType {
@@ -40,19 +48,19 @@ export type Mutation = {
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 export type Query = {
@@ -64,22 +72,22 @@ export type Query = {
 
 export type QueryFeedArgs = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type Repository = {
-  name: string,
-  full_name: string,
-  description?: Maybe<string>,
-  html_url: string,
-  stargazers_count: number,
-  open_issues_count?: Maybe<number>,
+  name: Scalars['String'],
+  full_name: Scalars['String'],
+  description?: Maybe<Scalars['String']>,
+  html_url: Scalars['String'],
+  stargazers_count: Scalars['Int'],
+  open_issues_count?: Maybe<Scalars['Int']>,
   owner?: Maybe<User>,
 };
 
@@ -89,17 +97,17 @@ export type Subscription = {
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type User = {
-  login: string,
-  avatar_url: string,
-  html_url: string,
+  login: Scalars['String'],
+  avatar_url: Scalars['String'],
+  html_url: Scalars['String'],
 };
 
 export type Vote = {
-  vote_value: number,
+  vote_value: Scalars['Int'],
 };
 
 export enum VoteType {
@@ -108,16 +116,16 @@ export enum VoteType {
   Cancel = 'CANCEL'
 }
 export type OnCommentAddedSubscriptionVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
 
 export type CommentQueryVariables = {
-  repoFullName: string,
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  repoFullName: Scalars['String'],
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 
@@ -134,15 +142,15 @@ export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | '
 
 export type FeedQueryVariables = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
 
 export type SubmitRepositoryMutationVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
@@ -151,8 +159,8 @@ export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRe
 export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
 
 export type SubmitCommentMutationVariables = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 
@@ -161,7 +169,7 @@ export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComme
 export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
 
 export type VoteMutationVariables = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 

--- a/dev-test/githunt/types.stencilApollo.class.tsx
+++ b/dev-test/githunt/types.stencilApollo.class.tsx
@@ -1,29 +1,37 @@
 // tslint:disable
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Comment = {
-  id: number,
+  id: Scalars['Int'],
   postedBy: User,
-  createdAt: number,
-  content: string,
-  repoName: string,
+  createdAt: Scalars['Float'],
+  content: Scalars['String'],
+  repoName: Scalars['String'],
 };
 
 export type Entry = {
   repository: Repository,
   postedBy: User,
-  createdAt: number,
-  score: number,
-  hotScore: number,
+  createdAt: Scalars['Float'],
+  score: Scalars['Int'],
+  hotScore: Scalars['Float'],
   comments: Array<Maybe<Comment>>,
-  commentCount: number,
-  id: number,
+  commentCount: Scalars['Int'],
+  id: Scalars['Int'],
   vote: Vote,
 };
 
 
 export type EntryCommentsArgs = {
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 export enum FeedType {
@@ -40,19 +48,19 @@ export type Mutation = {
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 export type Query = {
@@ -64,22 +72,22 @@ export type Query = {
 
 export type QueryFeedArgs = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type Repository = {
-  name: string,
-  full_name: string,
-  description?: Maybe<string>,
-  html_url: string,
-  stargazers_count: number,
-  open_issues_count?: Maybe<number>,
+  name: Scalars['String'],
+  full_name: Scalars['String'],
+  description?: Maybe<Scalars['String']>,
+  html_url: Scalars['String'],
+  stargazers_count: Scalars['Int'],
+  open_issues_count?: Maybe<Scalars['Int']>,
   owner?: Maybe<User>,
 };
 
@@ -89,17 +97,17 @@ export type Subscription = {
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type User = {
-  login: string,
-  avatar_url: string,
-  html_url: string,
+  login: Scalars['String'],
+  avatar_url: Scalars['String'],
+  html_url: Scalars['String'],
 };
 
 export type Vote = {
-  vote_value: number,
+  vote_value: Scalars['Int'],
 };
 
 export enum VoteType {
@@ -108,16 +116,16 @@ export enum VoteType {
   Cancel = 'CANCEL'
 }
 export type OnCommentAddedSubscriptionVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
 
 export type CommentQueryVariables = {
-  repoFullName: string,
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  repoFullName: Scalars['String'],
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 
@@ -134,15 +142,15 @@ export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | '
 
 export type FeedQueryVariables = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
 
 export type SubmitRepositoryMutationVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
@@ -151,8 +159,8 @@ export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRe
 export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
 
 export type SubmitCommentMutationVariables = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 
@@ -161,7 +169,7 @@ export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComme
 export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
 
 export type VoteMutationVariables = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 

--- a/dev-test/githunt/types.stencilApollo.tsx
+++ b/dev-test/githunt/types.stencilApollo.tsx
@@ -1,29 +1,37 @@
 // tslint:disable
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Comment = {
-  id: number,
+  id: Scalars['Int'],
   postedBy: User,
-  createdAt: number,
-  content: string,
-  repoName: string,
+  createdAt: Scalars['Float'],
+  content: Scalars['String'],
+  repoName: Scalars['String'],
 };
 
 export type Entry = {
   repository: Repository,
   postedBy: User,
-  createdAt: number,
-  score: number,
-  hotScore: number,
+  createdAt: Scalars['Float'],
+  score: Scalars['Int'],
+  hotScore: Scalars['Float'],
   comments: Array<Maybe<Comment>>,
-  commentCount: number,
-  id: number,
+  commentCount: Scalars['Int'],
+  id: Scalars['Int'],
   vote: Vote,
 };
 
 
 export type EntryCommentsArgs = {
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 export enum FeedType {
@@ -40,19 +48,19 @@ export type Mutation = {
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 export type Query = {
@@ -64,22 +72,22 @@ export type Query = {
 
 export type QueryFeedArgs = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type Repository = {
-  name: string,
-  full_name: string,
-  description?: Maybe<string>,
-  html_url: string,
-  stargazers_count: number,
-  open_issues_count?: Maybe<number>,
+  name: Scalars['String'],
+  full_name: Scalars['String'],
+  description?: Maybe<Scalars['String']>,
+  html_url: Scalars['String'],
+  stargazers_count: Scalars['Int'],
+  open_issues_count?: Maybe<Scalars['Int']>,
   owner?: Maybe<User>,
 };
 
@@ -89,17 +97,17 @@ export type Subscription = {
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type User = {
-  login: string,
-  avatar_url: string,
-  html_url: string,
+  login: Scalars['String'],
+  avatar_url: Scalars['String'],
+  html_url: Scalars['String'],
 };
 
 export type Vote = {
-  vote_value: number,
+  vote_value: Scalars['Int'],
 };
 
 export enum VoteType {
@@ -108,16 +116,16 @@ export enum VoteType {
   Cancel = 'CANCEL'
 }
 export type OnCommentAddedSubscriptionVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
 
 export type CommentQueryVariables = {
-  repoFullName: string,
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  repoFullName: Scalars['String'],
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 
@@ -134,15 +142,15 @@ export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | '
 
 export type FeedQueryVariables = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
 
 export type SubmitRepositoryMutationVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
@@ -151,8 +159,8 @@ export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRe
 export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
 
 export type SubmitCommentMutationVariables = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 
@@ -161,7 +169,7 @@ export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComme
 export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
 
 export type VoteMutationVariables = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 

--- a/dev-test/githunt/types.ts
+++ b/dev-test/githunt/types.ts
@@ -1,28 +1,36 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Comment = {
-  id: number,
+  id: Scalars['Int'],
   postedBy: User,
-  createdAt: number,
-  content: string,
-  repoName: string,
+  createdAt: Scalars['Float'],
+  content: Scalars['String'],
+  repoName: Scalars['String'],
 };
 
 export type Entry = {
   repository: Repository,
   postedBy: User,
-  createdAt: number,
-  score: number,
-  hotScore: number,
+  createdAt: Scalars['Float'],
+  score: Scalars['Int'],
+  hotScore: Scalars['Float'],
   comments: Array<Maybe<Comment>>,
-  commentCount: number,
-  id: number,
+  commentCount: Scalars['Int'],
+  id: Scalars['Int'],
   vote: Vote,
 };
 
 
 export type EntryCommentsArgs = {
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 export enum FeedType {
@@ -39,19 +47,19 @@ export type Mutation = {
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 export type Query = {
@@ -63,22 +71,22 @@ export type Query = {
 
 export type QueryFeedArgs = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type Repository = {
-  name: string,
-  full_name: string,
-  description?: Maybe<string>,
-  html_url: string,
-  stargazers_count: number,
-  open_issues_count?: Maybe<number>,
+  name: Scalars['String'],
+  full_name: Scalars['String'],
+  description?: Maybe<Scalars['String']>,
+  html_url: Scalars['String'],
+  stargazers_count: Scalars['Int'],
+  open_issues_count?: Maybe<Scalars['Int']>,
   owner?: Maybe<User>,
 };
 
@@ -88,17 +96,17 @@ export type Subscription = {
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 export type User = {
-  login: string,
-  avatar_url: string,
-  html_url: string,
+  login: Scalars['String'],
+  avatar_url: Scalars['String'],
+  html_url: Scalars['String'],
 };
 
 export type Vote = {
-  vote_value: number,
+  vote_value: Scalars['Int'],
 };
 
 export enum VoteType {
@@ -107,16 +115,16 @@ export enum VoteType {
   Cancel = 'CANCEL'
 }
 export type OnCommentAddedSubscriptionVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
 export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
 
 export type CommentQueryVariables = {
-  repoFullName: string,
-  limit?: Maybe<number>,
-  offset?: Maybe<number>
+  repoFullName: Scalars['String'],
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
 };
 
 
@@ -133,15 +141,15 @@ export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | '
 
 export type FeedQueryVariables = {
   type: FeedType,
-  offset?: Maybe<number>,
-  limit?: Maybe<number>
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
 };
 
 
 export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
 
 export type SubmitRepositoryMutationVariables = {
-  repoFullName: string
+  repoFullName: Scalars['String']
 };
 
 
@@ -150,8 +158,8 @@ export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRe
 export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
 
 export type SubmitCommentMutationVariables = {
-  repoFullName: string,
-  commentContent: string
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
 };
 
 
@@ -160,7 +168,7 @@ export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComme
 export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
 
 export type VoteMutationVariables = {
-  repoFullName: string,
+  repoFullName: Scalars['String'],
   type: VoteType
 };
 

--- a/dev-test/star-wars/types.avoidOptionals.ts
+++ b/dev-test/star-wars/types.avoidOptionals.ts
@@ -1,31 +1,39 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Character = {
-  id: string,
-  name: string,
+  id: Scalars['ID'],
+  name: Scalars['String'],
   friends: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
 };
 
 export type ColorInput = {
-  red: number,
-  green: number,
-  blue: number,
+  red: Scalars['Int'],
+  green: Scalars['Int'],
+  blue: Scalars['Int'],
 };
 
 export type Droid = Character & {
-  id: string,
-  name: string,
+  id: Scalars['ID'],
+  name: Scalars['String'],
   friends: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
-  primaryFunction: Maybe<string>,
+  primaryFunction: Maybe<Scalars['String']>,
 };
 
 
 export type DroidFriendsConnectionArgs = {
-  first: Maybe<number>,
-  after: Maybe<string>
+  first: Maybe<Scalars['Int']>,
+  after: Maybe<Scalars['ID']>
 };
 
 export enum Episode {
@@ -35,23 +43,23 @@ export enum Episode {
 }
 
 export type FriendsConnection = {
-  totalCount: Maybe<number>,
+  totalCount: Maybe<Scalars['Int']>,
   edges: Maybe<Array<Maybe<FriendsEdge>>>,
   friends: Maybe<Array<Maybe<Character>>>,
   pageInfo: PageInfo,
 };
 
 export type FriendsEdge = {
-  cursor: string,
+  cursor: Scalars['ID'],
   node: Maybe<Character>,
 };
 
 export type Human = Character & {
-  id: string,
-  name: string,
-  homePlanet: Maybe<string>,
-  height: Maybe<number>,
-  mass: Maybe<number>,
+  id: Scalars['ID'],
+  name: Scalars['String'],
+  homePlanet: Maybe<Scalars['String']>,
+  height: Maybe<Scalars['Float']>,
+  mass: Maybe<Scalars['Float']>,
   friends: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
@@ -65,8 +73,8 @@ export type HumanHeightArgs = {
 
 
 export type HumanFriendsConnectionArgs = {
-  first: Maybe<number>,
-  after: Maybe<string>
+  first: Maybe<Scalars['Int']>,
+  after: Maybe<Scalars['ID']>
 };
 
 export enum LengthUnit {
@@ -85,9 +93,9 @@ export type MutationCreateReviewArgs = {
 };
 
 export type PageInfo = {
-  startCursor: Maybe<string>,
-  endCursor: Maybe<string>,
-  hasNextPage: boolean,
+  startCursor: Maybe<Scalars['ID']>,
+  endCursor: Maybe<Scalars['ID']>,
+  hasNextPage: Scalars['Boolean'],
 };
 
 export type Query = {
@@ -112,46 +120,46 @@ export type QueryReviewsArgs = {
 
 
 export type QuerySearchArgs = {
-  text: Maybe<string>
+  text: Maybe<Scalars['String']>
 };
 
 
 export type QueryCharacterArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryDroidArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryHumanArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryStarshipArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 export type Review = {
-  stars: number,
-  commentary: Maybe<string>,
+  stars: Scalars['Int'],
+  commentary: Maybe<Scalars['String']>,
 };
 
 export type ReviewInput = {
-  stars: number,
-  commentary: Maybe<string>,
+  stars: Scalars['Int'],
+  commentary: Maybe<Scalars['String']>,
   favoriteColor: Maybe<ColorInput>,
 };
 
 export type SearchResult = Human | Droid | Starship;
 
 export type Starship = {
-  id: string,
-  name: string,
-  length: Maybe<number>,
+  id: Scalars['ID'],
+  name: Scalars['String'],
+  length: Maybe<Scalars['Float']>,
 };
 
 
@@ -203,7 +211,7 @@ export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Chara
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode: Maybe<Episode>,
-  includeName: boolean
+  includeName: Scalars['Boolean']
 };
 
 
@@ -211,7 +219,7 @@ export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { he
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode: Maybe<Episode>,
-  skipName: boolean
+  skipName: Scalars['Boolean']
 };
 
 

--- a/dev-test/star-wars/types.d.ts
+++ b/dev-test/star-wars/types.d.ts
@@ -1,53 +1,61 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Character = {
-  id: string,
-  name: string,
+  id: Scalars['ID'],
+  name: Scalars['String'],
   friends?: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
 };
 
 export type ColorInput = {
-  red: number,
-  green: number,
-  blue: number,
+  red: Scalars['Int'],
+  green: Scalars['Int'],
+  blue: Scalars['Int'],
 };
 
 export type Droid = Character & {
-  id: string,
-  name: string,
+  id: Scalars['ID'],
+  name: Scalars['String'],
   friends?: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
-  primaryFunction?: Maybe<string>,
+  primaryFunction?: Maybe<Scalars['String']>,
 };
 
 
 export type DroidFriendsConnectionArgs = {
-  first?: Maybe<number>,
-  after?: Maybe<string>
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['ID']>
 };
 
 export type Episode = 'NEWHOPE' | 'EMPIRE' | 'JEDI';
 
 export type FriendsConnection = {
-  totalCount?: Maybe<number>,
+  totalCount?: Maybe<Scalars['Int']>,
   edges?: Maybe<Array<Maybe<FriendsEdge>>>,
   friends?: Maybe<Array<Maybe<Character>>>,
   pageInfo: PageInfo,
 };
 
 export type FriendsEdge = {
-  cursor: string,
+  cursor: Scalars['ID'],
   node?: Maybe<Character>,
 };
 
 export type Human = Character & {
-  id: string,
-  name: string,
-  homePlanet?: Maybe<string>,
-  height?: Maybe<number>,
-  mass?: Maybe<number>,
+  id: Scalars['ID'],
+  name: Scalars['String'],
+  homePlanet?: Maybe<Scalars['String']>,
+  height?: Maybe<Scalars['Float']>,
+  mass?: Maybe<Scalars['Float']>,
   friends?: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
@@ -61,8 +69,8 @@ export type HumanHeightArgs = {
 
 
 export type HumanFriendsConnectionArgs = {
-  first?: Maybe<number>,
-  after?: Maybe<string>
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['ID']>
 };
 
 export type LengthUnit = 'METER' | 'FOOT';
@@ -78,9 +86,9 @@ export type MutationCreateReviewArgs = {
 };
 
 export type PageInfo = {
-  startCursor?: Maybe<string>,
-  endCursor?: Maybe<string>,
-  hasNextPage: boolean,
+  startCursor?: Maybe<Scalars['ID']>,
+  endCursor?: Maybe<Scalars['ID']>,
+  hasNextPage: Scalars['Boolean'],
 };
 
 export type Query = {
@@ -105,46 +113,46 @@ export type QueryReviewsArgs = {
 
 
 export type QuerySearchArgs = {
-  text?: Maybe<string>
+  text?: Maybe<Scalars['String']>
 };
 
 
 export type QueryCharacterArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryDroidArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryHumanArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryStarshipArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 export type Review = {
-  stars: number,
-  commentary?: Maybe<string>,
+  stars: Scalars['Int'],
+  commentary?: Maybe<Scalars['String']>,
 };
 
 export type ReviewInput = {
-  stars: number,
-  commentary: Maybe<string>,
-  favoriteColor: Maybe<ColorInput>,
+  stars: Scalars['Int'],
+  commentary?: Maybe<Scalars['String']>,
+  favoriteColor?: Maybe<ColorInput>,
 };
 
 export type SearchResult = Human | Droid | Starship;
 
 export type Starship = {
-  id: string,
-  name: string,
-  length?: Maybe<number>,
+  id: Scalars['ID'],
+  name: Scalars['String'],
+  length?: Maybe<Scalars['Float']>,
 };
 
 
@@ -196,7 +204,7 @@ export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Chara
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
-  includeName: boolean
+  includeName: Scalars['Boolean']
 };
 
 
@@ -204,7 +212,7 @@ export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { he
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
-  skipName: boolean
+  skipName: Scalars['Boolean']
 };
 
 

--- a/dev-test/star-wars/types.immutableTypes.ts
+++ b/dev-test/star-wars/types.immutableTypes.ts
@@ -1,31 +1,39 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Character = {
-  readonly id: string,
-  readonly name: string,
+  readonly id: Scalars['ID'],
+  readonly name: Scalars['String'],
   readonly friends?: Maybe<ReadonlyArray<Maybe<Character>>>,
   readonly friendsConnection: FriendsConnection,
   readonly appearsIn: ReadonlyArray<Maybe<Episode>>,
 };
 
 export type ColorInput = {
-  red: number,
-  green: number,
-  blue: number,
+  red: Scalars['Int'],
+  green: Scalars['Int'],
+  blue: Scalars['Int'],
 };
 
 export type Droid = Character & {
-  readonly id: string,
-  readonly name: string,
+  readonly id: Scalars['ID'],
+  readonly name: Scalars['String'],
   readonly friends?: Maybe<ReadonlyArray<Maybe<Character>>>,
   readonly friendsConnection: FriendsConnection,
   readonly appearsIn: ReadonlyArray<Maybe<Episode>>,
-  readonly primaryFunction?: Maybe<string>,
+  readonly primaryFunction?: Maybe<Scalars['String']>,
 };
 
 
 export type DroidFriendsConnectionArgs = {
-  first?: Maybe<number>,
-  after?: Maybe<string>
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['ID']>
 };
 
 export enum Episode {
@@ -35,23 +43,23 @@ export enum Episode {
 }
 
 export type FriendsConnection = {
-  readonly totalCount?: Maybe<number>,
+  readonly totalCount?: Maybe<Scalars['Int']>,
   readonly edges?: Maybe<ReadonlyArray<Maybe<FriendsEdge>>>,
   readonly friends?: Maybe<ReadonlyArray<Maybe<Character>>>,
   readonly pageInfo: PageInfo,
 };
 
 export type FriendsEdge = {
-  readonly cursor: string,
+  readonly cursor: Scalars['ID'],
   readonly node?: Maybe<Character>,
 };
 
 export type Human = Character & {
-  readonly id: string,
-  readonly name: string,
-  readonly homePlanet?: Maybe<string>,
-  readonly height?: Maybe<number>,
-  readonly mass?: Maybe<number>,
+  readonly id: Scalars['ID'],
+  readonly name: Scalars['String'],
+  readonly homePlanet?: Maybe<Scalars['String']>,
+  readonly height?: Maybe<Scalars['Float']>,
+  readonly mass?: Maybe<Scalars['Float']>,
   readonly friends?: Maybe<ReadonlyArray<Maybe<Character>>>,
   readonly friendsConnection: FriendsConnection,
   readonly appearsIn: ReadonlyArray<Maybe<Episode>>,
@@ -65,8 +73,8 @@ export type HumanHeightArgs = {
 
 
 export type HumanFriendsConnectionArgs = {
-  first?: Maybe<number>,
-  after?: Maybe<string>
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['ID']>
 };
 
 export enum LengthUnit {
@@ -85,9 +93,9 @@ export type MutationCreateReviewArgs = {
 };
 
 export type PageInfo = {
-  readonly startCursor?: Maybe<string>,
-  readonly endCursor?: Maybe<string>,
-  readonly hasNextPage: boolean,
+  readonly startCursor?: Maybe<Scalars['ID']>,
+  readonly endCursor?: Maybe<Scalars['ID']>,
+  readonly hasNextPage: Scalars['Boolean'],
 };
 
 export type Query = {
@@ -112,46 +120,46 @@ export type QueryReviewsArgs = {
 
 
 export type QuerySearchArgs = {
-  text?: Maybe<string>
+  text?: Maybe<Scalars['String']>
 };
 
 
 export type QueryCharacterArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryDroidArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryHumanArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryStarshipArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 export type Review = {
-  readonly stars: number,
-  readonly commentary?: Maybe<string>,
+  readonly stars: Scalars['Int'],
+  readonly commentary?: Maybe<Scalars['String']>,
 };
 
 export type ReviewInput = {
-  stars: number,
-  commentary: Maybe<string>,
-  favoriteColor: Maybe<ColorInput>,
+  stars: Scalars['Int'],
+  commentary?: Maybe<Scalars['String']>,
+  favoriteColor?: Maybe<ColorInput>,
 };
 
 export type SearchResult = Human | Droid | Starship;
 
 export type Starship = {
-  readonly id: string,
-  readonly name: string,
-  readonly length?: Maybe<number>,
+  readonly id: Scalars['ID'],
+  readonly name: Scalars['String'],
+  readonly length?: Maybe<Scalars['Float']>,
 };
 
 
@@ -203,7 +211,7 @@ export type HeroNameQuery = ({ readonly __typename?: 'Query' } & { readonly hero
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
-  includeName: boolean
+  includeName: Scalars['Boolean']
 };
 
 
@@ -211,7 +219,7 @@ export type HeroNameConditionalInclusionQuery = ({ readonly __typename?: 'Query'
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
-  skipName: boolean
+  skipName: Scalars['Boolean']
 };
 
 

--- a/dev-test/star-wars/types.skipSchema.ts
+++ b/dev-test/star-wars/types.skipSchema.ts
@@ -1,31 +1,39 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Character = {
-  id: string,
-  name: string,
+  id: Scalars['ID'],
+  name: Scalars['String'],
   friends?: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
 };
 
 export type ColorInput = {
-  red: number,
-  green: number,
-  blue: number,
+  red: Scalars['Int'],
+  green: Scalars['Int'],
+  blue: Scalars['Int'],
 };
 
 export type Droid = Character & {
-  id: string,
-  name: string,
+  id: Scalars['ID'],
+  name: Scalars['String'],
   friends?: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
-  primaryFunction?: Maybe<string>,
+  primaryFunction?: Maybe<Scalars['String']>,
 };
 
 
 export type DroidFriendsConnectionArgs = {
-  first?: Maybe<number>,
-  after?: Maybe<string>
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['ID']>
 };
 
 export enum Episode {
@@ -35,23 +43,23 @@ export enum Episode {
 }
 
 export type FriendsConnection = {
-  totalCount?: Maybe<number>,
+  totalCount?: Maybe<Scalars['Int']>,
   edges?: Maybe<Array<Maybe<FriendsEdge>>>,
   friends?: Maybe<Array<Maybe<Character>>>,
   pageInfo: PageInfo,
 };
 
 export type FriendsEdge = {
-  cursor: string,
+  cursor: Scalars['ID'],
   node?: Maybe<Character>,
 };
 
 export type Human = Character & {
-  id: string,
-  name: string,
-  homePlanet?: Maybe<string>,
-  height?: Maybe<number>,
-  mass?: Maybe<number>,
+  id: Scalars['ID'],
+  name: Scalars['String'],
+  homePlanet?: Maybe<Scalars['String']>,
+  height?: Maybe<Scalars['Float']>,
+  mass?: Maybe<Scalars['Float']>,
   friends?: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
@@ -65,8 +73,8 @@ export type HumanHeightArgs = {
 
 
 export type HumanFriendsConnectionArgs = {
-  first?: Maybe<number>,
-  after?: Maybe<string>
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['ID']>
 };
 
 export enum LengthUnit {
@@ -85,9 +93,9 @@ export type MutationCreateReviewArgs = {
 };
 
 export type PageInfo = {
-  startCursor?: Maybe<string>,
-  endCursor?: Maybe<string>,
-  hasNextPage: boolean,
+  startCursor?: Maybe<Scalars['ID']>,
+  endCursor?: Maybe<Scalars['ID']>,
+  hasNextPage: Scalars['Boolean'],
 };
 
 export type Query = {
@@ -112,46 +120,46 @@ export type QueryReviewsArgs = {
 
 
 export type QuerySearchArgs = {
-  text?: Maybe<string>
+  text?: Maybe<Scalars['String']>
 };
 
 
 export type QueryCharacterArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryDroidArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryHumanArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryStarshipArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 export type Review = {
-  stars: number,
-  commentary?: Maybe<string>,
+  stars: Scalars['Int'],
+  commentary?: Maybe<Scalars['String']>,
 };
 
 export type ReviewInput = {
-  stars: number,
-  commentary: Maybe<string>,
-  favoriteColor: Maybe<ColorInput>,
+  stars: Scalars['Int'],
+  commentary?: Maybe<Scalars['String']>,
+  favoriteColor?: Maybe<ColorInput>,
 };
 
 export type SearchResult = Human | Droid | Starship;
 
 export type Starship = {
-  id: string,
-  name: string,
-  length?: Maybe<number>,
+  id: Scalars['ID'],
+  name: Scalars['String'],
+  length?: Maybe<Scalars['Float']>,
 };
 
 
@@ -203,7 +211,7 @@ export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Chara
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
-  includeName: boolean
+  includeName: Scalars['Boolean']
 };
 
 
@@ -211,7 +219,7 @@ export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { he
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
-  skipName: boolean
+  skipName: Scalars['Boolean']
 };
 
 

--- a/dev-test/star-wars/types.ts
+++ b/dev-test/star-wars/types.ts
@@ -1,31 +1,39 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Character = {
-  id: string,
-  name: string,
+  id: Scalars['ID'],
+  name: Scalars['String'],
   friends?: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
 };
 
 export type ColorInput = {
-  red: number,
-  green: number,
-  blue: number,
+  red: Scalars['Int'],
+  green: Scalars['Int'],
+  blue: Scalars['Int'],
 };
 
 export type Droid = Character & {
-  id: string,
-  name: string,
+  id: Scalars['ID'],
+  name: Scalars['String'],
   friends?: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
-  primaryFunction?: Maybe<string>,
+  primaryFunction?: Maybe<Scalars['String']>,
 };
 
 
 export type DroidFriendsConnectionArgs = {
-  first?: Maybe<number>,
-  after?: Maybe<string>
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['ID']>
 };
 
 export enum Episode {
@@ -35,23 +43,23 @@ export enum Episode {
 }
 
 export type FriendsConnection = {
-  totalCount?: Maybe<number>,
+  totalCount?: Maybe<Scalars['Int']>,
   edges?: Maybe<Array<Maybe<FriendsEdge>>>,
   friends?: Maybe<Array<Maybe<Character>>>,
   pageInfo: PageInfo,
 };
 
 export type FriendsEdge = {
-  cursor: string,
+  cursor: Scalars['ID'],
   node?: Maybe<Character>,
 };
 
 export type Human = Character & {
-  id: string,
-  name: string,
-  homePlanet?: Maybe<string>,
-  height?: Maybe<number>,
-  mass?: Maybe<number>,
+  id: Scalars['ID'],
+  name: Scalars['String'],
+  homePlanet?: Maybe<Scalars['String']>,
+  height?: Maybe<Scalars['Float']>,
+  mass?: Maybe<Scalars['Float']>,
   friends?: Maybe<Array<Maybe<Character>>>,
   friendsConnection: FriendsConnection,
   appearsIn: Array<Maybe<Episode>>,
@@ -65,8 +73,8 @@ export type HumanHeightArgs = {
 
 
 export type HumanFriendsConnectionArgs = {
-  first?: Maybe<number>,
-  after?: Maybe<string>
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['ID']>
 };
 
 export enum LengthUnit {
@@ -85,9 +93,9 @@ export type MutationCreateReviewArgs = {
 };
 
 export type PageInfo = {
-  startCursor?: Maybe<string>,
-  endCursor?: Maybe<string>,
-  hasNextPage: boolean,
+  startCursor?: Maybe<Scalars['ID']>,
+  endCursor?: Maybe<Scalars['ID']>,
+  hasNextPage: Scalars['Boolean'],
 };
 
 export type Query = {
@@ -112,46 +120,46 @@ export type QueryReviewsArgs = {
 
 
 export type QuerySearchArgs = {
-  text?: Maybe<string>
+  text?: Maybe<Scalars['String']>
 };
 
 
 export type QueryCharacterArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryDroidArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryHumanArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 
 export type QueryStarshipArgs = {
-  id: string
+  id: Scalars['ID']
 };
 
 export type Review = {
-  stars: number,
-  commentary?: Maybe<string>,
+  stars: Scalars['Int'],
+  commentary?: Maybe<Scalars['String']>,
 };
 
 export type ReviewInput = {
-  stars: number,
-  commentary: Maybe<string>,
-  favoriteColor: Maybe<ColorInput>,
+  stars: Scalars['Int'],
+  commentary?: Maybe<Scalars['String']>,
+  favoriteColor?: Maybe<ColorInput>,
 };
 
 export type SearchResult = Human | Droid | Starship;
 
 export type Starship = {
-  id: string,
-  name: string,
-  length?: Maybe<number>,
+  id: Scalars['ID'],
+  name: Scalars['String'],
+  length?: Maybe<Scalars['Float']>,
 };
 
 
@@ -203,7 +211,7 @@ export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Chara
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
-  includeName: boolean
+  includeName: Scalars['Boolean']
 };
 
 
@@ -211,7 +219,7 @@ export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { he
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
-  skipName: boolean
+  skipName: Scalars['Boolean']
 };
 
 

--- a/dev-test/test-schema/flow-types.flow.js
+++ b/dev-test/test-schema/flow-types.flow.js
@@ -1,5 +1,14 @@
 /* @flow */
 
+
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Query = {
   allUsers: Array<?User>,
   userById?: ?User,
@@ -7,16 +16,18 @@ export type Query = {
 
 
 export type QueryUserByIdArgs = {
-  id: number
+  id: $ElementType<Scalars, 'Int'>
 };
 
 export type User = {
-  id: number,
-  name: string,
-  email: string,
+  id: $ElementType<Scalars, 'Int'>,
+  name: $ElementType<Scalars, 'String'>,
+  email: $ElementType<Scalars, 'String'>,
 };
 
 import { type GraphQLResolveInfo } from 'graphql';
+
+export type ArrayOrIterable<T> = Array<T> | Iterable<T>;
 
 export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
   parent?: Parent,
@@ -65,14 +76,14 @@ export type DirectiveResolverFn<Result = {}, Parent = {}, Args = {}, Context = {
 ) => Result | Promise<Result>;
 
 export interface QueryResolvers<Context = any, ParentType = Query> {
-  allUsers?: Resolver<Array<?User>, ParentType, Context>,
+  allUsers?: Resolver<ArrayOrIterable<?User>, ParentType, Context>,
   userById?: Resolver<?User, ParentType, Context, QueryUserByIdArgs>,
 }
 
 export interface UserResolvers<Context = any, ParentType = User> {
-  id?: Resolver<number, ParentType, Context>,
-  name?: Resolver<string, ParentType, Context>,
-  email?: Resolver<string, ParentType, Context>,
+  id?: Resolver<$ElementType<Scalars, 'Int'>, ParentType, Context>,
+  name?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
+  email?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
 }
 
 export type IResolvers<Context = any> = {

--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -1,14 +1,22 @@
 // tslint:disable
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type QueryRoot = {
   allUsers: Array<Maybe<User>>,
   userById?: Maybe<User>,
-  answer: Array<number>,
+  answer: Array<Scalars['Int']>,
 };
 
 
 export type QueryRootUserByIdArgs = {
-  id: number
+  id: Scalars['Int']
 };
 
 export type SubscriptionRoot = {
@@ -16,12 +24,14 @@ export type SubscriptionRoot = {
 };
 
 export type User = {
-  id: number,
-  name: string,
-  email: string,
+  id: Scalars['Int'],
+  name: Scalars['String'],
+  email: Scalars['String'],
 };
 
 import { GraphQLResolveInfo } from 'graphql';
+
+export type ArrayOrIterable<T> = Array<T> | Iterable<T>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent?: TParent,
@@ -79,9 +89,9 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 ) => TResult | Promise<TResult>;
 
 export interface QueryRootResolvers<Context = any, ParentType = QueryRoot> {
-  allUsers?: Resolver<Array<Maybe<User>>, ParentType, Context>,
+  allUsers?: Resolver<ArrayOrIterable<Maybe<User>>, ParentType, Context>,
   userById?: Resolver<Maybe<User>, ParentType, Context, QueryRootUserByIdArgs>,
-  answer?: Resolver<Array<number>, ParentType, Context>,
+  answer?: Resolver<ArrayOrIterable<Scalars['Int']>, ParentType, Context>,
 }
 
 export interface SubscriptionRootResolvers<Context = any, ParentType = SubscriptionRoot> {
@@ -89,9 +99,9 @@ export interface SubscriptionRootResolvers<Context = any, ParentType = Subscript
 }
 
 export interface UserResolvers<Context = any, ParentType = User> {
-  id?: Resolver<number, ParentType, Context>,
-  name?: Resolver<string, ParentType, Context>,
-  email?: Resolver<string, ParentType, Context>,
+  id?: Resolver<Scalars['Int'], ParentType, Context>,
+  name?: Resolver<Scalars['String'], ParentType, Context>,
+  email?: Resolver<Scalars['String'], ParentType, Context>,
 }
 
 export type IResolvers<Context = any> = {

--- a/dev-test/test-schema/resolvers-types.ts
+++ b/dev-test/test-schema/resolvers-types.ts
@@ -1,23 +1,33 @@
 // tslint:disable
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Query = {
   allUsers: Array<Maybe<User>>,
   userById?: Maybe<User>,
-  answer: Array<number>,
+  answer: Array<Scalars['Int']>,
 };
 
 
 export type QueryUserByIdArgs = {
-  id: number
+  id: Scalars['Int']
 };
 
 export type User = {
-  id: number,
-  name: string,
-  email: string,
+  id: Scalars['Int'],
+  name: Scalars['String'],
+  email: Scalars['String'],
 };
 
 import { GraphQLResolveInfo } from 'graphql';
+
+export type ArrayOrIterable<T> = Array<T> | Iterable<T>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent?: TParent,
@@ -75,15 +85,15 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 ) => TResult | Promise<TResult>;
 
 export interface QueryResolvers<Context = any, ParentType = Query> {
-  allUsers?: Resolver<Array<Maybe<User>>, ParentType, Context>,
+  allUsers?: Resolver<ArrayOrIterable<Maybe<User>>, ParentType, Context>,
   userById?: Resolver<Maybe<User>, ParentType, Context, QueryUserByIdArgs>,
-  answer?: Resolver<Array<number>, ParentType, Context>,
+  answer?: Resolver<ArrayOrIterable<Scalars['Int']>, ParentType, Context>,
 }
 
 export interface UserResolvers<Context = any, ParentType = User> {
-  id?: Resolver<number, ParentType, Context>,
-  name?: Resolver<string, ParentType, Context>,
-  email?: Resolver<string, ParentType, Context>,
+  id?: Resolver<Scalars['Int'], ParentType, Context>,
+  name?: Resolver<Scalars['String'], ParentType, Context>,
+  email?: Resolver<Scalars['String'], ParentType, Context>,
 }
 
 export type IResolvers<Context = any> = {

--- a/dev-test/test-schema/typings.avoidOptionals.ts
+++ b/dev-test/test-schema/typings.avoidOptionals.ts
@@ -1,4 +1,12 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Query = {
   allUsers: Array<Maybe<User>>,
   userById: Maybe<User>,
@@ -6,11 +14,11 @@ export type Query = {
 
 
 export type QueryUserByIdArgs = {
-  id: number
+  id: Scalars['Int']
 };
 
 export type User = {
-  id: number,
-  name: string,
-  email: string,
+  id: Scalars['Int'],
+  name: Scalars['String'],
+  email: Scalars['String'],
 };

--- a/dev-test/test-schema/typings.immutableTypes.ts
+++ b/dev-test/test-schema/typings.immutableTypes.ts
@@ -1,4 +1,12 @@
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Query = {
   allUsers: Array<Maybe<User>>,
   userById?: Maybe<User>,
@@ -6,11 +14,11 @@ export type Query = {
 
 
 export type QueryUserByIdArgs = {
-  id: number
+  id: Scalars['Int']
 };
 
 export type User = {
-  id: number,
-  name: string,
-  email: string,
+  id: Scalars['Int'],
+  name: Scalars['String'],
+  email: Scalars['String'],
 };

--- a/dev-test/test-schema/typings.ts
+++ b/dev-test/test-schema/typings.ts
@@ -1,5 +1,13 @@
 // tslint:disable
 type Maybe<T> = T | null;
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
 export type Query = {
   allUsers: Array<Maybe<User>>,
   userById?: Maybe<User>,
@@ -7,16 +15,18 @@ export type Query = {
 
 
 export type QueryUserByIdArgs = {
-  id: number
+  id: Scalars['Int']
 };
 
 export type User = {
-  id: number,
-  name: string,
-  email: string,
+  id: Scalars['Int'],
+  name: Scalars['String'],
+  email: Scalars['String'],
 };
 
 import { GraphQLResolveInfo } from 'graphql';
+
+export type ArrayOrIterable<T> = Array<T> | Iterable<T>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent?: TParent,
@@ -74,14 +84,14 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 ) => TResult | Promise<TResult>;
 
 export interface QueryResolvers<Context = any, ParentType = Query> {
-  allUsers?: Resolver<Array<Maybe<User>>, ParentType, Context>,
+  allUsers?: Resolver<ArrayOrIterable<Maybe<User>>, ParentType, Context>,
   userById?: Resolver<Maybe<User>, ParentType, Context, QueryUserByIdArgs>,
 }
 
 export interface UserResolvers<Context = any, ParentType = User> {
-  id?: Resolver<number, ParentType, Context>,
-  name?: Resolver<string, ParentType, Context>,
-  email?: Resolver<string, ParentType, Context>,
+  id?: Resolver<Scalars['Int'], ParentType, Context>,
+  name?: Resolver<Scalars['String'], ParentType, Context>,
+  email?: Resolver<Scalars['String'], ParentType, Context>,
 }
 
 export type IResolvers<Context = any> = {

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -46,6 +46,7 @@
     "@types/is-glob": "4.0.0",
     "@types/prettier": "1.16.1",
     "@types/valid-url": "1.0.2",
+    "@types/mkdirp": "0.5.2",
     "babel-types": "7.0.0-beta.3",
     "babylon": "7.0.0-beta.47",
     "chalk": "2.4.2",

--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -2,6 +2,8 @@ import { FileOutput, Types, debugLog } from 'graphql-codegen-plugin-helpers';
 import { executeCodegen } from './codegen';
 import { createWatcher } from './utils/watcher';
 import { fileExists, writeSync } from './utils/file-system';
+import { sync as mkdirpSync } from 'mkdirp';
+import { dirname } from 'path';
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
@@ -23,6 +25,8 @@ export async function generate(config: Types.Config, saveToFile = true): Promise
           return;
         }
 
+        const basedir = dirname(result.filename);
+        mkdirpSync(basedir);
         writeSync(result.filename, result.content);
       })
     );

--- a/packages/graphql-codegen-cli/tests/codegen.spec.ts
+++ b/packages/graphql-codegen-cli/tests/codegen.spec.ts
@@ -1,3 +1,4 @@
+import 'graphql-codegen-testing';
 import { GraphQLObjectType, buildSchema, buildASTSchema, parse, print } from 'graphql';
 import { mergeSchemas } from 'graphql-codegen-core';
 import { executeCodegen } from '../src';
@@ -166,7 +167,7 @@ describe('Codegen Executor', () => {
 
       expect(output.length).toBe(1);
       expect(output[0].filename).toBe('out.ts');
-      expect(output[0].content).toContain('hello?: Maybe<string>');
+      expect(output[0].content).toContain(`hello?: Maybe<Scalars['String']>`);
     });
   });
 
@@ -628,7 +629,14 @@ describe('Codegen Executor', () => {
       });
 
       expect(output.length).toBe(1);
-      expect(output[0].content).toContain('type UniqueId = any');
+      expect(output[0].content).toBeSimilarStringTo(`export type Scalars = {
+        ID: string;
+        String: string;
+        Boolean: boolean;
+        Int: number;
+        Float: number;
+        UniqueID: any;
+      };`);
     });
   });
 

--- a/packages/plugins/flow-operations/tests/validate-flow.ts
+++ b/packages/plugins/flow-operations/tests/validate-flow.ts
@@ -1,9 +1,0 @@
-import * as flow from 'flow-parser';
-
-export function validateFlow(code: string) {
-  const result = flow.parse(code);
-
-  if (result.errors.length > 0) {
-    throw new Error(result.errors.map(error => error.message).join('\n'));
-  }
-}

--- a/packages/plugins/flow-resolvers/src/visitor.ts
+++ b/packages/plugins/flow-resolvers/src/visitor.ts
@@ -18,6 +18,10 @@ export class FlowResolversVisitor extends BaseResolversVisitor<FlowResolversPlug
     return `${schemaTypeName}?: ${resolverType}<>,`;
   }
 
+  protected _getScalar(name: string): string {
+    return `$ElementType<Scalars, '${name}'>`;
+  }
+
   protected buildMapperImport(source: string, types: string[]): string {
     return `import { ${types.map(t => `type ${t}`).join(', ')} } from '${source}';`;
   }

--- a/packages/plugins/flow-resolvers/src/visitor.ts
+++ b/packages/plugins/flow-resolvers/src/visitor.ts
@@ -1,6 +1,5 @@
-import { ListTypeNode, NamedTypeNode, NonNullTypeNode } from 'graphql/language/ast';
 import { FlowResolversPluginConfig } from './index';
-import { GraphQLSchema } from 'graphql';
+import { ListTypeNode, NamedTypeNode, NonNullTypeNode, GraphQLSchema } from 'graphql';
 import * as autoBind from 'auto-bind';
 import { ParsedResolversConfig, BaseResolversVisitor } from 'graphql-codegen-visitor-plugin-common';
 import { FlowOperationVariablesToObject } from 'graphql-codegen-flow';

--- a/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
@@ -41,43 +41,44 @@ describe('Flow Resolvers Plugin', () => {
     const result = plugin(schema, [], {}, { outputFile: '' });
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?number,
-      arg2?: ?string, arg3?: ?boolean }> = DirectiveResolverFn<Result, Parent, Context, Args>;
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
 
-    export interface MyOtherTypeResolvers<Context = any, ParentType = MyOtherType> {
-      bar?: Resolver<string, ParentType, Context>,
-    }
+    expect(result).toBeSimilarStringTo(`export interface MyOtherTypeResolvers<Context = any, ParentType = MyOtherType> {
+      bar?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
+    }`);
 
-    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<MyScalar, any> {
+    expect(result)
+      .toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<$ElementType<Scalars, 'MyScalar'>, any> {
       name: 'MyScalar'
-    }
+    }`);
 
-    export interface MyTypeResolvers<Context = any, ParentType = MyType> {
-      foo?: Resolver<string, ParentType, Context>,
+    expect(result).toBeSimilarStringTo(`export interface MyTypeResolvers<Context = any, ParentType = MyType> {
+      foo?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
       otherType?: Resolver<?MyOtherType, ParentType, Context>,
-      withArgs?: Resolver<?string, ParentType, Context, MyTypeWithArgsArgs>,
-    }
+      withArgs?: Resolver<?$ElementType<Scalars, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+    }`);
 
-    export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
+    expect(result).toBeSimilarStringTo(`export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
       __resolveType: TypeResolveFn<'MyType' | 'MyOtherType'>
-    }
+    }`);
 
-    export interface NodeResolvers<Context = any, ParentType = Node> {
+    expect(result).toBeSimilarStringTo(`export interface NodeResolvers<Context = any, ParentType = Node> {
       __resolveType: TypeResolveFn<'SomeNode'>
-    }
+    }`);
 
-    export interface QueryResolvers<Context = any, ParentType = Query> {
+    expect(result).toBeSimilarStringTo(`export interface QueryResolvers<Context = any, ParentType = Query> {
       something?: Resolver<MyType, ParentType, Context>,
-    }
+    }`);
 
-    export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
-      id?: Resolver<string, ParentType, Context>,
-    }
+    expect(result).toBeSimilarStringTo(`export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
+      id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
+    }`);
 
-    export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
+    expect(result)
+      .toBeSimilarStringTo(`export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
       somethingChanged?: SubscriptionResolver<?MyOtherType, ParentType, Context>,
-    }
-    `);
+    }`);
   });
 
   it('Should generate the correct imports when schema has scalars', () => {
@@ -109,21 +110,21 @@ describe('Flow Resolvers Plugin', () => {
     );
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?number,
-      arg2?: ?string, arg3?: ?boolean }> = DirectiveResolverFn<Result, Parent, Context, Args>;
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
 
     export interface MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> {
-      bar?: Resolver<string, ParentType, Context>,
+      bar?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
     }
 
-    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<MyScalar, any> {
+    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<$ElementType<Scalars, 'MyScalar'>, any> {
       name: 'MyScalar'
     }
 
     export interface MyTypeResolvers<Context = any, ParentType = MyType> {
-      foo?: Resolver<string, ParentType, Context>,
+      foo?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
       otherType?: Resolver<?MyCustomOtherType, ParentType, Context>,
-      withArgs?: Resolver<?string, ParentType, Context, MyTypeWithArgsArgs>,
+      withArgs?: Resolver<?$ElementType<Scalars, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
     }
 
     export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
@@ -139,7 +140,7 @@ describe('Flow Resolvers Plugin', () => {
     }
 
     export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
-      id?: Resolver<string, ParentType, Context>,
+      id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
     }
 
     export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
@@ -162,21 +163,21 @@ describe('Flow Resolvers Plugin', () => {
 
     expect(result).toBeSimilarStringTo(`import { type MyCustomOtherType } from './some-file';`);
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?number,
-      arg2?: ?string, arg3?: ?boolean }> = DirectiveResolverFn<Result, Parent, Context, Args>;
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
 
     export interface MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> {
-      bar?: Resolver<string, ParentType, Context>,
+      bar?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
     }
 
-    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<MyScalar, any> {
+    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<$ElementType<Scalars, 'MyScalar'>, any> {
       name: 'MyScalar'
     }
 
     export interface MyTypeResolvers<Context = any, ParentType = MyType> {
-      foo?: Resolver<string, ParentType, Context>,
+      foo?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
       otherType?: Resolver<?MyCustomOtherType, ParentType, Context>,
-      withArgs?: Resolver<?string, ParentType, Context, MyTypeWithArgsArgs>,
+      withArgs?: Resolver<?$ElementType<Scalars, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
     }
 
     export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
@@ -192,7 +193,7 @@ describe('Flow Resolvers Plugin', () => {
     }
 
     export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
-      id?: Resolver<string, ParentType, Context>,
+      id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
     }
 
     export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
@@ -208,6 +209,8 @@ describe('Flow Resolvers Plugin', () => {
       { outputFile: '' }
     );
 
-    expect(result).toBeSimilarStringTo(`f?: Resolver<?string, ParentType, Context, TMyTypeFArgs>,`);
+    expect(result).toBeSimilarStringTo(
+      `f?: Resolver<?$ElementType<Scalars, 'String'>, ParentType, Context, TMyTypeFArgs>,`
+    );
   });
 });

--- a/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
@@ -64,7 +64,8 @@ describe('Flow Resolvers Plugin', () => {
     }`);
 
     expect(result).toBeSimilarStringTo(`export interface NodeResolvers<Context = any, ParentType = Node> {
-      __resolveType: TypeResolveFn<'SomeNode'>
+      __resolveType: TypeResolveFn<'SomeNode'>,
+      id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
     }`);
 
     expect(result).toBeSimilarStringTo(`export interface QueryResolvers<Context = any, ParentType = Query> {
@@ -132,7 +133,8 @@ describe('Flow Resolvers Plugin', () => {
     }
 
     export interface NodeResolvers<Context = any, ParentType = Node> {
-      __resolveType: TypeResolveFn<'SomeNode'>
+      __resolveType: TypeResolveFn<'SomeNode'>,
+      id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
     }
 
     export interface QueryResolvers<Context = any, ParentType = Query> {
@@ -185,7 +187,8 @@ describe('Flow Resolvers Plugin', () => {
     }
 
     export interface NodeResolvers<Context = any, ParentType = Node> {
-      __resolveType: TypeResolveFn<'SomeNode'>
+      __resolveType: TypeResolveFn<'SomeNode'>,
+      id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
     }
 
     export interface QueryResolvers<Context = any, ParentType = Query> {

--- a/packages/plugins/flow-resolvers/tests/validate-flow.ts
+++ b/packages/plugins/flow-resolvers/tests/validate-flow.ts
@@ -1,9 +1,0 @@
-import * as flow from 'flow-parser';
-
-export function validateFlow(code: string) {
-  const result = flow.parse(code);
-
-  if (result.errors.length > 0) {
-    throw new Error(result.errors.map(error => error.message).join('\n'));
-  }
-}

--- a/packages/plugins/flow/src/flow-variables-to-object.ts
+++ b/packages/plugins/flow/src/flow-variables-to-object.ts
@@ -10,6 +10,10 @@ export class FlowOperationVariablesToObject extends OperationVariablesToObject {
     return str;
   }
 
+  protected getScalar(name: string): string {
+    return `$ElementType<Scalars, '${name}'>`;
+  }
+
   public wrapAstTypeWithModifiers(baseType: string, typeNode: TypeNode): string {
     if (typeNode.kind === Kind.NON_NULL_TYPE) {
       const type = this.wrapAstTypeWithModifiers(baseType, typeNode.type);

--- a/packages/plugins/flow/src/index.ts
+++ b/packages/plugins/flow/src/index.ts
@@ -16,13 +16,14 @@ export const plugin: PluginFunction<FlowPluginConfig> = (
   documents: DocumentFile[],
   config: FlowPluginConfig
 ) => {
-  const result = `/* @flow */\n\n`;
+  const header = `/* @flow */\n\n`;
   const printedSchema = printSchema(schema);
   const astNode = parse(printedSchema);
+  const visitor = new FlowVisitor(schema, config);
 
   const visitorResult = visit(astNode, {
-    leave: new FlowVisitor(schema, config)
+    leave: visitor
   });
 
-  return result + visitorResult.definitions.join('\n');
+  return [header, visitor.scalarsDefinition, ...visitorResult.definitions].join('\n');
 };

--- a/packages/plugins/flow/src/index.ts
+++ b/packages/plugins/flow/src/index.ts
@@ -21,7 +21,7 @@ export const plugin: PluginFunction<FlowPluginConfig> = (
   const astNode = parse(printedSchema);
 
   const visitorResult = visit(astNode, {
-    leave: new FlowVisitor(config)
+    leave: new FlowVisitor(schema, config)
   });
 
   return result + visitorResult.definitions.join('\n');

--- a/packages/plugins/flow/src/visitor.ts
+++ b/packages/plugins/flow/src/visitor.ts
@@ -42,14 +42,6 @@ export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginPa
     return `$ElementType<Scalars, '${name}'>`;
   }
 
-  public ScalarTypeDefinition = (node: ScalarTypeDefinitionNode): string => {
-    return new DeclarationBlock(this._declarationBlockConfig)
-      .export()
-      .asKind('type')
-      .withName(this.convertName(node))
-      .withContent(this.scalars[(node.name as any) as string] || 'any').string;
-  };
-
   NamedType(node: NamedTypeNode): string {
     return `?${super.NamedType(node)}`;
   }

--- a/packages/plugins/flow/src/visitor.ts
+++ b/packages/plugins/flow/src/visitor.ts
@@ -5,7 +5,8 @@ import {
   FieldDefinitionNode,
   EnumTypeDefinitionNode,
   ScalarTypeDefinitionNode,
-  NamedTypeNode
+  NamedTypeNode,
+  GraphQLSchema
 } from 'graphql';
 import {
   BaseTypesVisitor,
@@ -24,8 +25,8 @@ export interface FlowPluginParsedConfig extends ParsedTypesConfig {
 }
 
 export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginParsedConfig> {
-  constructor(pluginConfig: FlowPluginConfig) {
-    super(pluginConfig, {
+  constructor(schema: GraphQLSchema, pluginConfig: FlowPluginConfig) {
+    super(schema, pluginConfig, {
       useFlowExactObjects: pluginConfig.useFlowExactObjects || false,
       useFlowReadOnlyTypes: pluginConfig.useFlowReadOnlyTypes || false
     } as FlowPluginParsedConfig);
@@ -35,6 +36,10 @@ export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginPa
     this.setDeclarationBlockConfig({
       blockWrapper: this.config.useFlowExactObjects ? '|' : ''
     });
+  }
+
+  protected _getScalar(name: string): string {
+    return `$ElementType<Scalars, '${name}'>`;
   }
 
   public ScalarTypeDefinition = (node: ScalarTypeDefinitionNode): string => {

--- a/packages/plugins/typescript-mongodb/src/visitor.ts
+++ b/packages/plugins/typescript-mongodb/src/visitor.ts
@@ -1,12 +1,10 @@
-import { UnionTypeDefinitionNode } from 'graphql/language/ast';
 import { FieldsTree } from './fields-tree';
 import {
   getBaseTypeNode,
   DeclarationBlock,
   getConfigValue,
   ParsedConfig,
-  BaseVisitor,
-  indent
+  BaseVisitor
 } from 'graphql-codegen-visitor-plugin-common';
 import { TypeScriptOperationVariablesToObject } from 'graphql-codegen-typescript';
 import * as autoBind from 'auto-bind';
@@ -20,7 +18,8 @@ import {
   Kind,
   ValueNode,
   isEnumType,
-  InterfaceTypeDefinitionNode
+  InterfaceTypeDefinitionNode,
+  UnionTypeDefinitionNode
 } from 'graphql';
 
 type AdditionalField = { path: string; type: string };

--- a/packages/plugins/typescript-operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript-operations/tests/ts-documents.spec.ts
@@ -1,7 +1,6 @@
 import 'graphql-codegen-testing';
 import { parse, buildClientSchema, buildSchema } from 'graphql';
 import { readFileSync } from 'fs';
-import { format } from 'prettier';
 import { plugin } from '../src/index';
 import { validateTs } from '../../typescript/tests/validate';
 import { plugin as tsPlugin } from '../../typescript/src/index';
@@ -110,7 +109,7 @@ describe('TypeScript Operations Plugin', () => {
   });
 
   describe('Scalars', () => {
-    it.only('Should include scalars when doing pick', async () => {
+    it('Should include scalars when doing pick', async () => {
       const testSchema = buildSchema(/* GraphQL */ `
         scalar Date
         type Query {
@@ -516,7 +515,7 @@ describe('TypeScript Operations Plugin', () => {
 
       expect(result).toBeSimilarStringTo(
         `export type MeQueryVariables = {
-          repoFullName: string
+          repoFullName: Scalars['String']
         };`
       );
       expect(result).toBeSimilarStringTo(
@@ -661,14 +660,14 @@ describe('TypeScript Operations Plugin', () => {
 
       expect(result).toBeSimilarStringTo(
         `export type TestQueryQueryVariables = {
-          username?: Maybe<string>,
-          email?: Maybe<string>,
-          password: string,
+          username?: Maybe<Scalars['String']>,
+          email?: Maybe<Scalars['String']>,
+          password: Scalars['String'],
           input?: Maybe<InputType>,
           mandatoryInput: InputType,
-          testArray?: Maybe<Array<Maybe<string>>>,
-          requireString: Array<Maybe<string>>,
-          innerRequired: Array<string>
+          testArray?: Maybe<Array<Maybe<Scalars['String']>>>,
+          requireString: Array<Maybe<Scalars['String']>>,
+          innerRequired: Array<Scalars['String']>
         };`
       );
       validate(result, config);
@@ -725,14 +724,8 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
 
-      expect(format(content)).toBeSimilarStringTo(
-        format(`
-          type SubmitMessageMutation = { __typename?: 'Mutation' } & {
-            mutation:
-              | ({ __typename?: 'DeleteMutation' } & Pick<DeleteMutation, 'deleted'>)
-              | ({ __typename?: 'UpdateMutation' } & Pick<UpdateMutation, 'updated'>);
-          };
-      `)
+      expect(content).toBeSimilarStringTo(
+        `export type SubmitMessageMutation = ({ __typename?: 'Mutation' } & { mutation: (({ __typename?: 'DeleteMutation' } & Pick<DeleteMutation, 'deleted'>) | ({ __typename?: 'UpdateMutation' } & Pick<UpdateMutation, 'updated'>)) });`
       );
     });
 
@@ -764,10 +757,8 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
 
-      expect(format(content)).toBeSimilarStringTo(
-        format(`
-          export type PostQuery = { __typename?: 'Query' } & { post: { __typename?: 'Post' } & ({ __typename: 'Post' }) };
-        `)
+      expect(content).toBeSimilarStringTo(
+        `export type PostQuery = ({ __typename?: 'Query' } & { post: ({ __typename?: 'Post' } & ({ __typename: 'Post' })) });`
       );
     });
 
@@ -801,14 +792,8 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
 
-      expect(format(content)).toBeSimilarStringTo(
-        format(`
-          export type InfoQuery = { __typename?: 'Query' } & {
-            __schema: { __typename?: '__Schema' } & {
-              queryType: { __typename?: '__Type' } & { fields: Maybe<Array<{ __typename?: '__Field' } & Pick<__Field, 'name'>>> };
-            };
-          };
-        `)
+      expect(content).toBeSimilarStringTo(
+        `export type InfoQuery = ({ __typename?: 'Query' } & { __schema: ({ __typename?: '__Schema' } & { queryType: ({ __typename?: '__Type' } & { fields: Maybe<Array<({ __typename?: '__Field' } & Pick<__Field, 'name'>)>> }) }) });`
       );
     });
 
@@ -845,22 +830,8 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
 
-      expect(format(content)).toBeSimilarStringTo(
-        format(`
-        export type InfoQuery = { __typename?: 'Query' } & {
-          __type: Maybe<
-            { __typename?: '__Type' } & Pick<__Type, 'name'> & {
-                fields: Maybe<
-                  Array<
-                    { __typename?: '__Field' } & Pick<__Field, 'name'> & {
-                        type: { __typename?: '__Type' } & Pick<__Type, 'name' | 'kind'>;
-                      }
-                  >
-                >;
-              }
-          >;
-        };
-      `)
+      expect(content).toBeSimilarStringTo(
+        `export type InfoQuery = ({ __typename?: 'Query' } & { __type: Maybe<({ __typename?: '__Type' } & Pick<__Type, 'name'> & { fields: Maybe<Array<({ __typename?: '__Field' } & Pick<__Field, 'name'> & { type: ({ __typename?: '__Type' } & Pick<__Type, 'name' | 'kind'>) })>> })> });`
       );
     });
 
@@ -958,16 +929,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
 
-      expect(format(content)).toBeSimilarStringTo(
-        format(`
-          export type PREFIX_UsersQueryVariables = {
-            filter: PREFIX_Filter;
-          };
-          
-          export type PREFIX_UsersQuery = { __typename?: 'Query' } & {
-            users: Maybe<Array<Maybe<{ __typename?: 'User' } & Pick<PREFIX_User, 'access'>>>>;
-          };      
-      `)
+      expect(content).toBeSimilarStringTo(`export type PREFIX_UsersQueryVariables = {
+        filter: PREFIX_Filter
+      };`);
+      expect(content).toBeSimilarStringTo(
+        `export type PREFIX_UsersQuery = ({ __typename?: 'Query' } & { users: Maybe<Array<Maybe<({ __typename?: 'User' } & Pick<PREFIX_User, 'access'>)>>> });`
       );
     });
   });

--- a/packages/plugins/typescript-resolvers/src/visitor.ts
+++ b/packages/plugins/typescript-resolvers/src/visitor.ts
@@ -1,6 +1,5 @@
-import { ListTypeNode, NamedTypeNode, NonNullTypeNode } from 'graphql/language/ast';
 import { TypeScriptResolversPluginConfig } from './index';
-import { GraphQLSchema } from 'graphql';
+import { ListTypeNode, NamedTypeNode, NonNullTypeNode, GraphQLSchema } from 'graphql';
 import * as autoBind from 'auto-bind';
 import { ParsedResolversConfig, BaseResolversVisitor } from 'graphql-codegen-visitor-plugin-common';
 import { TypeScriptOperationVariablesToObject } from 'graphql-codegen-typescript';

--- a/packages/plugins/typescript-resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/ts-resolvers.spec.ts
@@ -50,42 +50,44 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(result).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
 
-    export interface MyOtherTypeResolvers<Context = any, ParentType = MyOtherType> {
+    expect(result).toBeSimilarStringTo(`export interface MyOtherTypeResolvers<Context = any, ParentType = MyOtherType> {
       bar?: Resolver<Scalars['String'], ParentType, Context>,
-    }
+    }`);
 
-    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
+    expect(result)
+      .toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
       name: 'MyScalar'
-    }
+    }`);
 
-    export interface MyTypeResolvers<Context = any, ParentType = MyType> {
+    expect(result).toBeSimilarStringTo(`export interface MyTypeResolvers<Context = any, ParentType = MyType> {
       foo?: Resolver<Scalars['String'], ParentType, Context>,
       otherType?: Resolver<Maybe<MyOtherType>, ParentType, Context>,
       withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
-    }
+    }`);
 
-    export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
+    expect(result).toBeSimilarStringTo(`export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
       __resolveType: TypeResolveFn<'MyType' | 'MyOtherType'>
-    }
+    }`);
 
-    export interface NodeResolvers<Context = any, ParentType = Node> {
-      __resolveType: TypeResolveFn<'SomeNode'>
-    }
-
-    export interface QueryResolvers<Context = any, ParentType = Query> {
-      something?: Resolver<MyType, ParentType, Context>,
-    }
-
-    export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
+    expect(result).toBeSimilarStringTo(`export interface NodeResolvers<Context = any, ParentType = Node> {
+      __resolveType: TypeResolveFn<'SomeNode'>,
       id?: Resolver<Scalars['ID'], ParentType, Context>,
-    }
+    }`);
 
-    export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
+    expect(result).toBeSimilarStringTo(`export interface QueryResolvers<Context = any, ParentType = Query> {
+      something?: Resolver<MyType, ParentType, Context>,
+    }`);
+
+    expect(result).toBeSimilarStringTo(`export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
+      id?: Resolver<Scalars['ID'], ParentType, Context>,
+    }`);
+
+    expect(result)
+      .toBeSimilarStringTo(`export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
       somethingChanged?: SubscriptionResolver<Maybe<MyOtherType>, ParentType, Context>,
-    }
-    `);
+    }`);
 
     await validate(result);
   });
@@ -122,42 +124,45 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(result).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
 
-    export interface MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> {
+    expect(result)
+      .toBeSimilarStringTo(`export interface MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> {
       bar?: Resolver<Scalars['String'], ParentType, Context>,
-    }
+    }`);
 
-    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
+    expect(result)
+      .toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
       name: 'MyScalar'
-    }
+    }`);
 
-    export interface MyTypeResolvers<Context = any, ParentType = MyType> {
+    expect(result).toBeSimilarStringTo(`export interface MyTypeResolvers<Context = any, ParentType = MyType> {
       foo?: Resolver<Scalars['String'], ParentType, Context>,
       otherType?: Resolver<Maybe<MyCustomOtherType>, ParentType, Context>,
       withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
-    }
+    }`);
 
-    export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
+    expect(result).toBeSimilarStringTo(`export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
       __resolveType: TypeResolveFn<'MyType' | 'MyOtherType'>
-    }
+    }`);
 
-    export interface NodeResolvers<Context = any, ParentType = Node> {
-      __resolveType: TypeResolveFn<'SomeNode'>
-    }
-
-    export interface QueryResolvers<Context = any, ParentType = Query> {
-      something?: Resolver<MyType, ParentType, Context>,
-    }
-
-    export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
+    expect(result).toBeSimilarStringTo(`export interface NodeResolvers<Context = any, ParentType = Node> {
+      __resolveType: TypeResolveFn<'SomeNode'>,
       id?: Resolver<Scalars['ID'], ParentType, Context>,
-    }
+    }`);
 
-    export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
+    expect(result).toBeSimilarStringTo(`export interface QueryResolvers<Context = any, ParentType = Query> {
+      something?: Resolver<MyType, ParentType, Context>,
+    }`);
+
+    expect(result).toBeSimilarStringTo(`export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
+      id?: Resolver<Scalars['ID'], ParentType, Context>,
+    }`);
+
+    expect(result)
+      .toBeSimilarStringTo(`export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
       somethingChanged?: SubscriptionResolver<Maybe<MyCustomOtherType>, ParentType, Context>,
-    }
-    `);
+    }`);
     await validate(`type MyCustomOtherType = {}\n${result}`);
   });
 
@@ -176,42 +181,45 @@ describe('TypeScript Resolvers Plugin', () => {
     expect(result).toBeSimilarStringTo(`import { MyCustomOtherType } from './my-file';`);
     expect(result).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
 
-    export interface MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> {
+    expect(result)
+      .toBeSimilarStringTo(`export interface MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> {
       bar?: Resolver<Scalars['String'], ParentType, Context>,
-    }
+    }`);
 
-    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
+    expect(result)
+      .toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
       name: 'MyScalar'
-    }
+    }`);
 
-    export interface MyTypeResolvers<Context = any, ParentType = MyType> {
+    expect(result).toBeSimilarStringTo(`export interface MyTypeResolvers<Context = any, ParentType = MyType> {
       foo?: Resolver<Scalars['String'], ParentType, Context>,
       otherType?: Resolver<Maybe<MyCustomOtherType>, ParentType, Context>,
       withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
-    }
+    }`);
 
-    export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
+    expect(result).toBeSimilarStringTo(`export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
       __resolveType: TypeResolveFn<'MyType' | 'MyOtherType'>
-    }
+    }`);
 
-    export interface NodeResolvers<Context = any, ParentType = Node> {
-      __resolveType: TypeResolveFn<'SomeNode'>
-    }
-
-    export interface QueryResolvers<Context = any, ParentType = Query> {
-      something?: Resolver<MyType, ParentType, Context>,
-    }
-
-    export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
+    expect(result).toBeSimilarStringTo(`export interface NodeResolvers<Context = any, ParentType = Node> {
+      __resolveType: TypeResolveFn<'SomeNode'>,
       id?: Resolver<Scalars['ID'], ParentType, Context>,
-    }
+    }`);
 
-    export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
+    expect(result).toBeSimilarStringTo(`export interface QueryResolvers<Context = any, ParentType = Query> {
+      something?: Resolver<MyType, ParentType, Context>,
+    }`);
+
+    expect(result).toBeSimilarStringTo(`export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
+      id?: Resolver<Scalars['ID'], ParentType, Context>,
+    }`);
+
+    expect(result)
+      .toBeSimilarStringTo(`export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
       somethingChanged?: SubscriptionResolver<Maybe<MyCustomOtherType>, ParentType, Context>,
-    }
-    `);
+    }`);
     await validate(result);
   });
 

--- a/packages/plugins/typescript-resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/ts-resolvers.spec.ts
@@ -49,21 +49,21 @@ describe('TypeScript Resolvers Plugin', () => {
     const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<number>,
-      arg2?: Maybe<string>, arg3?: Maybe<boolean> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
 
     export interface MyOtherTypeResolvers<Context = any, ParentType = MyOtherType> {
-      bar?: Resolver<string, ParentType, Context>,
+      bar?: Resolver<Scalars['String'], ParentType, Context>,
     }
 
-    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<MyScalar, any> {
+    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
       name: 'MyScalar'
     }
 
     export interface MyTypeResolvers<Context = any, ParentType = MyType> {
-      foo?: Resolver<string, ParentType, Context>,
+      foo?: Resolver<Scalars['String'], ParentType, Context>,
       otherType?: Resolver<Maybe<MyOtherType>, ParentType, Context>,
-      withArgs?: Resolver<Maybe<string>, ParentType, Context, MyTypeWithArgsArgs>,
+      withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
     }
 
     export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
@@ -79,7 +79,7 @@ describe('TypeScript Resolvers Plugin', () => {
     }
 
     export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
-      id?: Resolver<string, ParentType, Context>,
+      id?: Resolver<Scalars['ID'], ParentType, Context>,
     }
 
     export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
@@ -121,21 +121,21 @@ describe('TypeScript Resolvers Plugin', () => {
     );
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<number>,
-      arg2?: Maybe<string>, arg3?: Maybe<boolean> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
 
     export interface MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> {
-      bar?: Resolver<string, ParentType, Context>,
+      bar?: Resolver<Scalars['String'], ParentType, Context>,
     }
 
-    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<MyScalar, any> {
+    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
       name: 'MyScalar'
     }
 
     export interface MyTypeResolvers<Context = any, ParentType = MyType> {
-      foo?: Resolver<string, ParentType, Context>,
+      foo?: Resolver<Scalars['String'], ParentType, Context>,
       otherType?: Resolver<Maybe<MyCustomOtherType>, ParentType, Context>,
-      withArgs?: Resolver<Maybe<string>, ParentType, Context, MyTypeWithArgsArgs>,
+      withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
     }
 
     export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
@@ -151,7 +151,7 @@ describe('TypeScript Resolvers Plugin', () => {
     }
 
     export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
-      id?: Resolver<string, ParentType, Context>,
+      id?: Resolver<Scalars['ID'], ParentType, Context>,
     }
 
     export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
@@ -175,21 +175,21 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(result).toBeSimilarStringTo(`import { MyCustomOtherType } from './my-file';`);
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<number>,
-      arg2?: Maybe<string>, arg3?: Maybe<boolean> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
 
     export interface MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> {
-      bar?: Resolver<string, ParentType, Context>,
+      bar?: Resolver<Scalars['String'], ParentType, Context>,
     }
 
-    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<MyScalar, any> {
+    export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
       name: 'MyScalar'
     }
 
     export interface MyTypeResolvers<Context = any, ParentType = MyType> {
-      foo?: Resolver<string, ParentType, Context>,
+      foo?: Resolver<Scalars['String'], ParentType, Context>,
       otherType?: Resolver<Maybe<MyCustomOtherType>, ParentType, Context>,
-      withArgs?: Resolver<Maybe<string>, ParentType, Context, MyTypeWithArgsArgs>,
+      withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
     }
 
     export interface MyUnionResolvers<Context = any, ParentType = MyUnion> {
@@ -205,7 +205,7 @@ describe('TypeScript Resolvers Plugin', () => {
     }
 
     export interface SomeNodeResolvers<Context = any, ParentType = SomeNode> {
-      id?: Resolver<string, ParentType, Context>,
+      id?: Resolver<Scalars['ID'], ParentType, Context>,
     }
 
     export interface SubscriptionResolvers<Context = any, ParentType = Subscription> {
@@ -220,7 +220,7 @@ describe('TypeScript Resolvers Plugin', () => {
     const config = { typesPrefix: 'T' };
     const result = await plugin(testSchema, [], config, { outputFile: '' });
 
-    expect(result).toBeSimilarStringTo(`f?: Resolver<Maybe<string>, ParentType, Context, TMyTypeFArgs>,`);
+    expect(result).toBeSimilarStringTo(`f?: Resolver<Maybe<Scalars['String']>, ParentType, Context, TMyTypeFArgs>,`);
     await validate(result, config, testSchema);
   });
   it('should generate Resolvers interface', async () => {
@@ -315,8 +315,8 @@ describe('TypeScript Resolvers Plugin', () => {
       }
 
       export interface UserResolvers<Context = any, ParentType = User> {
-        id?: Resolver<string, ParentType, Context>,
-        name?: Resolver<string, ParentType, Context>,
+        id?: Resolver<Scalars['ID'], ParentType, Context>,
+        name?: Resolver<Scalars['String'], ParentType, Context>,
         roles?: Resolver<ArrayOrIterable<Role>, ParentType, Context>,
       }
 

--- a/packages/plugins/typescript/src/introspection-visitor.ts
+++ b/packages/plugins/typescript/src/introspection-visitor.ts
@@ -1,4 +1,4 @@
-import { GraphQLNamedType, EnumTypeDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
+import { GraphQLSchema, GraphQLNamedType, EnumTypeDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
 import { TsVisitor } from './visitor';
 import { TypeScriptPluginConfig } from './index';
 import * as autoBind from 'auto-bind';
@@ -6,8 +6,8 @@ import * as autoBind from 'auto-bind';
 export class TsIntrospectionVisitor extends TsVisitor {
   private typesToInclude: GraphQLNamedType[] = [];
 
-  constructor(pluginConfig: TypeScriptPluginConfig = {}, typesToInclude: GraphQLNamedType[]) {
-    super(pluginConfig);
+  constructor(schema: GraphQLSchema, pluginConfig: TypeScriptPluginConfig = {}, typesToInclude: GraphQLNamedType[]) {
+    super(schema, pluginConfig);
 
     this.typesToInclude = typesToInclude;
     autoBind(this);

--- a/packages/plugins/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/src/visitor.ts
@@ -8,7 +8,8 @@ import {
   NonNullTypeNode,
   EnumTypeDefinitionNode,
   Kind,
-  InputValueDefinitionNode
+  InputValueDefinitionNode,
+  GraphQLSchema
 } from 'graphql';
 import { TypeScriptOperationVariablesToObject } from './typescript-variables-to-object';
 
@@ -24,19 +25,15 @@ export class TsVisitor<
   TRawConfig extends TypeScriptPluginConfig = TypeScriptPluginConfig,
   TParsedConfig extends TypeScriptPluginParsedConfig = TypeScriptPluginParsedConfig
 > extends BaseTypesVisitor<TRawConfig, TParsedConfig> {
-  constructor(pluginConfig: TRawConfig, additionalConfig: Partial<TParsedConfig> = {}) {
-    super(
-      pluginConfig,
-      {
-        avoidOptionals: pluginConfig.avoidOptionals || false,
-        maybeValue: pluginConfig.maybeValue || 'T | null',
-        constEnums: pluginConfig.constEnums || false,
-        enumsAsTypes: pluginConfig.enumsAsTypes || false,
-        immutableTypes: pluginConfig.immutableTypes || false,
-        ...(additionalConfig || {})
-      } as TParsedConfig,
-      null
-    );
+  constructor(schema: GraphQLSchema, pluginConfig: TRawConfig, additionalConfig: Partial<TParsedConfig> = {}) {
+    super(schema, pluginConfig, {
+      avoidOptionals: pluginConfig.avoidOptionals || false,
+      maybeValue: pluginConfig.maybeValue || 'T | null',
+      constEnums: pluginConfig.constEnums || false,
+      enumsAsTypes: pluginConfig.enumsAsTypes || false,
+      immutableTypes: pluginConfig.immutableTypes || false,
+      ...(additionalConfig || {})
+    } as TParsedConfig);
 
     autoBind(this);
     this.setArgumentsTransformer(

--- a/packages/plugins/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/tests/typescript.spec.ts
@@ -221,6 +221,89 @@ describe('TypeScript', () => {
     });
   });
 
+  describe.only('Scalars', () => {
+    it('Should generate a scalars mapping correctly for built-in scalars', async () => {
+      const schema = buildSchema(`
+      type MyType {
+        foo: String
+        bar: String!
+      }`);
+      const result = await plugin(schema, [], {}, { outputFile: '' });
+
+      expect(result).toBeSimilarStringTo(`
+      export type Scalars = {
+        ID: string,
+        String: string,
+        Boolean: boolean,
+        Int: number,
+        Float: number,
+      };`);
+
+      expect(result).toBeSimilarStringTo(`
+      export type MyType = {
+        foo?: Maybe<Scalars['String']>,
+        bar: Scalars['String'],
+      };`);
+      validateTs(result);
+    });
+
+    it('Should generate a scalars mapping correctly for custom scalars', async () => {
+      const schema = buildSchema(`
+      scalar MyScalar
+
+      type MyType {
+        foo: String
+        bar: MyScalar!
+      }`);
+      const result = await plugin(schema, [], {}, { outputFile: '' });
+
+      expect(result).toBeSimilarStringTo(`
+      export type Scalars = {
+        ID: string,
+        String: string,
+        Boolean: boolean,
+        Int: number,
+        Float: number,
+        MyScalar: any,
+      };`);
+
+      expect(result).toBeSimilarStringTo(`
+      export type MyType = {
+        foo?: Maybe<Scalars['String']>,
+        bar: Scalars['MyScalar'],
+      };`);
+      validateTs(result);
+    });
+
+    it('Should generate a scalars mapping correctly for custom scalars with mapping', async () => {
+      const schema = buildSchema(`
+      scalar MyScalar
+
+      type MyType {
+        foo: String
+        bar: MyScalar!
+      }`);
+      const result = await plugin(schema, [], { scalars: { MyScalar: 'Date' } }, { outputFile: '' });
+
+      expect(result).toBeSimilarStringTo(`
+      export type Scalars = {
+        ID: string,
+        String: string,
+        Boolean: boolean,
+        Int: number,
+        Float: number,
+        MyScalar: Date,
+      };`);
+
+      expect(result).toBeSimilarStringTo(`
+      export type MyType = {
+        foo?: Maybe<Scalars['String']>,
+        bar: Scalars['MyScalar'],
+      };`);
+      validateTs(result);
+    });
+  });
+
   describe('Object (type)', () => {
     it('Should build type correctly', async () => {
       const schema = buildSchema(`

--- a/packages/plugins/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/tests/typescript.spec.ts
@@ -15,8 +15,8 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type MyType = {
-          foo: Maybe<string>,
-          bar: string,
+          foo: Maybe<Scalars['String']>,
+          bar: Scalars['String'],
         };
       `);
       validateTs(result);
@@ -31,7 +31,7 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type MyType = {
-          readonly foo: ReadonlyArray<string>,
+          readonly foo: ReadonlyArray<Scalars['String']>,
         };
       `);
       validateTs(result);
@@ -111,10 +111,10 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type mytypefooargs = {
-          a: string,
-          b?: Maybe<string>,
-          c?: Maybe<Array<Maybe<string>>>,
-          d: Array<number>
+          a: Scalars['String'],
+          b?: Maybe<Scalars['String']>,
+          c?: Maybe<Array<Maybe<Scalars['String']>>>,
+          d: Array<Scalars['Int']>
         };
     `);
       expect(result).toBeSimilarStringTo(`
@@ -157,10 +157,10 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type MyTypefooArgs = {
-          a: string,
-          b?: Maybe<string>,
-          c?: Maybe<Array<Maybe<string>>>,
-          d: Array<number>
+          a: Scalars['String'],
+          b?: Maybe<Scalars['String']>,
+          c?: Maybe<Array<Maybe<Scalars['String']>>>,
+          d: Array<Scalars['Int']>
         };
       `);
 
@@ -221,7 +221,7 @@ describe('TypeScript', () => {
     });
   });
 
-  describe.only('Scalars', () => {
+  describe('Scalars', () => {
     it('Should generate a scalars mapping correctly for built-in scalars', async () => {
       const schema = buildSchema(`
       type MyType {
@@ -315,8 +315,8 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type MyType = {
-          foo?: Maybe<string>,
-          bar: string,
+          foo?: Maybe<Scalars['String']>,
+          bar: Scalars['String'],
         };
       `);
       validateTs(result);
@@ -336,12 +336,12 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type MyInterface = {
-          foo: string,
+          foo: Scalars['String'],
         };
       `);
       expect(result).toBeSimilarStringTo(`
         export type MyType = MyInterface & {
-          foo: string,
+          foo: Scalars['String'],
         };
       `);
       validateTs(result);
@@ -366,18 +366,18 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type MyInterface = {
-          foo: string,
+          foo: Scalars['String'],
         };
       `);
       expect(result).toBeSimilarStringTo(`
         export type MyOtherInterface = {
-          bar: string,
+          bar: Scalars['String'],
         };
       `);
       expect(result).toBeSimilarStringTo(`
         export type MyType = MyInterface & MyOtherInterface & {
-          foo: string,
-          bar: string,
+          foo: Scalars['String'],
+          bar: Scalars['String'],
         };
       `);
       validateTs(result);
@@ -402,7 +402,7 @@ describe('TypeScript', () => {
       `);
       expect(result).toBeSimilarStringTo(`
         export type MyOtherType = {
-          bar: string,
+          bar: Scalars['String'],
         };
       `);
       validateTs(result);
@@ -442,8 +442,8 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type MyInterface = {
-          foo?: Maybe<string>,
-          bar: string,
+          foo?: Maybe<Scalars['String']>,
+          bar: Scalars['String'],
         };
       `);
       validateTs(result);
@@ -476,15 +476,15 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type mytypefooargs = {
-          a: string,
-          b?: Maybe<string>,
-          c?: Maybe<Array<Maybe<string>>>,
-          d: Array<number>
+          a: Scalars['String'],
+          b?: Maybe<Scalars['String']>,
+          c?: Maybe<Array<Maybe<Scalars['String']>>>,
+          d: Array<Scalars['Int']>
         };
     `);
       expect(result).toBeSimilarStringTo(`
         export type mytype = {
-          foo?: Maybe<string>,
+          foo?: Maybe<Scalars['String']>,
         };
     `);
 
@@ -502,16 +502,16 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type Imytypefooargs = {
-          a: string,
-          b?: Maybe<string>,
-          c?: Maybe<Array<Maybe<string>>>,
-          d: Array<number>
+          a: Scalars['String'],
+          b?: Maybe<Scalars['String']>,
+          c?: Maybe<Array<Maybe<Scalars['String']>>>,
+          d: Array<Scalars['Int']>
         };
       `);
 
       expect(result).toBeSimilarStringTo(`
         export type Imytype = {
-          foo?: Maybe<string>,
+          foo?: Maybe<Scalars['String']>,
         };
       `);
 
@@ -572,10 +572,10 @@ describe('TypeScript', () => {
         `);
       expect(result).toBeSimilarStringTo(`
         export type mytype = {
-          f?: Maybe<string>,
+          f?: Maybe<Scalars['String']>,
           bar?: Maybe<myenum>,
-          b_a_r?: Maybe<string>,
-          myOtherField?: Maybe<string>,
+          b_a_r?: Maybe<Scalars['String']>,
+          myOtherField?: Maybe<Scalars['String']>,
         };
         `);
       expect(result).toBeSimilarStringTo(`
@@ -588,22 +588,22 @@ describe('TypeScript', () => {
         `);
       expect(result).toBeSimilarStringTo(`
         export type some_interface = {
-          id: string,
+          id: Scalars['ID'],
         };
         `);
       expect(result).toBeSimilarStringTo(`
         export type impl1 = some_interface & {
-          id: string,
+          id: Scalars['ID'],
         };
         `);
       expect(result).toBeSimilarStringTo(`
         export type impl_2 = some_interface & {
-          id: string,
+          id: Scalars['ID'],
         };
         `);
       expect(result).toBeSimilarStringTo(`
         export type impl_3 = some_interface & {
-          id: string,
+          id: Scalars['ID'],
         };
         `);
       expect(result).toBeSimilarStringTo(`
@@ -628,10 +628,10 @@ describe('TypeScript', () => {
       `);
       expect(result).toBeSimilarStringTo(`
       export type MyType = {
-        f?: Maybe<string>,
+        f?: Maybe<Scalars['String']>,
         bar?: Maybe<MyEnum>,
-        b_a_r?: Maybe<string>,
-        myOtherField?: Maybe<string>,
+        b_a_r?: Maybe<Scalars['String']>,
+        myOtherField?: Maybe<Scalars['String']>,
       };
       `);
       expect(result).toBeSimilarStringTo(`
@@ -644,22 +644,22 @@ describe('TypeScript', () => {
       `);
       expect(result).toBeSimilarStringTo(`
       export type Some_Interface = {
-        id: string,
+        id: Scalars['ID'],
       };
       `);
       expect(result).toBeSimilarStringTo(`
       export type Impl1 = Some_Interface & {
-        id: string,
+        id: Scalars['ID'],
       };
       `);
       expect(result).toBeSimilarStringTo(`
       export type Impl_2 = Some_Interface & {
-        id: string,
+        id: Scalars['ID'],
       };
       `);
       expect(result).toBeSimilarStringTo(`
       export type Impl_3 = Some_Interface & {
-        id: string,
+        id: Scalars['ID'],
       };
       `);
       expect(result).toBeSimilarStringTo(`
@@ -684,10 +684,10 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
       export type IMyType = {
-        f?: Maybe<string>,
+        f?: Maybe<Scalars['String']>,
         bar?: Maybe<IMyEnum>,
-        b_a_r?: Maybe<string>,
-        myOtherField?: Maybe<string>,
+        b_a_r?: Maybe<Scalars['String']>,
+        myOtherField?: Maybe<Scalars['String']>,
       };`);
       expect(result).toBeSimilarStringTo(`
       export type IMy_Type = {
@@ -697,22 +697,22 @@ describe('TypeScript', () => {
       expect(result).toBeSimilarStringTo(`export type IMyUnion = IMy_Type | IMyType;`);
       expect(result).toBeSimilarStringTo(`
       export type ISome_Interface = {
-        id: string,
+        id: Scalars['ID'],
       };
       `);
       expect(result).toBeSimilarStringTo(`
       export type IImpl1 = ISome_Interface & {
-        id: string,
+        id: Scalars['ID'],
       };
       `);
       expect(result).toBeSimilarStringTo(`
       export type IImpl_2 = ISome_Interface & {
-        id: string,
+        id: Scalars['ID'],
       };
       `);
       expect(result).toBeSimilarStringTo(`
       export type IImpl_3 = ISome_Interface & {
-        id: string,
+        id: Scalars['ID'],
       };
       `);
       expect(result).toBeSimilarStringTo(`
@@ -734,10 +734,10 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
-          a: string,
-          b?: Maybe<string>,
-          c?: Maybe<Array<Maybe<string>>>,
-          d: Array<number>
+          a: Scalars['String'],
+          b?: Maybe<Scalars['String']>,
+          c?: Maybe<Array<Maybe<Scalars['String']>>>,
+          d: Array<Scalars['Int']>
         };
     `);
 
@@ -752,9 +752,9 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
-          a: string,
-          b: string,
-          c?: Maybe<string>
+          a: Scalars['String'],
+          b: Scalars['String'],
+          c?: Maybe<Scalars['String']>
         };
     `);
 
@@ -781,24 +781,22 @@ describe('TypeScript', () => {
     });
 
     it('Should add custom prefix for mutation arguments', async () => {
-      const schema = buildSchema(
-        `input Input { name: String } type Mutation { foo(id: String, input: Input): String }`
-      );
+      const schema = buildSchema(`input Input { name: String } type Mutation { foo(id: ID, input: Input): String }`);
       const result = await plugin(schema, [], { typesPrefix: 'T' }, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
         export type TInput = {
-          name?: Maybe<string>,
+          name?: Maybe<Scalars['String']>,
         };
       `);
 
       expect(result).toBeSimilarStringTo(`
         export type TMutation = {
-          foo?: Maybe<string>,
+          foo?: Maybe<Scalars['String']>,
         };
 
         export type TMutationFooArgs = {
-          id?: Maybe<string>,
+          id?: Maybe<Scalars['ID']>,
           input?: Maybe<TInput>
         };
       `);

--- a/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -9,14 +9,12 @@ import {
   NamedTypeNode,
   FieldDefinitionNode,
   ObjectTypeDefinitionNode,
-  GraphQLSchema
-} from 'graphql';
-import {
+  GraphQLSchema,
   NonNullTypeNode,
   UnionTypeDefinitionNode,
   ScalarTypeDefinitionNode,
   InterfaceTypeDefinitionNode
-} from 'graphql/language/ast';
+} from 'graphql';
 import { DirectiveDefinitionNode, GraphQLObjectType, InputValueDefinitionNode } from 'graphql';
 import { OperationVariablesToObject } from './variables-to-object';
 import { ParsedMapper, parseMapper, transformMappers } from './mappers';

--- a/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -308,8 +308,12 @@ export class BaseResolversVisitor<
       .export()
       .asKind('interface')
       .withName(name, `<Context = ${this.config.contextType.type}, ParentType = ${node.name}>`)
-      .withBlock(indent(`__resolveType: TypeResolveFn<${implementingTypes.map(name => `'${name}'`).join(' | ')}>`))
-      .string;
+      .withBlock(
+        [
+          indent(`__resolveType: TypeResolveFn<${implementingTypes.map(name => `'${name}'`).join(' | ')}>,`),
+          ...(node.fields || []).map((f: any) => f(node.name))
+        ].join('\n')
+      ).string;
   }
 
   SchemaDefinition() {

--- a/packages/plugins/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/base-types-visitor.ts
@@ -3,14 +3,6 @@ import { EnumValuesMap, ScalarsMap } from './types';
 import { OperationVariablesToObject } from './variables-to-object';
 import { DeclarationBlockConfig, DeclarationBlock, indent, wrapWithSingleQuotes, buildScalars } from './utils';
 import {
-  NonNullTypeNode,
-  UnionTypeDefinitionNode,
-  InterfaceTypeDefinitionNode,
-  ScalarTypeDefinitionNode,
-  EnumValueDefinitionNode,
-  NamedTypeNode
-} from 'graphql/language/ast';
-import {
   InputObjectTypeDefinitionNode,
   InputValueDefinitionNode,
   NameNode,
@@ -19,7 +11,13 @@ import {
   EnumTypeDefinitionNode,
   DirectiveDefinitionNode,
   ListTypeNode,
-  GraphQLSchema
+  GraphQLSchema,
+  NonNullTypeNode,
+  UnionTypeDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  ScalarTypeDefinitionNode,
+  EnumValueDefinitionNode,
+  NamedTypeNode
 } from 'graphql';
 import { DEFAULT_SCALARS } from './scalars';
 

--- a/packages/plugins/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/base-types-visitor.ts
@@ -1,7 +1,7 @@
 import { BaseVisitor, ParsedConfig, RawConfig } from './base-visitor';
 import { EnumValuesMap, ScalarsMap } from './types';
 import { OperationVariablesToObject } from './variables-to-object';
-import { DeclarationBlockConfig, DeclarationBlock, indent, wrapWithSingleQuotes } from './utils';
+import { DeclarationBlockConfig, DeclarationBlock, indent, wrapWithSingleQuotes, buildScalars } from './utils';
 import {
   NonNullTypeNode,
   UnionTypeDefinitionNode,
@@ -19,11 +19,9 @@ import {
   EnumTypeDefinitionNode,
   DirectiveDefinitionNode,
   ListTypeNode,
-  isScalarType,
-  GraphQLScalarType
+  GraphQLSchema
 } from 'graphql';
 import { DEFAULT_SCALARS } from './scalars';
-import { GraphQLSchema } from 'graphql';
 
 export interface ParsedTypesConfig extends ParsedConfig {
   enumValues: EnumValuesMap;
@@ -31,23 +29,6 @@ export interface ParsedTypesConfig extends ParsedConfig {
 
 export interface RawTypesConfig extends RawConfig {
   enumValues?: EnumValuesMap;
-}
-
-function buildScalars(schema: GraphQLSchema, scalarsMapping: ScalarsMap): ScalarsMap {
-  const typeMap = schema.getTypeMap();
-  let result = { ...scalarsMapping };
-
-  Object.keys(typeMap)
-    .map(typeName => typeMap[typeName])
-    .filter(type => isScalarType(type))
-    .map((scalarType: GraphQLScalarType) => {
-      const name = scalarType.name;
-      const value = scalarsMapping[name] || 'any';
-
-      result[name] = value;
-    });
-
-  return result;
 }
 
 export class BaseTypesVisitor<

--- a/packages/plugins/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/base-types-visitor.ts
@@ -107,7 +107,9 @@ export class BaseTypesVisitor<
 
   UnionTypeDefinition(node: UnionTypeDefinitionNode, key: string | number, parent: any): string {
     const originalNode = parent[key] as UnionTypeDefinitionNode;
-    const possibleTypes = originalNode.types.map(t => this.convertName(t)).join(' | ');
+    const possibleTypes = originalNode.types
+      .map(t => (this.scalars[t.name.value] ? this._getScalar(t.name.value) : this.convertName(t)))
+      .join(' | ');
 
     return new DeclarationBlock(this._declarationBlockConfig)
       .export()

--- a/packages/plugins/visitor-plugin-common/src/mappers.ts
+++ b/packages/plugins/visitor-plugin-common/src/mappers.ts
@@ -1,0 +1,39 @@
+import { RawResolversConfig, ParsedResolversConfig } from './base-resolvers-visitor';
+
+export interface ParsedMapper {
+  isExternal: boolean;
+  type: string;
+  source?: string;
+}
+
+export function parseMapper(mapper: string): ParsedMapper {
+  if (isExternalMapper(mapper)) {
+    const [source, type] = mapper.split('#');
+    return {
+      isExternal: true,
+      source,
+      type
+    };
+  }
+
+  return {
+    isExternal: false,
+    type: mapper
+  };
+}
+
+export function isExternalMapper(value: string): boolean {
+  return value.includes('#');
+}
+
+export function transformMappers(rawMappers: RawResolversConfig['mappers']): ParsedResolversConfig['mappers'] {
+  const result: ParsedResolversConfig['mappers'] = {};
+
+  Object.keys(rawMappers).forEach(gqlTypeName => {
+    const mapperDef = rawMappers[gqlTypeName];
+    const parsedMapper = parseMapper(mapperDef);
+    result[gqlTypeName] = parsedMapper;
+  });
+
+  return result;
+}

--- a/packages/plugins/visitor-plugin-common/src/scalars.ts
+++ b/packages/plugins/visitor-plugin-common/src/scalars.ts
@@ -3,8 +3,5 @@ export const DEFAULT_SCALARS = {
   String: 'string',
   Boolean: 'boolean',
   Int: 'number',
-  Float: 'number',
-  string: 'string',
-  number: 'number',
-  boolean: 'boolean'
+  Float: 'number'
 };

--- a/packages/plugins/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/visitor-plugin-common/src/utils.ts
@@ -10,8 +10,12 @@ import {
   GraphQLList,
   isListType,
   GraphQLOutputType,
-  GraphQLNamedType
+  GraphQLNamedType,
+  isScalarType,
+  GraphQLSchema,
+  GraphQLScalarType
 } from 'graphql';
+import { ScalarsMap } from './types';
 
 function isWrapperType(t: GraphQLOutputType): t is GraphQLNonNull<any> | GraphQLList<any> {
   return isListType(t) || isNonNullType(t);
@@ -193,3 +197,20 @@ export const wrapTypeWithModifiers = (prefix = '') => (
     return `${prefix}${baseType}`;
   }
 };
+
+export function buildScalars(schema: GraphQLSchema, scalarsMapping: ScalarsMap): ScalarsMap {
+  const typeMap = schema.getTypeMap();
+  let result = { ...scalarsMapping };
+
+  Object.keys(typeMap)
+    .map(typeName => typeMap[typeName])
+    .filter(type => isScalarType(type))
+    .map((scalarType: GraphQLScalarType) => {
+      const name = scalarType.name;
+      const value = scalarsMapping[name] || 'any';
+
+      result[name] = value;
+    });
+
+  return result;
+}

--- a/packages/plugins/visitor-plugin-common/src/variables-to-object.ts
+++ b/packages/plugins/visitor-plugin-common/src/variables-to-object.ts
@@ -46,7 +46,7 @@ export class OperationVariablesToObject {
     const baseType = typeof variable.type === 'string' ? variable.type : getBaseTypeNode(variable.type);
     const typeName = typeof baseType === 'string' ? baseType : baseType.name.value;
     const typeValue = this._scalars[typeName]
-      ? this.getScalar(this._scalars[typeName])
+      ? this.getScalar(typeName)
       : this._convertName(baseType, {
           useTypesPrefix: true
         });

--- a/packages/plugins/visitor-plugin-common/src/variables-to-object.ts
+++ b/packages/plugins/visitor-plugin-common/src/variables-to-object.ts
@@ -43,13 +43,19 @@ export class OperationVariablesToObject {
   }
 
   protected transformVariable<TDefinitionType extends InterfaceOrVariable>(variable: TDefinitionType): string {
-    const baseType = typeof variable.type === 'string' ? variable.type : getBaseTypeNode(variable.type);
-    const typeName = typeof baseType === 'string' ? baseType : baseType.name.value;
-    const typeValue = this._scalars[typeName]
-      ? this.getScalar(typeName)
-      : this._convertName(baseType, {
-          useTypesPrefix: true
-        });
+    let typeValue = null;
+
+    if (typeof variable.type === 'string') {
+      typeValue = variable.type;
+    } else {
+      const baseType = getBaseTypeNode(variable.type);
+      const typeName = baseType.name.value;
+      typeValue = this._scalars[typeName]
+        ? this.getScalar(typeName)
+        : this._convertName(baseType, {
+            useTypesPrefix: true
+          });
+    }
 
     const fieldName = this.getName(variable);
     const fieldType = this.wrapAstTypeWithModifiers(typeValue, variable.type);

--- a/packages/plugins/visitor-plugin-common/src/variables-to-object.ts
+++ b/packages/plugins/visitor-plugin-common/src/variables-to-object.ts
@@ -38,14 +38,18 @@ export class OperationVariablesToObject {
     return variablesNode.map(variable => indent(this.transformVariable(variable))).join(',\n');
   }
 
+  protected getScalar(name: string): string {
+    return `Scalars['${name}']`;
+  }
+
   protected transformVariable<TDefinitionType extends InterfaceOrVariable>(variable: TDefinitionType): string {
     const baseType = typeof variable.type === 'string' ? variable.type : getBaseTypeNode(variable.type);
     const typeName = typeof baseType === 'string' ? baseType : baseType.name.value;
-    const typeValue =
-      this._scalars[typeName] ||
-      this._convertName(baseType, {
-        useTypesPrefix: true
-      });
+    const typeValue = this._scalars[typeName]
+      ? this.getScalar(this._scalars[typeName])
+      : this._convertName(baseType, {
+          useTypesPrefix: true
+        });
 
     const fieldName = this.getName(variable);
     const fieldType = this.wrapAstTypeWithModifiers(typeValue, variable.type);


### PR DESCRIPTION
The goal is to create the following (with the option to add custom mapping):

```ts
      export type Scalars = {
        ID: string,
        String: string,
        Boolean: boolean,
        Int: number,
        Float: number,
        MyScalar: Date,
      };
```

and then use it this way:
```ts
      export type MyType = {
        foo?: Maybe<Scalars['String']>,
        bar: Scalars['MyScalar'],
      };
```

> And using `$ElementType` for flow.

Is helps us with 2 issues:
- Usage of scalars anywhere will point to the same location.
- Easier integration with JavaScript types, like `Date`, without dealing with conflicts and circular references.