### PR TITLE
Update import statement in getting-started docs

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -118,7 +118,7 @@ There are different methods to use GraphQL Code Generator besides the [CLI](../c
 We can `require()` (or `import`) `@graphql-codegen/core` directly with Node.JS:
 
 ```js
-import { generate } from '@graphql-codegen/core';
+import { generate } from '@graphql-codegen/cli';
 
 async function doSomething() {
   const generatedFiles = await generate(


### PR DESCRIPTION
The docs referenced a method from the incorrect package. `generate` is available in `@graphql-codegen/cli` and `codegen` is available in `@graphql-codegen/core`. From the usage in the code that followed, it seems `generate` is the intended method.