### PR TITLE
Remove use of NODE_TLS_REJECT_UNAUTHORIZED env var.

### DIFF
--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -6,8 +6,6 @@ import { sync as mkdirpSync } from 'mkdirp';
 import { dirname } from 'path';
 import { debugLog } from './utils/debugging';
 
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 export async function generate(config: Types.Config, saveToFile = true): Promise<Types.FileOutput[] | any> {
   async function writeOutput(generationResult: Types.FileOutput[]) {
     if (!saveToFile) {


### PR DESCRIPTION
This PR addresses issue: https://github.com/dotansimha/graphql-code-generator/issues/1806.

Following the recommendations from, this PR removes the use of the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable: https://nodejs.org/api/cli.html#cli_node_tls_reject_unauthorized_value

> If value equals '0', certificate validation is disabled for TLS connections. This makes TLS, and HTTPS by extension, insecure. *The use of this environment variable is strongly discouraged.*
