### PR TITLE
[docs] Add missing `add` in yarn command

### DIFF
--- a/docs/plugins/typescript.md
+++ b/docs/plugins/typescript.md
@@ -11,7 +11,7 @@ It generates types for your entire schema: types, input types, enums, interfaces
 
 Install using `yarn`:
 
-    $ yarn -D @graphql-codegen/typescript
+    $ yarn add -D @graphql-codegen/typescript
 
 ## Configuration
 


### PR DESCRIPTION
The `add` was missing in the yarn installation command making it invalid.