### PR TITLE
Update programatic usage in docs

### DIFF
--- a/docs/getting-started/programmatic-usage.md
+++ b/docs/getting-started/programmatic-usage.md
@@ -22,7 +22,7 @@ import { plugin as typescriptPlugin } from '@graphql-codegen/typescript';
 import { printSchema, parse, GraphQLSchema } from 'graphql';
 
 const schema: GraphQLSchema = buildSchema(`type A {}`);
-const outputFile = 'relative/or/absolute/path/filename.ts';
+const outputFile = 'relative/pathTo/filename.ts';
 const config = {
   // used by a plugin internally, although the 'typescript' plugin currently
   // returns the string output, rather than writing to a file

--- a/docs/getting-started/programmatic-usage.md
+++ b/docs/getting-started/programmatic-usage.md
@@ -17,18 +17,28 @@ Then, create a configuration object ([complete signature](https://github.com/dot
 
 ```ts
 import { buildSchema } from 'graphql';
+import * as fs from 'fs';
 import { plugin as typescriptPlugin } from '@graphql-codegen/typescript';
+import { printSchema, parse, GraphQLSchema } from 'graphql';
 
+const schema: GraphQLSchema = buildSchema(`type A {}`);
+const outputFile = 'relative/or/absolute/path/filename.ts';
 const config = {
-  schema: buildSchema(`type A {}`)
+  // used by a plugin internally, although the 'typescript' plugin currently
+  // returns the string output, rather than writing to a file
+  filename: outputFile,
+  schema: parse(printSchema(schema)),
   plugins: {
     typescript: {}, // Here you can pass configuration to the plugin
   },
   pluginMap: {
-    typescript: typescriptPlugin,
+    typescript: {
+      plugin: typescriptPlugin
+    },
   }
 };
 ```
+Notice that a plugin name key in `pluginMap` and `plugins` must match to identify a plugin and its configuration.
 
 > You need to import the plugin in your favorite way, you can also use `await import` to lazy load it.
 
@@ -36,8 +46,9 @@ Then, provide the config object to `codegen`:
 
 ```ts
 const output = await codegen(config);
+fs.writeFile(path.join(__dirname, outpuFile), output, () => {
+      console.log('Outputs generated!');
+    });
 ```
-
-The output of `codegen` is an array with the output file path and the file contant.
 
 > We are using this API in the live demo in GraphQL Code Generator website, [here is the code](https://github.com/dotansimha/graphql-code-generator/blob/master/website/live-demo/src/App.js#L79).


### PR DESCRIPTION
- convert schema to `DocumentNode` as required by `codegen`
- I also noticed that the `typescript` plugin also currently does not use the `outputFile` option to write the output to the file system.