### PR TITLE
change generic parameter name of context type to prevent clash

### DIFF
--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -103,26 +103,26 @@ export type ResolversTypes = {
   Boolean: Scalars['Boolean'],
 };
 
-export type QueryRootResolvers<Context = any, ParentType = ResolversTypes['QueryRoot']> = {
-  allUsers?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, Context>,
-  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, Context, QueryRootUserByIdArgs>,
-  answer?: Resolver<Array<ResolversTypes['Int']>, ParentType, Context>,
+export type QueryRootResolvers<ContextType = any, ParentType = ResolversTypes['QueryRoot']> = {
+  allUsers?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, ContextType>,
+  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, QueryRootUserByIdArgs>,
+  answer?: Resolver<Array<ResolversTypes['Int']>, ParentType, ContextType>,
 };
 
-export type SubscriptionRootResolvers<Context = any, ParentType = ResolversTypes['SubscriptionRoot']> = {
-  newUser?: SubscriptionResolver<Maybe<ResolversTypes['User']>, ParentType, Context>,
+export type SubscriptionRootResolvers<ContextType = any, ParentType = ResolversTypes['SubscriptionRoot']> = {
+  newUser?: SubscriptionResolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
 };
 
-export type UserResolvers<Context = any, ParentType = ResolversTypes['User']> = {
-  id?: Resolver<ResolversTypes['Int'], ParentType, Context>,
-  name?: Resolver<ResolversTypes['String'], ParentType, Context>,
-  email?: Resolver<ResolversTypes['String'], ParentType, Context>,
+export type UserResolvers<ContextType = any, ParentType = ResolversTypes['User']> = {
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>,
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
 };
 
-export type Resolvers<Context = any> = {
-  QueryRoot?: QueryRootResolvers<Context>,
-  SubscriptionRoot?: SubscriptionRootResolvers<Context>,
-  User?: UserResolvers<Context>,
+export type Resolvers<ContextType = any> = {
+  QueryRoot?: QueryRootResolvers<ContextType>,
+  SubscriptionRoot?: SubscriptionRootResolvers<ContextType>,
+  User?: UserResolvers<ContextType>,
 };
 
 
@@ -130,4 +130,4 @@ export type Resolvers<Context = any> = {
  * @deprecated
  * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
 */
-export type IResolvers<Context = any> = Resolvers<Context>;
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;

--- a/dev-test/test-schema/resolvers-types.ts
+++ b/dev-test/test-schema/resolvers-types.ts
@@ -98,21 +98,21 @@ export type ResolversTypes = {
   Boolean: Scalars['Boolean'],
 };
 
-export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
-  allUsers?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, Context>,
-  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, Context, QueryUserByIdArgs>,
-  answer?: Resolver<Array<ResolversTypes['Int']>, ParentType, Context>,
+export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
+  allUsers?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, ContextType>,
+  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, QueryUserByIdArgs>,
+  answer?: Resolver<Array<ResolversTypes['Int']>, ParentType, ContextType>,
 };
 
-export type UserResolvers<Context = any, ParentType = ResolversTypes['User']> = {
-  id?: Resolver<ResolversTypes['Int'], ParentType, Context>,
-  name?: Resolver<ResolversTypes['String'], ParentType, Context>,
-  email?: Resolver<ResolversTypes['String'], ParentType, Context>,
+export type UserResolvers<ContextType = any, ParentType = ResolversTypes['User']> = {
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>,
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
 };
 
-export type Resolvers<Context = any> = {
-  Query?: QueryResolvers<Context>,
-  User?: UserResolvers<Context>,
+export type Resolvers<ContextType = any> = {
+  Query?: QueryResolvers<ContextType>,
+  User?: UserResolvers<ContextType>,
 };
 
 
@@ -120,4 +120,4 @@ export type Resolvers<Context = any> = {
  * @deprecated
  * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
 */
-export type IResolvers<Context = any> = Resolvers<Context>;
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;

--- a/dev-test/test-schema/typings.ts
+++ b/dev-test/test-schema/typings.ts
@@ -97,20 +97,20 @@ export type ResolversTypes = {
   Boolean: Scalars['Boolean'],
 };
 
-export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
-  allUsers?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, Context>,
-  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, Context, QueryUserByIdArgs>,
+export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
+  allUsers?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, ContextType>,
+  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, QueryUserByIdArgs>,
 };
 
-export type UserResolvers<Context = any, ParentType = ResolversTypes['User']> = {
-  id?: Resolver<ResolversTypes['Int'], ParentType, Context>,
-  name?: Resolver<ResolversTypes['String'], ParentType, Context>,
-  email?: Resolver<ResolversTypes['String'], ParentType, Context>,
+export type UserResolvers<ContextType = any, ParentType = ResolversTypes['User']> = {
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>,
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
 };
 
-export type Resolvers<Context = any> = {
-  Query?: QueryResolvers<Context>,
-  User?: UserResolvers<Context>,
+export type Resolvers<ContextType = any> = {
+  Query?: QueryResolvers<ContextType>,
+  User?: UserResolvers<ContextType>,
 };
 
 
@@ -118,4 +118,4 @@ export type Resolvers<Context = any> = {
  * @deprecated
  * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
 */
-export type IResolvers<Context = any> = Resolvers<Context>;
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;

--- a/docs/plugins/typescript-resolvers.md
+++ b/docs/plugins/typescript-resolvers.md
@@ -81,15 +81,15 @@ type User {
 Given the schema above, the output should be the following:
 
 ```typescript
-export interface QueryResolvers<Context = any, ParentType = Query> {
-  allUsers?: Resolver<Array<Maybe<User>>, ParentType, Context>;
-  userById?: Resolver<Maybe<User>, ParentType, Context, QueryUserByIdArgs>;
+export interface QueryResolvers<ContextType = any, ParentType = Query> {
+  allUsers?: Resolver<Array<Maybe<User>>, ParentType, ContextType>;
+  userById?: Resolver<Maybe<User>, ParentType, ContextType, QueryUserByIdArgs>;
 }
 
-export interface UserResolvers<Context = any, ParentType = User> {
-  id?: Resolver<number, ParentType, Context>;
-  name?: Resolver<string, ParentType, Context>;
-  email?: Resolver<string, ParentType, Context>;
+export interface UserResolvers<ContextType = any, ParentType = User> {
+  id?: Resolver<number, ParentType, ContextType>;
+  name?: Resolver<string, ParentType, ContextType>;
+  email?: Resolver<string, ParentType, ContextType>;
 }
 ```
 

--- a/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
@@ -8,11 +8,11 @@ describe('Flow Resolvers Plugin', () => {
     const result = plugin(schema, [], {}, { outputFile: '' });
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
-      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
-      bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+    expect(result).toBeSimilarStringTo(`export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+      bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
     }`);
 
     expect(result).toBeSimilarStringTo(`export type MyScalarScalarConfig = {
@@ -20,31 +20,31 @@ describe('Flow Resolvers Plugin', () => {
       name: 'MyScalar'
     };`);
 
-    expect(result).toBeSimilarStringTo(`export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
-      foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
-      otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
-      withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+    expect(result).toBeSimilarStringTo(`export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+      foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
+      otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
+      withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType, MyTypeWithArgsArgs>,
     }`);
 
-    expect(result).toBeSimilarStringTo(`export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
-      __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+    expect(result).toBeSimilarStringTo(`export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+      __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
     }`);
 
-    expect(result).toBeSimilarStringTo(`export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
-      __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-      id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+    expect(result).toBeSimilarStringTo(`export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+      __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+      id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
     }`);
 
-    expect(result).toBeSimilarStringTo(`export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
-      something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
+    expect(result).toBeSimilarStringTo(`export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+      something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
     }`);
 
-    expect(result).toBeSimilarStringTo(`export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
-      id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+    expect(result).toBeSimilarStringTo(`export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+      id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
     }`);
 
-    expect(result).toBeSimilarStringTo(`export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
-      somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+    expect(result).toBeSimilarStringTo(`export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+      somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
     }`);
   });
 
@@ -63,6 +63,6 @@ describe('Flow Resolvers Plugin', () => {
   it('Should generate the correct resolver args type names when typesPrefix is specified', () => {
     const result = plugin(buildSchema(`type MyType { f(a: String): String }`), [], { typesPrefix: 'T' }, { outputFile: '' });
 
-    expect(result).toBeSimilarStringTo(`f?: Resolver<?$ElementType<TResolversTypes, 'String'>, ParentType, Context, TMyTypeFArgs>,`);
+    expect(result).toBeSimilarStringTo(`f?: Resolver<?$ElementType<TResolversTypes, 'String'>, ParentType, ContextType, TMyTypeFArgs>,`);
   });
 });

--- a/packages/plugins/flow-resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/flow-resolvers/tests/mapping.spec.ts
@@ -204,12 +204,12 @@ describe('ResolversTypes', () => {
 
     expect(result).toBeSimilarStringTo(`import { type MyCustomOtherType } from './my-file';`);
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
-      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-        export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
-          bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+        export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+          bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
         };
       `);
 
@@ -220,41 +220,41 @@ describe('ResolversTypes', () => {
       };`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
-        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
-        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
-        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
+        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
+        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
-        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
-        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
-        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
       };
     `);
     await validate(result);
@@ -275,12 +275,12 @@ describe('ResolversTypes', () => {
 
     expect(result).toBeSimilarStringTo(`import { type MyCustomOtherType } from './my-file';`);
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
-      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-        export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
-          bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+        export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+          bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
         };
       `);
 
@@ -291,41 +291,41 @@ describe('ResolversTypes', () => {
       };`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
-        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
-        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
-        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
+        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
+        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
-        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
-        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
-        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
       };
     `);
     await validate(result);
@@ -344,12 +344,12 @@ describe('ResolversTypes', () => {
     );
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
-      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
-        bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+      export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+        bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
       };
     `);
 
@@ -360,41 +360,41 @@ describe('ResolversTypes', () => {
     };`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
-        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
-        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
-        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
+        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
+        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
-        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
-        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
-        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
       };
     `);
     await validate(`type MyNodeType = {};\n${result}`);
@@ -411,12 +411,12 @@ describe('ResolversTypes', () => {
     );
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
-      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
-        bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+      export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+        bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
       };
     `);
 
@@ -427,41 +427,41 @@ describe('ResolversTypes', () => {
     };`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
-        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
-        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
-        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
+        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
+        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
-        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
-        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
-        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
       };
     `);
     await validate(result);
@@ -480,12 +480,12 @@ describe('ResolversTypes', () => {
     expect(result).toContain(`import { type MyBaseType } from './my-file';`);
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
-      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
-        bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+      export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+        bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
       };
     `);
 
@@ -496,41 +496,41 @@ describe('ResolversTypes', () => {
     };`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
-        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
-        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
-        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+        foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
+        otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
+        withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
-        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+        something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
-        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+        id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
-        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+        somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
       };
     `);
     await validate(result);

--- a/packages/plugins/typescript-resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/mapping.spec.ts
@@ -432,12 +432,12 @@ describe('ResolversTypes', () => {
 
     expect(result).toBeSimilarStringTo(`import { MyCustomOtherType } from './my-file';`);
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-        export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
-          bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
+          bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         };
       `);
 
@@ -447,41 +447,41 @@ describe('ResolversTypes', () => {
       `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
     `);
     await validate(result);
@@ -503,12 +503,12 @@ describe('ResolversTypes', () => {
 
     expect(result).toBeSimilarStringTo(`import { MyCustomOtherType } from './my-file';`);
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-        export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
-          bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+        export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
+          bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         };
       `);
 
@@ -518,41 +518,41 @@ describe('ResolversTypes', () => {
       `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
     `);
     await validate(result);
@@ -572,12 +572,12 @@ describe('ResolversTypes', () => {
     );
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+      export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
@@ -588,41 +588,41 @@ describe('ResolversTypes', () => {
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
     `);
     await validate(`type MyNodeType = {};\n${result}`);
@@ -640,12 +640,12 @@ describe('ResolversTypes', () => {
     );
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+      export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
@@ -656,41 +656,41 @@ describe('ResolversTypes', () => {
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
     `);
     await validate(result);
@@ -710,12 +710,12 @@ describe('ResolversTypes', () => {
     expect(result).toContain(`import { MyBaseType } from './my-file';`);
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+      export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
@@ -726,41 +726,41 @@ describe('ResolversTypes', () => {
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
     `);
     await validate(result);

--- a/packages/plugins/typescript-resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript-resolvers/tests/ts-resolvers.spec.ts
@@ -14,7 +14,7 @@ describe('TypeScript Resolvers Plugin', () => {
        * @deprecated
        * Use "DirectiveResolvers" root object instead. If you wish to get "IDirectiveResolvers", add "typesPrefix: I" to your config.
       */
-      export type IDirectiveResolvers<Context = any> = DirectiveResolvers<Context>;`);
+      export type IDirectiveResolvers<ContextType = any> = DirectiveResolvers<ContextType>;`);
       await validate(result);
     });
 
@@ -34,7 +34,7 @@ describe('TypeScript Resolvers Plugin', () => {
        * @deprecated
        * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
       */
-      export type IResolvers<Context = any> = Resolvers<Context>;`);
+      export type IResolvers<ContextType = any> = Resolvers<ContextType>;`);
       await validate(result);
     });
 
@@ -54,7 +54,7 @@ describe('TypeScript Resolvers Plugin', () => {
        * @deprecated
        * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
       */
-      export type IResolvers<Context = any> = Resolvers<Context>;`);
+      export type IResolvers<ContextType = any> = Resolvers<ContextType>;`);
       await validate(result);
     });
 
@@ -75,7 +75,7 @@ describe('TypeScript Resolvers Plugin', () => {
         testSchema,
         [],
         {
-          contextType: 'AppContext',
+          contextType: 'Context',
           useIndexSignature: true,
         },
         {
@@ -88,7 +88,7 @@ describe('TypeScript Resolvers Plugin', () => {
         `
           import { makeExecutableSchema } from 'graphql-tools';
   
-          interface AppContext {
+          interface Context {
             users: Array<{
               id: string;
               name: string;
@@ -111,9 +111,9 @@ describe('TypeScript Resolvers Plugin', () => {
       ].join('\n');
 
       expect(content).toBeSimilarStringTo(`
-        export type Resolvers<Context = AppContext> = ResolversObject<{
-          Query?: QueryResolvers<Context>,
-          User?: UserResolvers<Context>,
+        export type Resolvers<ContextType = Context> = ResolversObject<{
+          Query?: QueryResolvers<ContextType>,
+          User?: UserResolvers<ContextType>,
         }>;
       `);
 
@@ -203,12 +203,12 @@ describe('TypeScript Resolvers Plugin', () => {
     const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+      export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
@@ -217,41 +217,41 @@ describe('TypeScript Resolvers Plugin', () => {
     }`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
     `);
 
@@ -262,12 +262,12 @@ describe('TypeScript Resolvers Plugin', () => {
     const result = await plugin(schema, [], { avoidOptionals: true }, { outputFile: '' });
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = any, Args = {   arg: Maybe<Scalars['Int']>,
-      arg2: Maybe<Scalars['String']>, arg3: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg: Maybe<Scalars['Int']>,
+      arg2: Maybe<Scalars['String']>, arg3: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = any, ParentType = ResolversTypes['MyOtherType']> = {
-        bar: Resolver<ResolversTypes['String'], ParentType, Context>,
+      export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
+        bar: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
@@ -276,41 +276,41 @@ describe('TypeScript Resolvers Plugin', () => {
     }`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = any, ParentType = ResolversTypes['MyType']> = {
-        foo: Resolver<ResolversTypes['String'], ParentType, Context>,
-        otherType: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
-        withArgs: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
+        foo: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+        otherType: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
+        withArgs: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = any, ParentType = ResolversTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = any, ParentType = ResolversTypes['Query']> = {
-        something: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
+        something: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = any, ParentType = ResolversTypes['SomeNode']> = {
-        id: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
+        id: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = any, ParentType = ResolversTypes['Subscription']> = {
-        somethingChanged: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
     `);
 
@@ -322,61 +322,61 @@ describe('TypeScript Resolvers Plugin', () => {
       schema,
       [],
       {
-        contextType: 'MyCustomContext',
+        contextType: 'MyCustomCtx',
       },
       { outputFile: '' }
     );
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = MyCustomContext, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = MyCustomCtx, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+      export type MyOtherTypeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type NodeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      export type QueryResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
     `);
 
-    await validate(`type MyCustomContext = {};\n` + result);
+    await validate(`type MyCustomCtx = {};\n` + result);
   });
 
   it('Should allow to override context with mapped context type', async () => {
@@ -384,59 +384,59 @@ describe('TypeScript Resolvers Plugin', () => {
       schema,
       [],
       {
-        contextType: './my-file#MyCustomContext',
+        contextType: './my-file#MyCustomCtx',
       },
       { outputFile: '' }
     );
 
-    expect(result).toBeSimilarStringTo(`import { MyCustomContext } from './my-file';`);
+    expect(result).toBeSimilarStringTo(`import { MyCustomCtx } from './my-file';`);
 
     expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, Context = MyCustomContext, Args = {   arg?: Maybe<Scalars['Int']>,
-      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, Context, Args>;`);
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = MyCustomCtx, Args = {   arg?: Maybe<Scalars['Int']>,
+      arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyOtherTypeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, Context>,
+      export type MyOtherTypeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyTypeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, Context>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, Context, MyTypeWithArgsArgs>,
+      export type MyTypeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, MyTypeWithArgsArgs>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type MyUnionResolvers<Context = MyCustomContext, ParentType = ResolversTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, Context>
+      export type MyUnionResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, Context>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type NodeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type QueryResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, Context>,
+      export type QueryResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SomeNodeResolvers<Context = MyCustomContext, ParentType = ResolversTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type SomeNodeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
     expect(result).toBeSimilarStringTo(`
-      export type SubscriptionResolvers<Context = MyCustomContext, ParentType = ResolversTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, Context>,
+      export type SubscriptionResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
     `);
 
@@ -481,8 +481,8 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(content).toBeSimilarStringTo(`CCCUnion: CccUnion`); // In ResolversTypes
     expect(content).toBeSimilarStringTo(`
-    export type CccUnionResolvers<Context = any, ParentType = ResolversTypes['CCCUnion']> = {
-      __resolveType: TypeResolveFn<'CCCFoo' | 'CCCBar', ParentType, Context>
+    export type CccUnionResolvers<ContextType = any, ParentType = ResolversTypes['CCCUnion']> = {
+      __resolveType: TypeResolveFn<'CCCFoo' | 'CCCBar', ParentType, ContextType>
     };
     `);
 
@@ -494,7 +494,7 @@ describe('TypeScript Resolvers Plugin', () => {
     const config = { typesPrefix: 'T' };
     const result = await plugin(testSchema, [], config, { outputFile: '' });
 
-    expect(result).toBeSimilarStringTo(`f?: Resolver<Maybe<TResolversTypes['String']>, ParentType, Context, TMyTypeFArgs>,`);
+    expect(result).toBeSimilarStringTo(`f?: Resolver<Maybe<TResolversTypes['String']>, ParentType, ContextType, TMyTypeFArgs>,`);
     await validate(result, config, testSchema);
   });
 
@@ -532,19 +532,19 @@ describe('TypeScript Resolvers Plugin', () => {
     );
 
     expect(content).toBeSimilarStringTo(`
-      export type Resolvers<Context = any> = {
+      export type Resolvers<ContextType = any> = {
         Date?: GraphQLScalarType,
         Node?: NodeResolvers,
-        Post?: PostResolvers<Context>,
+        Post?: PostResolvers<ContextType>,
         PostOrUser?: PostOrUserResolvers,
-        Query?: QueryResolvers<Context>,
-        User?: UserResolvers<Context>,
+        Query?: QueryResolvers<ContextType>,
+        User?: UserResolvers<ContextType>,
       };
     `);
 
     expect(content).toBeSimilarStringTo(`
-      export type DirectiveResolvers<Context = any> = {
-        modify?: ModifyDirectiveResolver<any, any, Context>,
+      export type DirectiveResolvers<ContextType = any> = {
+        modify?: ModifyDirectiveResolver<any, any, ContextType>,
       };
     `);
   });
@@ -566,7 +566,7 @@ describe('TypeScript Resolvers Plugin', () => {
     );
 
     expect(content).not.toBeSimilarStringTo(`
-      export type DirectiveResolvers<Context = any> = {};
+      export type DirectiveResolvers<ContextType = any> = {};
     `);
   });
 
@@ -840,9 +840,9 @@ describe('TypeScript Resolvers Plugin', () => {
     const result = await plugin(schemaWithNoImplementors, [], {}, { outputFile: '' });
 
     expect(result).toBeSimilarStringTo(`
-      export type NodeResolvers<Context = any, ParentType = ResolversTypes['Node']> = {
-        __resolveType: TypeResolveFn<null, ParentType, Context>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, Context>,
+      export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
+        __resolveType: TypeResolveFn<null, ParentType, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
   });

--- a/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -383,7 +383,7 @@ export class BaseResolversVisitor<TRawConfig extends RawResolversConfig = RawRes
 
   public getRootResolver(): string {
     const name = this.convertName('Resolvers');
-    const contextType = `<Context = ${this.config.contextType.type}>`;
+    const contextType = `<ContextType = ${this.config.contextType.type}>`;
 
     // This is here because we don't want to break IResolvers, so there is a mapping by default,
     // and if the developer is overriding typesPrefix, it won't get generated at all.
@@ -393,7 +393,7 @@ export class BaseResolversVisitor<TRawConfig extends RawResolversConfig = RawRes
  * @deprecated
  * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
 */
-export type IResolvers${contextType} = ${name}<Context>;`
+export type IResolvers${contextType} = ${name}<ContextType>;`
       : '';
 
     return [
@@ -421,7 +421,7 @@ export type IResolvers${contextType} = ${name}<Context>;`
   public getAllDirectiveResolvers(): string {
     if (Object.keys(this._collectedDirectiveResolvers).length) {
       const name = this.convertName('DirectiveResolvers');
-      const contextType = `<Context = ${this.config.contextType.type}>`;
+      const contextType = `<ContextType = ${this.config.contextType.type}>`;
 
       // This is here because we don't want to break IResolvers, so there is a mapping by default,
       // and if the developer is overriding typesPrefix, it won't get generated at all.
@@ -431,7 +431,7 @@ export type IResolvers${contextType} = ${name}<Context>;`
 * @deprecated
 * Use "DirectiveResolvers" root object instead. If you wish to get "IDirectiveResolvers", add "typesPrefix: I" to your config.
 */
-export type IDirectiveResolvers${contextType} = ${name}<Context>;`
+export type IDirectiveResolvers${contextType} = ${name}<ContextType>;`
         : '';
 
       return [
@@ -508,7 +508,7 @@ export type IDirectiveResolvers${contextType} = ${name}<Context>;`
       const isSubscriptionType = subscriptionType && subscriptionType.name === parentName;
 
       return indent(
-        `${node.name}${this.config.avoidOptionals ? '' : '?'}: ${isSubscriptionType ? 'SubscriptionResolver' : 'Resolver'}<${mappedType}, ParentType, Context${
+        `${node.name}${this.config.avoidOptionals ? '' : '?'}: ${isSubscriptionType ? 'SubscriptionResolver' : 'Resolver'}<${mappedType}, ParentType, ContextType${
           hasArguments
             ? `, ${this.convertName(parentName, {
                 useTypesPrefix: true,
@@ -533,10 +533,10 @@ export type IDirectiveResolvers${contextType} = ${name}<Context>;`
     const block = new DeclarationBlock(this._declarationBlockConfig)
       .export()
       .asKind('type')
-      .withName(name, `<Context = ${this.config.contextType.type}, ParentType = ${type}>`)
+      .withName(name, `<ContextType = ${this.config.contextType.type}, ParentType = ${type}>`)
       .withBlock(node.fields.map((f: any) => f(node.name)).join('\n'));
 
-    this._collectedResolvers[node.name as any] = name + '<Context>';
+    this._collectedResolvers[node.name as any] = name + '<ContextType>';
 
     return block.string;
   }
@@ -557,8 +557,8 @@ export type IDirectiveResolvers${contextType} = ${name}<Context>;`
     return new DeclarationBlock(this._declarationBlockConfig)
       .export()
       .asKind('type')
-      .withName(name, `<Context = ${this.config.contextType.type}, ParentType = ${type}>`)
-      .withBlock(indent(`__resolveType: TypeResolveFn<${possibleTypes}, ParentType, Context>`)).string;
+      .withName(name, `<ContextType = ${this.config.contextType.type}, ParentType = ${type}>`)
+      .withBlock(indent(`__resolveType: TypeResolveFn<${possibleTypes}, ParentType, ContextType>`)).string;
   }
 
   ScalarTypeDefinition(node: ScalarTypeDefinitionNode): string {
@@ -591,7 +591,7 @@ export type IDirectiveResolvers${contextType} = ${name}<Context>;`
     const hasArguments = node.arguments && node.arguments.length > 0;
     const directiveArgs = hasArguments ? this._variablesTransfomer.transform<InputValueDefinitionNode>(node.arguments) : '';
 
-    this._collectedDirectiveResolvers[node.name as any] = directiveName + '<any, any, Context>';
+    this._collectedDirectiveResolvers[node.name as any] = directiveName + '<any, any, ContextType>';
 
     return new DeclarationBlock({
       ...this._declarationBlockConfig,
@@ -601,8 +601,8 @@ export type IDirectiveResolvers${contextType} = ${name}<Context>;`
     })
       .export()
       .asKind('type')
-      .withName(directiveName, `<Result, Parent, Context = ${this.config.contextType.type}, Args = { ${directiveArgs} }>`)
-      .withContent(`DirectiveResolverFn<Result, Parent, Context, Args>`).string;
+      .withName(directiveName, `<Result, Parent, ContextType = ${this.config.contextType.type}, Args = { ${directiveArgs} }>`)
+      .withContent(`DirectiveResolverFn<Result, Parent, ContextType, Args>`).string;
   }
 
   InterfaceTypeDefinition(node: InterfaceTypeDefinitionNode): string {
@@ -630,8 +630,8 @@ export type IDirectiveResolvers${contextType} = ${name}<Context>;`
     return new DeclarationBlock(this._declarationBlockConfig)
       .export()
       .asKind('type')
-      .withName(name, `<Context = ${this.config.contextType.type}, ParentType = ${type}>`)
-      .withBlock([indent(`__resolveType: TypeResolveFn<${possibleTypes}, ParentType, Context>,`), ...(node.fields || []).map((f: any) => f(node.name))].join('\n')).string;
+      .withName(name, `<ContextType = ${this.config.contextType.type}, ParentType = ${type}>`)
+      .withBlock([indent(`__resolveType: TypeResolveFn<${possibleTypes}, ParentType, ContextType>,`), ...(node.fields || []).map((f: any) => f(node.name))].join('\n')).string;
   }
 
   SchemaDefinition() {


### PR DESCRIPTION
when having a context interface name `Context`, it didn't work because the generic parameter was referring to itself. By naming it `ContextType` it's less common, and thus the change of having clash is smaller.

fixes #1681