### PR TITLE
Improve Resolvers plugins

### DIFF
--- a/packages/plugins/flow-resolvers/src/visitor.ts
+++ b/packages/plugins/flow-resolvers/src/visitor.ts
@@ -11,7 +11,6 @@ export class FlowResolversVisitor extends BaseResolversVisitor<FlowResolversPlug
     super(pluginConfig, null, schema);
     autoBind(this);
     this.setVariablesTransformer(new FlowOperationVariablesToObject(this.config.scalars, this.convertName));
-    this._enableDefaultMapperGenerics = false;
   }
 
   protected _getScalar(name: string): string {

--- a/packages/plugins/flow-resolvers/src/visitor.ts
+++ b/packages/plugins/flow-resolvers/src/visitor.ts
@@ -39,9 +39,31 @@ export class FlowResolversVisitor extends BaseResolversVisitor<FlowResolversPlug
     return baseValue;
   }
 
+  protected applyMaybe(str: string): string {
+    return `?${str}`;
+  }
+
+  protected clearMaybe(str: string): string {
+    if (str.startsWith('?')) {
+      return str.substr(1);
+    }
+
+    return str;
+  }
+
+  protected getTypeToUse(name: string): string {
+    const resolversType = this.convertName('ResolversTypes');
+
+    return `$ElementType<${resolversType}, '${name}'>`;
+  }
+
+  protected replaceFieldsInType(typeName: string, relevantFields: { fieldName: string; replaceWithType: string }[]): string {
+    return `$Diff<${typeName}, { ${relevantFields.map(f => `${f.fieldName}: * `).join(', ')} }> & { ${relevantFields.map(f => `${f.fieldName}: ${f.replaceWithType}`).join(', ')} }`;
+  }
+
   ScalarTypeDefinition(node: ScalarTypeDefinitionNode): string {
     const nameAsString = (node.name as any) as string;
-    const baseName = this.scalars[nameAsString] ? this._getScalar(nameAsString) : this.convertName(node);
+    const baseName = this.getTypeToUse(nameAsString);
     this._collectedResolvers[node.name as any] = 'GraphQLScalarType';
 
     return new DeclarationBlock({

--- a/packages/plugins/flow-resolvers/src/visitor.ts
+++ b/packages/plugins/flow-resolvers/src/visitor.ts
@@ -11,6 +11,7 @@ export class FlowResolversVisitor extends BaseResolversVisitor<FlowResolversPlug
     super(pluginConfig, null, schema);
     autoBind(this);
     this.setVariablesTransformer(new FlowOperationVariablesToObject(this.config.scalars, this.convertName));
+    this._enableDefaultMapperGenerics = false;
   }
 
   protected _getScalar(name: string): string {

--- a/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
@@ -1,42 +1,9 @@
 import '@graphql-codegen/testing';
 import { buildSchema } from 'graphql';
 import { plugin } from '../src';
+import { schema } from '../../typescript-resolvers/tests/common';
 
 describe('Flow Resolvers Plugin', () => {
-  const schema = buildSchema(/* GraphQL */ `
-    type MyType {
-      foo: String!
-      otherType: MyOtherType
-      withArgs(arg: String, arg2: String!): String
-    }
-
-    type MyOtherType {
-      bar: String!
-    }
-
-    type Query {
-      something: MyType!
-    }
-
-    type Subscription {
-      somethingChanged: MyOtherType
-    }
-
-    interface Node {
-      id: ID!
-    }
-
-    type SomeNode implements Node {
-      id: ID!
-    }
-
-    union MyUnion = MyType | MyOtherType
-
-    scalar MyScalar
-
-    directive @myDirective(arg: Int!, arg2: String!, arg3: Boolean!) on FIELD
-  `);
-
   it('Should generate basic type resolvers', () => {
     const result = plugin(schema, [], {}, { outputFile: '' });
 
@@ -44,40 +11,40 @@ describe('Flow Resolvers Plugin', () => {
     export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
       arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`export type MyOtherTypeResolvers<Context = any, ParentType = MyOtherType> = {
-      bar?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
+    expect(result).toBeSimilarStringTo(`export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+      bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
     }`);
 
     expect(result).toBeSimilarStringTo(`export type MyScalarScalarConfig = {
-      ...GraphQLScalarTypeConfig<$ElementType<Scalars, 'MyScalar'>, any>, 
+      ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
       name: 'MyScalar'
     };`);
 
-    expect(result).toBeSimilarStringTo(`export type MyTypeResolvers<Context = any, ParentType = MyType> = {
-      foo?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
-      otherType?: Resolver<?MyOtherType, ParentType, Context>,
-      withArgs?: Resolver<?$ElementType<Scalars, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+    expect(result).toBeSimilarStringTo(`export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+      foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+      otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+      withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
     }`);
 
-    expect(result).toBeSimilarStringTo(`export type MyUnionResolvers<Context = any, ParentType = MyUnion> = {
+    expect(result).toBeSimilarStringTo(`export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
       __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
     }`);
 
-    expect(result).toBeSimilarStringTo(`export type NodeResolvers<Context = any, ParentType = Node> = {
+    expect(result).toBeSimilarStringTo(`export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
       __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-      id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
+      id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
     }`);
 
-    expect(result).toBeSimilarStringTo(`export type QueryResolvers<Context = any, ParentType = Query> = {
-      something?: Resolver<MyType, ParentType, Context>,
+    expect(result).toBeSimilarStringTo(`export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+      something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
     }`);
 
-    expect(result).toBeSimilarStringTo(`export type SomeNodeResolvers<Context = any, ParentType = SomeNode> = {
-      id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
+    expect(result).toBeSimilarStringTo(`export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+      id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
     }`);
 
-    expect(result).toBeSimilarStringTo(`export type SubscriptionResolvers<Context = any, ParentType = Subscription> = {
-      somethingChanged?: SubscriptionResolver<?MyOtherType, ParentType, Context>,
+    expect(result).toBeSimilarStringTo(`export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+      somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
     }`);
   });
 
@@ -93,129 +60,9 @@ describe('Flow Resolvers Plugin', () => {
     expect(result).not.toBeSimilarStringTo(`import { type GraphQLResolveInfo, type GraphQLScalarTypeConfig } from 'graphql';`);
   });
 
-  it('Should generate basic type resolvers with mapping', () => {
-    const result = plugin(
-      schema,
-      [],
-      {
-        mappers: {
-          MyOtherType: 'MyCustomOtherType',
-        },
-      },
-      { outputFile: '' }
-    );
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
-        arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> = {
-        bar?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`export type MyScalarScalarConfig = {
-      ...GraphQLScalarTypeConfig<$ElementType<Scalars, 'MyScalar'>, any>, 
-      name: 'MyScalar'
-    };`);
-    expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = MyType> = {
-        foo?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
-        otherType?: Resolver<?MyCustomOtherType, ParentType, Context>,
-        withArgs?: Resolver<?$ElementType<Scalars, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = MyUnion> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = Node> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = Query> = {
-        something?: Resolver<MyType, ParentType, Context>,
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = SomeNode> = {
-        id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = Subscription> = {
-        somethingChanged?: SubscriptionResolver<?MyCustomOtherType, ParentType, Context>,
-      }
-    `);
-  });
-
-  it('Should generate basic type resolvers with external mapping', () => {
-    const result = plugin(
-      schema,
-      [],
-      {
-        mappers: {
-          MyOtherType: './some-file#MyCustomOtherType',
-        },
-      },
-      { outputFile: '' }
-    );
-
-    expect(result).toBeSimilarStringTo(`import { type MyCustomOtherType } from './some-file';`);
-    expect(result).toBeSimilarStringTo(`
-      export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
-        arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> = {
-        bar?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`export type MyScalarScalarConfig = {
-      ...GraphQLScalarTypeConfig<$ElementType<Scalars, 'MyScalar'>, any>, 
-      name: 'MyScalar'
-    };`);
-    expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = MyType> = {
-        foo?: Resolver<$ElementType<Scalars, 'String'>, ParentType, Context>,
-        otherType?: Resolver<?MyCustomOtherType, ParentType, Context>,
-        withArgs?: Resolver<?$ElementType<Scalars, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = MyUnion> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = Node> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = Query> = {
-        something?: Resolver<MyType, ParentType, Context>,
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = SomeNode> = {
-        id?: Resolver<$ElementType<Scalars, 'ID'>, ParentType, Context>,
-      }
-    `);
-    expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = Subscription> = {
-        somethingChanged?: SubscriptionResolver<?MyCustomOtherType, ParentType, Context>,
-      }
-    `);
-  });
   it('Should generate the correct resolver args type names when typesPrefix is specified', () => {
     const result = plugin(buildSchema(`type MyType { f(a: String): String }`), [], { typesPrefix: 'T' }, { outputFile: '' });
 
-    expect(result).toBeSimilarStringTo(`f?: Resolver<?$ElementType<Scalars, 'String'>, ParentType, Context, TMyTypeFArgs>,`);
+    expect(result).toBeSimilarStringTo(`f?: Resolver<?$ElementType<TResolversTypes, 'String'>, ParentType, Context, TMyTypeFArgs>,`);
   });
 });

--- a/packages/plugins/flow-resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/flow-resolvers/tests/mapping.spec.ts
@@ -599,4 +599,59 @@ describe('ResolversTypes', () => {
     };`);
     await validate(`type MyTypeCustom = {}; type MyOtherTypeCustom = {}; ${result}`);
   });
+
+  it('Should build ResolversTypes with defaultMapper set using {T}', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        defaultMapper: '$Shape<{T}>',
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: $Shape<Query>,
+      MyType: $Shape<MyType>,
+      String: $ElementType<Scalars, 'String'>,
+      MyOtherType: $Shape<MyOtherType>,
+      Subscription: $Shape<Subscription>,
+      Boolean: $ElementType<Scalars, 'Boolean'>,
+      Node: $Shape<Node>,
+      ID: $ElementType<Scalars, 'ID'>,
+      SomeNode: $Shape<SomeNode>,
+      MyUnion: $Shape<MyUnion>,
+      MyScalar: $ElementType<Scalars, 'MyScalar'>,
+      Int: $ElementType<Scalars, 'Int'>,
+    };`);
+  });
+
+  it('Should build ResolversTypes with defaultMapper set using {T} with external identifier', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        defaultMapper: './my-wrapper#CustomPartial<{T}>',
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`import { type CustomPartial } from './my-wrapper';`);
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: CustomPartial<Query>,
+      MyType: CustomPartial<MyType>,
+      String: $ElementType<Scalars, 'String'>,
+      MyOtherType: CustomPartial<MyOtherType>,
+      Subscription: CustomPartial<Subscription>,
+      Boolean: $ElementType<Scalars, 'Boolean'>,
+      Node: CustomPartial<Node>,
+      ID: $ElementType<Scalars, 'ID'>,
+      SomeNode: CustomPartial<SomeNode>,
+      MyUnion: CustomPartial<MyUnion>,
+      MyScalar: $ElementType<Scalars, 'MyScalar'>,
+      Int: $ElementType<Scalars, 'Int'>,
+    };`);
+  });
 });

--- a/packages/plugins/flow-resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/flow-resolvers/tests/mapping.spec.ts
@@ -1,0 +1,602 @@
+import '@graphql-codegen/testing';
+import { schema } from '../../typescript-resolvers/tests/common';
+import { plugin } from '../src';
+import { buildSchema } from 'graphql';
+import { validateFlow as validate } from '../../flow/tests/validate-flow';
+
+describe('ResolversTypes', () => {
+  it('Should build ResolversTypes object when there are no mappers', async () => {
+    const result = await plugin(schema, [], {}, { outputFile: '' });
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: Query,
+      MyType: MyType,
+      String: $ElementType<Scalars, 'String'>,
+      MyOtherType: MyOtherType,
+      Subscription: Subscription,
+      Boolean: $ElementType<Scalars, 'Boolean'>,
+      Node: Node,
+      ID: $ElementType<Scalars, 'ID'>,
+      SomeNode: SomeNode,
+      MyUnion: MyUnion,
+      MyScalar: $ElementType<Scalars, 'MyScalar'>,
+      Int: $ElementType<Scalars, 'Int'>,
+    };`);
+  });
+
+  it('Should build ResolversTypes with simple mappers', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          Query: 'MyQueryType',
+          MyType: 'MyTypeDb',
+          String: 'number',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: MyQueryType,
+      MyType: MyTypeDb,
+      String: number,
+      MyOtherType: $Diff<MyOtherType, { bar: * }> & { bar: $ElementType<ResolversTypes, 'String'> },
+      Subscription: Subscription,
+      Boolean: $ElementType<Scalars, 'Boolean'>,
+      Node: Node,
+      ID: $ElementType<Scalars, 'ID'>,
+      SomeNode: SomeNode,
+      MyUnion: MyUnion,
+      MyScalar: $ElementType<Scalars, 'MyScalar'>,
+      Int: $ElementType<Scalars, 'Int'>,
+    };`);
+  });
+
+  it('Should build ResolversTypes with defaultMapper set', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          Query: 'MyQueryType',
+          MyType: 'MyTypeDb',
+          String: 'string',
+        },
+        defaultMapper: 'any',
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: MyQueryType,
+      MyType: MyTypeDb,
+      String: string,
+      MyOtherType: any,
+      Subscription: any,
+      Boolean: any,
+      Node: any,
+      ID: any,
+      SomeNode: any,
+      MyUnion: any,
+      MyScalar: any,
+      Int: any,
+    };`);
+  });
+
+  it('Should build ResolversTypes with external mappers', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          Query: './my-module#CustomQueryRootType',
+          MyType: 'MyTypeDb',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: CustomQueryRootType,
+      MyType: MyTypeDb,
+      String: $ElementType<Scalars, 'String'>,
+      MyOtherType: MyOtherType,
+      Subscription: Subscription,
+      Boolean: $ElementType<Scalars, 'Boolean'>,
+      Node: Node,
+      ID: $ElementType<Scalars, 'ID'>,
+      SomeNode: SomeNode,
+      MyUnion: MyUnion,
+      MyScalar: $ElementType<Scalars, 'MyScalar'>,
+      Int: $ElementType<Scalars, 'Int'>,
+    };`);
+  });
+
+  it('should warn about unused mappers by default', async () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+    const testSchema = buildSchema(/* GraphQL */ `
+      type Query {
+        comments: [Comment!]!
+      }
+
+      type User {
+        id: ID!
+        name: String!
+      }
+
+      type Comment {
+        id: ID!
+        text: String!
+        author: User!
+      }
+    `);
+
+    await plugin(
+      testSchema,
+      [],
+      {
+        mappers: {
+          Comment: 'number',
+          Post: 'string',
+        },
+      },
+      {
+        outputFile: 'graphql.ts',
+      }
+    );
+
+    expect(spy).toHaveBeenCalledWith('Unused mappers: Post');
+    spy.mockRestore();
+  });
+
+  it('should be able not to warn about unused mappers', async () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+    const testSchema = buildSchema(/* GraphQL */ `
+      type Query {
+        comments: [Comment!]!
+      }
+
+      type User {
+        id: ID!
+        name: String!
+      }
+
+      type Comment {
+        id: ID!
+        text: String!
+        author: User!
+      }
+    `);
+
+    await plugin(
+      testSchema,
+      [],
+      {
+        mappers: {
+          Comment: 'number',
+          Post: 'string',
+        },
+        showUnusedMappers: false,
+      },
+      {
+        outputFile: 'graphql.ts',
+      }
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('Should generate basic type resolvers with external mappers', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          MyOtherType: './my-file#MyCustomOtherType',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`import { type MyCustomOtherType } from './my-file';`);
+    expect(result).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+
+    expect(result).toBeSimilarStringTo(`
+        export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+          bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+        };
+      `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyScalarScalarConfig = {
+        ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
+        name: 'MyScalar'
+      };`);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+      };
+    `);
+    await validate(result);
+  });
+
+  it('Should generate basic type resolvers with external mappers using same imported type', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          MyType: './my-file#MyCustomOtherType',
+          MyOtherType: './my-file#MyCustomOtherType',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`import { type MyCustomOtherType } from './my-file';`);
+    expect(result).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+
+    expect(result).toBeSimilarStringTo(`
+        export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+          bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+        };
+      `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyScalarScalarConfig = {
+        ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
+        name: 'MyScalar'
+      };`);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+      };
+    `);
+    await validate(result);
+  });
+
+  it('Should generate the correct resolvers when used with mappers with interfaces', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          Node: 'MyNodeType',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+        bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+    export type MyScalarScalarConfig = {
+      ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
+      name: 'MyScalar'
+    };`);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+      };
+    `);
+    await validate(`type MyNodeType = {};\n${result}`);
+  });
+
+  it('Should generate basic type resolvers with defaultMapper set to any', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        defaultMapper: 'any',
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+        bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+    export type MyScalarScalarConfig = {
+      ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
+      name: 'MyScalar'
+    };`);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+      };
+    `);
+    await validate(result);
+  });
+
+  it('Should generate basic type resolvers with defaultMapper set to external identifier', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        defaultMapper: './my-file#MyBaseType',
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toContain(`import { type MyBaseType } from './my-file';`);
+
+    expect(result).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+        bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+    export type MyScalarScalarConfig = {
+      ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
+      name: 'MyScalar'
+    };`);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+      };
+    `);
+    await validate(result);
+  });
+
+  it('Should replace using Omit when non-mapped type is pointing to mapped type', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          MyOtherType: 'MyOtherTypeCustom',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: Query,
+      MyType: $Diff<MyType, { otherType: * }> & { otherType: ?$ElementType<ResolversTypes, 'MyOtherType'> },
+      String: $ElementType<Scalars, 'String'>,
+      MyOtherType: MyOtherTypeCustom,
+      Subscription: $Diff<Subscription, { somethingChanged: * }> & { somethingChanged: ?$ElementType<ResolversTypes, 'MyOtherType'> },
+      Boolean: $ElementType<Scalars, 'Boolean'>,
+      Node: Node,
+      ID: $ElementType<Scalars, 'ID'>,
+      SomeNode: SomeNode,
+      MyUnion: MyUnion,
+      MyScalar: $ElementType<Scalars, 'MyScalar'>,
+      Int: $ElementType<Scalars, 'Int'>,
+    };`);
+    await validate(`type MyOtherTypeCustom = {}; ${result}`);
+  });
+
+  it('Should not replace using Omit when non-mapped type is pointing to mapped type', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          MyOtherType: 'MyOtherTypeCustom',
+          MyType: 'MyTypeCustom',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: $Diff<Query, { something: * }> & { something: $ElementType<ResolversTypes, 'MyType'> },
+      MyType: MyTypeCustom,
+      String: $ElementType<Scalars, 'String'>,
+      MyOtherType: MyOtherTypeCustom,
+      Subscription: $Diff<Subscription, { somethingChanged: * }> & { somethingChanged: ?$ElementType<ResolversTypes, 'MyOtherType'> },
+      Boolean: $ElementType<Scalars, 'Boolean'>,
+      Node: Node,
+      ID: $ElementType<Scalars, 'ID'>,
+      SomeNode: SomeNode,
+      MyUnion: MyUnion,
+      MyScalar: $ElementType<Scalars, 'MyScalar'>,
+      Int: $ElementType<Scalars, 'Int'>,
+    };`);
+    await validate(`type MyTypeCustom = {}; type MyOtherTypeCustom = {}; ${result}`);
+  });
+});

--- a/packages/plugins/typescript-resolvers/src/index.ts
+++ b/packages/plugins/typescript-resolvers/src/index.ts
@@ -179,11 +179,12 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   const printedSchema = printSchema(schema);
   const astNode = parse(printedSchema);
   const visitorResult = visit(astNode, { leave: visitor });
+  const resolversTypeMapping = visitor.buildResolversTypes();
   const { getRootResolver, getAllDirectiveResolvers, mappersImports, unusedMappers } = visitor;
 
   if (showUnusedMappers && unusedMappers.length) {
     console['warn'](`Unused mappers: ${unusedMappers.join(',')}`);
   }
 
-  return [...mappersImports, header, ...visitorResult.definitions.filter(d => typeof d === 'string'), getRootResolver(), getAllDirectiveResolvers()].join('\n');
+  return [...mappersImports, header, resolversTypeMapping, ...visitorResult.definitions.filter(d => typeof d === 'string'), getRootResolver(), getAllDirectiveResolvers()].join('\n');
 };

--- a/packages/plugins/typescript-resolvers/src/index.ts
+++ b/packages/plugins/typescript-resolvers/src/index.ts
@@ -41,24 +41,6 @@ export interface TypeScriptResolversPluginConfig extends RawResolversConfig {
    */
   useIndexSignature?: boolean;
   /**
-   * @name showUnusedMappers
-   * @type boolean
-   * @description Warns about unused mappers.
-   * @default true
-   *
-   * @example
-   * ```yml
-   * generates:
-   * path/to/file.ts:
-   *  plugins:
-   *    - typescript
-   *    - typescript-resolvers
-   *  config:
-   *    showUnusedMappers: true
-   * ```
-   */
-  showUnusedMappers?: boolean;
-  /**
    * @name noSchemaStitching
    * @type boolean
    * @description Disables Schema Stitching support
@@ -124,6 +106,8 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
 
   const header = `
 import { ${imports.join(', ')} } from 'graphql';
+
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 ${indexSignature}
 

--- a/packages/plugins/typescript-resolvers/tests/common.ts
+++ b/packages/plugins/typescript-resolvers/tests/common.ts
@@ -1,0 +1,43 @@
+import { buildSchema } from 'graphql';
+import { plugin as tsPlugin } from '../../typescript/src/index';
+import { validateTs } from '../../typescript/tests/validate';
+
+export const schema = buildSchema(/* GraphQL */ `
+  type MyType {
+    foo: String!
+    otherType: MyOtherType
+    withArgs(arg: String, arg2: String!): String
+  }
+
+  type MyOtherType {
+    bar: String!
+  }
+
+  type Query {
+    something: MyType!
+  }
+
+  type Subscription {
+    somethingChanged: MyOtherType
+  }
+
+  interface Node {
+    id: ID!
+  }
+
+  type SomeNode implements Node {
+    id: ID!
+  }
+
+  union MyUnion = MyType | MyOtherType
+
+  scalar MyScalar
+
+  directive @myDirective(arg: Int!, arg2: String!, arg3: Boolean!) on FIELD
+`);
+
+export const validate = async (content: string, config: any = {}, pluginSchema = schema) => {
+  const mergedContent = (await tsPlugin(pluginSchema, [], config, { outputFile: '' })) + '\n' + content;
+
+  validateTs(mergedContent);
+};

--- a/packages/plugins/typescript-resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/mapping.spec.ts
@@ -77,6 +77,7 @@ describe('ResolversTypes', () => {
       testSchema,
       [],
       {
+        noSchemaStitching: true,
         mappers: {
           ID: 'number',
           Chat: 'number',
@@ -121,6 +122,7 @@ describe('ResolversTypes', () => {
       schema,
       [],
       {
+        noSchemaStitching: true,
         defaultMapper: 'Partial<{T}>',
       },
       { outputFile: '' }
@@ -148,6 +150,7 @@ describe('ResolversTypes', () => {
       schema,
       [],
       {
+        noSchemaStitching: true,
         defaultMapper: './my-wrapper#CustomPartial<{T}>',
       },
       { outputFile: '' }
@@ -172,6 +175,16 @@ describe('ResolversTypes', () => {
   });
 
   it('Should map to a custom type on every level when {T} is used as default mapper', async () => {
+    const config = {
+      scalars: {
+        ID: 'number',
+      },
+      noSchemaStitching: true,
+      defaultMapper: 'Partial<{T}>',
+      mappers: {
+        User: 'number',
+      },
+    };
     const testSchema = buildSchema(/* GraphQL */ `
       type User {
         id: ID!
@@ -189,28 +202,18 @@ describe('ResolversTypes', () => {
         me: User
       }
     `);
-    const result = await plugin(
-      testSchema,
-      [],
-      {
-        defaultMapper: 'Partial<{T}>',
-        mappers: {
-          User: 'number',
-        },
-      },
-      { outputFile: '' }
-    );
+    const result = await plugin(testSchema, [], config, { outputFile: '' });
 
-    // expect(result).toBeSimilarStringTo(`
-    //   export type ResolversTypes = {
-    //     Query: Partial<Query>,
-    //     User: CustomUser,
-    //     ID: Scalars['ID'],
-    //     String: Scalars['String'],
-    //     Chat: Partial<Chat>,
-    //     Boolean: Scalars['Boolean'],
-    //   };
-    // `);
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: Omit<Partial<Query>, 'me'> & { me: Maybe<ResolversTypes['User']> },
+      User: number,
+      ID: Scalars['ID'],
+      String: Scalars['String'],
+      Chat: Omit<Partial<Chat>, 'owner' | 'members'> & { owner: ResolversTypes['User'], members: Maybe<Array<ResolversTypes['User']>> },
+      Boolean: Scalars['Boolean'],
+    };
+    `);
 
     const usage = `
       const resolvers: Resolvers = {
@@ -241,15 +244,7 @@ describe('ResolversTypes', () => {
       }
     `;
 
-    await validate(
-      [result, usage].join('\n\n'),
-      {
-        scalars: {
-          ID: 'number',
-        },
-      },
-      testSchema
-    );
+    await validate([result, usage].join('\n\n'), config, testSchema);
   });
 
   it('Should build ResolversTypes with defaultMapper set', async () => {
@@ -257,6 +252,7 @@ describe('ResolversTypes', () => {
       schema,
       [],
       {
+        noSchemaStitching: true,
         mappers: {
           Query: 'MyQueryType',
           MyType: 'MyTypeDb',
@@ -289,6 +285,7 @@ describe('ResolversTypes', () => {
       schema,
       [],
       {
+        noSchemaStitching: true,
         mappers: {
           Query: './my-module#CustomQueryRootType',
           MyType: 'MyTypeDb',
@@ -337,6 +334,7 @@ describe('ResolversTypes', () => {
       testSchema,
       [],
       {
+        noSchemaStitching: true,
         mappers: {
           Comment: 'number',
           Post: 'string',
@@ -374,6 +372,7 @@ describe('ResolversTypes', () => {
       testSchema,
       [],
       {
+        noSchemaStitching: true,
         mappers: {
           Comment: 'number',
           Post: 'string',
@@ -394,6 +393,7 @@ describe('ResolversTypes', () => {
       schema,
       [],
       {
+        noSchemaStitching: true,
         mappers: {
           MyOtherType: './my-file#MyCustomOtherType',
         },
@@ -463,6 +463,7 @@ describe('ResolversTypes', () => {
       schema,
       [],
       {
+        noSchemaStitching: true,
         mappers: {
           MyType: './my-file#MyCustomOtherType',
           MyOtherType: './my-file#MyCustomOtherType',
@@ -533,6 +534,7 @@ describe('ResolversTypes', () => {
       schema,
       [],
       {
+        noSchemaStitching: true,
         mappers: {
           Node: 'MyNodeType',
         },
@@ -602,6 +604,7 @@ describe('ResolversTypes', () => {
       schema,
       [],
       {
+        noSchemaStitching: true,
         defaultMapper: 'any',
       },
       { outputFile: '' }
@@ -669,6 +672,7 @@ describe('ResolversTypes', () => {
       schema,
       [],
       {
+        noSchemaStitching: true,
         defaultMapper: './my-file#MyBaseType',
       },
       { outputFile: '' }
@@ -738,6 +742,7 @@ describe('ResolversTypes', () => {
       schema,
       [],
       {
+        noSchemaStitching: true,
         mappers: {
           MyOtherType: 'MyOtherTypeCustom',
         },
@@ -768,6 +773,7 @@ describe('ResolversTypes', () => {
       schema,
       [],
       {
+        noSchemaStitching: true,
         mappers: {
           MyOtherType: 'MyOtherTypeCustom',
           MyType: 'MyTypeCustom',

--- a/packages/plugins/typescript-resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/mapping.spec.ts
@@ -206,11 +206,11 @@ describe('ResolversTypes', () => {
 
     expect(result).toBeSimilarStringTo(`
     export type ResolversTypes = {
-      Query: Omit<Partial<Query>, 'me'> & { me: Maybe<ResolversTypes['User']> },
+      Query: Partial<Omit<Query, 'me'> & { me: Maybe<ResolversTypes['User']> }>,
       User: number,
       ID: Scalars['ID'],
       String: Scalars['String'],
-      Chat: Omit<Partial<Chat>, 'owner' | 'members'> & { owner: ResolversTypes['User'], members: Maybe<Array<ResolversTypes['User']>> },
+      Chat: Partial<Omit<Chat, 'owner' | 'members'> & { owner: ResolversTypes['User'], members: Maybe<Array<ResolversTypes['User']>> }>,
       Boolean: Scalars['Boolean'],
     };
     `);

--- a/packages/plugins/typescript-resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/mapping.spec.ts
@@ -55,6 +55,61 @@ describe('ResolversTypes', () => {
     };`);
   });
 
+  it('Should build ResolversTypes with defaultMapper set using {T}', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        defaultMapper: 'Partial<{T}>',
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: Partial<Query>,
+      MyType: Partial<MyType>,
+      String: Scalars['String'],
+      MyOtherType: Partial<MyOtherType>,
+      Subscription: Partial<Subscription>,
+      Boolean: Scalars['Boolean'],
+      Node: Partial<Node>,
+      ID: Scalars['ID'],
+      SomeNode: Partial<SomeNode>,
+      MyUnion: Partial<MyUnion>,
+      MyScalar: Scalars['MyScalar'],
+      Int: Scalars['Int'],
+    };`);
+  });
+
+  it('Should build ResolversTypes with defaultMapper set using {T} with external identifier', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        defaultMapper: './my-wrapper#CustomPartial<{T}>',
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`import { CustomPartial } from './my-wrapper';`);
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: CustomPartial<Query>,
+      MyType: CustomPartial<MyType>,
+      String: Scalars['String'],
+      MyOtherType: CustomPartial<MyOtherType>,
+      Subscription: CustomPartial<Subscription>,
+      Boolean: Scalars['Boolean'],
+      Node: CustomPartial<Node>,
+      ID: Scalars['ID'],
+      SomeNode: CustomPartial<SomeNode>,
+      MyUnion: CustomPartial<MyUnion>,
+      MyScalar: Scalars['MyScalar'],
+      Int: Scalars['Int'],
+    };`);
+  });
+
   it('Should build ResolversTypes with defaultMapper set', async () => {
     const result = await plugin(
       schema,

--- a/packages/plugins/typescript-resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/mapping.spec.ts
@@ -1,0 +1,538 @@
+import '@graphql-codegen/testing';
+import { schema, validate } from './common';
+import { plugin } from '../src';
+import { buildSchema } from 'graphql';
+
+describe('ResolversTypes', () => {
+  it('Should build ResolversTypes object when there are no mappers', async () => {
+    const result = await plugin(schema, [], {}, { outputFile: '' });
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: Query,
+      MyType: MyType,
+      String: Scalars['String'],
+      MyOtherType: MyOtherType,
+      Subscription: Subscription,
+      Boolean: Scalars['Boolean'],
+      Node: Node,
+      ID: Scalars['ID'],
+      SomeNode: SomeNode,
+      MyUnion: MyUnion,
+      MyScalar: Scalars['MyScalar'],
+      Int: Scalars['Int'],
+    };`);
+  });
+
+  it('Should build ResolversTypes with simple mappers', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          Query: 'MyQueryType',
+          MyType: 'MyTypeDb',
+          String: 'string',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: MyQueryType,
+      MyType: MyTypeDb,
+      String: string,
+      MyOtherType: MyOtherType,
+      Subscription: Subscription,
+      Boolean: Scalars['Boolean'],
+      Node: Node,
+      ID: Scalars['ID'],
+      SomeNode: SomeNode,
+      MyUnion: MyUnion,
+      MyScalar: Scalars['MyScalar'],
+      Int: Scalars['Int'],
+    };`);
+  });
+
+  it('Should build ResolversTypes with defaultMapper set', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          Query: 'MyQueryType',
+          MyType: 'MyTypeDb',
+          String: 'string',
+        },
+        defaultMapper: 'any',
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: MyQueryType,
+      MyType: MyTypeDb,
+      String: string,
+      MyOtherType: any,
+      Subscription: any,
+      Boolean: any,
+      Node: any,
+      ID: any,
+      SomeNode: any,
+      MyUnion: any,
+      MyScalar: any,
+      Int: any,
+    };`);
+  });
+
+  it('Should build ResolversTypes with external mappers', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          Query: './my-module#CustomQueryRootType',
+          MyType: 'MyTypeDb',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: CustomQueryRootType,
+      MyType: MyTypeDb,
+      String: Scalars['String'],
+      MyOtherType: MyOtherType,
+      Subscription: Subscription,
+      Boolean: Scalars['Boolean'],
+      Node: Node,
+      ID: Scalars['ID'],
+      SomeNode: SomeNode,
+      MyUnion: MyUnion,
+      MyScalar: Scalars['MyScalar'],
+      Int: Scalars['Int'],
+    };`);
+  });
+
+  it('should warn about unused mappers by default', async () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+    const testSchema = buildSchema(/* GraphQL */ `
+      type Query {
+        comments: [Comment!]!
+      }
+
+      type User {
+        id: ID!
+        name: String!
+      }
+
+      type Comment {
+        id: ID!
+        text: String!
+        author: User!
+      }
+    `);
+
+    await plugin(
+      testSchema,
+      [],
+      {
+        mappers: {
+          Comment: 'number',
+          Post: 'string',
+        },
+      },
+      {
+        outputFile: 'graphql.ts',
+      }
+    );
+
+    expect(spy).toHaveBeenCalledWith('Unused mappers: Post');
+    spy.mockRestore();
+  });
+
+  it('should be able not to warn about unused mappers', async () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+    const testSchema = buildSchema(/* GraphQL */ `
+      type Query {
+        comments: [Comment!]!
+      }
+
+      type User {
+        id: ID!
+        name: String!
+      }
+
+      type Comment {
+        id: ID!
+        text: String!
+        author: User!
+      }
+    `);
+
+    await plugin(
+      testSchema,
+      [],
+      {
+        mappers: {
+          Comment: 'number',
+          Post: 'string',
+        },
+        showUnusedMappers: false,
+      },
+      {
+        outputFile: 'graphql.ts',
+      }
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('Should generate basic type resolvers with external mappers', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          MyOtherType: './my-file#MyCustomOtherType',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`import { MyCustomOtherType } from './my-file';`);
+    expect(result).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+
+    expect(result).toBeSimilarStringTo(`
+        export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
+          bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        };
+      `);
+
+    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
+      name: 'MyScalar'
+        }
+      `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      };
+    `);
+    await validate(result);
+  });
+
+  it('Should generate basic type resolvers with external mappers using same imported type', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          MyType: './my-file#MyCustomOtherType',
+          MyOtherType: './my-file#MyCustomOtherType',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`import { MyCustomOtherType } from './my-file';`);
+    expect(result).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+
+    expect(result).toBeSimilarStringTo(`
+        export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
+          bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        };
+      `);
+
+    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
+      name: 'MyScalar'
+        }
+      `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      };
+    `);
+    await validate(result);
+  });
+
+  it('Should generate the correct resolvers when used with mappers with interfaces', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        mappers: {
+          Node: 'MyNodeType',
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
+        name: 'MyScalar'
+      }
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      };
+    `);
+    await validate(`type MyNodeType = {};\n${result}`);
+  });
+
+  it('Should generate basic type resolvers with defaultMapper set to any', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        defaultMapper: 'any',
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
+        name: 'MyScalar'
+      }
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      };
+    `);
+    await validate(result);
+  });
+
+  it('Should generate basic type resolvers with defaultMapper set to external identifier', async () => {
+    const result = await plugin(
+      schema,
+      [],
+      {
+        defaultMapper: './my-file#MyBaseType',
+      },
+      { outputFile: '' }
+    );
+
+    expect(result).toContain(`import { MyBaseType } from './my-file';`);
+
+    expect(result).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
+        name: 'MyScalar'
+      }
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      };
+    `);
+
+    expect(result).toBeSimilarStringTo(`
+      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      };
+    `);
+    await validate(result);
+  });
+});

--- a/packages/plugins/typescript-resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/ts-resolvers.spec.ts
@@ -3,48 +3,9 @@ import { buildSchema } from 'graphql';
 import { plugin } from '../src';
 import { plugin as tsPlugin } from '../../typescript/src/index';
 import { validateTs } from '../../typescript/tests/validate';
+import { schema, validate } from './common';
 
 describe('TypeScript Resolvers Plugin', () => {
-  const schema = buildSchema(/* GraphQL */ `
-    type MyType {
-      foo: String!
-      otherType: MyOtherType
-      withArgs(arg: String, arg2: String!): String
-    }
-
-    type MyOtherType {
-      bar: String!
-    }
-
-    type Query {
-      something: MyType!
-    }
-
-    type Subscription {
-      somethingChanged: MyOtherType
-    }
-
-    interface Node {
-      id: ID!
-    }
-
-    type SomeNode implements Node {
-      id: ID!
-    }
-
-    union MyUnion = MyType | MyOtherType
-
-    scalar MyScalar
-
-    directive @myDirective(arg: Int!, arg2: String!, arg3: Boolean!) on FIELD
-  `);
-
-  const validate = async (content: string, config: any = {}, pluginSchema = schema) => {
-    const mergedContent = (await tsPlugin(pluginSchema, [], config, { outputFile: '' })) + '\n' + content;
-
-    validateTs(mergedContent);
-  };
-
   describe('Backward Compatability', () => {
     it('Should generate IDirectiveResolvers by default', async () => {
       const result = await plugin(schema, [], {}, { outputFile: '' });
@@ -246,51 +207,51 @@ describe('TypeScript Resolvers Plugin', () => {
       arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = MyOtherType> = {
-        bar?: Resolver<Scalars['String'], ParentType, Context>,
+      export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
+    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
       name: 'MyScalar'
     }`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = MyType> = {
-        foo?: Resolver<Scalars['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<MyOtherType>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = MyUnion> = {
+      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = Node> = {
+      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = Query> = {
-        something?: Resolver<MyType, ParentType, Context>,
+      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = SomeNode> = {
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = Subscription> = {
-        somethingChanged?: SubscriptionResolver<Maybe<MyOtherType>, ParentType, Context>,
+      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
       };
     `);
 
@@ -305,51 +266,51 @@ describe('TypeScript Resolvers Plugin', () => {
       arg2: Maybe<Scalars['String']>, arg3: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = MyOtherType> = {
-        bar: Resolver<Scalars['String'], ParentType, Context>,
+      export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
+        bar: Resolver<ResolversTypes['String'], ParentType, Context>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
+    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
       name: 'MyScalar'
     }`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = MyType> = {
-        foo: Resolver<Scalars['String'], ParentType, Context>,
-        otherType: Resolver<Maybe<MyOtherType>, ParentType, Context>,
-        withArgs: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
+        foo: Resolver<ResolversTypes['String'], ParentType, Context>,
+        otherType: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+        withArgs: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = MyUnion> = {
+      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = Node> = {
+      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id: Resolver<Scalars['ID'], ParentType, Context>,
+        id: Resolver<ResolversTypes['ID'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = Query> = {
-        something: Resolver<MyType, ParentType, Context>,
+      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
+        something: Resolver<ResolversTypes['MyType'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = SomeNode> = {
-        id: Resolver<Scalars['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
+        id: Resolver<ResolversTypes['ID'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = Subscription> = {
-        somethingChanged: SubscriptionResolver<Maybe<MyOtherType>, ParentType, Context>,
+      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
       };
     `);
 
@@ -371,47 +332,47 @@ describe('TypeScript Resolvers Plugin', () => {
       arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = MyCustomContext, ParentType = MyOtherType> = {
-        bar?: Resolver<Scalars['String'], ParentType, Context>,
+      export type MyOtherTypeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = MyCustomContext, ParentType = MyType> = {
-        foo?: Resolver<Scalars['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<MyOtherType>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = MyCustomContext, ParentType = MyUnion> = {
+      export type MyUnionResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = MyCustomContext, ParentType = Node> = {
+      export type NodeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = MyCustomContext, ParentType = Query> = {
-        something?: Resolver<MyType, ParentType, Context>,
+      export type QueryResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = MyCustomContext, ParentType = SomeNode> = {
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = MyCustomContext, ParentType = Subscription> = {
-        somethingChanged?: SubscriptionResolver<Maybe<MyOtherType>, ParentType, Context>,
+      export type SubscriptionResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
       };
     `);
 
@@ -435,47 +396,47 @@ describe('TypeScript Resolvers Plugin', () => {
       arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = MyCustomContext, ParentType = MyOtherType> = {
-        bar?: Resolver<Scalars['String'], ParentType, Context>,
+      export type MyOtherTypeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = MyCustomContext, ParentType = MyType> = {
-        foo?: Resolver<Scalars['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<MyOtherType>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = MyCustomContext, ParentType = MyUnion> = {
+      export type MyUnionResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = MyCustomContext, ParentType = Node> = {
+      export type NodeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = MyCustomContext, ParentType = Query> = {
-        something?: Resolver<MyType, ParentType, Context>,
+      export type QueryResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = MyCustomContext, ParentType = SomeNode> = {
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = MyCustomContext, ParentType = Subscription> = {
-        somethingChanged?: SubscriptionResolver<Maybe<MyOtherType>, ParentType, Context>,
+      export type SubscriptionResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
       };
     `);
 
@@ -498,419 +459,6 @@ describe('TypeScript Resolvers Plugin', () => {
     await validate(result, {}, testSchema);
   });
 
-  it('Should generate basic type resolvers with mapping', async () => {
-    const result = await plugin(
-      schema,
-      [],
-      {
-        mappers: {
-          MyOtherType: 'MyCustomOtherType',
-        },
-      },
-      { outputFile: '' }
-    );
-
-    expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> = {
-        bar?: Resolver<Scalars['String'], ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
-        name: 'MyScalar'
-      }
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = MyType> = {
-        foo?: Resolver<Scalars['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<MyCustomOtherType>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = MyUnion> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = Node> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = Query> = {
-        something?: Resolver<MyType, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = SomeNode> = {
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = Subscription> = {
-        somethingChanged?: SubscriptionResolver<Maybe<MyCustomOtherType>, ParentType, Context>,
-      };
-    `);
-    await validate(`type MyCustomOtherType = {}\n${result}`);
-  });
-
-  it('Should generate the correct resolvers when used with mappers with interfaces', async () => {
-    const result = await plugin(
-      schema,
-      [],
-      {
-        mappers: {
-          Node: 'MyNodeType',
-        },
-      },
-      { outputFile: '' }
-    );
-
-    expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = MyOtherType> = {
-        bar?: Resolver<Scalars['String'], ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
-        name: 'MyScalar'
-      }
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = MyType> = {
-        foo?: Resolver<Scalars['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<MyOtherType>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = MyUnion> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = MyNodeType> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = Query> = {
-        something?: Resolver<MyType, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = SomeNode> = {
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = Subscription> = {
-        somethingChanged?: SubscriptionResolver<Maybe<MyOtherType>, ParentType, Context>,
-      };
-    `);
-    await validate(`type MyNodeType = {};\n${result}`);
-  });
-
-  it('Should generate basic type resolvers with defaultMapper set to any', async () => {
-    const result = await plugin(
-      schema,
-      [],
-      {
-        defaultMapper: 'any',
-      },
-      { outputFile: '' }
-    );
-
-    expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = any> = {
-        bar?: Resolver<any, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
-        name: 'MyScalar'
-      }
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = any> = {
-        foo?: Resolver<any, ParentType, Context>,
-        otherType?: Resolver<Maybe<any>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<any>, ParentType, Context, MyTypeWithArgsArgs>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = any> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = any> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<any, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = any> = {
-        something?: Resolver<any, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = any> = {
-        id?: Resolver<any, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = any> = {
-        somethingChanged?: SubscriptionResolver<Maybe<any>, ParentType, Context>,
-      };
-    `);
-    await validate(result);
-  });
-
-  it('Should generate basic type resolvers with defaultMapper set to external identifier', async () => {
-    const result = await plugin(
-      schema,
-      [],
-      {
-        defaultMapper: './my-file#MyBaseType',
-      },
-      { outputFile: '' }
-    );
-
-    expect(result).toContain(`import { MyBaseType } from './my-file';`);
-
-    expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = MyBaseType> = {
-        bar?: Resolver<MyBaseType, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
-        name: 'MyScalar'
-      }
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = MyBaseType> = {
-        foo?: Resolver<MyBaseType, ParentType, Context>,
-        otherType?: Resolver<Maybe<MyBaseType>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<MyBaseType>, ParentType, Context, MyTypeWithArgsArgs>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = MyBaseType> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = MyBaseType> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<MyBaseType, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = MyBaseType> = {
-        something?: Resolver<MyBaseType, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = MyBaseType> = {
-        id?: Resolver<MyBaseType, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = MyBaseType> = {
-        somethingChanged?: SubscriptionResolver<Maybe<MyBaseType>, ParentType, Context>,
-      };
-    `);
-    await validate(result);
-  });
-
-  it('Should generate basic type resolvers with external mappers', async () => {
-    const result = await plugin(
-      schema,
-      [],
-      {
-        mappers: {
-          MyOtherType: './my-file#MyCustomOtherType',
-        },
-      },
-      { outputFile: '' }
-    );
-
-    expect(result).toBeSimilarStringTo(`import { MyCustomOtherType } from './my-file';`);
-    expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
-
-    expect(result).toBeSimilarStringTo(`
-        export type MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> = {
-          bar?: Resolver<Scalars['String'], ParentType, Context>,
-        };
-      `);
-
-    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
-      name: 'MyScalar'
-        }
-      `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = MyType> = {
-        foo?: Resolver<Scalars['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<MyCustomOtherType>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = MyUnion> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = Node> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = Query> = {
-        something?: Resolver<MyType, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = SomeNode> = {
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = Subscription> = {
-        somethingChanged?: SubscriptionResolver<Maybe<MyCustomOtherType>, ParentType, Context>,
-      };
-    `);
-    await validate(result);
-  });
-
-  it('Should generate basic type resolvers with external mappers using same imported type', async () => {
-    const result = await plugin(
-      schema,
-      [],
-      {
-        mappers: {
-          MyType: './my-file#MyCustomOtherType',
-          MyOtherType: './my-file#MyCustomOtherType',
-        },
-      },
-      { outputFile: '' }
-    );
-
-    expect(result).toBeSimilarStringTo(`import { MyCustomOtherType } from './my-file';`);
-    expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
-
-    expect(result).toBeSimilarStringTo(`
-        export type MyOtherTypeResolvers<Context = any, ParentType = MyCustomOtherType> = {
-          bar?: Resolver<Scalars['String'], ParentType, Context>,
-        };
-      `);
-
-    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<Scalars['MyScalar'], any> {
-      name: 'MyScalar'
-        }
-      `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = MyCustomOtherType> = {
-        foo?: Resolver<Scalars['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<MyCustomOtherType>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<Scalars['String']>, ParentType, Context, MyTypeWithArgsArgs>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = MyUnion> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = Node> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = Query> = {
-        something?: Resolver<MyCustomOtherType, ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = SomeNode> = {
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
-      };
-    `);
-
-    expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = Subscription> = {
-        somethingChanged?: SubscriptionResolver<Maybe<MyCustomOtherType>, ParentType, Context>,
-      };
-    `);
-    await validate(result);
-  });
-
   it('Should not convert type names in unions', async () => {
     const testSchema = buildSchema(/* GraphQL */ `
       type CCCFoo {
@@ -931,10 +479,11 @@ describe('TypeScript Resolvers Plugin', () => {
     const tsContent = await tsPlugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
     const content = await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
 
+    expect(content).toBeSimilarStringTo(`CCCUnion: CccUnion`); // In ResolversTypes
     expect(content).toBeSimilarStringTo(`
-      export type CccUnionResolvers<Context = any, ParentType = CccUnion> = {
-        __resolveType: TypeResolveFn<'CCCFoo' | 'CCCBar', ParentType, Context>
-      };
+    export type CccUnionResolvers<Context = any, ParentType = ResolversTypes['CCCUnion']> = {
+      __resolveType: TypeResolveFn<'CCCFoo' | 'CCCBar', ParentType, Context>
+    };
     `);
 
     await validateTs([tsContent, content].join('\n'));
@@ -945,7 +494,7 @@ describe('TypeScript Resolvers Plugin', () => {
     const config = { typesPrefix: 'T' };
     const result = await plugin(testSchema, [], config, { outputFile: '' });
 
-    expect(result).toBeSimilarStringTo(`f?: Resolver<Maybe<Scalars['String']>, ParentType, Context, TMyTypeFArgs>,`);
+    expect(result).toBeSimilarStringTo(`f?: Resolver<Maybe<TResolversTypes['String']>, ParentType, Context, TMyTypeFArgs>,`);
     await validate(result, config, testSchema);
   });
 
@@ -1073,26 +622,6 @@ describe('TypeScript Resolvers Plugin', () => {
       `,
     ].join('\n');
 
-    expect(content).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = AppContext, ParentType = Query> = ResolversObject<{
-        users?: Resolver<Array<User>, ParentType, Context>,
-      }>;
-    `);
-
-    expect(content).toBeSimilarStringTo(`
-      export type UserResolvers<Context = AppContext, ParentType = User> = ResolversObject<{
-        id?: Resolver<Scalars['ID'], ParentType, Context>,
-        name?: Resolver<Scalars['String'], ParentType, Context>,
-      }>;
-    `);
-
-    expect(content).toBeSimilarStringTo(`
-      export type Resolvers<Context = AppContext> = ResolversObject<{
-        Query?: QueryResolvers<Context>,
-        User?: UserResolvers<Context>,
-      }>;
-    `);
-
     validateTs(content);
   });
 
@@ -1149,81 +678,6 @@ describe('TypeScript Resolvers Plugin', () => {
     ].join('\n');
 
     validateTs(content);
-  });
-
-  it('should warn about unused mappers by default', async () => {
-    const spy = jest.spyOn(console, 'warn').mockImplementation();
-    const testSchema = buildSchema(/* GraphQL */ `
-      type Query {
-        comments: [Comment!]!
-      }
-
-      type User {
-        id: ID!
-        name: String!
-      }
-
-      type Comment {
-        id: ID!
-        text: String!
-        author: User!
-      }
-    `);
-
-    await plugin(
-      testSchema,
-      [],
-      {
-        mappers: {
-          Comment: 'number',
-          Post: 'string',
-        },
-      },
-      {
-        outputFile: 'graphql.ts',
-      }
-    );
-
-    expect(spy).toHaveBeenCalledWith('Unused mappers: Post');
-    spy.mockRestore();
-  });
-
-  it('should be able not to warn about unused mappers', async () => {
-    const spy = jest.spyOn(console, 'warn').mockImplementation();
-    const testSchema = buildSchema(/* GraphQL */ `
-      type Query {
-        comments: [Comment!]!
-      }
-
-      type User {
-        id: ID!
-        name: String!
-      }
-
-      type Comment {
-        id: ID!
-        text: String!
-        author: User!
-      }
-    `);
-
-    await plugin(
-      testSchema,
-      [],
-      {
-        mappers: {
-          Comment: 'number',
-          Post: 'string',
-        },
-        showUnusedMappers: false,
-      },
-      {
-        outputFile: 'graphql.ts',
-      }
-    );
-
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
   });
 
   it('should generate subscription types correctly', async () => {

--- a/packages/plugins/typescript/tests/validate.ts
+++ b/packages/plugins/typescript/tests/validate.ts
@@ -63,7 +63,8 @@ export function validateTs(
     if (diagnostic.file) {
       let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
       let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
-      errors.push(`${line + 1},${character + 1}: ${message}`);
+      errors.push(`${line + 1},${character + 1}: ${message} ->
+  ${contents.split('\n')[line]}`);
     } else {
       errors.push(`${ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')}`);
     }

--- a/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -178,21 +178,17 @@ export class BaseResolversVisitor<TRawConfig extends RawResolversConfig = RawRes
           return prev;
         }
 
-        let shouldApplyOmit = true;
+        let shouldApplyOmit = false;
 
         if (this.config.mappers[typeName] && this.config.mappers[typeName].type) {
           this.markMapperAsUsed(typeName);
-          shouldApplyOmit = false;
           prev[typeName] = this.config.mappers[typeName].type;
-        } else if (this.config.defaultMapper && this.config.defaultMapper.type) {
-          if (this.config.defaultMapper.type.includes('{T}')) {
-            prev[typeName] = this.config.scalars[typeName] ? this._getScalar(typeName) : this.config.defaultMapper.type.replace('{T}', this.convertName(typeName));
-          } else {
-            prev[typeName] = this.config.defaultMapper.type;
-          }
+        } else if (this.config.defaultMapper && this.config.defaultMapper.type && !this.config.defaultMapper.type.includes('{T}')) {
+          prev[typeName] = this.config.defaultMapper.type;
         } else if (this.config.scalars[typeName]) {
           prev[typeName] = this._getScalar(typeName);
         } else {
+          shouldApplyOmit = true;
           prev[typeName] = this.convertName(typeName);
         }
 
@@ -218,6 +214,10 @@ export class BaseResolversVisitor<TRawConfig extends RawResolversConfig = RawRes
           if (relevantFields.length > 0) {
             prev[typeName] = this.replaceFieldsInType(prev[typeName], relevantFields);
           }
+        }
+
+        if (!this.config.scalars[typeName] && !this.config.mappers[typeName] && this.config.defaultMapper && this.config.defaultMapper.type.includes('{T}')) {
+          prev[typeName] = this.config.defaultMapper.type.replace('{T}', prev[typeName]);
         }
 
         return prev;

--- a/packages/plugins/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/visitor-plugin-common/src/utils.ts
@@ -212,18 +212,6 @@ export function toPascalCase(str: string, transformUnderscore = false): string {
   return convertNameParts(str, pascalCase, transformUnderscore);
 }
 
-export const wrapTypeWithModifiers = (prefix = '') => (baseType: string, type: GraphQLObjectType | GraphQLNonNull<GraphQLObjectType> | GraphQLList<GraphQLObjectType>): string => {
-  if (isNonNullType(type)) {
-    return wrapTypeWithModifiers(prefix)(baseType, type.ofType).substr(1);
-  } else if (isListType(type)) {
-    const innerType = wrapTypeWithModifiers(prefix)(baseType, type.ofType);
-
-    return `${prefix}Array<${innerType}>`;
-  } else {
-    return `${prefix}${baseType}`;
-  }
-};
-
 export function buildScalars(schema: GraphQLSchema, scalarsMapping: ScalarsMap): ScalarsMap {
   const typeMap = schema.getTypeMap();
   let result = { ...scalarsMapping };


### PR DESCRIPTION
This PR will resolve the following issues related to resolvers packages:
- [x] https://github.com/dotansimha/graphql-code-generator/issues/1595
- [x] https://github.com/dotansimha/graphql-code-generator/issues/1591 
- [x] https://github.com/dotansimha/graphql-code-generator/issues/1589
- [x] Implement all in TypeScript
- [x] Implement all in Flow
- [x] Move `unusedMappers` config to the base package
- [x] Update documentation