### PR TITLE
Should not convert type names in unions

### DIFF
--- a/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -347,7 +347,7 @@ export type IDirectiveResolvers${contextType} = ${name}<Context>;`
     });
     const originalNode = parent[key] as UnionTypeDefinitionNode;
     const possibleTypes = originalNode.types
-      .map(node => this.convertName(node))
+      .map(node => node.name.value)
       .map(f => `'${f}'`)
       .join(' | ');
 


### PR DESCRIPTION
```patch
-__resolveType: TypeResolveFn<'CccFoo' | 'CccBar', ParentType, Context>
+__resolveType: TypeResolveFn<'CCCFoo' | 'CCCBar', ParentType, Context>
```