### PR TITLE
Docs fix and import React Apollo when withMutationFn is configured

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/index.ts
+++ b/packages/plugins/typescript/react-apollo/src/index.ts
@@ -93,7 +93,7 @@ export interface ReactApolloRawPluginConfig extends RawClientSideBasePluginConfi
    */
   hooksImportFrom?: string;
   /**
-   * @name hooksImportFrom
+   * @name reactApolloImportFrom
    * @type string
    * @description You can specify module that exports components `Query`, `Mutation`, `Subscription` and HOCs
    * This is useful for further abstraction of some common tasks (eg. error handling).

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -36,7 +36,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
       imports.push(`import * as React from 'react';`);
     }
 
-    if (this.config.withComponent || this.config.withHOC) {
+    if (this.config.withComponent || this.config.withHOC || this.config.withMutationFn) {
       imports.push(`import * as ReactApollo from '${typeof this.config.reactApolloImportFrom === 'string' ? this.config.reactApolloImportFrom : 'react-apollo'}';`);
     }
 

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -154,6 +154,7 @@ describe('React Apollo', () => {
           withHooks: true,
           withHOC: false,
           withComponent: false,
+          withMutationFn: false
         },
         {
           outputFile: 'graphql.tsx',


### PR DESCRIPTION
Small fix in docs. Also update to import ReactApollo when `withMutationFn` is enabled but ReactApollo features are disabled.