### PR TITLE
Fix typo in @example comment

### DIFF
--- a/packages/plugins/typescript-react-apollo/src/index.ts
+++ b/packages/plugins/typescript-react-apollo/src/index.ts
@@ -58,7 +58,7 @@ export interface ReactApolloRawPluginConfig extends RawClientSideBasePluginConfi
    *    - typescript-operations
    *    - typescript-react-apollo
    *  config:
-   *    withComponent: false
+   *    withHooks: false
    * ```
    */
   withHooks?: boolean;


### PR DESCRIPTION
I noticed a typo when reading [the documentation of typescript-react-apollo](https://graphql-code-generator.com/docs/plugins/typescript-react-apollo).