### PR TITLE
Add first boilerplate setup for webpack loader

### DIFF
--- a/packages/graphql-codegen-webpack-loader/.gitignore
+++ b/packages/graphql-codegen-webpack-loader/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+dist
+temp
+yarn-error.log
+tests/coverage/

--- a/packages/graphql-codegen-webpack-loader/.npmignore
+++ b/packages/graphql-codegen-webpack-loader/.npmignore
@@ -1,0 +1,6 @@
+src
+node_modules
+tests
+!dist
+jest.config.js
+tsconfig.json

--- a/packages/graphql-codegen-webpack-loader/README.md
+++ b/packages/graphql-codegen-webpack-loader/README.md
@@ -1,0 +1,9 @@
+# GraphQL Code Generator
+
+<p align="center">
+    <img src="https://github.com/dotansimha/graphql-code-generator/blob/master/logo.png?raw=true" />
+</p>
+
+Live demo and full documentation: [graphql-code-generator.com](https://graphql-code-generator.com)
+
+Project repository: [graphql-code-generator](https://github.com/dotansimha/graphql-code-generator)

--- a/packages/graphql-codegen-webpack-loader/package.json
+++ b/packages/graphql-codegen-webpack-loader/package.json
@@ -45,7 +45,10 @@
     "tslib": "1.9.3"
   },
   "devDependencies": {
-    "ts-jest": "24.0.2"
+    "memory-fs": "^0.4.1",
+    "raw-loader": "^2.0.0",
+    "ts-jest": "24.0.2",
+    "webpack": "^4.31.0"
   },
   "sideEffects": false,
   "main": "dist/commonjs/index.js",

--- a/packages/graphql-codegen-webpack-loader/package.json
+++ b/packages/graphql-codegen-webpack-loader/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@graphql-codegen/webpack-loader",
+  "version": "1.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dotansimha/graphql-code-generator.git"
+  },
+  "scripts": {
+    "clean": "rimraf ./dist",
+    "lint": "tslint src/**/*.ts",
+    "prebuild": "yarn clean",
+    "build": "tsc -m esnext --outDir dist/esnext && tsc -m commonjs --outDir dist/commonjs",
+    "test": "jest --config ../../jest.config.js"
+  },
+  "keywords": [
+    "gql",
+    "generator",
+    "code",
+    "types",
+    "interfaces",
+    "graphql",
+    "codegen",
+    "apollo",
+    "node",
+    "typescript",
+    "ts",
+    "flow",
+    "types",
+    "d.ts",
+    "typings",
+    "webpack",
+    "loader"
+  ],
+  "author": "Dotan Simha <dotansimha@gmail.com>",
+  "bugs": {
+    "url": "https://github.com/dotansimha/graphql-codegen/issues"
+  },
+  "homepage": "https://github.com/dotansimha/graphql-codegen#readme",
+  "peerDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+  },
+  "dependencies": {
+    "loader-utils": "^1.2.3",
+    "tslib": "1.9.3"
+  },
+  "devDependencies": {
+    "ts-jest": "24.0.2"
+  },
+  "sideEffects": false,
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esnext/index.js",
+  "typings": "dist/esnext/index.d.ts",
+  "typescript": {
+    "definition": "dist/esnext/index.d.ts"
+  },
+  "jest-junit": {
+    "outputDirectory": "../../test-results/core"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/graphql-codegen-webpack-loader/src/index.ts
+++ b/packages/graphql-codegen-webpack-loader/src/index.ts
@@ -1,0 +1,14 @@
+import { getOptions } from 'loader-utils';
+
+export default function loader(content) {
+  const options = getOptions(this) || {};
+  const callback = this.async();
+
+  // TODO: Load options.schema
+
+  // TODO: Transform file `content` with the graphql-codegen plugins
+  const transformed = content;
+
+  // Once done transforming, call `callback` with the new code
+  callback(transformed);
+}

--- a/packages/graphql-codegen-webpack-loader/src/index.ts
+++ b/packages/graphql-codegen-webpack-loader/src/index.ts
@@ -7,8 +7,8 @@ export default function loader(content) {
   // TODO: Load options.schema
 
   // TODO: Transform file `content` with the graphql-codegen plugins
-  const transformed = content;
+  const transformed = `export default \`${content}\``;
 
   // Once done transforming, call `callback` with the new code
-  callback(transformed);
+  callback(null, transformed);
 }

--- a/packages/graphql-codegen-webpack-loader/tests/compiler.js
+++ b/packages/graphql-codegen-webpack-loader/tests/compiler.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const webpack = require('webpack');
+const memoryfs = require('memory-fs');
+
+module.exports = (fixture, options = {}) => {
+  const compiler = webpack({
+    context: __dirname,
+    entry: `./fixtures/${fixture}`,
+    output: {
+      path: path.resolve(__dirname),
+      filename: 'bundle.js',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.graphql$/,
+          use: [
+            {
+              loader: path.resolve(__dirname, '../src/index.ts'),
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  compiler.outputFileSystem = new memoryfs();
+
+  return new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      if (err) reject(err);
+      if (stats.hasErrors()) reject(new Error(stats.toJson().errors));
+
+      resolve(stats);
+    });
+  });
+};

--- a/packages/graphql-codegen-webpack-loader/tests/fixtures/getViewer.graphql
+++ b/packages/graphql-codegen-webpack-loader/tests/fixtures/getViewer.graphql
@@ -1,0 +1,5 @@
+query getViewer {
+  viewer {
+    id
+  }
+}

--- a/packages/graphql-codegen-webpack-loader/tests/webpack-loader.spec.ts
+++ b/packages/graphql-codegen-webpack-loader/tests/webpack-loader.spec.ts
@@ -1,0 +1,7 @@
+import loader from '../src';
+
+describe('webpack-loader', () => {
+  it('is exports a loader', () => {
+    expect(loader).toBeDefined();
+  });
+});

--- a/packages/graphql-codegen-webpack-loader/tests/webpack-loader.spec.ts
+++ b/packages/graphql-codegen-webpack-loader/tests/webpack-loader.spec.ts
@@ -1,7 +1,16 @@
-import loader from '../src';
+const compiler = require('./compiler');
 
 describe('webpack-loader', () => {
-  it('is exports a loader', () => {
-    expect(loader).toBeDefined();
+  it('is exports a loader', async () => {
+    const stats = await compiler('getViewer.graphql');
+    const output = stats.toJson().modules[0].source;
+
+    expect(output).toMatchInlineSnapshot(`
+      "export default \`query getViewer {
+        viewer {
+          id
+        }
+      }\`"
+    `);
   });
 });

--- a/packages/graphql-codegen-webpack-loader/tsconfig.json
+++ b/packages/graphql-codegen-webpack-loader/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "importHelpers": true,
+    "experimentalDecorators": true,
+    "module": "esnext",
+    "target": "es2018",
+    "lib": ["es6", "esnext", "es2015", "dom"],
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false
+  },
+  "files": ["src/index.ts"],
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12199,6 +12199,14 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+raw-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-2.0.0.tgz#e2813d9e1e3f80d1bbade5ad082e809679e20c26"
+  integrity sha512-kZnO5MoIyrojfrPWqrhFNLZemIAX8edMOCp++yC5RKxzFB3m92DqKNhKlU6+FvpOhWtvyh3jOaD7J6/9tpdIKg==
+  dependencies:
+    loader-utils "^1.1.0"
+    schema-utils "^1.0.0"
+
 rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -14992,6 +15000,36 @@ webpack@4.29.6:
   version "4.29.6"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.29.6.tgz#66bf0ec8beee4d469f8b598d3988ff9d8d90e955"
   integrity sha512-MwBwpiE1BQpMDkbnUUaW6K8RFZjljJHArC6tWQJoFm0oQtfoSebtg4Y7/QHnJ/SddtjYLHaKGX64CFjG5rehJw==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    "@webassemblyjs/helper-module-context" "1.8.5"
+    "@webassemblyjs/wasm-edit" "1.8.5"
+    "@webassemblyjs/wasm-parser" "1.8.5"
+    acorn "^6.0.5"
+    acorn-dynamic-import "^4.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^1.0.0"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.0"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^1.0.0"
+    tapable "^1.1.0"
+    terser-webpack-plugin "^1.1.0"
+    watchpack "^1.5.0"
+    webpack-sources "^1.3.0"
+
+webpack@^4.31.0:
+  version "4.31.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.31.0.tgz#ae201d45f0571336e42d1c2b5c8ab56c4d3b0c63"
+  integrity sha512-n6RVO3X0LbbipoE62akME9K/JI7qYrwwufs20VvgNNpqUoH4860KkaxJTbGq5bgkVZF9FqyyTG/0WPLH3PVNJA==
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/helper-module-context" "1.8.5"


### PR DESCRIPTION
Reference #1828, this solely does the first setup for the package and nothing else.

@dotansimha how are we going to run the raw file contents through the graphql-codegen plugins?