### PR TITLE
Remove typesPrefix from Enum values

### DIFF
--- a/packages/plugins/typescript-react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript-react-apollo/tests/react-apollo.spec.ts
@@ -420,6 +420,20 @@ query MyFeed {
       expect(content).not.toContain(`export class TestComponent`);
       await validateTypeScript(content, schema, docs, {});
     });
+
+    it('should not add typesPrefix to Component', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { typesPrefix: 'I' },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).not.toContain(`export class ITestComponent`);
+    });
   });
 
   describe('HOC', () => {
@@ -458,8 +472,23 @@ query MyFeed {
       );
 
       expect(content).not.toContain(`export type TestProps`);
-      expect(content).not.toContain(`export function TestHOC`);
+      expect(content).not.toContain(`export function withTest`);
       await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should not add typesPrefix to HOCs', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { typesPrefix: 'I' },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toContain(`export type ITestProps`);
+      expect(content).toContain(`export function withTest`);
     });
   });
 
@@ -553,6 +582,20 @@ export function useListenToCommentsSubscription(baseOptions?: ReactApolloHooks.S
   return ReactApolloHooks.useSubscription<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>(ListenToCommentsDocument, baseOptions);
 };`);
       await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should not add typesPrefix to hooks', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { withHooks: true, typesPrefix: 'I' },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toContain(`export function useTestQuery`);
     });
   });
 });

--- a/packages/plugins/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/tests/typescript.spec.ts
@@ -217,7 +217,7 @@ describe('TypeScript', () => {
       directive @default(
         value: Any,
       ) on ENUM_VALUE | FIELD_DEFINITION
-    
+
       type CardEdge {
         count: Int! @default(value: 1)
       }`);
@@ -332,7 +332,7 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export enum foo {
-          YES = 'YES', 
+          YES = 'YES',
           NO = 'NO'
         }
       `);
@@ -378,7 +378,7 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
         export enum Foo {
-          yes = 'YES', 
+          yes = 'YES',
           no = 'NO'
         }
       `);
@@ -625,7 +625,7 @@ describe('TypeScript', () => {
         type MyType {
           foo: MyOtherType!
         }
-        
+
         type MyOtherType {
           bar: String!
         }
@@ -656,7 +656,7 @@ describe('TypeScript', () => {
       type MyOtherType {
         bar: String!
       }
-      
+
       union MyUnion = MyType | MyOtherType
       `);
       const result = await plugin(schema, [], {}, { outputFile: '' });
@@ -909,9 +909,9 @@ describe('TypeScript', () => {
 
       expect(result).toBeSimilarStringTo(`
       export enum IMyEnum {
-        IA = 'A',
-        IB = 'B',
-        IC = 'C'
+        A = 'A',
+        B = 'B',
+        C = 'C'
       }`);
 
       expect(result).toBeSimilarStringTo(`

--- a/packages/plugins/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/base-types-visitor.ts
@@ -233,7 +233,7 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
   protected buildEnumValuesBlock(typeName: string, values: ReadonlyArray<EnumValueDefinitionNode>): string {
     return values
       .map(enumOption => {
-        const optionName = this.convertName(enumOption);
+        const optionName = this.convertName(enumOption, { useTypesPrefix: false });
         const comment = transformComment((enumOption.description as any) as string, 1);
         let enumValue: string = (enumOption.name as any) as string;
 

--- a/packages/plugins/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -171,14 +171,11 @@ import ${gqlImport.propName ? `{ ${gqlImport.propName === 'gql' ? 'gql' : `${gql
       return null;
     }
 
-    const documentName = this.convertName(node, {
+    const documentVariableName = this.convertName(node, {
       suffix: 'Document',
       useTypesPrefix: false,
     });
-    const documentVariableName = this.convertName(node, {
-      suffix: 'Document',
-    });
-    const documentString = `export const ${documentName}${this.config.noGraphQLTag ? ': DocumentNode' : ''} = ${this._gql(node)};`;
+    const documentString = `export const ${documentVariableName}${this.config.noGraphQLTag ? ': DocumentNode' : ''} = ${this._gql(node)};`;
     const operationType: string = toPascalCase(node.operation);
     const operationResultType: string = this.convertName(node, {
       suffix: operationType,


### PR DESCRIPTION
This is in addition to #1551, and removes the configured typesPrefix from Enum values.

e.g. Instead of having `IColors.IRED`, it would be `IColors.RED`