### PR TITLE
Set SubscriptionResolver type to full array type.

### DIFF
--- a/packages/plugins/flow-resolvers/src/index.ts
+++ b/packages/plugins/flow-resolvers/src/index.ts
@@ -46,7 +46,7 @@ export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
 }
 
 export type SubscriptionResolver<Result, Parent = {}, Context = {}, Args = {}> =
-  | ((...args: any[]) => ISubscriptionResolverObject<Result, Parent, Context, Args>)
+  | ((...args: Array<any>) => ISubscriptionResolverObject<Result, Parent, Context, Args>)
   | ISubscriptionResolverObject<Result, Parent, Context, Args>;
 
 export type TypeResolveFn<Types, Parent = {}, Context = {}> = (


### PR DESCRIPTION
The reason for that is that most Flow users will want to use the verbose version of array notation, according to https://github.com/gajus/eslint-plugin-flowtype/blob/master/.README/rules/array-style-simple-type.md

This change will also keep consistency with other plugins (i.e. `flow`) which generate `?Array<sometype>` (cf. https://github.com/dotansimha/graphql-code-generator/blob/master/packages/plugins/flow/src/flow-variables-to-object.ts#L25)