### PR TITLE
docs: clarify the importance of order of plugins

### DIFF
--- a/docs/plugins/add.md
+++ b/docs/plugins/add.md
@@ -10,6 +10,10 @@ You can use this plugin to add custom code, imports, comments and more to your o
 ## Installation
 
     $ yarn add -D @graphql-codegen/add
+    
+    
+> Notice that the order of plugins in the yaml config matters.
+> If you need to add something to the top of the file, for example `/* eslint-disable */`, makes sure to place the `add` plugin before the other plugins, so their output won't be on top of the `add` addition.
 
 ## Examples
 


### PR DESCRIPTION
clarify the importance of order of plugins In the add plugin docs