### PR TITLE
fix(flow-resolvers): non optional arguments in resolvers

### DIFF
--- a/packages/plugins/flow-resolvers/src/index.ts
+++ b/packages/plugins/flow-resolvers/src/index.ts
@@ -20,24 +20,24 @@ export const plugin: PluginFunction<FlowResolversPluginConfig> = (schema: GraphQ
 import { ${imports.join(', ')} } from 'graphql';
 
 export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
-  parent?: Parent,
-  args?: Args,
-  context?: Context,
-  info?: GraphQLResolveInfo
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
 ) => Promise<Result> | Result;
 
 export type SubscriptionSubscribeFn<Result, Parent, Context, Args> = (
-  parent?: Parent,
-  args?: Args,
-  context?: Context,
-  info?: GraphQLResolveInfo
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
 ) => AsyncIterator<Result> | Promise<AsyncIterator<Result>>;
 
 export type SubscriptionResolveFn<Result, Parent, Context, Args> = (
-  parent?: Parent,
-  args?: Args,
-  context?: Context,
-  info?: GraphQLResolveInfo
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
 ) => Result | Promise<Result>;
 
 export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
@@ -50,19 +50,19 @@ export type SubscriptionResolver<Result, Parent = {}, Context = {}, Args = {}> =
   | ISubscriptionResolverObject<Result, Parent, Context, Args>;
 
 export type TypeResolveFn<Types, Parent = {}, Context = {}> = (
-  parent?: Parent,
-  context?: Context,
-  info?: GraphQLResolveInfo
+  parent: Parent,
+  context: Context,
+  info: GraphQLResolveInfo
 ) => ?Types;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
 export type DirectiveResolverFn<Result = {}, Parent = {}, Args = {}, Context = {}> = (
-  next?: NextResolverFn<Result>,
-  parent?: Parent,
-  args?: Args,
-  context?: Context,
-  info?: GraphQLResolveInfo
+  next: NextResolverFn<Result>,
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
 ) => Result | Promise<Result>;
 `;
 

--- a/packages/plugins/flow-resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
+++ b/packages/plugins/flow-resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Flow Resolvers Plugin Should generate basic type resolvers 1`] = `
+"
+import { type GraphQLResolveInfo, type GraphQLScalarTypeConfig } from 'graphql';
+
+export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
+) => Promise<Result> | Result;
+
+export type SubscriptionSubscribeFn<Result, Parent, Context, Args> = (
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
+) => AsyncIterator<Result> | Promise<AsyncIterator<Result>>;
+
+export type SubscriptionResolveFn<Result, Parent, Context, Args> = (
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
+) => Result | Promise<Result>;
+
+export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
+  subscribe: SubscriptionSubscribeFn<Result, Parent, Context, Args>;
+  resolve?: SubscriptionResolveFn<Result, Parent, Context, Args>;
+}
+
+export type SubscriptionResolver<Result, Parent = {}, Context = {}, Args = {}> =
+  | ((...args: Array<any>) => ISubscriptionResolverObject<Result, Parent, Context, Args>)
+  | ISubscriptionResolverObject<Result, Parent, Context, Args>;
+
+export type TypeResolveFn<Types, Parent = {}, Context = {}> = (
+  parent: Parent,
+  context: Context,
+  info: GraphQLResolveInfo
+) => ?Types;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<Result = {}, Parent = {}, Args = {}, Context = {}> = (
+  next: NextResolverFn<Result>,
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
+) => Result | Promise<Result>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  Query: {},
+  MyType: MyType,
+  String: $ElementType<Scalars, 'String'>,
+  MyOtherType: MyOtherType,
+  Subscription: {},
+  Boolean: $ElementType<Scalars, 'Boolean'>,
+  Node: Node,
+  ID: $ElementType<Scalars, 'ID'>,
+  SomeNode: SomeNode,
+  MyUnion: MyUnion,
+  MyScalar: $ElementType<Scalars, 'MyScalar'>,
+  Int: $ElementType<Scalars, 'Int'>,
+};
+
+export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
+  arg2?: ?$ElementType<Scalars, 'String'>,
+  arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
+  bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
+};
+
+export type MyScalarScalarConfig = {
+  ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
+  name: 'MyScalar'
+};
+
+export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
+  foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
+  otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
+  withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType, MyTypeWithArgsArgs>,
+};
+
+export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
+  __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+};
+
+export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
+  __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+  id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
+};
+
+export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+  something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
+};
+
+export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
+  id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
+};
+
+export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
+  somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
+};
+
+export type Resolvers<ContextType = any> = {
+  MyOtherType?: MyOtherTypeResolvers<ContextType>,
+  MyScalar?: GraphQLScalarType<>,
+  MyType?: MyTypeResolvers<ContextType>,
+  MyUnion?: MyUnionResolvers<>,
+  Node?: NodeResolvers<>,
+  Query?: QueryResolvers<ContextType>,
+  SomeNode?: SomeNodeResolvers<ContextType>,
+  Subscription?: SubscriptionResolvers<ContextType>,
+};
+
+
+/**
+ * @deprecated
+ * Use \\"Resolvers\\" root object instead. If you wish to get \\"IResolvers\\", add \\"typesPrefix: I\\" to your config.
+*/
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;
+export type DirectiveResolvers<ContextType = any> = {
+  myDirective?: MyDirectiveDirectiveResolver<any, any, ContextType>,
+};
+
+
+/**
+* @deprecated
+* Use \\"DirectiveResolvers\\" root object instead. If you wish to get \\"IDirectiveResolvers\\", add \\"typesPrefix: I\\" to your config.
+*/
+export type IDirectiveResolvers<ContextType = any> = DirectiveResolvers<ContextType>;"
+`;

--- a/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow-resolvers/tests/flow-resolvers.spec.ts
@@ -7,45 +7,7 @@ describe('Flow Resolvers Plugin', () => {
   it('Should generate basic type resolvers', () => {
     const result = plugin(schema, [], {}, { outputFile: '' });
 
-    expect(result).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
-      arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
-
-    expect(result).toBeSimilarStringTo(`export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
-      bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
-    }`);
-
-    expect(result).toBeSimilarStringTo(`export type MyScalarScalarConfig = {
-      ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
-      name: 'MyScalar'
-    };`);
-
-    expect(result).toBeSimilarStringTo(`export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
-      foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
-      otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
-      withArgs?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType, MyTypeWithArgsArgs>,
-    }`);
-
-    expect(result).toBeSimilarStringTo(`export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
-      __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
-    }`);
-
-    expect(result).toBeSimilarStringTo(`export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
-      __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-      id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
-    }`);
-
-    expect(result).toBeSimilarStringTo(`export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
-      something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
-    }`);
-
-    expect(result).toBeSimilarStringTo(`export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
-      id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
-    }`);
-
-    expect(result).toBeSimilarStringTo(`export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
-      somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
-    }`);
+    expect(result).toMatchSnapshot();
   });
 
   it('Should generate the correct imports when schema has scalars', () => {


### PR DESCRIPTION
Fixes https://github.com/dotansimha/graphql-code-generator/issues/1725.

## The changes

- As discussed, the resolvers arguments shouldn't be optional. 
- There was also no test coverage for these type definitions so I added a snapshot test which covers them as well as the existing "string comparison" tests (removed since they were made obsolete by the snapshot test).