### PR TITLE
Fix urql typescript types

### DIFF
--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -60,7 +60,7 @@ export function use${operationName}() {
 };`;
     }
     return `
-export function use${operationName}(options: Urql.Use${operationType}Args<${operationVariablesTypes}> = {}) {
+export function use${operationName}(options: Omit<Urql.Use${operationType}Args<${operationVariablesTypes}>, 'query'> = {}) {
   return Urql.use${operationType}<${operationResultType}>({ query: ${documentVariableName}, ...options });
 };`;
   }

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -503,7 +503,7 @@ query MyFeed {
       );
 
       expect(content).toBeSimilarStringTo(`
-export function useFeedQuery(options: Urql.UseQueryArgs<FeedQueryVariables> = {}) {
+export function useFeedQuery(options: Omit<Urql.UseQueryArgs<FeedQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<FeedQuery>({ query: FeedDocument, ...options });
 };`);
 
@@ -553,7 +553,7 @@ export function useSubmitRepositoryMutation() {
       );
 
       expect(content).toBeSimilarStringTo(`
-export function useListenToCommentsSubscription(options: Urql.UseSubscriptionArgs<ListenToCommentsSubscriptionVariables> = {}) {
+export function useListenToCommentsSubscription(options: Omit<Urql.UseSubscriptionArgs<ListenToCommentsSubscriptionVariables>, 'query'> = {}) {
   return Urql.useSubscription<ListenToCommentsSubscription>({ query: ListenToCommentsDocument, ...options });
 };`);
       await validateTypeScript(content, schema, docs, {});


### PR DESCRIPTION
These would throw an error saying "Required field `query` not provided".  Need to omit that.