### PR TITLE
Switch plugins to 1.0.0 versions

### DIFF
--- a/docs/migration/from-0-18.md
+++ b/docs/migration/from-0-18.md
@@ -55,9 +55,9 @@ So start by updating your `package.json`:
 ```json
 {
   "devDependencies": {
-    "@graphql-codegen/cli": "1.0.0",
-    "@graphql-codegen/typescript": "0.18.0",
-    "@graphql-codegen/typescript-operations": "0.18.0"
+    "@graphql-codegen/cli": "^1.0.0",
+    "@graphql-codegen/typescript": "^1.0.0",
+    "@graphql-codegen/typescript-operations": "^1.0.0"
   }
 }
 ```


### PR DESCRIPTION
When I tried to follow the instructions in the migration guide, I saw the following errors:

```
Couldn't find any versions for "@graphql-codegen/typescript" that matches "0.18.0"
? Please choose a version of "@graphql-codegen/typescript" from this list: 1.0.2
Couldn't find any versions for "@graphql-codegen/typescript-operations" that matches "0.18.0"
? Please choose a version of "@graphql-codegen/typescript-operations" from this list: 1.0.2
```

Thank you for creating such a great tool!