### PR TITLE
Added transformUnderscore configuration to namingConvention

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -39,6 +39,8 @@ export interface RawConfig {
    * The format of the converter must be a valid `module#method`.
    * Allowed values for specific output are: `typeNames`, `enumValues`.
    * You can also use "keep" to keep all GraphQL names as-is.
+   * Additionally you can set `transformUndersocre` to `true` if you want do override the default behaviour,
+   * which is to preserver underscores.
    *
    * @example Override All Names
    * ```yml
@@ -56,6 +58,12 @@ export interface RawConfig {
    * ```yml
    * config:
    *   namingConvention: keep
+   * ```
+   * @example Transform Underscores
+   * ```yml
+   * config:
+   *   typeNames: change-case#pascalCase
+   *   transformUnderscore: true
    * ```
    */
   namingConvention?: NamingConvention;

--- a/packages/plugins/other/visitor-plugin-common/src/naming.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/naming.ts
@@ -87,12 +87,12 @@ export function convertFactory(config: { namingConvention?: NamingConvention }):
     if (typeof config.namingConvention === 'object') {
       if (!config.namingConvention[type]) {
         return (str: string, opts: ConvertOptions = {}) => {
-          return convertNameParts(str, pascalCase, !!(opts || {}).transformUnderscore);
+          return convertNameParts(str, pascalCase, config.namingConvention['transformUnderscore'] || !!(opts || {}).transformUnderscore);
         };
       }
 
       return (str: string, opts: ConvertOptions = {}) => {
-        return convertNameParts(str, resolveExternalModuleAndFn(config.namingConvention[type]), !!(opts || {}).transformUnderscore);
+        return convertNameParts(str, resolveExternalModuleAndFn(config.namingConvention[type]), config.namingConvention['transformUnderscore'] || !!(opts || {}).transformUnderscore);
       };
     }
 

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -17,4 +17,5 @@ export type NamingConvention = string | Function | NamingConventionMap;
 export interface NamingConventionMap {
   enumValues?: 'keep' | NamingConventionResolvePath | Function;
   typeNames?: 'keep' | NamingConventionResolvePath | Function;
+  transformUnderscore?: boolean;
 }

--- a/packages/plugins/other/visitor-plugin-common/tests/plugins-common.spec.ts
+++ b/packages/plugins/other/visitor-plugin-common/tests/plugins-common.spec.ts
@@ -91,4 +91,18 @@ describe('convertFactory', () => {
     expect(factory('_Myname', { transformUnderscore: true })).toBe('Myname');
     expect(factory('My_name', { transformUnderscore: true })).toBe('MyName');
   });
+
+  it('Should allow to override transformUnderscore in config', () => {
+    const factory = convertFactory({
+      namingConvention: {
+        typeNames: str => str.replace('_', ''),
+        enumValues: 'keep',
+        transformUnderscore: true,
+      },
+    });
+
+    expect(factory('My_Name')).toBe('MyName');
+    expect(factory('_Myname')).toBe('Myname');
+    expect(factory('My_name')).toBe('Myname');
+  });
 });


### PR DESCRIPTION
Added the field transformUnderscore to the namingConvention object to make it possible to override the default behavior to preserve Underscores. Without this it is not possible to fully customize the naming convention for the generated types, only the individual parts between underscores.

I was not sure if this is the best place for the configuration. Let me know if I should change it.
 