### PR TITLE
Fix `main` field in fragment-matcher package.json

### DIFF
--- a/packages/plugins/fragment-matcher/package.json
+++ b/packages/plugins/fragment-matcher/package.json
@@ -23,7 +23,8 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "sideEffects": false,
-  "main": "./dist/index.js",
+  "main": "./dist/commonjs/index.js",
+  "module": "dist/esnext/index.js",
   "typings": "dist/esnext/index.d.ts",
   "typescript": {
     "definition": "dist/esnext/index.d.ts"


### PR DESCRIPTION
Use commonjs build for `main`, es build for `module`

Fixes #1502 