### PR TITLE
Make suffix of generated React Apollo components customizable

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/index.ts
+++ b/packages/plugins/typescript/react-apollo/src/index.ts
@@ -101,9 +101,9 @@ export interface ReactApolloRawPluginConfig extends RawClientSideBasePluginConfi
    * @default react-apollo
    */
   reactApolloImportFrom?: string;
-  customSuffix?: string;
+  componentSuffix?: string;
   /**
-   * @name customSuffix
+   * @name componentSuffix
    * @type string
    * @description You can specify a suffix that gets attached to the name of the generated component.
    * @default Component

--- a/packages/plugins/typescript/react-apollo/src/index.ts
+++ b/packages/plugins/typescript/react-apollo/src/index.ts
@@ -106,7 +106,7 @@ export interface ReactApolloRawPluginConfig extends RawClientSideBasePluginConfi
    * @name customSuffix
    * @type string
    * @description You can specify a suffix that gets attached to the name of the generated component.
-   * @default react-apollo
+   * @default Component
    */
 }
 

--- a/packages/plugins/typescript/react-apollo/src/index.ts
+++ b/packages/plugins/typescript/react-apollo/src/index.ts
@@ -101,6 +101,13 @@ export interface ReactApolloRawPluginConfig extends RawClientSideBasePluginConfi
    * @default react-apollo
    */
   reactApolloImportFrom?: string;
+  customSuffix?: string;
+  /**
+   * @name customSuffix
+   * @type string
+   * @description You can specify a suffix that gets attached to the name of the generated component.
+   * @default react-apollo
+   */
 }
 
 export const plugin: PluginFunction<ReactApolloRawPluginConfig> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: ReactApolloRawPluginConfig) => {

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -12,13 +12,13 @@ export interface ReactApolloPluginConfig extends ClientSideBasePluginConfig {
   withMutationFn: boolean;
   hooksImportFrom: string;
   reactApolloImportFrom: string;
-  customSuffix: string;
+  componentSuffix: string;
 }
 
 export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPluginConfig, ReactApolloPluginConfig> {
   constructor(fragments: FragmentDefinitionNode[], rawConfig: ReactApolloRawPluginConfig) {
     super(fragments, rawConfig, {
-      customSuffix: getConfigValue(rawConfig.customSuffix, 'Component'),
+      componentSuffix: getConfigValue(rawConfig.componentSuffix, 'Component'),
       withHOC: getConfigValue(rawConfig.withHOC, true),
       withComponent: getConfigValue(rawConfig.withComponent, true),
       withHooks: getConfigValue(rawConfig.withHooks, false),
@@ -87,7 +87,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
   }
 
   private _buildComponent(node: OperationDefinitionNode, documentVariableName: string, operationType: string, operationResultType: string, operationVariablesTypes: string): string {
-    const componentName: string = this.convertName(node.name.value, { suffix: this.config.customSuffix, useTypesPrefix: false });
+    const componentName: string = this.convertName(node.name.value, { suffix: this.config.componentSuffix, useTypesPrefix: false });
 
     const isVariablesRequired = operationType === 'Query' && node.variableDefinitions.some(variableDef => variableDef.type.kind === Kind.NON_NULL_TYPE);
 

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -12,11 +12,13 @@ export interface ReactApolloPluginConfig extends ClientSideBasePluginConfig {
   withMutationFn: boolean;
   hooksImportFrom: string;
   reactApolloImportFrom: string;
+  customSuffix: string;
 }
 
 export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPluginConfig, ReactApolloPluginConfig> {
   constructor(fragments: FragmentDefinitionNode[], rawConfig: ReactApolloRawPluginConfig) {
     super(fragments, rawConfig, {
+      customSuffix: getConfigValue(rawConfig.customSuffix, 'Component'),
       withHOC: getConfigValue(rawConfig.withHOC, true),
       withComponent: getConfigValue(rawConfig.withComponent, true),
       withHooks: getConfigValue(rawConfig.withHooks, false),
@@ -85,7 +87,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
   }
 
   private _buildComponent(node: OperationDefinitionNode, documentVariableName: string, operationType: string, operationResultType: string, operationVariablesTypes: string): string {
-    const componentName: string = this.convertName(node.name.value, { suffix: 'Component', useTypesPrefix: false });
+    const componentName: string = this.convertName(node.name.value, { suffix: this.config.customSuffix, useTypesPrefix: false });
 
     const isVariablesRequired = operationType === 'Query' && node.variableDefinitions.some(variableDef => variableDef.type.kind === Kind.NON_NULL_TYPE);
 

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -430,7 +430,7 @@ query MyFeed {
       const content = await plugin(
         schema,
         docs,
-        { customSuffix: 'Q' },
+        { componentSuffix: 'Q' },
         {
           outputFile: 'graphql.tsx',
         }
@@ -442,7 +442,7 @@ query MyFeed {
           <ReactApollo.Query<TestQuery, TestQueryVariables> query={TestDocument} {...props} />
       );
       `);
-      await validateTypeScript(content, schema, docs, { customSuffix: 'Q' });
+      await validateTypeScript(content, schema, docs, { componentSuffix: 'Q' });
     });
 
     it('should not generate Component', async () => {

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -154,7 +154,7 @@ describe('React Apollo', () => {
           withHooks: true,
           withHOC: false,
           withComponent: false,
-          withMutationFn: false
+          withMutationFn: false,
         },
         {
           outputFile: 'graphql.tsx',
@@ -423,6 +423,26 @@ query MyFeed {
       );
       `);
       await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should generate a component with a custom suffix when specified', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = await plugin(
+        schema,
+        docs,
+        { customSuffix: 'Q' },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`
+      export const TestQ = (props: Omit<Omit<ReactApollo.QueryProps<TestQuery, TestQueryVariables>, 'query'>, 'variables'> & { variables?: TestQueryVariables }) => 
+      (
+          <ReactApollo.Query<TestQuery, TestQueryVariables> query={TestDocument} {...props} />
+      );
+      `);
+      await validateTypeScript(content, schema, docs, { customSuffix: 'Q' });
     });
 
     it('should not generate Component', async () => {


### PR DESCRIPTION
This PR addresses the following issue: #1834 

The default suffix is `Component`. It should be possible to specify the desired suffix (string) via `customSuffix` property in plugin config in `codegen.yml`.

I only made changes to the `typescript-react-apollo` plugin.
