### PR TITLE
Urql support

### DIFF
--- a/packages/plugins/typescript/urql/.gitignore
+++ b/packages/plugins/typescript/urql/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+dist
+temp
+yarn-error.log

--- a/packages/plugins/typescript/urql/.npmignore
+++ b/packages/plugins/typescript/urql/.npmignore
@@ -1,0 +1,5 @@
+src
+node_modules
+tests
+!dist
+example

--- a/packages/plugins/typescript/urql/package.json
+++ b/packages/plugins/typescript/urql/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@graphql-codegen/typescript-urql",
+  "version": "1.1.3",
+  "description": "GraphQL Code Generator plugin for generating a ready-to-use React Components/HOC/Hooks based on GraphQL operations with urql",
+  "repository": "git@github.com:dotansimha/graphql-code-generator.git",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc -m esnext --outDir dist/esnext && tsc -m commonjs --outDir dist/commonjs",
+    "test": "jest --config ../../../../jest.config.js"
+  },
+  "peerDependencies": {
+    "graphql-tag": "^2.0.0"
+  },
+  "dependencies": {
+    "@graphql-codegen/plugin-helpers": "1.1.3",
+    "@graphql-codegen/visitor-plugin-common": "1.1.3",
+    "tslib": "1.9.3"
+  },
+  "devDependencies": {
+    "@graphql-codegen/testing": "1.1.3",
+    "flow-bin": "0.98.0",
+    "flow-parser": "0.98.0",
+    "graphql": "14.2.1",
+    "jest": "24.8.0",
+    "ts-jest": "24.0.2",
+    "typescript": "3.4.5"
+  },
+  "sideEffects": false,
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esnext/index.js",
+  "typings": "dist/esnext/index.d.ts",
+  "typescript": {
+    "definition": "dist/esnext/index.d.ts"
+  },
+  "jest-junit": {
+    "outputDirectory": "../../../../test-results/typescript-react-apollo"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/typescript/urql/src/index.ts
+++ b/packages/plugins/typescript/urql/src/index.ts
@@ -1,0 +1,135 @@
+import { Types, PluginValidateFn, PluginFunction } from '@graphql-codegen/plugin-helpers';
+import { visit, GraphQLSchema, concatAST, Kind, FragmentDefinitionNode } from 'graphql';
+import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-common';
+import { UrqlVisitor } from './visitor';
+import { extname } from 'path';
+
+export interface UrqlRawPluginConfig extends RawClientSideBasePluginConfig {
+  /**
+   * @name withHOC
+   * @type boolean
+   * @description Customized the output by enabling/disabling the HOC.
+   * @default true
+   *
+   * @example
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *    - typescript-react-apollo
+   *  config:
+   *    withHOC: false
+   * ```
+   */
+  withHOC?: boolean;
+  /**
+   * @name withComponent
+   * @type boolean
+   * @description Customized the output by enabling/disabling the generated Component.
+   * @default true
+   *
+   * @example
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *    - typescript-react-apollo
+   *  config:
+   *    withComponent: false
+   * ```
+   */
+  withComponent?: boolean;
+  /**
+   * @name withHooks
+   * @type boolean
+   * @description Customized the output by enabling/disabling the generated React Hooks.
+   * @default false
+   *
+   * @example
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *    - typescript-react-apollo
+   *  config:
+   *    withHooks: false
+   * ```
+   */
+  withHooks?: boolean;
+
+  /**
+   * @name withMutationFn
+   * @type boolean
+   * @description Customized the output by enabling/disabling the generated mutation function signature.
+   * @default true
+   *
+   * @example
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *    - typescript-react-apollo
+   *  config:
+   *    withMutationFn: true
+   * ```
+   */
+  withMutationFn?: boolean;
+
+  /**
+   * @name hooksImportFrom
+   * @type string
+   * @description You can specify alternative module that is exports `useQuery` `useMutation` and `useSubscription`.
+   * This is useful for further abstraction of some common tasks (eg. error handling).
+   * Filepath relative to generated file can be also specified.
+   * @default react-apollo-hooks
+   */
+  hooksImportFrom?: string;
+  /**
+   * @name UrqlImportFrom
+   * @type string
+   * @description You can specify module that exports components `Query`, `Mutation`, `Subscription` and HOCs
+   * This is useful for further abstraction of some common tasks (eg. error handling).
+   * Filepath relative to generated file can be also specified.
+   * @default react-apollo
+   */
+  UrqlImportFrom?: string;
+}
+
+export const plugin: PluginFunction<UrqlRawPluginConfig> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: UrqlRawPluginConfig) => {
+  const allAst = concatAST(
+    documents.reduce((prev, v) => {
+      return [...prev, v.content];
+    }, [])
+  );
+  const operationsCount = allAst.definitions.filter(d => d.kind === Kind.OPERATION_DEFINITION);
+
+  if (operationsCount.length === 0) {
+    return '';
+  }
+
+  const allFragments = allAst.definitions.filter(d => d.kind === Kind.FRAGMENT_DEFINITION) as FragmentDefinitionNode[];
+  const visitor = new UrqlVisitor(allFragments, config) as any;
+  const visitorResult = visit(allAst, { leave: visitor });
+
+  return [visitor.getImports(), visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n');
+};
+
+export const validate: PluginValidateFn<any> = async (schema: GraphQLSchema, documents: Types.DocumentFile[], config: UrqlRawPluginConfig, outputFile: string) => {
+  if (config.withComponent === false) {
+    if (extname(outputFile) !== '.ts' && extname(outputFile) !== '.tsx') {
+      throw new Error(`Plugin "react-apollo" with "noComponents" requires extension to be ".ts" or ".tsx"!`);
+    }
+  } else {
+    if (extname(outputFile) !== '.tsx') {
+      throw new Error(`Plugin "react-apollo" requires extension to be ".tsx"!`);
+    }
+  }
+};

--- a/packages/plugins/typescript/urql/src/index.ts
+++ b/packages/plugins/typescript/urql/src/index.ts
@@ -6,25 +6,6 @@ import { extname } from 'path';
 
 export interface UrqlRawPluginConfig extends RawClientSideBasePluginConfig {
   /**
-   * @name withHOC
-   * @type boolean
-   * @description Customized the output by enabling/disabling the HOC.
-   * @default true
-   *
-   * @example
-   * ```yml
-   * generates:
-   * path/to/file.ts:
-   *  plugins:
-   *    - typescript
-   *    - typescript-operations
-   *    - typescript-react-apollo
-   *  config:
-   *    withHOC: false
-   * ```
-   */
-  withHOC?: boolean;
-  /**
    * @name withComponent
    * @type boolean
    * @description Customized the output by enabling/disabling the generated Component.
@@ -64,43 +45,14 @@ export interface UrqlRawPluginConfig extends RawClientSideBasePluginConfig {
   withHooks?: boolean;
 
   /**
-   * @name withMutationFn
-   * @type boolean
-   * @description Customized the output by enabling/disabling the generated mutation function signature.
-   * @default true
-   *
-   * @example
-   * ```yml
-   * generates:
-   * path/to/file.ts:
-   *  plugins:
-   *    - typescript
-   *    - typescript-operations
-   *    - typescript-react-apollo
-   *  config:
-   *    withMutationFn: true
-   * ```
-   */
-  withMutationFn?: boolean;
-
-  /**
-   * @name hooksImportFrom
-   * @type string
-   * @description You can specify alternative module that is exports `useQuery` `useMutation` and `useSubscription`.
-   * This is useful for further abstraction of some common tasks (eg. error handling).
-   * Filepath relative to generated file can be also specified.
-   * @default react-apollo-hooks
-   */
-  hooksImportFrom?: string;
-  /**
-   * @name UrqlImportFrom
+   * @name urqlImportFrom
    * @type string
    * @description You can specify module that exports components `Query`, `Mutation`, `Subscription` and HOCs
    * This is useful for further abstraction of some common tasks (eg. error handling).
    * Filepath relative to generated file can be also specified.
-   * @default react-apollo
+   * @default urql
    */
-  UrqlImportFrom?: string;
+  urqlImportFrom?: string;
 }
 
 export const plugin: PluginFunction<UrqlRawPluginConfig> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: UrqlRawPluginConfig) => {

--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -44,8 +44,8 @@ export class UrqlVisitor extends ClientSideBaseVisitor<UrqlRawPluginConfig, Urql
     const isVariablesRequired = operationType === 'Query' && node.variableDefinitions.some(variableDef => variableDef.type.kind === Kind.NON_NULL_TYPE);
 
     return `
-export const ${componentName} = (props: { variables${isVariablesRequired ? '' : '?'}: ${operationVariablesTypes}${operationType === 'Query' ? ', requestPolicy?: Urql.RequestPolicy' : ''} }) => (
-  <Urql.${operationType} query={${documentVariableName}} {...props} />
+export const ${componentName} = (props: Omit<Urql.${operationType}Props, 'query'> & { variables${isVariablesRequired ? '' : '?'}: ${operationVariablesTypes} }) => (
+  <Urql.${operationType} {...props} query={${documentVariableName}} />
 );
 `;
   }

--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -45,10 +45,8 @@ export class UrqlVisitor extends ClientSideBaseVisitor<UrqlRawPluginConfig, Urql
     const isVariablesRequired = operationType === 'Query' && node.variableDefinitions.some(variableDef => variableDef.type.kind === Kind.NON_NULL_TYPE);
 
     return `
-export const ${componentName} = (props: Omit<Omit<Urql.${operationType}Props<${operationResultType}, ${operationVariablesTypes}>, '${operationType.toLowerCase()}'>, 'variables'> & { variables${
-      isVariablesRequired ? '' : '?'
-    }: ${operationVariablesTypes} }) => (
-  <Urql.${operationType}<${operationResultType}, ${operationVariablesTypes}> ${node.operation}={${documentVariableName}} {...props} />
+export const ${componentName} = (props: { variables${isVariablesRequired ? '' : '?'}: ${operationVariablesTypes}${operationType === 'Query' ? ', requestPolicy?: Urql.RequestPolicy' : ''} }) => (
+  <Urql.${operationType} query={${documentVariableName}} {...props} />
 );
 `;
   }

--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -2,7 +2,6 @@ import { ClientSideBaseVisitor, ClientSideBasePluginConfig, getConfigValue } fro
 import { UrqlRawPluginConfig } from './index';
 import * as autoBind from 'auto-bind';
 import { FragmentDefinitionNode, OperationDefinitionNode, Kind } from 'graphql';
-import { toPascalCase } from '@graphql-codegen/plugin-helpers';
 import { titleCase } from 'change-case';
 
 export interface UrqlPluginConfig extends ClientSideBasePluginConfig {
@@ -17,7 +16,7 @@ export class UrqlVisitor extends ClientSideBaseVisitor<UrqlRawPluginConfig, Urql
       withComponent: getConfigValue(rawConfig.withComponent, true),
       withHooks: getConfigValue(rawConfig.withHooks, false),
       urqlImportFrom: getConfigValue(rawConfig.urqlImportFrom, null),
-    } as any);
+    });
 
     autoBind(this);
   }

--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -1,0 +1,116 @@
+import { ClientSideBaseVisitor, ClientSideBasePluginConfig, getConfigValue } from '@graphql-codegen/visitor-plugin-common';
+import { UrqlRawPluginConfig } from './index';
+import * as autoBind from 'auto-bind';
+import { FragmentDefinitionNode, OperationDefinitionNode, Kind } from 'graphql';
+import { toPascalCase } from '@graphql-codegen/plugin-helpers';
+import { titleCase } from 'change-case';
+
+export interface UrqlPluginConfig extends ClientSideBasePluginConfig {
+  withHOC: boolean;
+  withComponent: boolean;
+  withHooks: boolean;
+  withMutationFn: boolean;
+}
+
+export class UrqlVisitor extends ClientSideBaseVisitor<UrqlRawPluginConfig, UrqlPluginConfig> {
+  constructor(fragments: FragmentDefinitionNode[], rawConfig: UrqlRawPluginConfig) {
+    super(fragments, rawConfig, {
+      withHOC: getConfigValue(rawConfig.withHOC, true),
+      withComponent: getConfigValue(rawConfig.withComponent, true),
+      withHooks: getConfigValue(rawConfig.withHooks, false),
+      withMutationFn: getConfigValue(rawConfig.withMutationFn, true),
+    } as any);
+
+    autoBind(this);
+  }
+
+  public getImports(): string {
+    const baseImports = super.getImports();
+    const imports = [];
+
+    if (this.config.withComponent) {
+      imports.push(`import * as React from 'react';`);
+    }
+
+    if (this.config.withComponent || this.config.withHOC || this.config.withMutationFn || this.config.withHooks) {
+      imports.push(`import * as Urql from 'urql';`);
+    }
+
+    imports.push(`export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>`);
+
+    return [baseImports, ...imports].join('\n');
+  }
+
+  private _buildHocProps(operationName: string, operationType: string): string {
+    const typeVariableName = this.convertName(operationName + toPascalCase(operationType));
+    const variablesVarName = this.convertName(operationName + toPascalCase(operationType) + 'Variables');
+    const argType = operationType === 'mutation' ? 'MutateProps' : 'DataProps';
+
+    return `Partial<Urql.${argType}<${typeVariableName}, ${variablesVarName}>>`;
+  }
+
+  private _buildMutationFn(node: OperationDefinitionNode, operationResultType: string, operationVariablesTypes: string): string {
+    if (node.operation === 'mutation') {
+      return `export type ${this.convertName(node.name.value + 'MutationFn')} = Urql.MutationFn<${operationResultType}, ${operationVariablesTypes}>;`;
+    }
+    return null;
+  }
+
+  private _buildOperationHoc(node: OperationDefinitionNode, documentVariableName: string, operationResultType: string, operationVariablesTypes: string): string {
+    const operationName: string = this.convertName(node.name.value, { useTypesPrefix: false });
+    const propsTypeName: string = this.convertName(node.name.value, { suffix: 'Props' });
+
+    const propsVar = `export type ${propsTypeName}<TChildProps = {}> = ${this._buildHocProps(node.name.value, node.operation)} & TChildProps;`;
+
+    const hocString = `export function with${operationName}<TProps, TChildProps = {}>(operationOptions?: Urql.OperationOption<
+  TProps,
+  ${operationResultType},
+  ${operationVariablesTypes},
+  ${propsTypeName}<TChildProps>>) {
+    return Urql.with${titleCase(node.operation)}<TProps, ${operationResultType}, ${operationVariablesTypes}, ${propsTypeName}<TChildProps>>(${documentVariableName}, {
+      alias: 'with${operationName}',
+      ...operationOptions
+    });
+};`;
+
+    return [propsVar, hocString].filter(a => a).join('\n');
+  }
+
+  private _buildComponent(node: OperationDefinitionNode, documentVariableName: string, operationType: string, operationResultType: string, operationVariablesTypes: string): string {
+    const componentName: string = this.convertName(node.name.value, { suffix: 'Component', useTypesPrefix: false });
+
+    const isVariablesRequired = operationType === 'Query' && node.variableDefinitions.some(variableDef => variableDef.type.kind === Kind.NON_NULL_TYPE);
+
+    return `
+export const ${componentName} = (props: Omit<Omit<Urql.${operationType}Props<${operationResultType}, ${operationVariablesTypes}>, '${operationType.toLowerCase()}'>, 'variables'> & { variables${
+      isVariablesRequired ? '' : '?'
+    }: ${operationVariablesTypes} }) => (
+  <Urql.${operationType}<${operationResultType}, ${operationVariablesTypes}> ${node.operation}={${documentVariableName}} {...props} />
+);
+`;
+  }
+
+  private _buildHooks(node: OperationDefinitionNode, operationType: string, documentVariableName: string, operationResultType: string, operationVariablesTypes: string): string {
+    const operationName: string = this.convertName(node.name.value, { suffix: titleCase(operationType), useTypesPrefix: false });
+
+    if (operationType === 'Mutation') {
+      return `
+export function use${operationName}() {
+  return Urql.use${operationType}<${operationResultType}>(${documentVariableName});
+};`;
+    }
+    return `
+export function use${operationName}(options?: Urql.Use${operationType}Args<${operationVariablesTypes}> = {}) {
+  return Urql.use${operationType}<${operationResultType}>({ query: ${documentVariableName}, ...options });
+};`;
+  }
+
+  protected buildOperation(node: OperationDefinitionNode, documentVariableName: string, operationType: string, operationResultType: string, operationVariablesTypes: string): string {
+    const mutationFn = this.config.withMutationFn ? this._buildMutationFn(node, operationResultType, operationVariablesTypes) : null;
+    const component = this.config.withComponent ? this._buildComponent(node, documentVariableName, operationType, operationResultType, operationVariablesTypes) : null;
+    const hoc = this.config.withHOC ? this._buildOperationHoc(node, documentVariableName, operationResultType, operationVariablesTypes) : null;
+    const hooks = this.config.withHooks ? this._buildHooks(node, operationType, documentVariableName, operationResultType, operationVariablesTypes) : null;
+
+    return [mutationFn, component, hoc, hooks].filter(a => a).join('\n');
+  }
+}

--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -61,7 +61,7 @@ export function use${operationName}() {
 };`;
     }
     return `
-export function use${operationName}(options?: Urql.Use${operationType}Args<${operationVariablesTypes}> = {}) {
+export function use${operationName}(options: Urql.Use${operationType}Args<${operationVariablesTypes}> = {}) {
   return Urql.use${operationType}<${operationResultType}>({ query: ${documentVariableName}, ...options });
 };`;
   }

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -300,7 +300,7 @@ query MyFeed {
     });
   });
 
-  describe.skip('Component', () => {
+  describe('Component', () => {
     it('should generate Document variable', async () => {
       const docs = [{ filePath: '', content: basicDoc }];
       const content = await plugin(
@@ -366,9 +366,9 @@ query MyFeed {
       );
 
       expect(content).toBeSimilarStringTo(`
-      export const TestComponent = (props: Omit<Omit<ReactApollo.QueryProps<TestQuery, TestQueryVariables>, 'query'>, 'variables'> & { variables?: TestQueryVariables }) => 
+      export const TestComponent = (props: { variables?: TestQueryVariables, requestPolicy?: Urql.RequestPolicy }) => 
       (
-          <ReactApollo.Query<TestQuery, TestQueryVariables> query={TestDocument} {...props} />
+          <Urql.Query query={TestDocument} {...props} />
       );
       `);
       await validateTypeScript(content, schema, docs, {});
@@ -415,8 +415,8 @@ query MyFeed {
       );
 
       expect(content).toBeSimilarStringTo(`
-      export const TestComponent = (props: Omit<Omit<ReactApollo.QueryProps<TestQuery, TestQueryVariables>, 'query'>, 'variables'> & { variables: TestQueryVariables }) => (
-        <ReactApollo.Query<TestQuery, TestQueryVariables> query={TestDocument} {...props} />
+      export const TestComponent = (props: { variables: TestQueryVariables, requestPolicy?: Urql.RequestPolicy }) => (
+        <Urql.Query query={TestDocument} {...props} />
       );`);
       await validateTypeScript(content, schema, docs, {});
     });
@@ -447,8 +447,8 @@ query MyFeed {
       );
 
       expect(content).toBeSimilarStringTo(`
-      export const TestComponent = (props: Omit<Omit<ReactApollo.MutationProps<TestMutation, TestMutationVariables>, 'mutation'>, 'variables'> & { variables?: TestMutationVariables }) => (
-        <ReactApollo.Mutation<TestMutation, TestMutationVariables> mutation={TestDocument} {...props} />
+      export const TestComponent = (props: { variables?: TestMutationVariables }) => (
+        <Urql.Mutation query={TestDocument} {...props} />
       );`);
       await validateTypeScript(content, schema, docs, {});
     });
@@ -465,90 +465,6 @@ query MyFeed {
       );
 
       expect(content).not.toContain(`export class ITestComponent`);
-    });
-  });
-
-  describe.skip('HOC', () => {
-    it('should generate HOCs', async () => {
-      const docs = [{ filePath: '', content: basicDoc }];
-      const content = await plugin(
-        schema,
-        docs,
-        {},
-        {
-          outputFile: 'graphql.tsx',
-        }
-      );
-
-      expect(content).toBeSimilarStringTo(`export type TestProps<TChildProps = {}> = Partial<ReactApollo.DataProps<TestQuery, TestQueryVariables>> & TChildProps;`);
-
-      expect(content).toBeSimilarStringTo(`export function withTest<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
-  TProps,
-  TestQuery,
-  TestQueryVariables,
-  TestProps<TChildProps>>) {
-    return ReactApollo.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps>>(TestDocument, {
-      alias: 'withTest',
-      ...operationOptions
-    });
-};`);
-      await validateTypeScript(content, schema, docs, {});
-    });
-
-    it('should not generate HOCs', async () => {
-      const docs = [{ filePath: '', content: basicDoc }];
-      const content = await plugin(
-        schema,
-        docs,
-        { withHOC: false },
-        {
-          outputFile: 'graphql.tsx',
-        }
-      );
-
-      expect(content).not.toContain(`export type TestProps`);
-      expect(content).not.toContain(`export function withTest`);
-      await validateTypeScript(content, schema, docs, {});
-    });
-
-    it('should not add typesPrefix to HOCs', async () => {
-      const docs = [{ filePath: '', content: basicDoc }];
-      const content = await plugin(
-        schema,
-        docs,
-        { typesPrefix: 'I' },
-        {
-          outputFile: 'graphql.tsx',
-        }
-      );
-
-      expect(content).toContain(`export type ITestProps`);
-      expect(content).toContain(`export function withTest`);
-    });
-    it('should generate mutation function signature correctly', async () => {
-      const docs = [
-        {
-          filePath: '',
-          content: parse(/* GraphQL */ `
-            mutation submitComment($repoFullName: String!, $commentContent: String!) {
-              submitComment(repoFullName: $repoFullName, commentContent: $commentContent) {
-                id
-              }
-            }
-          `),
-        },
-      ];
-      const content = await plugin(
-        schema,
-        docs,
-        { withMutationFn: true },
-        {
-          outputFile: 'graphql.tsx',
-        }
-      );
-
-      expect(content).toContain(`export type SubmitCommentMutationFn = ReactApollo.MutationFn<SubmitCommentMutation, SubmitCommentMutationVariables>;`);
-      await validateTypeScript(content, schema, docs, {});
     });
   });
 
@@ -580,7 +496,7 @@ query MyFeed {
       const content = await plugin(
         schema,
         docs,
-        { withHooks: true, withComponent: false, withHOC: false },
+        { withHooks: true, withComponent: false },
         {
           outputFile: 'graphql.tsx',
         }
@@ -630,7 +546,6 @@ export function useSubmitRepositoryMutation() {
         {
           withHooks: true,
           withComponent: false,
-          withHOC: false,
         },
         {
           outputFile: 'graphql.tsx',

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -503,7 +503,7 @@ query MyFeed {
       );
 
       expect(content).toBeSimilarStringTo(`
-export function useFeedQuery(options?: Urql.UseQueryArgs<FeedQueryVariables> = {}) {
+export function useFeedQuery(options: Urql.UseQueryArgs<FeedQueryVariables> = {}) {
   return Urql.useQuery<FeedQuery>({ query: FeedDocument, ...options });
 };`);
 
@@ -553,7 +553,7 @@ export function useSubmitRepositoryMutation() {
       );
 
       expect(content).toBeSimilarStringTo(`
-export function useListenToCommentsSubscription(options?: Urql.UseSubscriptionArgs<ListenToCommentsSubscriptionVariables> = {}) {
+export function useListenToCommentsSubscription(options: Urql.UseSubscriptionArgs<ListenToCommentsSubscriptionVariables> = {}) {
   return Urql.useSubscription<ListenToCommentsSubscription>({ query: ListenToCommentsDocument, ...options });
 };`);
       await validateTypeScript(content, schema, docs, {});

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -366,9 +366,9 @@ query MyFeed {
       );
 
       expect(content).toBeSimilarStringTo(`
-      export const TestComponent = (props: { variables?: TestQueryVariables, requestPolicy?: Urql.RequestPolicy }) => 
+      export const TestComponent = (props: Omit<Urql.QueryProps,  'query'> & { variables?: TestQueryVariables }) => 
       (
-          <Urql.Query query={TestDocument} {...props} />
+          <Urql.Query {...props} query={TestDocument} />
       );
       `);
       await validateTypeScript(content, schema, docs, {});
@@ -415,8 +415,8 @@ query MyFeed {
       );
 
       expect(content).toBeSimilarStringTo(`
-      export const TestComponent = (props: { variables: TestQueryVariables, requestPolicy?: Urql.RequestPolicy }) => (
-        <Urql.Query query={TestDocument} {...props} />
+      export const TestComponent = (props: Omit<Urql.QueryProps, 'query'> & { variables: TestQueryVariables }) => (
+        <Urql.Query {...props} query={TestDocument} />
       );`);
       await validateTypeScript(content, schema, docs, {});
     });
@@ -447,8 +447,8 @@ query MyFeed {
       );
 
       expect(content).toBeSimilarStringTo(`
-      export const TestComponent = (props: { variables?: TestMutationVariables }) => (
-        <Urql.Mutation query={TestDocument} {...props} />
+      export const TestComponent = (props: Omit<Urql.MutationProps, 'query'> & { variables?: TestMutationVariables }) => (
+        <Urql.Mutation {...props} query={TestDocument} />
       );`);
       await validateTypeScript(content, schema, docs, {});
     });

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -100,23 +100,23 @@ describe('urql', () => {
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it.skip('should import ReactApollo from reactApolloImportFrom config option', async () => {
+    it('should import Urql from urqlImportFrom config option', async () => {
       const docs = [{ filePath: '', content: basicDoc }];
       const content = await plugin(
         schema,
         docs,
-        { withHooks: true, reactApolloImportFrom: 'custom-apollo' },
+        { withHooks: true, urqlImportFrom: 'custom-urql' },
         {
           outputFile: 'graphql.tsx',
         }
       );
 
-      expect(content).toBeSimilarStringTo(`import * as ReactApollo from 'custom-apollo';`);
+      expect(content).toBeSimilarStringTo(`import * as Urql from 'custom-urql';`);
       await validateTypeScript(content, schema, docs, {});
     });
   });
 
-  describe.skip('Fragments', () => {
+  describe('Fragments', () => {
     it('Should generate basic fragments documents correctly', async () => {
       const docs = [
         {

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -1,0 +1,661 @@
+import '@graphql-codegen/testing';
+import { plugin } from '../src/index';
+import { parse, GraphQLSchema, buildClientSchema, buildASTSchema } from 'graphql';
+import gql from 'graphql-tag';
+import { Types } from '@graphql-codegen/plugin-helpers';
+import { plugin as tsPlugin } from '@graphql-codegen/typescript/src';
+import { plugin as tsDocumentsPlugin } from '../../operations/src/index';
+import { validateTs } from '@graphql-codegen/typescript/tests/validate';
+import { readFileSync } from 'fs';
+
+describe('urql', () => {
+  const schema = buildClientSchema(JSON.parse(readFileSync('../../../../dev-test/githunt/schema.json').toString()));
+  const basicDoc = parse(/* GraphQL */ `
+    query test {
+      feed {
+        id
+        commentCount
+        repository {
+          full_name
+          html_url
+          owner {
+            avatar_url
+          }
+        }
+      }
+    }
+  `);
+
+  const validateTypeScript = async (output: string, testSchema: GraphQLSchema, documents: Types.DocumentFile[], config: any) => {
+    const tsOutput = await tsPlugin(testSchema, documents, config, { outputFile: '' });
+    const tsDocumentsOutput = await tsDocumentsPlugin(testSchema, documents, config, { outputFile: '' });
+    const merged = [tsOutput, tsDocumentsOutput, output].join('\n');
+    validateTs(merged, undefined, true);
+  };
+
+  it(`should skip if there's no operations`, async () => {
+    const content = await plugin(
+      schema,
+      [],
+      {},
+      {
+        outputFile: 'graphql.tsx',
+      }
+    );
+
+    expect(content).not.toContain(`import * as ReactApollo from 'react-apollo';`);
+    expect(content).not.toContain(`import * as React from 'react';`);
+    expect(content).not.toContain(`import gql from 'graphql-tag';`);
+    await validateTypeScript(content, schema, [], {});
+  });
+
+  describe('Imports', () => {
+    it('should import Urql dependencies', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`import * as Urql from 'urql';`);
+      expect(content).toBeSimilarStringTo(`import * as React from 'react';`);
+      expect(content).toBeSimilarStringTo(`import gql from 'graphql-tag';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import DocumentNode when using noGraphQLTag', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        {
+          noGraphQLTag: true,
+        },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toContain(`import { DocumentNode } from 'graphql';`);
+      expect(content).not.toBeSimilarStringTo(`import gql from 'graphql-tag';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it(`should use gql import from gqlImport config option`, async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { gqlImport: 'graphql.macro#gql' },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toContain(`import { gql } from 'graphql.macro';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it.skip('should import ReactApollo from reactApolloImportFrom config option', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { withHooks: true, reactApolloImportFrom: 'custom-apollo' },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`import * as ReactApollo from 'custom-apollo';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+  });
+
+  describe.skip('Fragments', () => {
+    it('Should generate basic fragments documents correctly', async () => {
+      const docs = [
+        {
+          filePath: 'a.graphql',
+          content: parse(/* GraphQL */ `
+            fragment MyFragment on Repository {
+              full_name
+            }
+
+            query {
+              feed {
+                id
+              }
+            }
+          `),
+        },
+      ];
+      const result = await plugin(schema, docs, {}, { outputFile: '' });
+
+      expect(result).toBeSimilarStringTo(`
+      export const MyFragmentFragmentDoc = gql\`
+      fragment MyFragment on Repository {
+        full_name
+      }
+      \`;`);
+      await validateTypeScript(result, schema, docs, {});
+    });
+
+    it('should generate Document variables for inline fragments', async () => {
+      const repositoryWithOwner = gql`
+        fragment RepositoryWithOwner on Repository {
+          full_name
+          html_url
+          owner {
+            avatar_url
+          }
+        }
+      `;
+      const feedWithRepository = gql`
+        fragment FeedWithRepository on Entry {
+          id
+          commentCount
+          repository(search: "phrase") {
+            ...RepositoryWithOwner
+          }
+        }
+
+        ${repositoryWithOwner}
+      `;
+      const myFeed = gql`
+        query MyFeed {
+          feed {
+            ...FeedWithRepository
+          }
+        }
+
+        ${feedWithRepository}
+      `;
+
+      const docs = [{ filePath: '', content: myFeed }];
+
+      const content = await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`export const FeedWithRepositoryFragmentDoc = gql\`
+fragment FeedWithRepository on Entry {
+  id
+  commentCount
+  repository(search: "phrase") {
+    ...RepositoryWithOwner
+  }
+}
+\${RepositoryWithOwnerFragmentDoc}\`;`);
+      expect(content).toBeSimilarStringTo(`export const RepositoryWithOwnerFragmentDoc = gql\`
+fragment RepositoryWithOwner on Repository {
+  full_name
+  html_url
+  owner {
+    avatar_url
+  }
+}
+\`;`);
+
+      expect(content).toBeSimilarStringTo(`export const MyFeedDocument = gql\`
+query MyFeed {
+  feed {
+    ...FeedWithRepository
+  }
+}
+\${FeedWithRepositoryFragmentDoc}\`;`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should avoid generating duplicate fragments', async () => {
+      const simpleFeed = gql`
+        fragment Item on Entry {
+          id
+        }
+      `;
+      const myFeed = gql`
+        query MyFeed {
+          feed {
+            ...Item
+          }
+          allFeeds: feed {
+            ...Item
+          }
+        }
+      `;
+      const documents = [simpleFeed, myFeed];
+      const docs = documents.map(content => ({ content, filePath: '' }));
+      const content = await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`
+        export const MyFeedDocument = gql\`
+        query MyFeed {
+            feed {
+              ...Item
+            }
+            allFeeds: feed {
+              ...Item
+            }
+          }
+          \${ItemFragmentDoc}\``);
+      expect(content).toBeSimilarStringTo(`
+        export const ItemFragmentDoc = gql\`
+        fragment Item on Entry {
+          id
+        }
+\`;`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should generate fragments in proper order (when one depends on other)', async () => {
+      const myFeed = gql`
+        fragment FeedWithRepository on Entry {
+          id
+          repository {
+            ...RepositoryWithOwner
+          }
+        }
+
+        fragment RepositoryWithOwner on Repository {
+          full_name
+        }
+
+        query MyFeed {
+          feed {
+            ...FeedWithRepository
+          }
+        }
+      `;
+      const documents = [myFeed];
+      const docs = documents.map(content => ({ content, filePath: '' }));
+      const content = await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      const feedWithRepositoryPos = content.indexOf('fragment FeedWithRepository');
+      const repositoryWithOwnerPos = content.indexOf('fragment RepositoryWithOwner');
+      expect(repositoryWithOwnerPos).toBeLessThan(feedWithRepositoryPos);
+      await validateTypeScript(content, schema, docs, {});
+    });
+  });
+
+  describe.skip('Component', () => {
+    it('should generate Document variable', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`
+          export const TestDocument =  gql\`
+          query test {
+            feed {
+              id
+              commentCount
+              repository {
+                full_name
+                html_url
+                owner {
+                  avatar_url
+                }
+              }
+            }
+          }
+          \`;
+        `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should generate Document variable with noGraphQlTag', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        {
+          noGraphQLTag: true,
+        },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`export const TestDocument: DocumentNode = {"kind":"Document","defin`);
+
+      // For issue #1599 - make sure there are not `loc` properties
+      expect(content).not.toContain(`loc":`);
+      expect(content).not.toContain(`loc':`);
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should generate Component', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`
+      export const TestComponent = (props: Omit<Omit<ReactApollo.QueryProps<TestQuery, TestQueryVariables>, 'query'>, 'variables'> & { variables?: TestQueryVariables }) => 
+      (
+          <ReactApollo.Query<TestQuery, TestQueryVariables> query={TestDocument} {...props} />
+      );
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should not generate Component', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { withComponent: false },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).not.toContain(`export class TestComponent`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should make variables property required if any of variable definitions is non-null', async () => {
+      const docs = [
+        {
+          filePath: '',
+          content: gql`
+            query Test($foo: String!) {
+              test(foo: $foo)
+            }
+          `,
+        },
+      ];
+      const schema = buildASTSchema(gql`
+        type Query {
+          test(foo: String!): Boolean
+        }
+      `);
+      const content = await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`
+      export const TestComponent = (props: Omit<Omit<ReactApollo.QueryProps<TestQuery, TestQueryVariables>, 'query'>, 'variables'> & { variables: TestQueryVariables }) => (
+        <ReactApollo.Query<TestQuery, TestQueryVariables> query={TestDocument} {...props} />
+      );`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should make variables property optional if operationType is mutation', async () => {
+      const docs = [
+        {
+          filePath: '',
+          content: gql`
+            mutation Test($foo: String!) {
+              test(foo: $foo)
+            }
+          `,
+        },
+      ];
+      const schema = buildASTSchema(gql`
+        type Mutation {
+          test(foo: String!): Boolean
+        }
+      `);
+      const content = await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`
+      export const TestComponent = (props: Omit<Omit<ReactApollo.MutationProps<TestMutation, TestMutationVariables>, 'mutation'>, 'variables'> & { variables?: TestMutationVariables }) => (
+        <ReactApollo.Mutation<TestMutation, TestMutationVariables> mutation={TestDocument} {...props} />
+      );`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should not add typesPrefix to Component', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { typesPrefix: 'I' },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).not.toContain(`export class ITestComponent`);
+    });
+  });
+
+  describe.skip('HOC', () => {
+    it('should generate HOCs', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`export type TestProps<TChildProps = {}> = Partial<ReactApollo.DataProps<TestQuery, TestQueryVariables>> & TChildProps;`);
+
+      expect(content).toBeSimilarStringTo(`export function withTest<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
+  TProps,
+  TestQuery,
+  TestQueryVariables,
+  TestProps<TChildProps>>) {
+    return ReactApollo.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps>>(TestDocument, {
+      alias: 'withTest',
+      ...operationOptions
+    });
+};`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should not generate HOCs', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { withHOC: false },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).not.toContain(`export type TestProps`);
+      expect(content).not.toContain(`export function withTest`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should not add typesPrefix to HOCs', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { typesPrefix: 'I' },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toContain(`export type ITestProps`);
+      expect(content).toContain(`export function withTest`);
+    });
+    it('should generate mutation function signature correctly', async () => {
+      const docs = [
+        {
+          filePath: '',
+          content: parse(/* GraphQL */ `
+            mutation submitComment($repoFullName: String!, $commentContent: String!) {
+              submitComment(repoFullName: $repoFullName, commentContent: $commentContent) {
+                id
+              }
+            }
+          `),
+        },
+      ];
+      const content = await plugin(
+        schema,
+        docs,
+        { withMutationFn: true },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toContain(`export type SubmitCommentMutationFn = ReactApollo.MutationFn<SubmitCommentMutation, SubmitCommentMutationVariables>;`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+  });
+
+  describe('Hooks', () => {
+    it('Should generate hooks for query and mutation', async () => {
+      const documents = parse(/* GraphQL */ `
+        query feed {
+          feed {
+            id
+            commentCount
+            repository {
+              full_name
+              html_url
+              owner {
+                avatar_url
+              }
+            }
+          }
+        }
+
+        mutation submitRepository($name: String) {
+          submitRepository(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+      const docs = [{ filePath: '', content: documents }];
+
+      const content = await plugin(
+        schema,
+        docs,
+        { withHooks: true, withComponent: false, withHOC: false },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`
+export function useFeedQuery(options?: Urql.UseQueryArgs<FeedQueryVariables> = {}) {
+  return Urql.useQuery<FeedQuery>({ query: FeedDocument, ...options });
+};`);
+
+      expect(content).toBeSimilarStringTo(`
+export function useSubmitRepositoryMutation() {
+  return Urql.useMutation<SubmitRepositoryMutation>(SubmitRepositoryDocument);
+};`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should not generate hooks for query and mutation', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { withHooks: false },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).not.toContain(`export function useTestQuery`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should generate subscription hooks', async () => {
+      const documents = parse(/* GraphQL */ `
+        subscription ListenToComments($name: String) {
+          commentAdded(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+
+      const docs = [{ filePath: '', content: documents }];
+
+      const content = await plugin(
+        schema,
+        docs,
+        {
+          withHooks: true,
+          withComponent: false,
+          withHOC: false,
+        },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`
+export function useListenToCommentsSubscription(options?: Urql.UseSubscriptionArgs<ListenToCommentsSubscriptionVariables> = {}) {
+  return Urql.useSubscription<ListenToCommentsSubscription>({ query: ListenToCommentsDocument, ...options });
+};`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should not add typesPrefix to hooks', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { withHooks: true, typesPrefix: 'I' },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toContain(`export function useTestQuery`);
+    });
+  });
+});

--- a/packages/plugins/typescript/urql/tsconfig.json
+++ b/packages/plugins/typescript/urql/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "importHelpers": true,
+    "experimentalDecorators": true,
+    "module": "esnext",
+    "target": "es2018",
+    "lib": ["es6", "esnext", "es2015"],
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "./dist/",
+    "noImplicitAny": false,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "exclude": ["node_modules", "tests", "dist", "example"]
+}


### PR DESCRIPTION
I mainly just copied the react-apollo plugin and rewrote the generated code to use the urql API, which differs from the `react-apollo` and `react-apollo-hooks` a bit.

- [x] Generate hooks
- [x] Generate components
- [x] Fix options
- [x] Test whether generated code actually works

Closes #1575 