### PR TITLE
Gracefully handle an interface with no known implementors

### DIFF
--- a/packages/plugins/typescript-resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/ts-resolvers.spec.ts
@@ -728,4 +728,25 @@ describe('TypeScript Resolvers Plugin', () => {
     ].join('\n');
     validateTs(content);
   });
+
+  it('Should generate valid types even when there are no implementers for an interface', async () => {
+    const schemaWithNoImplementors = buildSchema(/* GraphQL */ `
+      interface Node {
+        id: ID!
+      }
+
+      type Query {
+        node: Node!
+      }
+    `);
+
+    const result = await plugin(schemaWithNoImplementors, [], {}, { outputFile: '' });
+
+    expect(result).toBeSimilarStringTo(`
+      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<null, ParentType, Context>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      };
+    `);
+  });
 });

--- a/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -576,11 +576,13 @@ export type IDirectiveResolvers${contextType} = ${name}<Context>;`
 
     const type = this.getTypeToUse((node.name as any) as string);
 
+    const possibleTypes = implementingTypes.map(name => `'${name}'`).join(' | ') || 'null';
+
     return new DeclarationBlock(this._declarationBlockConfig)
       .export()
       .asKind('type')
       .withName(name, `<Context = ${this.config.contextType.type}, ParentType = ${type}>`)
-      .withBlock([indent(`__resolveType: TypeResolveFn<${implementingTypes.map(name => `'${name}'`).join(' | ')}, ParentType, Context>,`), ...(node.fields || []).map((f: any) => f(node.name))].join('\n')).string;
+      .withBlock([indent(`__resolveType: TypeResolveFn<${possibleTypes}, ParentType, Context>,`), ...(node.fields || []).map((f: any) => f(node.name))].join('\n')).string;
   }
 
   SchemaDefinition() {


### PR DESCRIPTION
Before this change, the generated code would have included:

```
__resolveType: TypeResolveFn<, ParentType, Context>
```

which would fail to parse due to the missing type parameter