### PR TITLE
docs(getting-started): import generate from cli not core

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -115,10 +115,10 @@ There are different methods to use GraphQL Code Generator besides the [CLI](../c
 
 ### Using in Runtime
 
-We can `require()` (or `import`) `@graphql-codegen/core` directly with Node.JS:
+We can `require()` (or `import`) `@graphql-codegen/cli` directly with Node.JS:
 
 ```js
-import { generate } from '@graphql-codegen/core';
+import { generate } from '@graphql-codegen/cli';
 
 async function doSomething() {
   const generatedFiles = await generate(


### PR DESCRIPTION
https://github.com/dotansimha/graphql-code-generator/blob/master/packages/graphql-codegen-cli/src/generate-and-save.ts#L11

This exported method must have been moved from core to cli without updating the docs?