### PR TITLE
do not apply omit to interface when mapper is configured

### DIFF
--- a/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -193,7 +193,7 @@ export class BaseResolversVisitor<TRawConfig extends RawResolversConfig = RawRes
         }
 
         const schemaType = allSchemaTypes[typeName];
-        if ((shouldApplyOmit && prev[typeName] !== 'any' && isObjectType(schemaType)) || isInterfaceType(schemaType)) {
+        if ((shouldApplyOmit && prev[typeName] !== 'any' && isObjectType(schemaType)) || (isInterfaceType(schemaType) && !this.config.mappers[typeName])) {
           const fields = schemaType.getFields();
           const relevantFields = Object.keys(fields)
             .map(fieldName => {


### PR DESCRIPTION
This PR makes sure that the omit logic is not applied when a mapper is specified for a graphql interface.

related #1670

P.s. is it possible to run the tests for a single package, instead of the whole suite? Preferably also without having to run `yarn build`.