### PR TITLE
Improve plugins output and solve duplicates issues 

### DIFF
--- a/dev-test/githunt/flow.flow.js
+++ b/dev-test/githunt/flow.flow.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 
-
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -13,6 +12,7 @@ export type Scalars = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
+  __typename?: 'Comment',
   /** The SQL ID of this entry */
   id: $ElementType<Scalars, 'Int'>,
   /** The GitHub user who posted the comment */
@@ -27,6 +27,7 @@ export type Comment = {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
+  __typename?: 'Entry',
   /** Information about the repository from GitHub */
   repository: Repository,
   /** The GitHub user who submitted this entry */
@@ -68,6 +69,7 @@ export const FeedTypeValues = Object.freeze({
 export type FeedType = $Values<typeof FeedTypeValues>;
 
 export type Mutation = {
+  __typename?: 'Mutation',
   /** Submit a new repository, returns the new submission */
   submitRepository?: ?Entry,
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -94,6 +96,7 @@ export type MutationSubmitCommentArgs = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   /** A feed of repository submissions */
   feed?: ?Array<?Entry>,
   /** A single entry */
@@ -118,6 +121,7 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
+  __typename?: 'Repository',
   /** Just the name of the repository, e.g. GitHunt-API */
   name: $ElementType<Scalars, 'String'>,
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -135,6 +139,7 @@ export type Repository = {
 };
 
 export type Subscription = {
+  __typename?: 'Subscription',
   /** Subscription fires on every comment added */
   commentAdded?: ?Comment,
 };
@@ -146,6 +151,7 @@ export type SubscriptionCommentAddedArgs = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
+  __typename?: 'User',
   /** The name of the user, e.g. apollostack */
   login: $ElementType<Scalars, 'String'>,
   /** The URL to a directly embeddable image for this user's avatar */
@@ -156,6 +162,7 @@ export type User = {
 
 /** XXX to be removed */
 export type Vote = {
+  __typename?: 'Vote',
   vote_value: $ElementType<Scalars, 'Int'>,
 };
 

--- a/dev-test/githunt/types.avoidOptionals.ts
+++ b/dev-test/githunt/types.avoidOptionals.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +10,7 @@ export type Scalars = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
+  __typename?: 'Comment',
   /** The SQL ID of this entry */
   id: Scalars['Int'],
   /** The GitHub user who posted the comment */
@@ -25,6 +25,7 @@ export type Comment = {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
+  __typename?: 'Entry',
   /** Information about the repository from GitHub */
   repository: Repository,
   /** The GitHub user who submitted this entry */
@@ -63,6 +64,7 @@ export enum FeedType {
 }
 
 export type Mutation = {
+  __typename?: 'Mutation',
   /** Submit a new repository, returns the new submission */
   submitRepository: Maybe<Entry>,
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -89,6 +91,7 @@ export type MutationSubmitCommentArgs = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   /** A feed of repository submissions */
   feed: Maybe<Array<Maybe<Entry>>>,
   /** A single entry */
@@ -113,6 +116,7 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
+  __typename?: 'Repository',
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'],
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -130,6 +134,7 @@ export type Repository = {
 };
 
 export type Subscription = {
+  __typename?: 'Subscription',
   /** Subscription fires on every comment added */
   commentAdded: Maybe<Comment>,
 };
@@ -141,6 +146,7 @@ export type SubscriptionCommentAddedArgs = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
+  __typename?: 'User',
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'],
   /** The URL to a directly embeddable image for this user's avatar */
@@ -151,6 +157,7 @@ export type User = {
 
 /** XXX to be removed */
 export type Vote = {
+  __typename?: 'Vote',
   vote_value: Scalars['Int'],
 };
 

--- a/dev-test/githunt/types.d.ts
+++ b/dev-test/githunt/types.d.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +10,7 @@ export type Scalars = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
+  __typename?: 'Comment',
   /** The SQL ID of this entry */
   id: Scalars['Int'],
   /** The GitHub user who posted the comment */
@@ -25,6 +25,7 @@ export type Comment = {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
+  __typename?: 'Entry',
   /** Information about the repository from GitHub */
   repository: Repository,
   /** The GitHub user who submitted this entry */
@@ -62,6 +63,7 @@ export type FeedType =
   'TOP';
 
 export type Mutation = {
+  __typename?: 'Mutation',
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>,
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -88,6 +90,7 @@ export type MutationSubmitCommentArgs = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>,
   /** A single entry */
@@ -112,6 +115,7 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
+  __typename?: 'Repository',
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'],
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -129,6 +133,7 @@ export type Repository = {
 };
 
 export type Subscription = {
+  __typename?: 'Subscription',
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>,
 };
@@ -140,6 +145,7 @@ export type SubscriptionCommentAddedArgs = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
+  __typename?: 'User',
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'],
   /** The URL to a directly embeddable image for this user's avatar */
@@ -150,6 +156,7 @@ export type User = {
 
 /** XXX to be removed */
 export type Vote = {
+  __typename?: 'Vote',
   vote_value: Scalars['Int'],
 };
 

--- a/dev-test/githunt/types.enumsAsTypes.ts
+++ b/dev-test/githunt/types.enumsAsTypes.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +10,7 @@ export type Scalars = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
+  __typename?: 'Comment',
   /** The SQL ID of this entry */
   id: Scalars['Int'],
   /** The GitHub user who posted the comment */
@@ -25,6 +25,7 @@ export type Comment = {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
+  __typename?: 'Entry',
   /** Information about the repository from GitHub */
   repository: Repository,
   /** The GitHub user who submitted this entry */
@@ -62,6 +63,7 @@ export type FeedType =
   'TOP';
 
 export type Mutation = {
+  __typename?: 'Mutation',
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>,
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -88,6 +90,7 @@ export type MutationSubmitCommentArgs = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>,
   /** A single entry */
@@ -112,6 +115,7 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
+  __typename?: 'Repository',
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'],
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -129,6 +133,7 @@ export type Repository = {
 };
 
 export type Subscription = {
+  __typename?: 'Subscription',
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>,
 };
@@ -140,6 +145,7 @@ export type SubscriptionCommentAddedArgs = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
+  __typename?: 'User',
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'],
   /** The URL to a directly embeddable image for this user's avatar */
@@ -150,6 +156,7 @@ export type User = {
 
 /** XXX to be removed */
 export type Vote = {
+  __typename?: 'Vote',
   vote_value: Scalars['Int'],
 };
 

--- a/dev-test/githunt/types.immutableTypes.ts
+++ b/dev-test/githunt/types.immutableTypes.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +10,7 @@ export type Scalars = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
+  __typename?: 'Comment',
   /** The SQL ID of this entry */
   readonly id: Scalars['Int'],
   /** The GitHub user who posted the comment */
@@ -25,6 +25,7 @@ export type Comment = {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
+  __typename?: 'Entry',
   /** Information about the repository from GitHub */
   readonly repository: Repository,
   /** The GitHub user who submitted this entry */
@@ -63,6 +64,7 @@ export enum FeedType {
 }
 
 export type Mutation = {
+  __typename?: 'Mutation',
   /** Submit a new repository, returns the new submission */
   readonly submitRepository?: Maybe<Entry>,
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -89,6 +91,7 @@ export type MutationSubmitCommentArgs = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   /** A feed of repository submissions */
   readonly feed?: Maybe<ReadonlyArray<Maybe<Entry>>>,
   /** A single entry */
@@ -113,6 +116,7 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
+  __typename?: 'Repository',
   /** Just the name of the repository, e.g. GitHunt-API */
   readonly name: Scalars['String'],
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -130,6 +134,7 @@ export type Repository = {
 };
 
 export type Subscription = {
+  __typename?: 'Subscription',
   /** Subscription fires on every comment added */
   readonly commentAdded?: Maybe<Comment>,
 };
@@ -141,6 +146,7 @@ export type SubscriptionCommentAddedArgs = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
+  __typename?: 'User',
   /** The name of the user, e.g. apollostack */
   readonly login: Scalars['String'],
   /** The URL to a directly embeddable image for this user's avatar */
@@ -151,6 +157,7 @@ export type User = {
 
 /** XXX to be removed */
 export type Vote = {
+  __typename?: 'Vote',
   readonly vote_value: Scalars['Int'],
 };
 

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -1,6 +1,10 @@
+import gql from 'graphql-tag';
+import * as React from 'react';
+import * as ReactApollo from 'react-apollo';
+import * as ReactApolloHooks from 'react-apollo-hooks';
+export type Maybe<T> = T | null;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 // tslint:disable
-
-type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -12,6 +16,7 @@ export type Scalars = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
+  __typename?: 'Comment',
   /** The SQL ID of this entry */
   id: Scalars['Int'],
   /** The GitHub user who posted the comment */
@@ -26,6 +31,7 @@ export type Comment = {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
+  __typename?: 'Entry',
   /** Information about the repository from GitHub */
   repository: Repository,
   /** The GitHub user who submitted this entry */
@@ -64,6 +70,7 @@ export enum FeedType {
 }
 
 export type Mutation = {
+  __typename?: 'Mutation',
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>,
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -90,6 +97,7 @@ export type MutationSubmitCommentArgs = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>,
   /** A single entry */
@@ -114,6 +122,7 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
+  __typename?: 'Repository',
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'],
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -131,6 +140,7 @@ export type Repository = {
 };
 
 export type Subscription = {
+  __typename?: 'Subscription',
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>,
 };
@@ -142,6 +152,7 @@ export type SubscriptionCommentAddedArgs = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
+  __typename?: 'User',
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'],
   /** The URL to a directly embeddable image for this user's avatar */
@@ -152,6 +163,7 @@ export type User = {
 
 /** XXX to be removed */
 export type Vote = {
+  __typename?: 'Vote',
   vote_value: Scalars['Int'],
 };
 
@@ -221,11 +233,6 @@ export type VoteMutationVariables = {
 
 
 export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
-
-import gql from 'graphql-tag';
-import * as React from 'react';
-import * as ReactApollo from 'react-apollo';
-import * as ReactApolloHooks from 'react-apollo-hooks';
 export const CommentsPageCommentFragmentDoc = gql`
     fragment CommentsPageComment on Comment {
   id
@@ -288,21 +295,22 @@ export const OnCommentAddedDocument = gql`
   }
 }
     `;
+export type OnCommentAddedComponentProps = Omit<Omit<ReactApollo.SubscriptionProps<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>, 'subscription'>, 'variables'> & { variables?: OnCommentAddedSubscriptionVariables };
 
-export class OnCommentAddedComponent extends React.Component<Partial<ReactApollo.SubscriptionProps<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Subscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables> subscription={OnCommentAddedDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
+    export const OnCommentAddedComponent = (props: OnCommentAddedComponentProps) => (
+      <ReactApollo.Subscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables> subscription={OnCommentAddedDocument} {...props} />
+    );
+    
 export type OnCommentAddedProps<TChildProps = {}> = Partial<ReactApollo.DataProps<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>> & TChildProps;
 export function withOnCommentAdded<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   OnCommentAddedSubscription,
   OnCommentAddedSubscriptionVariables,
   OnCommentAddedProps<TChildProps>>) {
-    return ReactApollo.withSubscription<TProps, OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables, OnCommentAddedProps<TChildProps>>(OnCommentAddedDocument, operationOptions);
+    return ReactApollo.withSubscription<TProps, OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables, OnCommentAddedProps<TChildProps>>(OnCommentAddedDocument, {
+      alias: 'withOnCommentAdded',
+      ...operationOptions
+    });
 };
 
 export function useOnCommentAddedSubscription(baseOptions?: ReactApolloHooks.SubscriptionHookOptions<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>) {
@@ -337,21 +345,22 @@ export const CommentDocument = gql`
   }
 }
     ${CommentsPageCommentFragmentDoc}`;
+export type CommentComponentProps = Omit<Omit<ReactApollo.QueryProps<CommentQuery, CommentQueryVariables>, 'query'>, 'variables'> & { variables: CommentQueryVariables };
 
-export class CommentComponent extends React.Component<Partial<ReactApollo.QueryProps<CommentQuery, CommentQueryVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Query<CommentQuery, CommentQueryVariables> query={CommentDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
+    export const CommentComponent = (props: CommentComponentProps) => (
+      <ReactApollo.Query<CommentQuery, CommentQueryVariables> query={CommentDocument} {...props} />
+    );
+    
 export type CommentProps<TChildProps = {}> = Partial<ReactApollo.DataProps<CommentQuery, CommentQueryVariables>> & TChildProps;
 export function withComment<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   CommentQuery,
   CommentQueryVariables,
   CommentProps<TChildProps>>) {
-    return ReactApollo.withQuery<TProps, CommentQuery, CommentQueryVariables, CommentProps<TChildProps>>(CommentDocument, operationOptions);
+    return ReactApollo.withQuery<TProps, CommentQuery, CommentQueryVariables, CommentProps<TChildProps>>(CommentDocument, {
+      alias: 'withComment',
+      ...operationOptions
+    });
 };
 
 export function useCommentQuery(baseOptions?: ReactApolloHooks.QueryHookOptions<CommentQueryVariables>) {
@@ -365,21 +374,22 @@ export const CurrentUserForProfileDocument = gql`
   }
 }
     `;
+export type CurrentUserForProfileComponentProps = Omit<Omit<ReactApollo.QueryProps<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>, 'query'>, 'variables'> & { variables?: CurrentUserForProfileQueryVariables };
 
-export class CurrentUserForProfileComponent extends React.Component<Partial<ReactApollo.QueryProps<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Query<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables> query={CurrentUserForProfileDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
+    export const CurrentUserForProfileComponent = (props: CurrentUserForProfileComponentProps) => (
+      <ReactApollo.Query<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables> query={CurrentUserForProfileDocument} {...props} />
+    );
+    
 export type CurrentUserForProfileProps<TChildProps = {}> = Partial<ReactApollo.DataProps<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>> & TChildProps;
 export function withCurrentUserForProfile<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   CurrentUserForProfileQuery,
   CurrentUserForProfileQueryVariables,
   CurrentUserForProfileProps<TChildProps>>) {
-    return ReactApollo.withQuery<TProps, CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables, CurrentUserForProfileProps<TChildProps>>(CurrentUserForProfileDocument, operationOptions);
+    return ReactApollo.withQuery<TProps, CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables, CurrentUserForProfileProps<TChildProps>>(CurrentUserForProfileDocument, {
+      alias: 'withCurrentUserForProfile',
+      ...operationOptions
+    });
 };
 
 export function useCurrentUserForProfileQuery(baseOptions?: ReactApolloHooks.QueryHookOptions<CurrentUserForProfileQueryVariables>) {
@@ -395,21 +405,22 @@ export const FeedDocument = gql`
   }
 }
     ${FeedEntryFragmentDoc}`;
+export type FeedComponentProps = Omit<Omit<ReactApollo.QueryProps<FeedQuery, FeedQueryVariables>, 'query'>, 'variables'> & { variables: FeedQueryVariables };
 
-export class FeedComponent extends React.Component<Partial<ReactApollo.QueryProps<FeedQuery, FeedQueryVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Query<FeedQuery, FeedQueryVariables> query={FeedDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
+    export const FeedComponent = (props: FeedComponentProps) => (
+      <ReactApollo.Query<FeedQuery, FeedQueryVariables> query={FeedDocument} {...props} />
+    );
+    
 export type FeedProps<TChildProps = {}> = Partial<ReactApollo.DataProps<FeedQuery, FeedQueryVariables>> & TChildProps;
 export function withFeed<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   FeedQuery,
   FeedQueryVariables,
   FeedProps<TChildProps>>) {
-    return ReactApollo.withQuery<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps>>(FeedDocument, operationOptions);
+    return ReactApollo.withQuery<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps>>(FeedDocument, {
+      alias: 'withFeed',
+      ...operationOptions
+    });
 };
 
 export function useFeedQuery(baseOptions?: ReactApolloHooks.QueryHookOptions<FeedQueryVariables>) {
@@ -422,22 +433,23 @@ export const SubmitRepositoryDocument = gql`
   }
 }
     `;
-
-export class SubmitRepositoryComponent extends React.Component<Partial<ReactApollo.MutationProps<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> mutation={SubmitRepositoryDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
-export type SubmitRepositoryProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>> & TChildProps;
 export type SubmitRepositoryMutationFn = ReactApollo.MutationFn<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
+export type SubmitRepositoryComponentProps = Omit<Omit<ReactApollo.MutationProps<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>, 'mutation'>, 'variables'> & { variables?: SubmitRepositoryMutationVariables };
+
+    export const SubmitRepositoryComponent = (props: SubmitRepositoryComponentProps) => (
+      <ReactApollo.Mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> mutation={SubmitRepositoryDocument} {...props} />
+    );
+    
+export type SubmitRepositoryProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>> & TChildProps;
 export function withSubmitRepository<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   SubmitRepositoryMutation,
   SubmitRepositoryMutationVariables,
   SubmitRepositoryProps<TChildProps>>) {
-    return ReactApollo.withMutation<TProps, SubmitRepositoryMutation, SubmitRepositoryMutationVariables, SubmitRepositoryProps<TChildProps>>(SubmitRepositoryDocument, operationOptions);
+    return ReactApollo.withMutation<TProps, SubmitRepositoryMutation, SubmitRepositoryMutationVariables, SubmitRepositoryProps<TChildProps>>(SubmitRepositoryDocument, {
+      alias: 'withSubmitRepository',
+      ...operationOptions
+    });
 };
 
 export function useSubmitRepositoryMutation(baseOptions?: ReactApolloHooks.MutationHookOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
@@ -450,22 +462,23 @@ export const SubmitCommentDocument = gql`
   }
 }
     ${CommentsPageCommentFragmentDoc}`;
-
-export class SubmitCommentComponent extends React.Component<Partial<ReactApollo.MutationProps<SubmitCommentMutation, SubmitCommentMutationVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Mutation<SubmitCommentMutation, SubmitCommentMutationVariables> mutation={SubmitCommentDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
-export type SubmitCommentProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<SubmitCommentMutation, SubmitCommentMutationVariables>> & TChildProps;
 export type SubmitCommentMutationFn = ReactApollo.MutationFn<SubmitCommentMutation, SubmitCommentMutationVariables>;
+export type SubmitCommentComponentProps = Omit<Omit<ReactApollo.MutationProps<SubmitCommentMutation, SubmitCommentMutationVariables>, 'mutation'>, 'variables'> & { variables?: SubmitCommentMutationVariables };
+
+    export const SubmitCommentComponent = (props: SubmitCommentComponentProps) => (
+      <ReactApollo.Mutation<SubmitCommentMutation, SubmitCommentMutationVariables> mutation={SubmitCommentDocument} {...props} />
+    );
+    
+export type SubmitCommentProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<SubmitCommentMutation, SubmitCommentMutationVariables>> & TChildProps;
 export function withSubmitComment<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   SubmitCommentMutation,
   SubmitCommentMutationVariables,
   SubmitCommentProps<TChildProps>>) {
-    return ReactApollo.withMutation<TProps, SubmitCommentMutation, SubmitCommentMutationVariables, SubmitCommentProps<TChildProps>>(SubmitCommentDocument, operationOptions);
+    return ReactApollo.withMutation<TProps, SubmitCommentMutation, SubmitCommentMutationVariables, SubmitCommentProps<TChildProps>>(SubmitCommentDocument, {
+      alias: 'withSubmitComment',
+      ...operationOptions
+    });
 };
 
 export function useSubmitCommentMutation(baseOptions?: ReactApolloHooks.MutationHookOptions<SubmitCommentMutation, SubmitCommentMutationVariables>) {
@@ -482,22 +495,23 @@ export const VoteDocument = gql`
   }
 }
     `;
-
-export class VoteComponent extends React.Component<Partial<ReactApollo.MutationProps<VoteMutation, VoteMutationVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Mutation<VoteMutation, VoteMutationVariables> mutation={VoteDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
-export type VoteProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<VoteMutation, VoteMutationVariables>> & TChildProps;
 export type VoteMutationFn = ReactApollo.MutationFn<VoteMutation, VoteMutationVariables>;
+export type VoteComponentProps = Omit<Omit<ReactApollo.MutationProps<VoteMutation, VoteMutationVariables>, 'mutation'>, 'variables'> & { variables?: VoteMutationVariables };
+
+    export const VoteComponent = (props: VoteComponentProps) => (
+      <ReactApollo.Mutation<VoteMutation, VoteMutationVariables> mutation={VoteDocument} {...props} />
+    );
+    
+export type VoteProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<VoteMutation, VoteMutationVariables>> & TChildProps;
 export function withVote<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   VoteMutation,
   VoteMutationVariables,
   VoteProps<TChildProps>>) {
-    return ReactApollo.withMutation<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps>>(VoteDocument, operationOptions);
+    return ReactApollo.withMutation<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps>>(VoteDocument, {
+      alias: 'withVote',
+      ...operationOptions
+    });
 };
 
 export function useVoteMutation(baseOptions?: ReactApolloHooks.MutationHookOptions<VoteMutation, VoteMutationVariables>) {

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -1,6 +1,9 @@
+import gql from 'graphql-tag';
+import * as React from 'react';
+import * as ReactApollo from 'react-apollo';
+export type Maybe<T> = T | null;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 // tslint:disable
-
-type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -12,6 +15,7 @@ export type Scalars = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
+  __typename?: 'Comment',
   /** The SQL ID of this entry */
   id: Scalars['Int'],
   /** The GitHub user who posted the comment */
@@ -26,6 +30,7 @@ export type Comment = {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
+  __typename?: 'Entry',
   /** Information about the repository from GitHub */
   repository: Repository,
   /** The GitHub user who submitted this entry */
@@ -64,6 +69,7 @@ export enum FeedType {
 }
 
 export type Mutation = {
+  __typename?: 'Mutation',
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>,
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -90,6 +96,7 @@ export type MutationSubmitCommentArgs = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>,
   /** A single entry */
@@ -114,6 +121,7 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
+  __typename?: 'Repository',
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'],
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -131,6 +139,7 @@ export type Repository = {
 };
 
 export type Subscription = {
+  __typename?: 'Subscription',
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>,
 };
@@ -142,6 +151,7 @@ export type SubscriptionCommentAddedArgs = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
+  __typename?: 'User',
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'],
   /** The URL to a directly embeddable image for this user's avatar */
@@ -152,6 +162,7 @@ export type User = {
 
 /** XXX to be removed */
 export type Vote = {
+  __typename?: 'Vote',
   vote_value: Scalars['Int'],
 };
 
@@ -221,10 +232,6 @@ export type VoteMutationVariables = {
 
 
 export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
-
-import gql from 'graphql-tag';
-import * as React from 'react';
-import * as ReactApollo from 'react-apollo';
 export const CommentsPageCommentFragmentDoc = gql`
     fragment CommentsPageComment on Comment {
   id
@@ -287,21 +294,22 @@ export const OnCommentAddedDocument = gql`
   }
 }
     `;
+export type OnCommentAddedComponentProps = Omit<Omit<ReactApollo.SubscriptionProps<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>, 'subscription'>, 'variables'> & { variables?: OnCommentAddedSubscriptionVariables };
 
-export class OnCommentAddedComponent extends React.Component<Partial<ReactApollo.SubscriptionProps<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Subscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables> subscription={OnCommentAddedDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
+    export const OnCommentAddedComponent = (props: OnCommentAddedComponentProps) => (
+      <ReactApollo.Subscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables> subscription={OnCommentAddedDocument} {...props} />
+    );
+    
 export type OnCommentAddedProps<TChildProps = {}> = Partial<ReactApollo.DataProps<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>> & TChildProps;
 export function withOnCommentAdded<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   OnCommentAddedSubscription,
   OnCommentAddedSubscriptionVariables,
   OnCommentAddedProps<TChildProps>>) {
-    return ReactApollo.withSubscription<TProps, OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables, OnCommentAddedProps<TChildProps>>(OnCommentAddedDocument, operationOptions);
+    return ReactApollo.withSubscription<TProps, OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables, OnCommentAddedProps<TChildProps>>(OnCommentAddedDocument, {
+      alias: 'withOnCommentAdded',
+      ...operationOptions
+    });
 };
 export const CommentDocument = gql`
     query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
@@ -332,21 +340,22 @@ export const CommentDocument = gql`
   }
 }
     ${CommentsPageCommentFragmentDoc}`;
+export type CommentComponentProps = Omit<Omit<ReactApollo.QueryProps<CommentQuery, CommentQueryVariables>, 'query'>, 'variables'> & { variables: CommentQueryVariables };
 
-export class CommentComponent extends React.Component<Partial<ReactApollo.QueryProps<CommentQuery, CommentQueryVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Query<CommentQuery, CommentQueryVariables> query={CommentDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
+    export const CommentComponent = (props: CommentComponentProps) => (
+      <ReactApollo.Query<CommentQuery, CommentQueryVariables> query={CommentDocument} {...props} />
+    );
+    
 export type CommentProps<TChildProps = {}> = Partial<ReactApollo.DataProps<CommentQuery, CommentQueryVariables>> & TChildProps;
 export function withComment<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   CommentQuery,
   CommentQueryVariables,
   CommentProps<TChildProps>>) {
-    return ReactApollo.withQuery<TProps, CommentQuery, CommentQueryVariables, CommentProps<TChildProps>>(CommentDocument, operationOptions);
+    return ReactApollo.withQuery<TProps, CommentQuery, CommentQueryVariables, CommentProps<TChildProps>>(CommentDocument, {
+      alias: 'withComment',
+      ...operationOptions
+    });
 };
 export const CurrentUserForProfileDocument = gql`
     query CurrentUserForProfile {
@@ -356,21 +365,22 @@ export const CurrentUserForProfileDocument = gql`
   }
 }
     `;
+export type CurrentUserForProfileComponentProps = Omit<Omit<ReactApollo.QueryProps<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>, 'query'>, 'variables'> & { variables?: CurrentUserForProfileQueryVariables };
 
-export class CurrentUserForProfileComponent extends React.Component<Partial<ReactApollo.QueryProps<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Query<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables> query={CurrentUserForProfileDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
+    export const CurrentUserForProfileComponent = (props: CurrentUserForProfileComponentProps) => (
+      <ReactApollo.Query<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables> query={CurrentUserForProfileDocument} {...props} />
+    );
+    
 export type CurrentUserForProfileProps<TChildProps = {}> = Partial<ReactApollo.DataProps<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>> & TChildProps;
 export function withCurrentUserForProfile<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   CurrentUserForProfileQuery,
   CurrentUserForProfileQueryVariables,
   CurrentUserForProfileProps<TChildProps>>) {
-    return ReactApollo.withQuery<TProps, CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables, CurrentUserForProfileProps<TChildProps>>(CurrentUserForProfileDocument, operationOptions);
+    return ReactApollo.withQuery<TProps, CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables, CurrentUserForProfileProps<TChildProps>>(CurrentUserForProfileDocument, {
+      alias: 'withCurrentUserForProfile',
+      ...operationOptions
+    });
 };
 export const FeedDocument = gql`
     query Feed($type: FeedType!, $offset: Int, $limit: Int) {
@@ -382,21 +392,22 @@ export const FeedDocument = gql`
   }
 }
     ${FeedEntryFragmentDoc}`;
+export type FeedComponentProps = Omit<Omit<ReactApollo.QueryProps<FeedQuery, FeedQueryVariables>, 'query'>, 'variables'> & { variables: FeedQueryVariables };
 
-export class FeedComponent extends React.Component<Partial<ReactApollo.QueryProps<FeedQuery, FeedQueryVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Query<FeedQuery, FeedQueryVariables> query={FeedDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
+    export const FeedComponent = (props: FeedComponentProps) => (
+      <ReactApollo.Query<FeedQuery, FeedQueryVariables> query={FeedDocument} {...props} />
+    );
+    
 export type FeedProps<TChildProps = {}> = Partial<ReactApollo.DataProps<FeedQuery, FeedQueryVariables>> & TChildProps;
 export function withFeed<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   FeedQuery,
   FeedQueryVariables,
   FeedProps<TChildProps>>) {
-    return ReactApollo.withQuery<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps>>(FeedDocument, operationOptions);
+    return ReactApollo.withQuery<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps>>(FeedDocument, {
+      alias: 'withFeed',
+      ...operationOptions
+    });
 };
 export const SubmitRepositoryDocument = gql`
     mutation submitRepository($repoFullName: String!) {
@@ -405,22 +416,23 @@ export const SubmitRepositoryDocument = gql`
   }
 }
     `;
-
-export class SubmitRepositoryComponent extends React.Component<Partial<ReactApollo.MutationProps<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> mutation={SubmitRepositoryDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
-export type SubmitRepositoryProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>> & TChildProps;
 export type SubmitRepositoryMutationFn = ReactApollo.MutationFn<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
+export type SubmitRepositoryComponentProps = Omit<Omit<ReactApollo.MutationProps<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>, 'mutation'>, 'variables'> & { variables?: SubmitRepositoryMutationVariables };
+
+    export const SubmitRepositoryComponent = (props: SubmitRepositoryComponentProps) => (
+      <ReactApollo.Mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> mutation={SubmitRepositoryDocument} {...props} />
+    );
+    
+export type SubmitRepositoryProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>> & TChildProps;
 export function withSubmitRepository<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   SubmitRepositoryMutation,
   SubmitRepositoryMutationVariables,
   SubmitRepositoryProps<TChildProps>>) {
-    return ReactApollo.withMutation<TProps, SubmitRepositoryMutation, SubmitRepositoryMutationVariables, SubmitRepositoryProps<TChildProps>>(SubmitRepositoryDocument, operationOptions);
+    return ReactApollo.withMutation<TProps, SubmitRepositoryMutation, SubmitRepositoryMutationVariables, SubmitRepositoryProps<TChildProps>>(SubmitRepositoryDocument, {
+      alias: 'withSubmitRepository',
+      ...operationOptions
+    });
 };
 export const SubmitCommentDocument = gql`
     mutation submitComment($repoFullName: String!, $commentContent: String!) {
@@ -429,22 +441,23 @@ export const SubmitCommentDocument = gql`
   }
 }
     ${CommentsPageCommentFragmentDoc}`;
-
-export class SubmitCommentComponent extends React.Component<Partial<ReactApollo.MutationProps<SubmitCommentMutation, SubmitCommentMutationVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Mutation<SubmitCommentMutation, SubmitCommentMutationVariables> mutation={SubmitCommentDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
-export type SubmitCommentProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<SubmitCommentMutation, SubmitCommentMutationVariables>> & TChildProps;
 export type SubmitCommentMutationFn = ReactApollo.MutationFn<SubmitCommentMutation, SubmitCommentMutationVariables>;
+export type SubmitCommentComponentProps = Omit<Omit<ReactApollo.MutationProps<SubmitCommentMutation, SubmitCommentMutationVariables>, 'mutation'>, 'variables'> & { variables?: SubmitCommentMutationVariables };
+
+    export const SubmitCommentComponent = (props: SubmitCommentComponentProps) => (
+      <ReactApollo.Mutation<SubmitCommentMutation, SubmitCommentMutationVariables> mutation={SubmitCommentDocument} {...props} />
+    );
+    
+export type SubmitCommentProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<SubmitCommentMutation, SubmitCommentMutationVariables>> & TChildProps;
 export function withSubmitComment<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   SubmitCommentMutation,
   SubmitCommentMutationVariables,
   SubmitCommentProps<TChildProps>>) {
-    return ReactApollo.withMutation<TProps, SubmitCommentMutation, SubmitCommentMutationVariables, SubmitCommentProps<TChildProps>>(SubmitCommentDocument, operationOptions);
+    return ReactApollo.withMutation<TProps, SubmitCommentMutation, SubmitCommentMutationVariables, SubmitCommentProps<TChildProps>>(SubmitCommentDocument, {
+      alias: 'withSubmitComment',
+      ...operationOptions
+    });
 };
 export const VoteDocument = gql`
     mutation vote($repoFullName: String!, $type: VoteType!) {
@@ -457,20 +470,21 @@ export const VoteDocument = gql`
   }
 }
     `;
-
-export class VoteComponent extends React.Component<Partial<ReactApollo.MutationProps<VoteMutation, VoteMutationVariables>>> {
-  render() {
-      return (
-          <ReactApollo.Mutation<VoteMutation, VoteMutationVariables> mutation={VoteDocument} {...(this as any)['props'] as any} />
-      );
-  }
-}
-export type VoteProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<VoteMutation, VoteMutationVariables>> & TChildProps;
 export type VoteMutationFn = ReactApollo.MutationFn<VoteMutation, VoteMutationVariables>;
+export type VoteComponentProps = Omit<Omit<ReactApollo.MutationProps<VoteMutation, VoteMutationVariables>, 'mutation'>, 'variables'> & { variables?: VoteMutationVariables };
+
+    export const VoteComponent = (props: VoteComponentProps) => (
+      <ReactApollo.Mutation<VoteMutation, VoteMutationVariables> mutation={VoteDocument} {...props} />
+    );
+    
+export type VoteProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<VoteMutation, VoteMutationVariables>> & TChildProps;
 export function withVote<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
   TProps,
   VoteMutation,
   VoteMutationVariables,
   VoteProps<TChildProps>>) {
-    return ReactApollo.withMutation<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps>>(VoteDocument, operationOptions);
+    return ReactApollo.withMutation<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps>>(VoteDocument, {
+      alias: 'withVote',
+      ...operationOptions
+    });
 };

--- a/dev-test/githunt/types.stencilApollo.class.tsx
+++ b/dev-test/githunt/types.stencilApollo.class.tsx
@@ -1,6 +1,8 @@
+import gql from 'graphql-tag';
+import 'stencil-apollo';
+import { Component, Prop } from '@stencil/core';
+export type Maybe<T> = T | null;
 // tslint:disable
-
-type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -12,6 +14,7 @@ export type Scalars = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
+  __typename?: 'Comment',
   /** The SQL ID of this entry */
   id: Scalars['Int'],
   /** The GitHub user who posted the comment */
@@ -26,6 +29,7 @@ export type Comment = {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
+  __typename?: 'Entry',
   /** Information about the repository from GitHub */
   repository: Repository,
   /** The GitHub user who submitted this entry */
@@ -64,6 +68,7 @@ export enum FeedType {
 }
 
 export type Mutation = {
+  __typename?: 'Mutation',
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>,
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -90,6 +95,7 @@ export type MutationSubmitCommentArgs = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>,
   /** A single entry */
@@ -114,6 +120,7 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
+  __typename?: 'Repository',
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'],
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -131,6 +138,7 @@ export type Repository = {
 };
 
 export type Subscription = {
+  __typename?: 'Subscription',
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>,
 };
@@ -142,6 +150,7 @@ export type SubscriptionCommentAddedArgs = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
+  __typename?: 'User',
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'],
   /** The URL to a directly embeddable image for this user's avatar */
@@ -152,6 +161,7 @@ export type User = {
 
 /** XXX to be removed */
 export type Vote = {
+  __typename?: 'Vote',
   vote_value: Scalars['Int'],
 };
 
@@ -222,9 +232,6 @@ export type VoteMutationVariables = {
 
 export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
 
-import gql from 'graphql-tag';
-import 'stencil-apollo';
-import { Component, Prop } from '@stencil/core';
 export const CommentsPageCommentFragmentDoc = gql`
     fragment CommentsPageComment on Comment {
   id
@@ -288,15 +295,15 @@ export const OnCommentAddedDocument = gql`
 }
     `;
 
-            @Component({
-                tag: 'apollo-on-comment-added'
-            })
-            export class OnCommentAddedComponent {
-                @Prop() renderer: import('stencil-apollo/dist/types/components/apollo-subscription/types').SubscriptionRenderer<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
-                render() {
-                    return <apollo-subscription subscription={ OnCommentAddedDocument } renderer={ this.renderer } />;
-                }
-            }
+@Component({
+    tag: 'apollo-on-comment-added'
+})
+export class OnCommentAddedComponent {
+    @Prop() renderer: StencilApollo.SubscriptionRenderer<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
+    render() {
+        return <apollo-subscription subscription={ OnCommentAddedDocument } renderer={ this.renderer } />;
+    }
+}
       
 export const CommentDocument = gql`
     query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
@@ -328,15 +335,15 @@ export const CommentDocument = gql`
 }
     ${CommentsPageCommentFragmentDoc}`;
 
-            @Component({
-                tag: 'apollo-comment'
-            })
-            export class CommentComponent {
-                @Prop() renderer: import('stencil-apollo/dist/types/components/apollo-query/types').QueryRenderer<CommentQuery, CommentQueryVariables>;
-                render() {
-                    return <apollo-query query={ CommentDocument } renderer={ this.renderer } />;
-                }
-            }
+@Component({
+    tag: 'apollo-comment'
+})
+export class CommentComponent {
+    @Prop() renderer: StencilApollo.QueryRenderer<CommentQuery, CommentQueryVariables>;
+    render() {
+        return <apollo-query query={ CommentDocument } renderer={ this.renderer } />;
+    }
+}
       
 export const CurrentUserForProfileDocument = gql`
     query CurrentUserForProfile {
@@ -347,15 +354,15 @@ export const CurrentUserForProfileDocument = gql`
 }
     `;
 
-            @Component({
-                tag: 'apollo-current-user-for-profile'
-            })
-            export class CurrentUserForProfileComponent {
-                @Prop() renderer: import('stencil-apollo/dist/types/components/apollo-query/types').QueryRenderer<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
-                render() {
-                    return <apollo-query query={ CurrentUserForProfileDocument } renderer={ this.renderer } />;
-                }
-            }
+@Component({
+    tag: 'apollo-current-user-for-profile'
+})
+export class CurrentUserForProfileComponent {
+    @Prop() renderer: StencilApollo.QueryRenderer<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
+    render() {
+        return <apollo-query query={ CurrentUserForProfileDocument } renderer={ this.renderer } />;
+    }
+}
       
 export const FeedDocument = gql`
     query Feed($type: FeedType!, $offset: Int, $limit: Int) {
@@ -368,15 +375,15 @@ export const FeedDocument = gql`
 }
     ${FeedEntryFragmentDoc}`;
 
-            @Component({
-                tag: 'apollo-feed'
-            })
-            export class FeedComponent {
-                @Prop() renderer: import('stencil-apollo/dist/types/components/apollo-query/types').QueryRenderer<FeedQuery, FeedQueryVariables>;
-                render() {
-                    return <apollo-query query={ FeedDocument } renderer={ this.renderer } />;
-                }
-            }
+@Component({
+    tag: 'apollo-feed'
+})
+export class FeedComponent {
+    @Prop() renderer: StencilApollo.QueryRenderer<FeedQuery, FeedQueryVariables>;
+    render() {
+        return <apollo-query query={ FeedDocument } renderer={ this.renderer } />;
+    }
+}
       
 export const SubmitRepositoryDocument = gql`
     mutation submitRepository($repoFullName: String!) {
@@ -386,15 +393,15 @@ export const SubmitRepositoryDocument = gql`
 }
     `;
 
-            @Component({
-                tag: 'apollo-submit-repository'
-            })
-            export class SubmitRepositoryComponent {
-                @Prop() renderer: import('stencil-apollo/dist/types/components/apollo-mutation/types').MutationRenderer<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
-                render() {
-                    return <apollo-mutation mutation={ SubmitRepositoryDocument } renderer={ this.renderer } />;
-                }
-            }
+@Component({
+    tag: 'apollo-submit-repository'
+})
+export class SubmitRepositoryComponent {
+    @Prop() renderer: StencilApollo.MutationRenderer<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
+    render() {
+        return <apollo-mutation mutation={ SubmitRepositoryDocument } renderer={ this.renderer } />;
+    }
+}
       
 export const SubmitCommentDocument = gql`
     mutation submitComment($repoFullName: String!, $commentContent: String!) {
@@ -404,15 +411,15 @@ export const SubmitCommentDocument = gql`
 }
     ${CommentsPageCommentFragmentDoc}`;
 
-            @Component({
-                tag: 'apollo-submit-comment'
-            })
-            export class SubmitCommentComponent {
-                @Prop() renderer: import('stencil-apollo/dist/types/components/apollo-mutation/types').MutationRenderer<SubmitCommentMutation, SubmitCommentMutationVariables>;
-                render() {
-                    return <apollo-mutation mutation={ SubmitCommentDocument } renderer={ this.renderer } />;
-                }
-            }
+@Component({
+    tag: 'apollo-submit-comment'
+})
+export class SubmitCommentComponent {
+    @Prop() renderer: StencilApollo.MutationRenderer<SubmitCommentMutation, SubmitCommentMutationVariables>;
+    render() {
+        return <apollo-mutation mutation={ SubmitCommentDocument } renderer={ this.renderer } />;
+    }
+}
       
 export const VoteDocument = gql`
     mutation vote($repoFullName: String!, $type: VoteType!) {
@@ -426,13 +433,13 @@ export const VoteDocument = gql`
 }
     `;
 
-            @Component({
-                tag: 'apollo-vote'
-            })
-            export class VoteComponent {
-                @Prop() renderer: import('stencil-apollo/dist/types/components/apollo-mutation/types').MutationRenderer<VoteMutation, VoteMutationVariables>;
-                render() {
-                    return <apollo-mutation mutation={ VoteDocument } renderer={ this.renderer } />;
-                }
-            }
+@Component({
+    tag: 'apollo-vote'
+})
+export class VoteComponent {
+    @Prop() renderer: StencilApollo.MutationRenderer<VoteMutation, VoteMutationVariables>;
+    render() {
+        return <apollo-mutation mutation={ VoteDocument } renderer={ this.renderer } />;
+    }
+}
       

--- a/dev-test/githunt/types.stencilApollo.tsx
+++ b/dev-test/githunt/types.stencilApollo.tsx
@@ -1,6 +1,7 @@
+import gql from 'graphql-tag';
+import * as StencilApollo from 'stencil-apollo';
+export type Maybe<T> = T | null;
 // tslint:disable
-
-type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -12,6 +13,7 @@ export type Scalars = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
+  __typename?: 'Comment',
   /** The SQL ID of this entry */
   id: Scalars['Int'],
   /** The GitHub user who posted the comment */
@@ -26,6 +28,7 @@ export type Comment = {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
+  __typename?: 'Entry',
   /** Information about the repository from GitHub */
   repository: Repository,
   /** The GitHub user who submitted this entry */
@@ -64,6 +67,7 @@ export enum FeedType {
 }
 
 export type Mutation = {
+  __typename?: 'Mutation',
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>,
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -90,6 +94,7 @@ export type MutationSubmitCommentArgs = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>,
   /** A single entry */
@@ -114,6 +119,7 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
+  __typename?: 'Repository',
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'],
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -131,6 +137,7 @@ export type Repository = {
 };
 
 export type Subscription = {
+  __typename?: 'Subscription',
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>,
 };
@@ -142,6 +149,7 @@ export type SubscriptionCommentAddedArgs = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
+  __typename?: 'User',
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'],
   /** The URL to a directly embeddable image for this user's avatar */
@@ -152,6 +160,7 @@ export type User = {
 
 /** XXX to be removed */
 export type Vote = {
+  __typename?: 'Vote',
   vote_value: Scalars['Int'],
 };
 
@@ -222,8 +231,6 @@ export type VoteMutationVariables = {
 
 export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
 
-import gql from 'graphql-tag';
-import * as StencilApollo from 'stencil-apollo';
 export const CommentsPageCommentFragmentDoc = gql`
     fragment CommentsPageComment on Comment {
   id
@@ -287,17 +294,17 @@ export const OnCommentAddedDocument = gql`
 }
     `;
 
-        export type OnCommentAddedProps = {
-            variables ?: OnCommentAddedSubscriptionVariables;
-            children ?: import('stencil-apollo/dist/types/components/apollo-subscription/types').SubscriptionRenderer<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
-        };
+export type OnCommentAddedProps = {
+    variables ?: OnCommentAddedSubscriptionVariables;
+    children ?: StencilApollo.SubscriptionRenderer<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
+};
       
 
-        export const OnCommentAddedComponent = (props: OnCommentAddedProps, children: [import('stencil-apollo/dist/types/components/apollo-subscription/types').SubscriptionRenderer<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>]) => (
-          <StencilApollo.Subscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables> subscription={ OnCommentAddedDocument } { ...props }>
-            {children[0]}
-          </StencilApollo.Subscription>
-        );
+export const OnCommentAddedComponent = (props: OnCommentAddedProps, children: [StencilApollo.SubscriptionRenderer<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>]) => (
+  <StencilApollo.Subscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables> subscription={ OnCommentAddedDocument } { ...props }>
+    {children[0]}
+  </StencilApollo.Subscription>
+);
       
 export const CommentDocument = gql`
     query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
@@ -329,17 +336,17 @@ export const CommentDocument = gql`
 }
     ${CommentsPageCommentFragmentDoc}`;
 
-        export type CommentProps = {
-            variables ?: CommentQueryVariables;
-            children ?: import('stencil-apollo/dist/types/components/apollo-query/types').QueryRenderer<CommentQuery, CommentQueryVariables>;
-        };
+export type CommentProps = {
+    variables ?: CommentQueryVariables;
+    children ?: StencilApollo.QueryRenderer<CommentQuery, CommentQueryVariables>;
+};
       
 
-        export const CommentComponent = (props: CommentProps, children: [import('stencil-apollo/dist/types/components/apollo-query/types').QueryRenderer<CommentQuery, CommentQueryVariables>]) => (
-          <StencilApollo.Query<CommentQuery, CommentQueryVariables> query={ CommentDocument } { ...props }>
-            {children[0]}
-          </StencilApollo.Query>
-        );
+export const CommentComponent = (props: CommentProps, children: [StencilApollo.QueryRenderer<CommentQuery, CommentQueryVariables>]) => (
+  <StencilApollo.Query<CommentQuery, CommentQueryVariables> query={ CommentDocument } { ...props }>
+    {children[0]}
+  </StencilApollo.Query>
+);
       
 export const CurrentUserForProfileDocument = gql`
     query CurrentUserForProfile {
@@ -350,17 +357,17 @@ export const CurrentUserForProfileDocument = gql`
 }
     `;
 
-        export type CurrentUserForProfileProps = {
-            variables ?: CurrentUserForProfileQueryVariables;
-            children ?: import('stencil-apollo/dist/types/components/apollo-query/types').QueryRenderer<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
-        };
+export type CurrentUserForProfileProps = {
+    variables ?: CurrentUserForProfileQueryVariables;
+    children ?: StencilApollo.QueryRenderer<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
+};
       
 
-        export const CurrentUserForProfileComponent = (props: CurrentUserForProfileProps, children: [import('stencil-apollo/dist/types/components/apollo-query/types').QueryRenderer<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>]) => (
-          <StencilApollo.Query<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables> query={ CurrentUserForProfileDocument } { ...props }>
-            {children[0]}
-          </StencilApollo.Query>
-        );
+export const CurrentUserForProfileComponent = (props: CurrentUserForProfileProps, children: [StencilApollo.QueryRenderer<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>]) => (
+  <StencilApollo.Query<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables> query={ CurrentUserForProfileDocument } { ...props }>
+    {children[0]}
+  </StencilApollo.Query>
+);
       
 export const FeedDocument = gql`
     query Feed($type: FeedType!, $offset: Int, $limit: Int) {
@@ -373,17 +380,17 @@ export const FeedDocument = gql`
 }
     ${FeedEntryFragmentDoc}`;
 
-        export type FeedProps = {
-            variables ?: FeedQueryVariables;
-            children ?: import('stencil-apollo/dist/types/components/apollo-query/types').QueryRenderer<FeedQuery, FeedQueryVariables>;
-        };
+export type FeedProps = {
+    variables ?: FeedQueryVariables;
+    children ?: StencilApollo.QueryRenderer<FeedQuery, FeedQueryVariables>;
+};
       
 
-        export const FeedComponent = (props: FeedProps, children: [import('stencil-apollo/dist/types/components/apollo-query/types').QueryRenderer<FeedQuery, FeedQueryVariables>]) => (
-          <StencilApollo.Query<FeedQuery, FeedQueryVariables> query={ FeedDocument } { ...props }>
-            {children[0]}
-          </StencilApollo.Query>
-        );
+export const FeedComponent = (props: FeedProps, children: [StencilApollo.QueryRenderer<FeedQuery, FeedQueryVariables>]) => (
+  <StencilApollo.Query<FeedQuery, FeedQueryVariables> query={ FeedDocument } { ...props }>
+    {children[0]}
+  </StencilApollo.Query>
+);
       
 export const SubmitRepositoryDocument = gql`
     mutation submitRepository($repoFullName: String!) {
@@ -393,17 +400,17 @@ export const SubmitRepositoryDocument = gql`
 }
     `;
 
-        export type SubmitRepositoryProps = {
-            variables ?: SubmitRepositoryMutationVariables;
-            children ?: import('stencil-apollo/dist/types/components/apollo-mutation/types').MutationRenderer<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
-        };
+export type SubmitRepositoryProps = {
+    variables ?: SubmitRepositoryMutationVariables;
+    children ?: StencilApollo.MutationRenderer<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
+};
       
 
-        export const SubmitRepositoryComponent = (props: SubmitRepositoryProps, children: [import('stencil-apollo/dist/types/components/apollo-mutation/types').MutationRenderer<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>]) => (
-          <StencilApollo.Mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> mutation={ SubmitRepositoryDocument } { ...props }>
-            {children[0]}
-          </StencilApollo.Mutation>
-        );
+export const SubmitRepositoryComponent = (props: SubmitRepositoryProps, children: [StencilApollo.MutationRenderer<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>]) => (
+  <StencilApollo.Mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> mutation={ SubmitRepositoryDocument } { ...props }>
+    {children[0]}
+  </StencilApollo.Mutation>
+);
       
 export const SubmitCommentDocument = gql`
     mutation submitComment($repoFullName: String!, $commentContent: String!) {
@@ -413,17 +420,17 @@ export const SubmitCommentDocument = gql`
 }
     ${CommentsPageCommentFragmentDoc}`;
 
-        export type SubmitCommentProps = {
-            variables ?: SubmitCommentMutationVariables;
-            children ?: import('stencil-apollo/dist/types/components/apollo-mutation/types').MutationRenderer<SubmitCommentMutation, SubmitCommentMutationVariables>;
-        };
+export type SubmitCommentProps = {
+    variables ?: SubmitCommentMutationVariables;
+    children ?: StencilApollo.MutationRenderer<SubmitCommentMutation, SubmitCommentMutationVariables>;
+};
       
 
-        export const SubmitCommentComponent = (props: SubmitCommentProps, children: [import('stencil-apollo/dist/types/components/apollo-mutation/types').MutationRenderer<SubmitCommentMutation, SubmitCommentMutationVariables>]) => (
-          <StencilApollo.Mutation<SubmitCommentMutation, SubmitCommentMutationVariables> mutation={ SubmitCommentDocument } { ...props }>
-            {children[0]}
-          </StencilApollo.Mutation>
-        );
+export const SubmitCommentComponent = (props: SubmitCommentProps, children: [StencilApollo.MutationRenderer<SubmitCommentMutation, SubmitCommentMutationVariables>]) => (
+  <StencilApollo.Mutation<SubmitCommentMutation, SubmitCommentMutationVariables> mutation={ SubmitCommentDocument } { ...props }>
+    {children[0]}
+  </StencilApollo.Mutation>
+);
       
 export const VoteDocument = gql`
     mutation vote($repoFullName: String!, $type: VoteType!) {
@@ -437,15 +444,15 @@ export const VoteDocument = gql`
 }
     `;
 
-        export type VoteProps = {
-            variables ?: VoteMutationVariables;
-            children ?: import('stencil-apollo/dist/types/components/apollo-mutation/types').MutationRenderer<VoteMutation, VoteMutationVariables>;
-        };
+export type VoteProps = {
+    variables ?: VoteMutationVariables;
+    children ?: StencilApollo.MutationRenderer<VoteMutation, VoteMutationVariables>;
+};
       
 
-        export const VoteComponent = (props: VoteProps, children: [import('stencil-apollo/dist/types/components/apollo-mutation/types').MutationRenderer<VoteMutation, VoteMutationVariables>]) => (
-          <StencilApollo.Mutation<VoteMutation, VoteMutationVariables> mutation={ VoteDocument } { ...props }>
-            {children[0]}
-          </StencilApollo.Mutation>
-        );
+export const VoteComponent = (props: VoteProps, children: [StencilApollo.MutationRenderer<VoteMutation, VoteMutationVariables>]) => (
+  <StencilApollo.Mutation<VoteMutation, VoteMutationVariables> mutation={ VoteDocument } { ...props }>
+    {children[0]}
+  </StencilApollo.Mutation>
+);
       

--- a/dev-test/githunt/types.ts
+++ b/dev-test/githunt/types.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +10,7 @@ export type Scalars = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
+  __typename?: 'Comment',
   /** The SQL ID of this entry */
   id: Scalars['Int'],
   /** The GitHub user who posted the comment */
@@ -25,6 +25,7 @@ export type Comment = {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
+  __typename?: 'Entry',
   /** Information about the repository from GitHub */
   repository: Repository,
   /** The GitHub user who submitted this entry */
@@ -63,6 +64,7 @@ export enum FeedType {
 }
 
 export type Mutation = {
+  __typename?: 'Mutation',
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>,
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -89,6 +91,7 @@ export type MutationSubmitCommentArgs = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>,
   /** A single entry */
@@ -113,6 +116,7 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
+  __typename?: 'Repository',
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'],
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -130,6 +134,7 @@ export type Repository = {
 };
 
 export type Subscription = {
+  __typename?: 'Subscription',
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>,
 };
@@ -141,6 +146,7 @@ export type SubscriptionCommentAddedArgs = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
+  __typename?: 'User',
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'],
   /** The URL to a directly embeddable image for this user's avatar */
@@ -151,6 +157,7 @@ export type User = {
 
 /** XXX to be removed */
 export type Vote = {
+  __typename?: 'Vote',
   vote_value: Scalars['Int'],
 };
 

--- a/dev-test/star-wars/types.avoidOptionals.ts
+++ b/dev-test/star-wars/types.avoidOptionals.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +10,7 @@ export type Scalars = {
 
 /** A character from the Star Wars universe */
 export type Character = {
+  __typename?: 'Character',
   /** The ID of the character */
   id: Scalars['ID'],
   /** The name of the character */
@@ -39,6 +39,7 @@ export type ColorInput = {
 
 /** An autonomous mechanical character in the Star Wars universe */
 export type Droid = Character & {
+  __typename?: 'Droid',
   /** The ID of the droid */
   id: Scalars['ID'],
   /** What others call this droid */
@@ -72,6 +73,7 @@ export enum Episode {
 
 /** A connection object for a character's friends */
 export type FriendsConnection = {
+  __typename?: 'FriendsConnection',
   /** The total number of friends */
   totalCount: Maybe<Scalars['Int']>,
   /** The edges for each of the character's friends. */
@@ -84,6 +86,7 @@ export type FriendsConnection = {
 
 /** An edge object for a character's friends */
 export type FriendsEdge = {
+  __typename?: 'FriendsEdge',
   /** A cursor used for pagination */
   cursor: Scalars['ID'],
   /** The character represented by this friendship edge */
@@ -92,6 +95,7 @@ export type FriendsEdge = {
 
 /** A humanoid creature from the Star Wars universe */
 export type Human = Character & {
+  __typename?: 'Human',
   /** The ID of the human */
   id: Scalars['ID'],
   /** What this human calls themselves */
@@ -135,6 +139,7 @@ export enum LengthUnit {
 
 /** The mutation type, represents all updates we can make to our data */
 export type Mutation = {
+  __typename?: 'Mutation',
   createReview: Maybe<Review>,
 };
 
@@ -147,6 +152,7 @@ export type MutationCreateReviewArgs = {
 
 /** Information for paginating this connection */
 export type PageInfo = {
+  __typename?: 'PageInfo',
   startCursor: Maybe<Scalars['ID']>,
   endCursor: Maybe<Scalars['ID']>,
   hasNextPage: Scalars['Boolean'],
@@ -154,6 +160,7 @@ export type PageInfo = {
 
 /** The query type, represents all of the entry points into our object graph */
 export type Query = {
+  __typename?: 'Query',
   hero: Maybe<Character>,
   reviews: Maybe<Array<Maybe<Review>>>,
   search: Maybe<Array<Maybe<SearchResult>>>,
@@ -207,6 +214,7 @@ export type QueryStarshipArgs = {
 
 /** Represents a review for a movie */
 export type Review = {
+  __typename?: 'Review',
   /** The number of stars this review gave, 1-5 */
   stars: Scalars['Int'],
   /** Comment about the movie */
@@ -226,6 +234,7 @@ export type ReviewInput = {
 export type SearchResult = Human | Droid | Starship;
 
 export type Starship = {
+  __typename?: 'Starship',
   /** The ID of the starship */
   id: Scalars['ID'],
   /** The name of the starship */
@@ -251,35 +260,35 @@ export type HeroAndFriendsNamesQueryVariables = {
 };
 
 
-export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<Pick<Character, 'name'>>>> })> });
+export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>>> })> });
 
 export type HeroAppearsInQueryVariables = {};
 
 
-export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name' | 'appearsIn'>> });
+export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name' | 'appearsIn'>)> });
 
 export type HeroDetailsQueryVariables = {
   episode: Maybe<Episode>
 };
 
 
-export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
+export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
 
 export type HeroDetailsWithFragmentQueryVariables = {
   episode: Maybe<Episode>
 };
 
 
-export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<HeroDetailsFragment> });
+export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> });
 
-export type HeroDetailsFragment = (Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
+export type HeroDetailsFragment = ({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
 
 export type HeroNameQueryVariables = {
   episode: Maybe<Episode>
 };
 
 
-export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode: Maybe<Episode>,
@@ -287,7 +296,7 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode: Maybe<Episode>,
@@ -295,21 +304,21 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroParentTypeDependentFieldQueryVariables = {
   episode: Maybe<Episode>
 };
 
 
-export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<(Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<(Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
+export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
 
 export type HeroTypeDependentAliasedFieldQueryVariables = {
   episode: Maybe<Episode>
 };
 
 
-export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<(({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] }))> });
+export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & (({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })))> });
 
 export type HumanWithNullHeightQueryVariables = {};
 
@@ -319,4 +328,4 @@ export type HumanWithNullHeightQuery = ({ __typename?: 'Query' } & { human: Mayb
 export type TwoHeroesQueryVariables = {};
 
 
-export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<Pick<Character, 'name'>>, luke: Maybe<Pick<Character, 'name'>> });
+export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>, luke: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });

--- a/dev-test/star-wars/types.d.ts
+++ b/dev-test/star-wars/types.d.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +10,7 @@ export type Scalars = {
 
 /** A character from the Star Wars universe */
 export type Character = {
+  __typename?: 'Character',
   /** The ID of the character */
   id: Scalars['ID'],
   /** The name of the character */
@@ -39,6 +39,7 @@ export type ColorInput = {
 
 /** An autonomous mechanical character in the Star Wars universe */
 export type Droid = Character & {
+  __typename?: 'Droid',
   /** The ID of the droid */
   id: Scalars['ID'],
   /** What others call this droid */
@@ -71,6 +72,7 @@ export type Episode =
 
 /** A connection object for a character's friends */
 export type FriendsConnection = {
+  __typename?: 'FriendsConnection',
   /** The total number of friends */
   totalCount?: Maybe<Scalars['Int']>,
   /** The edges for each of the character's friends. */
@@ -83,6 +85,7 @@ export type FriendsConnection = {
 
 /** An edge object for a character's friends */
 export type FriendsEdge = {
+  __typename?: 'FriendsEdge',
   /** A cursor used for pagination */
   cursor: Scalars['ID'],
   /** The character represented by this friendship edge */
@@ -91,6 +94,7 @@ export type FriendsEdge = {
 
 /** A humanoid creature from the Star Wars universe */
 export type Human = Character & {
+  __typename?: 'Human',
   /** The ID of the human */
   id: Scalars['ID'],
   /** What this human calls themselves */
@@ -133,6 +137,7 @@ export type LengthUnit =
 
 /** The mutation type, represents all updates we can make to our data */
 export type Mutation = {
+  __typename?: 'Mutation',
   createReview?: Maybe<Review>,
 };
 
@@ -145,6 +150,7 @@ export type MutationCreateReviewArgs = {
 
 /** Information for paginating this connection */
 export type PageInfo = {
+  __typename?: 'PageInfo',
   startCursor?: Maybe<Scalars['ID']>,
   endCursor?: Maybe<Scalars['ID']>,
   hasNextPage: Scalars['Boolean'],
@@ -152,6 +158,7 @@ export type PageInfo = {
 
 /** The query type, represents all of the entry points into our object graph */
 export type Query = {
+  __typename?: 'Query',
   hero?: Maybe<Character>,
   reviews?: Maybe<Array<Maybe<Review>>>,
   search?: Maybe<Array<Maybe<SearchResult>>>,
@@ -205,6 +212,7 @@ export type QueryStarshipArgs = {
 
 /** Represents a review for a movie */
 export type Review = {
+  __typename?: 'Review',
   /** The number of stars this review gave, 1-5 */
   stars: Scalars['Int'],
   /** Comment about the movie */
@@ -224,6 +232,7 @@ export type ReviewInput = {
 export type SearchResult = Human | Droid | Starship;
 
 export type Starship = {
+  __typename?: 'Starship',
   /** The ID of the starship */
   id: Scalars['ID'],
   /** The name of the starship */
@@ -249,35 +258,35 @@ export type HeroAndFriendsNamesQueryVariables = {
 };
 
 
-export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<Pick<Character, 'name'>>>> })> });
+export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>>> })> });
 
 export type HeroAppearsInQueryVariables = {};
 
 
-export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name' | 'appearsIn'>> });
+export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name' | 'appearsIn'>)> });
 
 export type HeroDetailsQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
+export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
 
 export type HeroDetailsWithFragmentQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<HeroDetailsFragment> });
+export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> });
 
-export type HeroDetailsFragment = (Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
+export type HeroDetailsFragment = ({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
 
 export type HeroNameQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -285,7 +294,7 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -293,21 +302,21 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroParentTypeDependentFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<(Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<(Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
+export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
 
 export type HeroTypeDependentAliasedFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<(({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] }))> });
+export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & (({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })))> });
 
 export type HumanWithNullHeightQueryVariables = {};
 
@@ -317,4 +326,4 @@ export type HumanWithNullHeightQuery = ({ __typename?: 'Query' } & { human: Mayb
 export type TwoHeroesQueryVariables = {};
 
 
-export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<Pick<Character, 'name'>>, luke: Maybe<Pick<Character, 'name'>> });
+export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>, luke: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });

--- a/dev-test/star-wars/types.immutableTypes.ts
+++ b/dev-test/star-wars/types.immutableTypes.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +10,7 @@ export type Scalars = {
 
 /** A character from the Star Wars universe */
 export type Character = {
+  __typename?: 'Character',
   /** The ID of the character */
   readonly id: Scalars['ID'],
   /** The name of the character */
@@ -39,6 +39,7 @@ export type ColorInput = {
 
 /** An autonomous mechanical character in the Star Wars universe */
 export type Droid = Character & {
+  __typename?: 'Droid',
   /** The ID of the droid */
   readonly id: Scalars['ID'],
   /** What others call this droid */
@@ -72,6 +73,7 @@ export enum Episode {
 
 /** A connection object for a character's friends */
 export type FriendsConnection = {
+  __typename?: 'FriendsConnection',
   /** The total number of friends */
   readonly totalCount?: Maybe<Scalars['Int']>,
   /** The edges for each of the character's friends. */
@@ -84,6 +86,7 @@ export type FriendsConnection = {
 
 /** An edge object for a character's friends */
 export type FriendsEdge = {
+  __typename?: 'FriendsEdge',
   /** A cursor used for pagination */
   readonly cursor: Scalars['ID'],
   /** The character represented by this friendship edge */
@@ -92,6 +95,7 @@ export type FriendsEdge = {
 
 /** A humanoid creature from the Star Wars universe */
 export type Human = Character & {
+  __typename?: 'Human',
   /** The ID of the human */
   readonly id: Scalars['ID'],
   /** What this human calls themselves */
@@ -135,6 +139,7 @@ export enum LengthUnit {
 
 /** The mutation type, represents all updates we can make to our data */
 export type Mutation = {
+  __typename?: 'Mutation',
   readonly createReview?: Maybe<Review>,
 };
 
@@ -147,6 +152,7 @@ export type MutationCreateReviewArgs = {
 
 /** Information for paginating this connection */
 export type PageInfo = {
+  __typename?: 'PageInfo',
   readonly startCursor?: Maybe<Scalars['ID']>,
   readonly endCursor?: Maybe<Scalars['ID']>,
   readonly hasNextPage: Scalars['Boolean'],
@@ -154,6 +160,7 @@ export type PageInfo = {
 
 /** The query type, represents all of the entry points into our object graph */
 export type Query = {
+  __typename?: 'Query',
   readonly hero?: Maybe<Character>,
   readonly reviews?: Maybe<ReadonlyArray<Maybe<Review>>>,
   readonly search?: Maybe<ReadonlyArray<Maybe<SearchResult>>>,
@@ -207,6 +214,7 @@ export type QueryStarshipArgs = {
 
 /** Represents a review for a movie */
 export type Review = {
+  __typename?: 'Review',
   /** The number of stars this review gave, 1-5 */
   readonly stars: Scalars['Int'],
   /** Comment about the movie */
@@ -226,6 +234,7 @@ export type ReviewInput = {
 export type SearchResult = Human | Droid | Starship;
 
 export type Starship = {
+  __typename?: 'Starship',
   /** The ID of the starship */
   readonly id: Scalars['ID'],
   /** The name of the starship */
@@ -251,35 +260,35 @@ export type HeroAndFriendsNamesQueryVariables = {
 };
 
 
-export type HeroAndFriendsNamesQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<(Pick<Character, 'name'> & { readonly friends: Maybe<ReadonlyArray<Maybe<Pick<Character, 'name'>>>> })> });
+export type HeroAndFriendsNamesQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & { readonly friends: Maybe<ReadonlyArray<Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>>> })> });
 
 export type HeroAppearsInQueryVariables = {};
 
 
-export type HeroAppearsInQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<Pick<Character, 'name' | 'appearsIn'>> });
+export type HeroAppearsInQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name' | 'appearsIn'>)> });
 
 export type HeroDetailsQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<(Pick<Character, 'name'> & (({ readonly __typename?: 'Human' } & Pick<Human, 'height'>) | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
+export type HeroDetailsQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ readonly __typename?: 'Human' } & Pick<Human, 'height'>) | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
 
 export type HeroDetailsWithFragmentQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsWithFragmentQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<HeroDetailsFragment> });
+export type HeroDetailsWithFragmentQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> });
 
-export type HeroDetailsFragment = (Pick<Character, 'name'> & (({ readonly __typename?: 'Human' } & Pick<Human, 'height'>) | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
+export type HeroDetailsFragment = ({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ readonly __typename?: 'Human' } & Pick<Human, 'height'>) | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
 
 export type HeroNameQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroNameQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -287,7 +296,7 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalInclusionQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameConditionalInclusionQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -295,21 +304,21 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalExclusionQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameConditionalExclusionQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroParentTypeDependentFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroParentTypeDependentFieldQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<(Pick<Character, 'name'> & (({ readonly __typename?: 'Human' } & { readonly friends: Maybe<ReadonlyArray<Maybe<(Pick<Character, 'name'> & ({ readonly __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ readonly __typename?: 'Droid' } & { readonly friends: Maybe<ReadonlyArray<Maybe<(Pick<Character, 'name'> & ({ readonly __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
+export type HeroParentTypeDependentFieldQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ readonly __typename?: 'Human' } & { readonly friends: Maybe<ReadonlyArray<Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ readonly __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ readonly __typename?: 'Droid' } & { readonly friends: Maybe<ReadonlyArray<Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ readonly __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
 
 export type HeroTypeDependentAliasedFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroTypeDependentAliasedFieldQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<(({ readonly __typename?: 'Human' } & { readonly property: Human['homePlanet'] }) | ({ readonly __typename?: 'Droid' } & { readonly property: Droid['primaryFunction'] }))> });
+export type HeroTypeDependentAliasedFieldQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & (({ readonly __typename?: 'Human' } & { readonly property: Human['homePlanet'] }) | ({ readonly __typename?: 'Droid' } & { readonly property: Droid['primaryFunction'] })))> });
 
 export type HumanWithNullHeightQueryVariables = {};
 
@@ -319,4 +328,4 @@ export type HumanWithNullHeightQuery = ({ readonly __typename?: 'Query' } & { re
 export type TwoHeroesQueryVariables = {};
 
 
-export type TwoHeroesQuery = ({ readonly __typename?: 'Query' } & { readonly r2: Maybe<Pick<Character, 'name'>>, readonly luke: Maybe<Pick<Character, 'name'>> });
+export type TwoHeroesQuery = ({ readonly __typename?: 'Query' } & { readonly r2: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>, readonly luke: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });

--- a/dev-test/star-wars/types.skipSchema.ts
+++ b/dev-test/star-wars/types.skipSchema.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +10,7 @@ export type Scalars = {
 
 /** A character from the Star Wars universe */
 export type Character = {
+  __typename?: 'Character',
   /** The ID of the character */
   id: Scalars['ID'],
   /** The name of the character */
@@ -39,6 +39,7 @@ export type ColorInput = {
 
 /** An autonomous mechanical character in the Star Wars universe */
 export type Droid = Character & {
+  __typename?: 'Droid',
   /** The ID of the droid */
   id: Scalars['ID'],
   /** What others call this droid */
@@ -72,6 +73,7 @@ export enum Episode {
 
 /** A connection object for a character's friends */
 export type FriendsConnection = {
+  __typename?: 'FriendsConnection',
   /** The total number of friends */
   totalCount?: Maybe<Scalars['Int']>,
   /** The edges for each of the character's friends. */
@@ -84,6 +86,7 @@ export type FriendsConnection = {
 
 /** An edge object for a character's friends */
 export type FriendsEdge = {
+  __typename?: 'FriendsEdge',
   /** A cursor used for pagination */
   cursor: Scalars['ID'],
   /** The character represented by this friendship edge */
@@ -92,6 +95,7 @@ export type FriendsEdge = {
 
 /** A humanoid creature from the Star Wars universe */
 export type Human = Character & {
+  __typename?: 'Human',
   /** The ID of the human */
   id: Scalars['ID'],
   /** What this human calls themselves */
@@ -135,6 +139,7 @@ export enum LengthUnit {
 
 /** The mutation type, represents all updates we can make to our data */
 export type Mutation = {
+  __typename?: 'Mutation',
   createReview?: Maybe<Review>,
 };
 
@@ -147,6 +152,7 @@ export type MutationCreateReviewArgs = {
 
 /** Information for paginating this connection */
 export type PageInfo = {
+  __typename?: 'PageInfo',
   startCursor?: Maybe<Scalars['ID']>,
   endCursor?: Maybe<Scalars['ID']>,
   hasNextPage: Scalars['Boolean'],
@@ -154,6 +160,7 @@ export type PageInfo = {
 
 /** The query type, represents all of the entry points into our object graph */
 export type Query = {
+  __typename?: 'Query',
   hero?: Maybe<Character>,
   reviews?: Maybe<Array<Maybe<Review>>>,
   search?: Maybe<Array<Maybe<SearchResult>>>,
@@ -207,6 +214,7 @@ export type QueryStarshipArgs = {
 
 /** Represents a review for a movie */
 export type Review = {
+  __typename?: 'Review',
   /** The number of stars this review gave, 1-5 */
   stars: Scalars['Int'],
   /** Comment about the movie */
@@ -226,6 +234,7 @@ export type ReviewInput = {
 export type SearchResult = Human | Droid | Starship;
 
 export type Starship = {
+  __typename?: 'Starship',
   /** The ID of the starship */
   id: Scalars['ID'],
   /** The name of the starship */
@@ -251,35 +260,35 @@ export type HeroAndFriendsNamesQueryVariables = {
 };
 
 
-export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<Pick<Character, 'name'>>>> })> });
+export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>>> })> });
 
 export type HeroAppearsInQueryVariables = {};
 
 
-export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name' | 'appearsIn'>> });
+export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name' | 'appearsIn'>)> });
 
 export type HeroDetailsQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
+export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
 
 export type HeroDetailsWithFragmentQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<HeroDetailsFragment> });
+export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> });
 
-export type HeroDetailsFragment = (Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
+export type HeroDetailsFragment = ({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
 
 export type HeroNameQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -287,7 +296,7 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -295,21 +304,21 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroParentTypeDependentFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<(Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<(Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
+export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
 
 export type HeroTypeDependentAliasedFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<(({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] }))> });
+export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & (({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })))> });
 
 export type HumanWithNullHeightQueryVariables = {};
 
@@ -319,4 +328,4 @@ export type HumanWithNullHeightQuery = ({ __typename?: 'Query' } & { human: Mayb
 export type TwoHeroesQueryVariables = {};
 
 
-export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<Pick<Character, 'name'>>, luke: Maybe<Pick<Character, 'name'>> });
+export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>, luke: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });

--- a/dev-test/star-wars/types.ts
+++ b/dev-test/star-wars/types.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +10,7 @@ export type Scalars = {
 
 /** A character from the Star Wars universe */
 export type Character = {
+  __typename?: 'Character',
   /** The ID of the character */
   id: Scalars['ID'],
   /** The name of the character */
@@ -39,6 +39,7 @@ export type ColorInput = {
 
 /** An autonomous mechanical character in the Star Wars universe */
 export type Droid = Character & {
+  __typename?: 'Droid',
   /** The ID of the droid */
   id: Scalars['ID'],
   /** What others call this droid */
@@ -72,6 +73,7 @@ export enum Episode {
 
 /** A connection object for a character's friends */
 export type FriendsConnection = {
+  __typename?: 'FriendsConnection',
   /** The total number of friends */
   totalCount?: Maybe<Scalars['Int']>,
   /** The edges for each of the character's friends. */
@@ -84,6 +86,7 @@ export type FriendsConnection = {
 
 /** An edge object for a character's friends */
 export type FriendsEdge = {
+  __typename?: 'FriendsEdge',
   /** A cursor used for pagination */
   cursor: Scalars['ID'],
   /** The character represented by this friendship edge */
@@ -92,6 +95,7 @@ export type FriendsEdge = {
 
 /** A humanoid creature from the Star Wars universe */
 export type Human = Character & {
+  __typename?: 'Human',
   /** The ID of the human */
   id: Scalars['ID'],
   /** What this human calls themselves */
@@ -135,6 +139,7 @@ export enum LengthUnit {
 
 /** The mutation type, represents all updates we can make to our data */
 export type Mutation = {
+  __typename?: 'Mutation',
   createReview?: Maybe<Review>,
 };
 
@@ -147,6 +152,7 @@ export type MutationCreateReviewArgs = {
 
 /** Information for paginating this connection */
 export type PageInfo = {
+  __typename?: 'PageInfo',
   startCursor?: Maybe<Scalars['ID']>,
   endCursor?: Maybe<Scalars['ID']>,
   hasNextPage: Scalars['Boolean'],
@@ -154,6 +160,7 @@ export type PageInfo = {
 
 /** The query type, represents all of the entry points into our object graph */
 export type Query = {
+  __typename?: 'Query',
   hero?: Maybe<Character>,
   reviews?: Maybe<Array<Maybe<Review>>>,
   search?: Maybe<Array<Maybe<SearchResult>>>,
@@ -207,6 +214,7 @@ export type QueryStarshipArgs = {
 
 /** Represents a review for a movie */
 export type Review = {
+  __typename?: 'Review',
   /** The number of stars this review gave, 1-5 */
   stars: Scalars['Int'],
   /** Comment about the movie */
@@ -226,6 +234,7 @@ export type ReviewInput = {
 export type SearchResult = Human | Droid | Starship;
 
 export type Starship = {
+  __typename?: 'Starship',
   /** The ID of the starship */
   id: Scalars['ID'],
   /** The name of the starship */
@@ -251,35 +260,35 @@ export type HeroAndFriendsNamesQueryVariables = {
 };
 
 
-export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<Pick<Character, 'name'>>>> })> });
+export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>>> })> });
 
 export type HeroAppearsInQueryVariables = {};
 
 
-export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name' | 'appearsIn'>> });
+export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name' | 'appearsIn'>)> });
 
 export type HeroDetailsQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
+export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
 
 export type HeroDetailsWithFragmentQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<HeroDetailsFragment> });
+export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> });
 
-export type HeroDetailsFragment = (Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
+export type HeroDetailsFragment = ({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
 
 export type HeroNameQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -287,7 +296,7 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -295,21 +304,21 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<Pick<Character, 'name'>> });
+export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
 
 export type HeroParentTypeDependentFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<(Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<(Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<(Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
+export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
 
 export type HeroTypeDependentAliasedFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<(({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] }))> });
+export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & (({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })))> });
 
 export type HumanWithNullHeightQueryVariables = {};
 
@@ -319,4 +328,4 @@ export type HumanWithNullHeightQuery = ({ __typename?: 'Query' } & { human: Mayb
 export type TwoHeroesQueryVariables = {};
 
 
-export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<Pick<Character, 'name'>>, luke: Maybe<Pick<Character, 'name'>> });
+export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>, luke: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });

--- a/dev-test/test-schema/flow-types.flow.js
+++ b/dev-test/test-schema/flow-types.flow.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 
-
+import { type GraphQLResolveInfo } from 'graphql';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -12,6 +12,7 @@ export type Scalars = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   allUsers: Array<?User>,
   userById?: ?User,
 };
@@ -22,32 +23,30 @@ export type QueryUserByIdArgs = {
 };
 
 export type User = {
+  __typename?: 'User',
   id: $ElementType<Scalars, 'Int'>,
   name: $ElementType<Scalars, 'String'>,
   email: $ElementType<Scalars, 'String'>,
 };
-
-import { type GraphQLResolveInfo } from 'graphql';
-
 export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
-  parent?: Parent,
-  args?: Args,
-  context?: Context,
-  info?: GraphQLResolveInfo
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
 ) => Promise<Result> | Result;
 
 export type SubscriptionSubscribeFn<Result, Parent, Context, Args> = (
-  parent?: Parent,
-  args?: Args,
-  context?: Context,
-  info?: GraphQLResolveInfo
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
 ) => AsyncIterator<Result> | Promise<AsyncIterator<Result>>;
 
 export type SubscriptionResolveFn<Result, Parent, Context, Args> = (
-  parent?: Parent,
-  args?: Args,
-  context?: Context,
-  info?: GraphQLResolveInfo
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
 ) => Result | Promise<Result>;
 
 export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
@@ -60,19 +59,19 @@ export type SubscriptionResolver<Result, Parent = {}, Context = {}, Args = {}> =
   | ISubscriptionResolverObject<Result, Parent, Context, Args>;
 
 export type TypeResolveFn<Types, Parent = {}, Context = {}> = (
-  parent?: Parent,
-  context?: Context,
-  info?: GraphQLResolveInfo
+  parent: Parent,
+  context: Context,
+  info: GraphQLResolveInfo
 ) => ?Types;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
 export type DirectiveResolverFn<Result = {}, Parent = {}, Args = {}, Context = {}> = (
-  next?: NextResolverFn<Result>,
-  parent?: Parent,
-  args?: Args,
-  context?: Context,
-  info?: GraphQLResolveInfo
+  next: NextResolverFn<Result>,
+  parent: Parent,
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
 ) => Result | Promise<Result>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -84,20 +83,20 @@ export type ResolversTypes = {
   Boolean: $ElementType<Scalars, 'Boolean'>,
 };
 
-export type QueryResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
-  allUsers?: Resolver<Array<?$ElementType<ResolversTypes, 'User'>>, ParentType, Context>,
-  userById?: Resolver<?$ElementType<ResolversTypes, 'User'>, ParentType, Context, QueryUserByIdArgs>,
+export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
+  allUsers?: Resolver<Array<?$ElementType<ResolversTypes, 'User'>>, ParentType, ContextType>,
+  userById?: Resolver<?$ElementType<ResolversTypes, 'User'>, ParentType, ContextType, QueryUserByIdArgs>,
 };
 
-export type UserResolvers<Context = any, ParentType = $ElementType<ResolversTypes, 'User'>> = {
-  id?: Resolver<$ElementType<ResolversTypes, 'Int'>, ParentType, Context>,
-  name?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
-  email?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, Context>,
+export type UserResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'User'>> = {
+  id?: Resolver<$ElementType<ResolversTypes, 'Int'>, ParentType, ContextType>,
+  name?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
+  email?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
 };
 
-export type Resolvers<Context = any> = {
-  Query?: QueryResolvers<Context>,
-  User?: UserResolvers<Context>,
+export type Resolvers<ContextType = any> = {
+  Query?: QueryResolvers<ContextType>,
+  User?: UserResolvers<ContextType>,
 };
 
 
@@ -105,4 +104,4 @@ export type Resolvers<Context = any> = {
  * @deprecated
  * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
 */
-export type IResolvers<Context = any> = Resolvers<Context>;
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;

--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -1,6 +1,7 @@
+import { GraphQLResolveInfo } from 'graphql';
+export type Maybe<T> = T | null;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 // tslint:disable
-
-type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +12,7 @@ export type Scalars = {
 };
 
 export type QueryRoot = {
+  __typename?: 'QueryRoot',
   allUsers: Array<Maybe<User>>,
   userById?: Maybe<User>,
   answer: Array<Scalars['Int']>,
@@ -22,19 +24,16 @@ export type QueryRootUserByIdArgs = {
 };
 
 export type SubscriptionRoot = {
+  __typename?: 'SubscriptionRoot',
   newUser?: Maybe<User>,
 };
 
 export type User = {
+  __typename?: 'User',
   id: Scalars['Int'],
   name: Scalars['String'],
   email: Scalars['String'],
 };
-
-import { GraphQLResolveInfo } from 'graphql';
-
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
-
 
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (

--- a/dev-test/test-schema/resolvers-types.ts
+++ b/dev-test/test-schema/resolvers-types.ts
@@ -1,6 +1,7 @@
+import { GraphQLResolveInfo } from 'graphql';
+export type Maybe<T> = T | null;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 // tslint:disable
-
-type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +12,7 @@ export type Scalars = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   allUsers: Array<Maybe<User>>,
   userById?: Maybe<User>,
   answer: Array<Scalars['Int']>,
@@ -22,15 +24,11 @@ export type QueryUserByIdArgs = {
 };
 
 export type User = {
+  __typename?: 'User',
   id: Scalars['Int'],
   name: Scalars['String'],
   email: Scalars['String'],
 };
-
-import { GraphQLResolveInfo } from 'graphql';
-
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
-
 
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (

--- a/dev-test/test-schema/typings.avoidOptionals.ts
+++ b/dev-test/test-schema/typings.avoidOptionals.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -10,6 +9,7 @@ export type Scalars = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   allUsers: Array<Maybe<User>>,
   userById: Maybe<User>,
 };
@@ -20,6 +20,7 @@ export type QueryUserByIdArgs = {
 };
 
 export type User = {
+  __typename?: 'User',
   id: Scalars['Int'],
   name: Scalars['String'],
   email: Scalars['String'],

--- a/dev-test/test-schema/typings.immutableTypes.ts
+++ b/dev-test/test-schema/typings.immutableTypes.ts
@@ -1,5 +1,4 @@
-
-type Maybe<T> = T | null;
+export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -10,6 +9,7 @@ export type Scalars = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   allUsers: Array<Maybe<User>>,
   userById?: Maybe<User>,
 };
@@ -20,6 +20,7 @@ export type QueryUserByIdArgs = {
 };
 
 export type User = {
+  __typename?: 'User',
   id: Scalars['Int'],
   name: Scalars['String'],
   email: Scalars['String'],

--- a/dev-test/test-schema/typings.ts
+++ b/dev-test/test-schema/typings.ts
@@ -1,6 +1,7 @@
+import { GraphQLResolveInfo } from 'graphql';
+export type Maybe<T> = T | null;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 // tslint:disable
-
-type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -11,6 +12,7 @@ export type Scalars = {
 };
 
 export type Query = {
+  __typename?: 'Query',
   allUsers: Array<Maybe<User>>,
   userById?: Maybe<User>,
 };
@@ -21,15 +23,11 @@ export type QueryUserByIdArgs = {
 };
 
 export type User = {
+  __typename?: 'User',
   id: Scalars['Int'],
   name: Scalars['String'],
   email: Scalars['String'],
 };
-
-import { GraphQLResolveInfo } from 'graphql';
-
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
-
 
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -65,7 +65,7 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
 }
 
 function resolveCompareValue(a: string) {
-  if (a.startsWith('/*')) {
+  if (a.startsWith('/*') || a.startsWith('//')) {
     return 0;
   } else if (a.startsWith('import')) {
     return 1;

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -61,7 +61,33 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
     }
   }
 
-  return [...prepend.values(), output, ...append.values()].join('\n');
+  return [...sortPrependValues(Array.from(prepend.values())), output, ...append.values()].join('\n');
+}
+
+function resolveCompareValue(a: string) {
+  if (a.startsWith('/*')) {
+    return 0;
+  } else if (a.startsWith('import')) {
+    return 1;
+  } else {
+    return 2;
+  }
+}
+
+function sortPrependValues(values: string[]): string[] {
+  return values.sort((a: string, b: string) => {
+    const aV = resolveCompareValue(a);
+    const bV = resolveCompareValue(b);
+
+    if (aV < bV) {
+      return -1;
+    }
+    if (aV > bV) {
+      return 1;
+    }
+
+    return 0;
+  });
 }
 
 function validateDocuments(schema: DocumentNode, files: Types.DocumentFile[]) {

--- a/packages/graphql-codegen-core/src/execute-plugin.ts
+++ b/packages/graphql-codegen-core/src/execute-plugin.ts
@@ -12,7 +12,7 @@ export interface ExecutePluginOptions {
   allPlugins: Types.ConfiguredPlugin[];
 }
 
-export async function executePlugin(options: ExecutePluginOptions, plugin: CodegenPlugin): Promise<string> {
+export async function executePlugin(options: ExecutePluginOptions, plugin: CodegenPlugin): Promise<Types.PluginOutput> {
   if (!plugin || !plugin.plugin || typeof plugin.plugin !== 'function') {
     throw new DetailedError(
       `Invalid Custom Plugin "${options.name}"`,

--- a/packages/plugins/flow/flow/src/index.ts
+++ b/packages/plugins/flow/flow/src/index.ts
@@ -53,5 +53,8 @@ export const plugin: PluginFunction<FlowPluginConfig> = (schema: GraphQLSchema, 
     leave: visitor,
   });
 
-  return [header, visitor.getEnumsImports(), visitor.scalarsDefinition, ...visitorResult.definitions].join('\n');
+  return {
+    prepend: [header, ...visitor.getEnumsImports()],
+    content: [visitor.scalarsDefinition, ...visitorResult.definitions].join('\n'),
+  };
 };

--- a/packages/plugins/flow/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/flow/tests/flow.spec.ts
@@ -2,6 +2,7 @@ import '@graphql-codegen/testing';
 import { buildSchema } from 'graphql';
 import { plugin } from '../src/index';
 import { validateFlow } from './validate-flow';
+import { Types } from '@graphql-codegen/plugin-helpers';
 
 describe('Flow Plugin', () => {
   describe('description to comment', () => {
@@ -57,9 +58,9 @@ describe('Flow Plugin', () => {
           captcha: String
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       /** New user account input fields */
       export type SignUpDetails = {
         /** First name */
@@ -88,9 +89,9 @@ describe('Flow Plugin', () => {
         "My custom scalar"
         scalar A
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       /** All built-in and custom scalars, mapped to their actual values */
       export type Scalars = {
           ID: string,
@@ -111,9 +112,9 @@ describe('Flow Plugin', () => {
           f: String
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** MyInput */
         export type MyInput`);
 
@@ -128,9 +129,9 @@ describe('Flow Plugin', () => {
           f: String!
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** MyInput */
         export type MyInput = {
           /** f is something */
@@ -150,9 +151,9 @@ describe('Flow Plugin', () => {
           f: String!
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** MyInput
          * multiline
          */
@@ -173,9 +174,9 @@ describe('Flow Plugin', () => {
           id: ID
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** my union */
         export type A = `);
 
@@ -193,13 +194,13 @@ describe('Flow Plugin', () => {
           id: ID
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** this is b */
         export type B = `);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** this is c */
         export type C = `);
 
@@ -213,9 +214,9 @@ describe('Flow Plugin', () => {
           id: ID
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type B = {
         __typename?: 'B',
         /** the id */
@@ -232,9 +233,9 @@ describe('Flow Plugin', () => {
           id: ID!
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type Node = {
         __typename?: 'Node',
         /** the id */
@@ -254,9 +255,9 @@ describe('Flow Plugin', () => {
           B
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export const MyEnumValues = Object.freeze({
         /** this is a */
         A: 'A', 
@@ -280,9 +281,9 @@ describe('Flow Plugin', () => {
         B
       }
         `);
-      const result = await plugin(schema, [], { useFlowExactObjects: true }, { outputFile: '' });
+      const result = (await plugin(schema, [], { useFlowExactObjects: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export const MyEnumValues = Object.freeze({
         A: 'A', 
         B: 'B'
@@ -296,9 +297,9 @@ describe('Flow Plugin', () => {
           foo: String
           bar: String!
         }`);
-      const result = await plugin(schema, [], { useFlowExactObjects: true }, { outputFile: '' });
+      const result = (await plugin(schema, [], { useFlowExactObjects: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {|
           __typename?: 'MyInterface',
           foo?: ?$ElementType<Scalars, 'String'>,
@@ -321,16 +322,16 @@ describe('Flow Plugin', () => {
           C
         }
       `);
-      const result = await plugin(schema, [], { useFlowReadOnlyTypes: true }, { outputFile: '' });
+      const result = (await plugin(schema, [], { useFlowReadOnlyTypes: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
           __typename?: 'MyInterface',
           +foo?: ?$ElementType<Scalars, 'String'>,
           +bar: $ElementType<Scalars, 'String'>,
         };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export const MyEnumValues = Object.freeze({
           A: 'A',
           B: 'B',
@@ -346,9 +347,9 @@ describe('Flow Plugin', () => {
   describe('Naming Convention & Types Prefix', () => {
     it('Should use custom namingConvention for type name and args typename', async () => {
       const schema = buildSchema(`type MyType { foo(a: String!, b: String, c: [String], d: [Int!]!): String }`);
-      const result = await plugin(schema, [], { namingConvention: 'change-case#lowerCase' }, { outputFile: '' });
+      const result = (await plugin(schema, [], { namingConvention: 'change-case#lowerCase' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type mytypefooargs = {
           a: $ElementType<Scalars, 'String'>,
           b?: ?$ElementType<Scalars, 'String'>,
@@ -356,7 +357,7 @@ describe('Flow Plugin', () => {
           d: Array<$ElementType<Scalars, 'Int'>>
         };
     `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type mytype = {
           __typename?: 'MyType',
           foo?: ?$ElementType<Scalars, 'String'>,
@@ -373,9 +374,9 @@ describe('Flow Plugin', () => {
           _MyOtherValue
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export const MyEnumValues = Object.freeze({
         MyValue: 'My_Value', 
         MyOtherValue: '_MyOtherValue'
@@ -389,9 +390,9 @@ describe('Flow Plugin', () => {
 
     it('Should use custom namingConvention and add custom prefix', async () => {
       const schema = buildSchema(`type MyType { foo(a: String!, b: String, c: [String], d: [Int!]!): String }`);
-      const result = await plugin(schema, [], { namingConvention: 'change-case#lowerCase', typesPrefix: 'I' }, { outputFile: '' });
+      const result = (await plugin(schema, [], { namingConvention: 'change-case#lowerCase', typesPrefix: 'I' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type Imytypefooargs = {
           a: $ElementType<Scalars, 'String'>,
           b?: ?$ElementType<Scalars, 'String'>,
@@ -400,7 +401,7 @@ describe('Flow Plugin', () => {
         };
       `);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type Imytype = {
           __typename?: 'MyType',
           foo?: ?$ElementType<Scalars, 'String'>,
@@ -453,18 +454,18 @@ describe('Flow Plugin', () => {
   `);
 
     it('Should generate correct values when using links between types - lowerCase', async () => {
-      const result = await plugin(schema, [], { namingConvention: 'change-case#lowerCase' }, { outputFile: '' });
+      const result = (await plugin(schema, [], { namingConvention: 'change-case#lowerCase' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export const myenumvalues = Object.freeze({
           a: 'A',
           b: 'B',
           c: 'C'
         });`);
 
-      expect(result).toBeSimilarStringTo(`export type myenum = $Values<typeof myenumvalues>;`);
+      expect(result.content).toBeSimilarStringTo(`export type myenum = $Values<typeof myenumvalues>;`);
 
-      expect(result).toBeSimilarStringTo(`export type mytype = {
+      expect(result.content).toBeSimilarStringTo(`export type mytype = {
           __typename?: 'MyType',
           f?: ?$ElementType<Scalars, 'String'>,
           bar?: ?myenum,
@@ -472,34 +473,34 @@ describe('Flow Plugin', () => {
           myOtherField?: ?$ElementType<Scalars, 'String'>,
         };`);
 
-      expect(result).toBeSimilarStringTo(`export type my_type = {
+      expect(result.content).toBeSimilarStringTo(`export type my_type = {
           __typename?: 'My_Type',
           linkTest?: ?mytype,
         };`);
 
-      expect(result).toBeSimilarStringTo(`export type myunion = my_type | mytype;`);
+      expect(result.content).toBeSimilarStringTo(`export type myunion = my_type | mytype;`);
 
-      expect(result).toBeSimilarStringTo(`export type some_interface = {
+      expect(result.content).toBeSimilarStringTo(`export type some_interface = {
           __typename?: 'Some_Interface',
           id: $ElementType<Scalars, 'ID'>,
         };`);
 
-      expect(result).toBeSimilarStringTo(`export type impl1 = some_interface & {
+      expect(result.content).toBeSimilarStringTo(`export type impl1 = some_interface & {
           __typename?: 'Impl1',
           id: $ElementType<Scalars, 'ID'>,
         };`);
 
-      expect(result).toBeSimilarStringTo(`export type impl_2 = some_interface & {
+      expect(result.content).toBeSimilarStringTo(`export type impl_2 = some_interface & {
           __typename?: 'Impl_2',
           id: $ElementType<Scalars, 'ID'>,
         };`);
 
-      expect(result).toBeSimilarStringTo(`export type impl_3 = some_interface & {
+      expect(result.content).toBeSimilarStringTo(`export type impl_3 = some_interface & {
           __typename?: 'impl_3',
           id: $ElementType<Scalars, 'ID'>,
         };`);
 
-      expect(result).toBeSimilarStringTo(`export type query = {
+      expect(result.content).toBeSimilarStringTo(`export type query = {
           __typename?: 'Query',
           something?: ?myunion,
           use_interface?: ?some_interface,
@@ -509,18 +510,18 @@ describe('Flow Plugin', () => {
     });
 
     it('Should generate correct values when using links between types - pascalCase (default)', async () => {
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export const MyEnumValues = Object.freeze({
         A: 'A',
         B: 'B',
         C: 'C'
       });`);
 
-      expect(result).toBeSimilarStringTo(`export type MyEnum = $Values<typeof MyEnumValues>;`);
+      expect(result.content).toBeSimilarStringTo(`export type MyEnum = $Values<typeof MyEnumValues>;`);
 
-      expect(result).toBeSimilarStringTo(`export type MyType = {
+      expect(result.content).toBeSimilarStringTo(`export type MyType = {
         __typename?: 'MyType',
         f?: ?$ElementType<Scalars, 'String'>,
         bar?: ?MyEnum,
@@ -528,34 +529,34 @@ describe('Flow Plugin', () => {
         myOtherField?: ?$ElementType<Scalars, 'String'>,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type My_Type = {
+      expect(result.content).toBeSimilarStringTo(`export type My_Type = {
         __typename?: 'My_Type',
         linkTest?: ?MyType,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type MyUnion = My_Type | MyType;`);
+      expect(result.content).toBeSimilarStringTo(`export type MyUnion = My_Type | MyType;`);
 
-      expect(result).toBeSimilarStringTo(`export type Some_Interface = {
+      expect(result.content).toBeSimilarStringTo(`export type Some_Interface = {
         __typename?: 'Some_Interface',
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type Impl1 = Some_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type Impl1 = Some_Interface & {
         __typename?: 'Impl1',
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type Impl_2 = Some_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type Impl_2 = Some_Interface & {
         __typename?: 'Impl_2',
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type Impl_3 = Some_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type Impl_3 = Some_Interface & {
         __typename?: 'impl_3',
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type Query = {
+      expect(result.content).toBeSimilarStringTo(`export type Query = {
         __typename?: 'Query',
         something?: ?MyUnion,
         use_interface?: ?Some_Interface,
@@ -565,17 +566,17 @@ describe('Flow Plugin', () => {
     });
 
     it('Should generate correct values when using links between types - pascalCase (default) with custom prefix', async () => {
-      const result = await plugin(schema, [], { typesPrefix: 'I' }, { outputFile: '' });
+      const result = (await plugin(schema, [], { typesPrefix: 'I' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export const IMyEnumValues = Object.freeze({
         A: 'A',
         B: 'B',
         C: 'C'
       });`);
-      expect(result).toBeSimilarStringTo(`export type IMyEnum = $Values<typeof IMyEnumValues>;`);
+      expect(result.content).toBeSimilarStringTo(`export type IMyEnum = $Values<typeof IMyEnumValues>;`);
 
-      expect(result).toBeSimilarStringTo(`export type IMyType = {
+      expect(result.content).toBeSimilarStringTo(`export type IMyType = {
         __typename?: 'MyType',
         f?: ?$ElementType<Scalars, 'String'>,
         bar?: ?IMyEnum,
@@ -583,34 +584,34 @@ describe('Flow Plugin', () => {
         myOtherField?: ?$ElementType<Scalars, 'String'>,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type IMy_Type = {
+      expect(result.content).toBeSimilarStringTo(`export type IMy_Type = {
         __typename?: 'My_Type',
         linkTest?: ?IMyType,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type IMyUnion = IMy_Type | IMyType;`);
+      expect(result.content).toBeSimilarStringTo(`export type IMyUnion = IMy_Type | IMyType;`);
 
-      expect(result).toBeSimilarStringTo(`export type ISome_Interface = {
+      expect(result.content).toBeSimilarStringTo(`export type ISome_Interface = {
         __typename?: 'Some_Interface',
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type IImpl1 = ISome_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type IImpl1 = ISome_Interface & {
         __typename?: 'Impl1',
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type IImpl_2 = ISome_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type IImpl_2 = ISome_Interface & {
         __typename?: 'Impl_2',
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type IImpl_3 = ISome_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type IImpl_3 = ISome_Interface & {
         __typename?: 'impl_3',
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result).toBeSimilarStringTo(`export type IQuery = {
+      expect(result.content).toBeSimilarStringTo(`export type IQuery = {
         __typename?: 'Query',
         something?: ?IMyUnion,
         use_interface?: ?ISome_Interface,
@@ -623,9 +624,9 @@ describe('Flow Plugin', () => {
   describe('Arguments', () => {
     it('Should generate correctly types for field arguments - with basic fields', async () => {
       const schema = buildSchema(`type MyType { foo(a: String!, b: String, c: [String], d: [Int!]!): String }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
           a: $ElementType<Scalars, 'String'>,
           b?: ?$ElementType<Scalars, 'String'>,
@@ -639,9 +640,9 @@ describe('Flow Plugin', () => {
 
     it('Should generate correctly types for field arguments - with default value', async () => {
       const schema = buildSchema(`type MyType { foo(a: String = "default", b: String! = "default", c: String): String }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
           a: $ElementType<Scalars, 'String'>,
           b: $ElementType<Scalars, 'String'>,
@@ -654,9 +655,9 @@ describe('Flow Plugin', () => {
 
     it('Should generate correctly types for field arguments - with input type', async () => {
       const schema = buildSchema(`input MyInput { f: String } type MyType { foo(a: MyInput, b: MyInput!, c: [MyInput], d: [MyInput]!, e: [MyInput!]!): String }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
           a?: ?MyInput,
           b: MyInput,
@@ -671,15 +672,15 @@ describe('Flow Plugin', () => {
 
     it('Should add custom prefix for mutation arguments', async () => {
       const schema = buildSchema(`input Input { name: String } type Mutation { foo(id: String, input: Input): String }`);
-      const result = await plugin(schema, [], { typesPrefix: 'T' }, { outputFile: '' });
+      const result = (await plugin(schema, [], { typesPrefix: 'T' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type TInput = {
           name?: ?$ElementType<Scalars, 'String'>,
         };
       `);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type TMutation = {
           __typename?: 'Mutation',
           foo?: ?$ElementType<Scalars, 'String'>,
@@ -699,9 +700,9 @@ describe('Flow Plugin', () => {
   describe('Enum', () => {
     it('Should build basic enum correctly', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export const MyEnumValues = Object.freeze({
           A: 'A',
           B: 'B',
@@ -716,9 +717,9 @@ describe('Flow Plugin', () => {
 
     it('Should build enum correctly with custom values', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
-      const result = await plugin(schema, [], { enumValues: { MyEnum: { A: 'SomeValue', B: 'TEST' } } }, { outputFile: '' });
+      const result = (await plugin(schema, [], { enumValues: { MyEnum: { A: 'SomeValue', B: 'TEST' } } }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export const MyEnumValues = Object.freeze({
           A: 'SomeValue',
           B: 'TEST',
@@ -733,20 +734,20 @@ describe('Flow Plugin', () => {
 
     it('Should build enum correctly with custom values and map to external enum', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
-      const result = await plugin(schema, [], { enumValues: { MyEnum: './my-file#MyEnum' } }, { outputFile: '' });
+      const result = (await plugin(schema, [], { enumValues: { MyEnum: './my-file#MyEnum' } }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).not.toContain(`export type MyEnum`);
-      expect(result).toContain(`import { type MyEnum } from './my-file';`);
+      expect(result.content).not.toContain(`export type MyEnum`);
+      expect(result.prepend).toContain(`import { type MyEnum } from './my-file';`);
 
       validateFlow(result);
     });
 
     it('Should build enum correctly with custom values and map to external enum with different identifier', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
-      const result = await plugin(schema, [], { enumValues: { MyEnum: './my-file#MyCustomEnum' } }, { outputFile: '' });
+      const result = (await plugin(schema, [], { enumValues: { MyEnum: './my-file#MyCustomEnum' } }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).not.toContain(`export type MyEnum`);
-      expect(result).toContain(`import { type MyCustomEnum as MyEnum } from './my-file';`);
+      expect(result.content).not.toContain(`export type MyEnum`);
+      expect(result.prepend).toContain(`import { type MyCustomEnum as MyEnum } from './my-file';`);
 
       validateFlow(result);
     });
@@ -755,9 +756,9 @@ describe('Flow Plugin', () => {
   describe('Scalars', () => {
     it('Should build basic scalar correctly as any', async () => {
       const schema = buildSchema(`scalar A`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
    export type Scalars = {
       ID: string,
       String: string,
@@ -775,9 +776,9 @@ describe('Flow Plugin', () => {
 
     it('Should build enum correctly with custom values', async () => {
       const schema = buildSchema(`scalar A`);
-      const result = await plugin(schema, [], { scalars: { A: 'MyCustomType' } }, { outputFile: '' });
+      const result = (await plugin(schema, [], { scalars: { A: 'MyCustomType' } }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
    export type Scalars = {
       ID: string,
       String: string,
@@ -813,9 +814,9 @@ describe('Flow Plugin', () => {
           k: [[String]]!
           l: [[String!]!]!
         }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyInput = {
           a: $ElementType<Scalars, 'String'>,
           b?: ?$ElementType<Scalars, 'Int'>,
@@ -843,9 +844,9 @@ describe('Flow Plugin', () => {
           foo: String
           bar: String!
         }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
           __typename?: 'MyType',
           foo?: ?$ElementType<Scalars, 'String'>,
@@ -865,15 +866,15 @@ describe('Flow Plugin', () => {
           foo: String!
         }
         `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
           __typename?: 'MyInterface',
           foo: $ElementType<Scalars, 'String'>,
         };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = MyInterface & {
           __typename?: 'MyType',
           foo: $ElementType<Scalars, 'String'>,
@@ -897,21 +898,21 @@ describe('Flow Plugin', () => {
           bar: String!
         }
         `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
           __typename?: 'MyInterface',
           foo: $ElementType<Scalars, 'String'>,
         };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyOtherInterface = {
           __typename?: 'MyOtherInterface',
           bar: $ElementType<Scalars, 'String'>,
         };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = MyInterface & MyOtherInterface & {
           __typename?: 'MyType',
           foo: $ElementType<Scalars, 'String'>,
@@ -931,15 +932,15 @@ describe('Flow Plugin', () => {
           bar: String!
         }
         `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
           __typename?: 'MyType',
           foo: MyOtherType,
         };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyOtherType = {
           __typename?: 'MyOtherType',
           bar: $ElementType<Scalars, 'String'>,
@@ -962,9 +963,9 @@ describe('Flow Plugin', () => {
       
       union MyUnion = MyType | MyOtherType
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type MyUnion = MyType | MyOtherType;
     `);
 
@@ -979,9 +980,9 @@ describe('Flow Plugin', () => {
           foo: String
           bar: String!
         }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
           __typename?: 'MyInterface',
           foo?: ?$ElementType<Scalars, 'String'>,
@@ -1001,7 +1002,7 @@ describe('Flow Plugin', () => {
         directive @universal on OBJECT | FIELD_DEFINITION | ENUM_VALUE
       `);
 
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
       validateFlow(result);
     });
@@ -1030,9 +1031,9 @@ describe('Flow Plugin', () => {
         }
       `);
 
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`export type UpdateUser = {
+      expect(result.content).toBeSimilarStringTo(`export type UpdateUser = {
           username?: ?$ElementType<Scalars, 'String'>,
           email?: ?$ElementType<Scalars, 'String'>,
         };`);
@@ -1063,7 +1064,7 @@ describe('Flow Plugin', () => {
       }
     `);
 
-    const content = await plugin(schema, [], { skipTypename: true }, { outputFile: '' });
+    const content = (await plugin(schema, [], { skipTypename: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
     expect(content).not.toContain('__typename');
 
     validateFlow(content);

--- a/packages/plugins/flow/flow/tests/validate-flow.ts
+++ b/packages/plugins/flow/flow/tests/validate-flow.ts
@@ -1,7 +1,8 @@
+import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 const flow = require('./flow.js');
 
-export function validateFlow(code: string) {
-  const errors = flow.checkContent('temp.flow.js', code);
+export function validateFlow(code: Types.PluginOutput) {
+  const errors = flow.checkContent('temp.flow.js', mergeOutputs([code]));
 
   var lint = errors.map(function(err) {
     var messages = err.message;

--- a/packages/plugins/flow/resolvers/src/index.ts
+++ b/packages/plugins/flow/resolvers/src/index.ts
@@ -16,10 +16,9 @@ export const plugin: PluginFunction<FlowResolversPluginConfig> = (schema: GraphQ
     imports.push('type GraphQLScalarTypeConfig');
   }
 
-  const header = `
-import { ${imports.join(', ')} } from 'graphql';
+  const gqlImports = `import { ${imports.join(', ')} } from 'graphql';`;
 
-export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
+  const header = `export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
   parent: Parent,
   args: Args,
   context: Context,
@@ -77,5 +76,8 @@ export type DirectiveResolverFn<Result = {}, Parent = {}, Args = {}, Context = {
     console['warn'](`Unused mappers: ${unusedMappers.join(',')}`);
   }
 
-  return [...mappersImports, header, resolversTypeMapping, ...visitorResult.definitions.filter(d => typeof d === 'string'), getRootResolver(), getAllDirectiveResolvers()].join('\n');
+  return {
+    prepend: [gqlImports, ...mappersImports],
+    content: [header, resolversTypeMapping, ...visitorResult.definitions.filter(d => typeof d === 'string'), getRootResolver(), getAllDirectiveResolvers()].join('\n'),
+  };
 };

--- a/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
+++ b/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
@@ -1,10 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Flow Resolvers Plugin Should generate basic type resolvers 1`] = `
-"
-import { type GraphQLResolveInfo, type GraphQLScalarTypeConfig } from 'graphql';
-
-export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
+Object {
+  "content": "export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
   parent: Parent,
   args: Args,
   context: Context,
@@ -132,5 +130,9 @@ export type DirectiveResolvers<ContextType = any> = {
 * @deprecated
 * Use \\"DirectiveResolvers\\" root object instead. If you wish to get \\"IDirectiveResolvers\\", add \\"typesPrefix: I\\" to your config.
 */
-export type IDirectiveResolvers<ContextType = any> = DirectiveResolvers<ContextType>;"
+export type IDirectiveResolvers<ContextType = any> = DirectiveResolvers<ContextType>;",
+  "prepend": Array [
+    "import { type GraphQLResolveInfo, type GraphQLScalarTypeConfig } from 'graphql';",
+  ],
+}
 `;

--- a/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
@@ -2,6 +2,7 @@ import '@graphql-codegen/testing';
 import { buildSchema } from 'graphql';
 import { plugin } from '../src';
 import { schema } from '../../../typescript/resolvers/tests/common';
+import { Types } from '@graphql-codegen/plugin-helpers';
 
 describe('Flow Resolvers Plugin', () => {
   it('Should generate basic type resolvers', () => {
@@ -11,20 +12,20 @@ describe('Flow Resolvers Plugin', () => {
   });
 
   it('Should generate the correct imports when schema has scalars', () => {
-    const result = plugin(buildSchema(`scalar MyScalar`), [], {}, { outputFile: '' });
+    const result = plugin(buildSchema(`scalar MyScalar`), [], {}, { outputFile: '' }) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`import { type GraphQLResolveInfo, type GraphQLScalarTypeConfig } from 'graphql';`);
+    expect(result.prepend).toContain(`import { type GraphQLResolveInfo, type GraphQLScalarTypeConfig } from 'graphql';`);
   });
 
   it('Should generate the correct imports when schema has no scalars', () => {
-    const result = plugin(buildSchema(`type MyType { f: String }`), [], {}, { outputFile: '' });
+    const result = plugin(buildSchema(`type MyType { f: String }`), [], {}, { outputFile: '' }) as Types.ComplexPluginOutput;
 
-    expect(result).not.toBeSimilarStringTo(`import { type GraphQLResolveInfo, type GraphQLScalarTypeConfig } from 'graphql';`);
+    expect(result.prepend).not.toContain(`import { type GraphQLResolveInfo, type GraphQLScalarTypeConfig } from 'graphql';`);
   });
 
   it('Should generate the correct resolver args type names when typesPrefix is specified', () => {
-    const result = plugin(buildSchema(`type MyType { f(a: String): String }`), [], { typesPrefix: 'T' }, { outputFile: '' });
+    const result = plugin(buildSchema(`type MyType { f(a: String): String }`), [], { typesPrefix: 'T' }, { outputFile: '' }) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`f?: Resolver<?$ElementType<TResolversTypes, 'String'>, ParentType, ContextType, TMyTypeFArgs>,`);
+    expect(result.content).toBeSimilarStringTo(`f?: Resolver<?$ElementType<TResolversTypes, 'String'>, ParentType, ContextType, TMyTypeFArgs>,`);
   });
 });

--- a/packages/plugins/flow/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/mapping.spec.ts
@@ -3,12 +3,13 @@ import { schema } from '../../../typescript/resolvers/tests/common';
 import { plugin } from '../src';
 import { buildSchema } from 'graphql';
 import { validateFlow as validate } from '../../flow/tests/validate-flow';
+import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 
 describe('ResolversTypes', () => {
   it('Should build ResolversTypes object when there are no mappers', async () => {
-    const result = await plugin(schema, [], {}, { outputFile: '' });
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: MyType,
@@ -26,7 +27,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should build ResolversTypes with simple mappers', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -36,9 +37,9 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: MyTypeDb,
@@ -56,7 +57,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should build ResolversTypes with defaultMapper set', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -67,9 +68,9 @@ describe('ResolversTypes', () => {
         defaultMapper: 'any',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: MyTypeDb,
@@ -87,7 +88,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should build ResolversTypes with external mappers', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -96,9 +97,9 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: MyTypeDb,
@@ -191,7 +192,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should generate basic type resolvers with external mappers', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -200,26 +201,26 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`import { type MyCustomOtherType } from './my-file';`);
-    expect(result).toBeSimilarStringTo(`
+    expect(result.prepend).toContain(`import { type MyCustomOtherType } from './my-file';`);
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
       arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
         export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
           bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
         };
       `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyScalarScalarConfig = {
         ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
         name: 'MyScalar'
       };`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
         foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
         otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
@@ -227,32 +228,32 @@ describe('ResolversTypes', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
         something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
         id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
         somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
       };
@@ -261,7 +262,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should generate basic type resolvers with external mappers using same imported type', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -271,26 +272,26 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`import { type MyCustomOtherType } from './my-file';`);
-    expect(result).toBeSimilarStringTo(`
+    expect(result.prepend).toContain(`import { type MyCustomOtherType } from './my-file';`);
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
       arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
         export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
           bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
         };
       `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyScalarScalarConfig = {
         ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
         name: 'MyScalar'
       };`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
         foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
         otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
@@ -298,32 +299,32 @@ describe('ResolversTypes', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
         something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
         id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
         somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
       };
@@ -332,7 +333,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should generate the correct resolvers when used with mappers with interfaces', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -341,25 +342,25 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
       arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
         bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyScalarScalarConfig = {
       ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
       name: 'MyScalar'
     };`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
         foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
         otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
@@ -367,66 +368,66 @@ describe('ResolversTypes', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
         something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
         id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
         somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
       };
     `);
-    await validate(`type MyNodeType = {};\n${result}`);
+    await validate(mergeOutputs([result, `type MyNodeType = {};`]));
   });
 
   it('Should generate basic type resolvers with defaultMapper set to any', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
         defaultMapper: 'any',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
       arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
         bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyScalarScalarConfig = {
       ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
       name: 'MyScalar'
     };`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
         foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
         otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
@@ -434,32 +435,32 @@ describe('ResolversTypes', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
         something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
         id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
         somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
       };
@@ -468,34 +469,34 @@ describe('ResolversTypes', () => {
   });
 
   it('Should generate basic type resolvers with defaultMapper set to external identifier', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
         defaultMapper: './my-file#MyBaseType',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toContain(`import { type MyBaseType } from './my-file';`);
+    expect(result.prepend).toContain(`import { type MyBaseType } from './my-file';`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: ?$ElementType<Scalars, 'Int'>,
       arg2?: ?$ElementType<Scalars, 'String'>, arg3?: ?$ElementType<Scalars, 'Boolean'> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyOtherType'>> = {
         bar?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyScalarScalarConfig = {
       ...GraphQLScalarTypeConfig<$ElementType<ResolversTypes, 'MyScalar'>, any>, 
       name: 'MyScalar'
     };`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyType'>> = {
         foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
         otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
@@ -503,32 +504,32 @@ describe('ResolversTypes', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'MyUnion'>> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Node'>> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Query'>> = {
         something?: Resolver<$ElementType<ResolversTypes, 'MyType'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'SomeNode'>> = {
         id?: Resolver<$ElementType<ResolversTypes, 'ID'>, ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = $ElementType<ResolversTypes, 'Subscription'>> = {
         somethingChanged?: SubscriptionResolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
       };
@@ -537,7 +538,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should replace using Omit when non-mapped type is pointing to mapped type', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -546,9 +547,9 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: $Diff<MyType, { otherType: * }> & { otherType: ?$ElementType<ResolversTypes, 'MyOtherType'> },
@@ -563,11 +564,11 @@ describe('ResolversTypes', () => {
       MyScalar: $ElementType<Scalars, 'MyScalar'>,
       Int: $ElementType<Scalars, 'Int'>,
     };`);
-    await validate(`type MyOtherTypeCustom = {}; ${result}`);
+    await validate(mergeOutputs([result, `type MyOtherTypeCustom = {};`]));
   });
 
   it('Should not replace using Omit when non-mapped type is pointing to mapped type', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -576,9 +577,9 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: $Diff<MyType, { otherType: *  }> & { otherType: ?$ElementType<ResolversTypes, 'MyOtherType'> },
@@ -593,20 +594,20 @@ describe('ResolversTypes', () => {
       MyScalar: $ElementType<Scalars, 'MyScalar'>,
       Int: $ElementType<Scalars, 'Int'>,
     };`);
-    await validate(`type MyTypeCustom = {}; type MyOtherTypeCustom = {}; ${result}`);
+    await validate(mergeOutputs([result, `type MyTypeCustom = {}; type MyOtherTypeCustom = {};`]));
   });
 
   it('Should build ResolversTypes with defaultMapper set using {T}', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
         defaultMapper: '$Shape<{T}>',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: $Shape<MyType>,
@@ -624,17 +625,17 @@ describe('ResolversTypes', () => {
   });
 
   it('Should build ResolversTypes with defaultMapper set using {T} with external identifier', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
         defaultMapper: './my-wrapper#CustomPartial<{T}>',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`import { type CustomPartial } from './my-wrapper';`);
-    expect(result).toBeSimilarStringTo(`
+    expect(result.prepend).toContain(`import { type CustomPartial } from './my-wrapper';`);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: CustomPartial<MyType>,

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -182,7 +182,7 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
     return `import { ${identifier} } from '${source}';`;
   }
 
-  public getEnumsImports(): string {
+  public getEnumsImports(): string[] {
     return Object.keys(this.config.enumValues)
       .map(enumName => {
         const mappedValue = this.config.enumValues[enumName];
@@ -199,8 +199,7 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
 
         return null;
       })
-      .filter(a => a)
-      .join('\n');
+      .filter(a => a);
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -175,13 +175,12 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
     };
   }
 
-  public getImports(): string {
+  public getImports(): string[] {
     const gqlImport = this._parseImport(this.config.gqlImport || 'graphql-tag');
     let imports = [];
 
     if (!this.config.noGraphQLTag) {
-      imports.push(`
-import ${gqlImport.propName ? `{ ${gqlImport.propName === 'gql' ? 'gql' : `${gqlImport.propName} as gql`} }` : 'gql'} from '${gqlImport.moduleName}';`);
+      imports.push(`import ${gqlImport.propName ? `{ ${gqlImport.propName === 'gql' ? 'gql' : `${gqlImport.propName} as gql`} }` : 'gql'} from '${gqlImport.moduleName}';`);
     } else {
       imports.push(`import { DocumentNode } from 'graphql';`);
     }
@@ -194,7 +193,7 @@ import ${gqlImport.propName ? `{ ${gqlImport.propName === 'gql' ? 'gql' : `${gql
         imports.push(`import { ${identifierName} } from '${externalFragment.importFrom}';`);
       });
 
-    return imports.join('\n');
+    return imports;
   }
 
   protected buildOperation(node: OperationDefinitionNode, documentVariableName: string, operationType: string, operationResultType: string, operationVariablesTypes: string): string {

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -271,3 +271,5 @@ export function getRootTypeNames(schema: GraphQLSchema): string[] {
 export function stripMapperTypeInterpolation(identifier: string): string {
   return identifier.includes('{T}') ? identifier.replace(/<.*?>/g, '') : identifier;
 }
+
+export const OMIT_TYPE = 'export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;';

--- a/packages/plugins/typescript/apollo-angular/src/index.ts
+++ b/packages/plugins/typescript/apollo-angular/src/index.ts
@@ -47,7 +47,10 @@ export const plugin: PluginFunction<ApolloAngularRawPluginConfig> = (schema: Gra
   const visitor = new ApolloAngularVisitor(allFragments, operations, config) as any;
   const visitorResult = visit(allAst, { leave: visitor });
 
-  return [visitor.getImports(), visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n');
+  return {
+    prepend: visitor.getImports(),
+    content: [visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n'),
+  };
 };
 
 export const addToSchema = gql`

--- a/packages/plugins/typescript/apollo-angular/src/visitor.ts
+++ b/packages/plugins/typescript/apollo-angular/src/visitor.ts
@@ -25,7 +25,7 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<ApolloAngularRaw
     autoBind(this);
   }
 
-  public getImports(): string {
+  public getImports(): string[] {
     const baseImports = super.getImports();
     const hasOperations = this._collectedOperations.length > 0;
 
@@ -56,7 +56,7 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<ApolloAngularRaw
       imports.push(`import { ${def.module} } from '${def.path}';`);
     });
 
-    return [baseImports, ...imports].join('\n');
+    return [...baseImports, ...imports];
   }
 
   private _extractNgModule(operation: OperationDefinitionNode) {

--- a/packages/plugins/typescript/compatibility/tests/compatibility.spec.ts
+++ b/packages/plugins/typescript/compatibility/tests/compatibility.spec.ts
@@ -8,19 +8,20 @@ import { plugin as raPlugin } from '../../../typescript/react-apollo/src';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { compileTs } from '../../typescript/tests/compile';
+import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 
-const validate = async (content: string, schema: GraphQLSchema, operations, config = {}, tsx = false, strict = false) => {
+const validate = async (content: Types.PluginOutput, schema: GraphQLSchema, operations, config = {}, tsx = false, strict = false) => {
   const tsPluginResult = await tsPlugin(schema, operations, config, { outputFile: '' });
   const tsOperationPluginResult = await tsOperationPlugin(schema, operations, config, { outputFile: '' });
-  const mergedOutput = [tsPluginResult, tsOperationPluginResult, content].join('\n');
+  const mergedOutput = mergeOutputs([tsPluginResult, tsOperationPluginResult, content]);
 
   validateTs(mergedOutput, undefined, tsx, strict);
 };
 
-const validateAndCompile = async (content: string, schema: GraphQLSchema, operations, config = {}, tsx = false) => {
+const validateAndCompile = async (content: Types.PluginOutput, schema: GraphQLSchema, operations, config = {}, tsx = false) => {
   const tsPluginResult = await tsPlugin(schema, operations, config, { outputFile: '' });
   const tsOperationPluginResult = await tsOperationPlugin(schema, operations, config, { outputFile: '' });
-  const mergedOutput = [tsPluginResult, tsOperationPluginResult, content].join('\n');
+  const mergedOutput = mergeOutputs([tsPluginResult, tsOperationPluginResult, content]);
 
   compileTs(mergedOutput, undefined, tsx);
 };
@@ -672,7 +673,7 @@ describe('Compatibility Plugin', () => {
       }`);
 
       const raPluginResult = await raPlugin(schema, ast, config, { outputFile: '' });
-      await validate(raPluginResult + '\n' + result, schema, ast, config, true);
+      await validate(mergeOutputs([raPluginResult, result]), schema, ast, config, true);
     });
 
     it('Should produce valid ts code with react-apollo and noNamespaces', async () => {
@@ -695,7 +696,7 @@ describe('Compatibility Plugin', () => {
       expect(result).toContain(`export const useMe4 = useMe4Query;`);
 
       const raPluginResult = await raPlugin(schema, ast, config as any, { outputFile: '' });
-      await validate(raPluginResult + '\n' + result, schema, ast, config, true);
+      await validate(mergeOutputs([raPluginResult, result]), schema, ast, config, true);
     });
 
     it('Should produce valid ts code with react-apollo with hooks', async () => {
@@ -726,7 +727,7 @@ describe('Compatibility Plugin', () => {
       }`);
 
       const raPluginResult = await raPlugin(schema, ast, config, { outputFile: '' });
-      await validate(raPluginResult + '\n' + result, schema, ast, config, true);
+      await validate(mergeOutputs([raPluginResult, result]), schema, ast, config, true);
     });
   });
 });

--- a/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
+++ b/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
@@ -3,11 +3,12 @@ import { plugin, addToSchema } from './../src/index';
 import { buildSchema, print, GraphQLSchema } from 'graphql';
 import { plugin as tsPlugin } from '../../typescript/src/index';
 import { validateTs } from '../../typescript/tests/validate';
+import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 
 describe('TypeScript Mongo', () => {
-  const validate = async (content: string, schema: GraphQLSchema, config: any) => {
+  const validate = async (content: Types.PluginOutput, schema: GraphQLSchema, config: any) => {
     const tsPluginOutput = await tsPlugin(schema, [], config, { outputFile: '' });
-    const result = [tsPluginOutput, content].join('\n');
+    const result = mergeOutputs([tsPluginOutput, content]);
     await validateTs(result);
   };
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -2,9 +2,10 @@ import '@graphql-codegen/testing';
 import { parse, buildClientSchema, buildSchema } from 'graphql';
 import { readFileSync } from 'fs';
 import { plugin } from '../src/index';
-import { validateTs } from '@graphql-codegen/typescript/tests/validate';
-import { plugin as tsPlugin } from '@graphql-codegen/typescript/src';
+import { validateTs } from '../../typescript/tests/validate';
+import { plugin as tsPlugin } from '../../typescript/src';
 import { compileTs } from '../../typescript/tests/compile';
+import { mergeOutputs, Types } from '@graphql-codegen/plugin-helpers';
 
 describe('TypeScript Operations Plugin', () => {
   const gitHuntSchema = buildClientSchema(JSON.parse(readFileSync('../../../../dev-test/githunt/schema.json', 'utf-8')));
@@ -87,7 +88,7 @@ describe('TypeScript Operations Plugin', () => {
     }
   `);
 
-  const validate = async (content: string, config: any = {}, pluginSchema = schema) => validateTs((await tsPlugin(pluginSchema, [], config, { outputFile: '' })) + '\n' + content);
+  const validate = async (content: Types.PluginOutput, config: any = {}, pluginSchema = schema) => validateTs(mergeOutputs([await tsPlugin(pluginSchema, [], config, { outputFile: '' }), content]));
 
   describe('Config', () => {
     it('Should handle "namespacedImportName" and add it when specified', async () => {
@@ -656,7 +657,7 @@ describe('TypeScript Operations Plugin', () => {
       export type AFragment = ({ __typename?: 'A' } & Pick<A, 'id'>);
       
       export type BFragment = ({ __typename?: 'A' } & Pick<A, 'x'>);`);
-      compileTs(result, config);
+      compileTs(mergeOutputs([result]), config);
     });
 
     it('Should support interfaces correctly when used with inline fragments', async () => {
@@ -1177,7 +1178,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
 
-      const content = [coreContent, pluginContent].join('\n');
+      const content = mergeOutputs([coreContent, pluginContent]);
 
       expect(content).toBeSimilarStringTo(`
       /** An enum describing what kind of type a given \`__Type\` is. */

--- a/packages/plugins/typescript/react-apollo/src/index.ts
+++ b/packages/plugins/typescript/react-apollo/src/index.ts
@@ -125,7 +125,10 @@ export const plugin: PluginFunction<ReactApolloRawPluginConfig> = (schema: Graph
   const visitor = new ReactApolloVisitor(allFragments, config) as any;
   const visitorResult = visit(allAst, { leave: visitor });
 
-  return [visitor.getImports(), visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n');
+  return {
+    prepend: visitor.getImports(),
+    content: [visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n'),
+  };
 };
 
 export const validate: PluginValidateFn<any> = async (schema: GraphQLSchema, documents: Types.DocumentFile[], config: ReactApolloRawPluginConfig, outputFile: string) => {

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -1,7 +1,7 @@
-import { ClientSideBaseVisitor, ClientSideBasePluginConfig, getConfigValue, LoadedFragment } from '@graphql-codegen/visitor-plugin-common';
+import { ClientSideBaseVisitor, ClientSideBasePluginConfig, getConfigValue, LoadedFragment, OMIT_TYPE } from '@graphql-codegen/visitor-plugin-common';
 import { ReactApolloRawPluginConfig } from './index';
 import * as autoBind from 'auto-bind';
-import { FragmentDefinitionNode, OperationDefinitionNode, Kind } from 'graphql';
+import { OperationDefinitionNode, Kind } from 'graphql';
 import { toPascalCase } from '@graphql-codegen/plugin-helpers';
 import { titleCase } from 'change-case';
 
@@ -32,23 +32,23 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
 
   private imports = new Set<string>();
 
-  private getReactImport() {
+  private getReactImport(): string {
     return `import * as React from 'react';`;
   }
 
-  private getReactApolloImport() {
+  private getReactApolloImport(): string {
     return `import * as ReactApollo from '${typeof this.config.reactApolloImportFrom === 'string' ? this.config.reactApolloImportFrom : 'react-apollo'}';`;
   }
 
-  private getReactApolloHooksImport() {
+  private getReactApolloHooksImport(): string {
     return `import * as ReactApolloHooks from '${typeof this.config.hooksImportFrom === 'string' ? this.config.hooksImportFrom : 'react-apollo-hooks'}';`;
   }
 
-  private getOmitDeclaration() {
-    return `export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;`;
+  private getOmitDeclaration(): string {
+    return OMIT_TYPE;
   }
 
-  public getImports(): string {
+  public getImports(): string[] {
     const baseImports = super.getImports();
     const hasOperations = this._collectedOperations.length > 0;
 
@@ -56,7 +56,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
       return baseImports;
     }
 
-    return [baseImports, ...this.imports].join('\n');
+    return [...baseImports, ...this.imports];
   }
 
   private _buildHocProps(operationName: string, operationType: string): string {

--- a/packages/plugins/typescript/resolvers/tests/common.ts
+++ b/packages/plugins/typescript/resolvers/tests/common.ts
@@ -1,3 +1,4 @@
+import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 import { buildSchema } from 'graphql';
 import { plugin as tsPlugin } from '../../typescript/src/index';
 import { validateTs } from '../../typescript/tests/validate';
@@ -36,8 +37,8 @@ export const schema = buildSchema(/* GraphQL */ `
   directive @myDirective(arg: Int!, arg2: String!, arg3: Boolean!) on FIELD
 `);
 
-export const validate = async (content: string, config: any = {}, pluginSchema = schema) => {
-  const mergedContent = (await tsPlugin(pluginSchema, [], config, { outputFile: '' })) + '\n' + content;
+export const validate = async (content: Types.PluginOutput, config: any = {}, pluginSchema = schema) => {
+  const mergedContent = mergeOutputs([await tsPlugin(pluginSchema, [], config, { outputFile: '' }), content]);
 
   validateTs(mergedContent);
 };

--- a/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
@@ -1,3 +1,4 @@
+import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 import '@graphql-codegen/testing';
 import { schema, validate } from './common';
 import { plugin } from '../src';
@@ -5,9 +6,9 @@ import { buildSchema } from 'graphql';
 
 describe('ResolversTypes', () => {
   it('Should build ResolversTypes object when there are no mappers', async () => {
-    const result = await plugin(schema, [], {}, { outputFile: '' });
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: MyType,
@@ -25,7 +26,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should build ResolversTypes with simple mappers', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -35,9 +36,9 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: MyTypeDb,
@@ -72,7 +73,7 @@ describe('ResolversTypes', () => {
         me: User
       }
     `);
-    const result = await plugin(
+    const result = (await plugin(
       testSchema,
       [],
       {
@@ -83,7 +84,7 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
     const usage = `
       const resolvers: Resolvers = {
@@ -106,7 +107,7 @@ describe('ResolversTypes', () => {
     `;
 
     await validate(
-      [result, usage].join('\n\n'),
+      [mergeOutputs(result), usage].join('\n\n'),
       {
         scalars: {
           ID: 'number',
@@ -117,7 +118,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should build ResolversTypes with defaultMapper set using {T}', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -125,9 +126,9 @@ describe('ResolversTypes', () => {
         defaultMapper: 'Partial<{T}>',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: Partial<MyType>,
@@ -145,7 +146,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should build ResolversTypes with defaultMapper set using {T} with external identifier', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -153,10 +154,10 @@ describe('ResolversTypes', () => {
         defaultMapper: './my-wrapper#CustomPartial<{T}>',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`import { CustomPartial } from './my-wrapper';`);
-    expect(result).toBeSimilarStringTo(`
+    expect(result.prepend).toContain(`import { CustomPartial } from './my-wrapper';`);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: CustomPartial<MyType>,
@@ -174,7 +175,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should build ResolversTypes with mapper set for concrete type using {T} with external identifier', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -184,10 +185,10 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`import { CustomPartial } from './my-wrapper';`);
-    expect(result).toBeSimilarStringTo(`
+    expect(result.prepend).toContain(`import { CustomPartial } from './my-wrapper';`);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: CustomPartial<MyType>,
@@ -232,9 +233,9 @@ describe('ResolversTypes', () => {
         me: User
       }
     `);
-    const result = await plugin(testSchema, [], config, { outputFile: '' });
+    const result = (await plugin(testSchema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       User: number,
@@ -274,11 +275,11 @@ describe('ResolversTypes', () => {
       }
     `;
 
-    await validate([result, usage].join('\n\n'), config, testSchema);
+    await validate([mergeOutputs(result), usage].join('\n\n'), config, testSchema);
   });
 
   it('Should build ResolversTypes with defaultMapper set', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -290,9 +291,9 @@ describe('ResolversTypes', () => {
         defaultMapper: 'any',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: MyTypeDb,
@@ -310,7 +311,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should build ResolversTypes with external mappers', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -321,9 +322,9 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: MyTypeDb,
@@ -341,7 +342,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should handle {T} in a mapper', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -351,9 +352,9 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
         Query: {},
         MyType: Partial<MyType>,
@@ -449,7 +450,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should generate basic type resolvers with external mappers', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -459,25 +460,25 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`import { MyCustomOtherType } from './my-file';`);
-    expect(result).toBeSimilarStringTo(`
+    expect(result.prepend).toContain(`import { MyCustomOtherType } from './my-file';`);
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
       arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
         export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
           bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         };
       `);
 
-    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
+    expect(result.content).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
       name: 'MyScalar'
         }
       `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
@@ -485,32 +486,32 @@ describe('ResolversTypes', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
         something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
         somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
@@ -519,7 +520,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should generate basic type resolvers with external mappers using same imported type', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -530,25 +531,25 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`import { MyCustomOtherType } from './my-file';`);
-    expect(result).toBeSimilarStringTo(`
+    expect(result.prepend).toContain(`import { MyCustomOtherType } from './my-file';`);
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
       arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
         export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
           bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         };
       `);
 
-    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
+    expect(result.content).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
       name: 'MyScalar'
         }
       `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
@@ -556,32 +557,32 @@ describe('ResolversTypes', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
         something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
         somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
@@ -590,7 +591,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should generate the correct resolvers when used with mappers with interfaces', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -600,25 +601,25 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
       arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
         bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
         name: 'MyScalar'
       }
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
@@ -626,41 +627,41 @@ describe('ResolversTypes', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
         something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
         somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
     `);
-    await validate(`type MyNodeType = {};\n${result}`);
+    await validate(mergeOutputs([result, `type MyNodeType = {};`]));
   });
 
   it('Should generate basic type resolvers with defaultMapper set to any', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -668,25 +669,25 @@ describe('ResolversTypes', () => {
         defaultMapper: 'any',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
       arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
         bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
         name: 'MyScalar'
       }
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
@@ -694,32 +695,32 @@ describe('ResolversTypes', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
         something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
         somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
@@ -728,7 +729,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should generate basic type resolvers with defaultMapper set to external identifier', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -736,27 +737,27 @@ describe('ResolversTypes', () => {
         defaultMapper: './my-file#MyBaseType',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toContain(`import { MyBaseType } from './my-file';`);
+    expect(result.prepend).toContain(`import { MyBaseType } from './my-file';`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
       arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
         bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
         name: 'MyScalar'
       }
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
@@ -764,32 +765,32 @@ describe('ResolversTypes', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
         something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
         somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
@@ -798,7 +799,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should replace using Omit when non-mapped type is pointing to mapped type', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -808,9 +809,9 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: Omit<MyType, 'otherType'> & { otherType?: Maybe<ResolversTypes['MyOtherType']> },
@@ -825,11 +826,11 @@ describe('ResolversTypes', () => {
       MyScalar: Scalars['MyScalar'],
       Int: Scalars['Int'],
     };`);
-    await validate(`type MyOtherTypeCustom = {}; ${result}`);
+    await validate(mergeOutputs([result, 'type MyOtherTypeCustom = {};']));
   });
 
   it('Should not replace using Omit when non-mapped type is pointing to mapped type', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
@@ -840,9 +841,9 @@ describe('ResolversTypes', () => {
         },
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       Query: {},
       MyType: MyTypeCustom,
@@ -857,6 +858,6 @@ describe('ResolversTypes', () => {
       MyScalar: Scalars['MyScalar'],
       Int: Scalars['Int'],
     };`);
-    await validate(`type MyTypeCustom = {}; type MyOtherTypeCustom = {}; ${result}`);
+    await validate(mergeOutputs([result, `type MyTypeCustom = {}; type MyOtherTypeCustom = {};`]));
   });
 });

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -4,12 +4,13 @@ import { plugin } from '../src';
 import { plugin as tsPlugin } from '../../typescript/src/index';
 import { validateTs } from '../../typescript/tests/validate';
 import { schema, validate } from './common';
+import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 
 describe('TypeScript Resolvers Plugin', () => {
   describe('Backward Compatability', () => {
     it('Should generate IDirectiveResolvers by default', async () => {
-      const result = await plugin(schema, [], {}, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
       /**
        * @deprecated
        * Use "DirectiveResolvers" root object instead. If you wish to get "IDirectiveResolvers", add "typesPrefix: I" to your config.
@@ -20,16 +21,16 @@ describe('TypeScript Resolvers Plugin', () => {
 
     it('Should not generate IDirectiveResolvers when prefix is overwritten', async () => {
       const config = { typesPrefix: 'PREFIX_' };
-      const result = await plugin(schema, [], config, { outputFile: '' });
-      expect(result).not.toContain(`export type IDirectiveResolvers`);
-      expect(result).not.toContain(`export type DirectiveResolvers`);
-      expect(result).toContain(`export type PREFIX_DirectiveResolvers`);
+      const result = (await plugin(schema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
+      expect(result.content).not.toContain(`export type IDirectiveResolvers`);
+      expect(result.content).not.toContain(`export type DirectiveResolvers`);
+      expect(result.content).toContain(`export type PREFIX_DirectiveResolvers`);
       await validate(result, config);
     });
 
     it('Should generate IResolvers by default', async () => {
-      const result = await plugin(schema, [], {}, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
       /**
        * @deprecated
        * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
@@ -40,16 +41,16 @@ describe('TypeScript Resolvers Plugin', () => {
 
     it('Should not generate IResolvers when prefix is overwritten', async () => {
       const config = { typesPrefix: 'PREFIX_' };
-      const result = await plugin(schema, [], config, { outputFile: '' });
-      expect(result).not.toContain(`export type IResolvers`);
-      expect(result).not.toContain(`export type Resolvers`);
-      expect(result).toContain(`export type PREFIX_Resolvers`);
+      const result = (await plugin(schema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
+      expect(result.content).not.toContain(`export type IResolvers`);
+      expect(result.content).not.toContain(`export type Resolvers`);
+      expect(result.content).toContain(`export type PREFIX_Resolvers`);
       await validate(result, config);
     });
 
     it('Should generate IResolvers by default with deprecated warning', async () => {
-      const result = await plugin(schema, [], {}, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
       /**
        * @deprecated
        * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
@@ -71,7 +72,7 @@ describe('TypeScript Resolvers Plugin', () => {
       `);
 
       const tsContent = await tsPlugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
-      const resolversContent = await plugin(
+      const resolversContent = (await plugin(
         testSchema,
         [],
         {
@@ -81,8 +82,8 @@ describe('TypeScript Resolvers Plugin', () => {
         {
           outputFile: 'graphql.ts',
         }
-      );
-      const content = [
+      )) as Types.ComplexPluginOutput;
+      const content = mergeOutputs([
         tsContent,
         resolversContent,
         `
@@ -108,7 +109,7 @@ describe('TypeScript Resolvers Plugin', () => {
             resolvers
           })
         `,
-      ].join('\n');
+      ]);
 
       expect(content).toBeSimilarStringTo(`
         export type Resolvers<ContextType = Context> = ResolversObject<{
@@ -122,15 +123,15 @@ describe('TypeScript Resolvers Plugin', () => {
   });
 
   it('Should use StitchingResolver by default', async () => {
-    const result = await plugin(schema, [], {}, { outputFile: '' });
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
         fragment: string;
         resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
       };
     `);
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
         | ResolverFn<TResult, TParent, TContext, TArgs>
         | StitchingResolver<TResult, TParent, TContext, TArgs>;
@@ -160,7 +161,7 @@ describe('TypeScript Resolvers Plugin', () => {
 
   it('Should not warn when noSchemaStitching is not defined', async () => {
     const spy = jest.spyOn(console, 'warn').mockImplementation();
-    const result = await plugin(schema, [], {}, { outputFile: '' });
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
     expect(spy).not.toHaveBeenCalled();
 
@@ -170,28 +171,28 @@ describe('TypeScript Resolvers Plugin', () => {
   });
 
   it('Should disable StitchingResolver on demand', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
         noSchemaStitching: true,
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).not.toBeSimilarStringTo(`
+    expect(result.content).not.toBeSimilarStringTo(`
       export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
         fragment: string;
         resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
       };
     `);
-    expect(result).not.toBeSimilarStringTo(`
+    expect(result.content).not.toBeSimilarStringTo(`
       export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
         | ResolverFn<TResult, TParent, TContext, TArgs>
         | StitchingResolver<TResult, TParent, TContext, TArgs>;
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
         ResolverFn<TResult, TParent, TContext, TArgs>;
     `);
@@ -200,23 +201,23 @@ describe('TypeScript Resolvers Plugin', () => {
   });
 
   it('Should generate basic type resolvers', async () => {
-    const result = await plugin(schema, [], {}, { outputFile: '' });
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg?: Maybe<Scalars['Int']>,
       arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
         bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
+    expect(result.content).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
       name: 'MyScalar'
     }`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
@@ -224,32 +225,32 @@ describe('TypeScript Resolvers Plugin', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
         something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
         somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
@@ -259,23 +260,23 @@ describe('TypeScript Resolvers Plugin', () => {
   });
 
   it('Should generate basic type resolvers with avoidOptionals', async () => {
-    const result = await plugin(schema, [], { avoidOptionals: true }, { outputFile: '' });
+    const result = (await plugin(schema, [], { avoidOptionals: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = {   arg: Maybe<Scalars['Int']>,
       arg2: Maybe<Scalars['String']>, arg3: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyOtherType']> = {
         bar: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
+    expect(result.content).toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
       name: 'MyScalar'
     }`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType = ResolversTypes['MyType']> = {
         foo: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         otherType: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
@@ -283,32 +284,32 @@ describe('TypeScript Resolvers Plugin', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType = ResolversTypes['Query']> = {
         something: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType = ResolversTypes['SomeNode']> = {
         id: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType = ResolversTypes['Subscription']> = {
         somethingChanged: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
@@ -318,26 +319,26 @@ describe('TypeScript Resolvers Plugin', () => {
   });
 
   it('Should allow to override context with simple identifier', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
         contextType: 'MyCustomCtx',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = MyCustomCtx, Args = {   arg?: Maybe<Scalars['Int']>,
       arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyOtherType']> = {
         bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
@@ -345,63 +346,63 @@ describe('TypeScript Resolvers Plugin', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Query']> = {
         something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['SomeNode']> = {
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Subscription']> = {
         somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
     `);
 
-    await validate(`type MyCustomCtx = {};\n` + result);
+    await validate(mergeOutputs([result, `type MyCustomCtx = {};`]));
   });
 
   it('Should allow to override context with mapped context type', async () => {
-    const result = await plugin(
+    const result = (await plugin(
       schema,
       [],
       {
         contextType: './my-file#MyCustomCtx',
       },
       { outputFile: '' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`import { MyCustomCtx } from './my-file';`);
+    expect(result.prepend).toContain(`import { MyCustomCtx } from './my-file';`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = MyCustomCtx, Args = {   arg?: Maybe<Scalars['Int']>,
       arg2?: Maybe<Scalars['String']>, arg3?: Maybe<Scalars['Boolean']> }> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyOtherType']> = {
         bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
@@ -409,32 +410,32 @@ describe('TypeScript Resolvers Plugin', () => {
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['MyUnion']> = {
         __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Query']> = {
         something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['SomeNode']> = {
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
       };
     `);
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = MyCustomCtx, ParentType = ResolversTypes['Subscription']> = {
         somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
       };
@@ -445,17 +446,17 @@ describe('TypeScript Resolvers Plugin', () => {
 
   it('Should generate the correct imports when schema has scalars', async () => {
     const testSchema = buildSchema(`scalar MyScalar`);
-    const result = await plugin(testSchema, [], {}, { outputFile: '' });
+    const result = (await plugin(testSchema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';`);
+    expect(result.prepend).toContain(`import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';`);
     await validate(result, {}, schema);
   });
 
   it('Should generate the correct imports when schema has no scalars', async () => {
     const testSchema = buildSchema(`type MyType { f: String }`);
-    const result = await plugin(testSchema, [], {}, { outputFile: '' });
+    const result = (await plugin(testSchema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(result).not.toBeSimilarStringTo(`import { GraphQLResolveInfo, GraphQLScalarTypeConfig } from 'graphql';`);
+    expect(result.prepend).not.toContain(`import { GraphQLResolveInfo, GraphQLScalarTypeConfig } from 'graphql';`);
     await validate(result, {}, testSchema);
   });
 
@@ -476,25 +477,25 @@ describe('TypeScript Resolvers Plugin', () => {
       union CCCUnion = CCCFoo | CCCBar
     `);
 
-    const tsContent = await tsPlugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
-    const content = await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
+    const tsContent = (await tsPlugin(testSchema, [], {}, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
+    const content = (await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
 
-    expect(content).toBeSimilarStringTo(`CCCUnion: ResolversTypes['CCCFoo'] | ResolversTypes['CCCBar']`); // In ResolversTypes
-    expect(content).toBeSimilarStringTo(`
+    expect(content.content).toBeSimilarStringTo(`CCCUnion: ResolversTypes['CCCFoo'] | ResolversTypes['CCCBar']`); // In ResolversTypes
+    expect(content.content).toBeSimilarStringTo(`
     export type CccUnionResolvers<ContextType = any, ParentType = ResolversTypes['CCCUnion']> = {
       __resolveType: TypeResolveFn<'CCCFoo' | 'CCCBar', ParentType, ContextType>
     };
     `);
 
-    await validateTs([tsContent, content].join('\n'));
+    await validateTs(mergeOutputs([tsContent, content]));
   });
 
   it('Should generate the correct resolver args type names when typesPrefix is specified', async () => {
     const testSchema = buildSchema(`type MyType { f(a: String): String }`);
     const config = { typesPrefix: 'T' };
-    const result = await plugin(testSchema, [], config, { outputFile: '' });
+    const result = (await plugin(testSchema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`f?: Resolver<Maybe<TResolversTypes['String']>, ParentType, ContextType, TMyTypeFArgs>,`);
+    expect(result.content).toBeSimilarStringTo(`f?: Resolver<Maybe<TResolversTypes['String']>, ParentType, ContextType, TMyTypeFArgs>,`);
     await validate(result, config, testSchema);
   });
 
@@ -522,16 +523,16 @@ describe('TypeScript Resolvers Plugin', () => {
       }
     `);
 
-    const content = await plugin(
+    const content = (await plugin(
       testSchema,
       [],
       { scalars: { Date: 'Date' } },
       {
         outputFile: 'graphql.ts',
       }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(content).toBeSimilarStringTo(`
+    expect(content.content).toBeSimilarStringTo(`
       export type Resolvers<ContextType = any> = {
         Date?: GraphQLScalarType,
         Node?: NodeResolvers,
@@ -542,7 +543,7 @@ describe('TypeScript Resolvers Plugin', () => {
       };
     `);
 
-    expect(content).toBeSimilarStringTo(`
+    expect(content.content).toBeSimilarStringTo(`
       export type DirectiveResolvers<ContextType = any> = {
         modify?: ModifyDirectiveResolver<any, any, ContextType>,
       };
@@ -556,16 +557,16 @@ describe('TypeScript Resolvers Plugin', () => {
       }
     `);
 
-    const content = await plugin(
+    const content = (await plugin(
       testSchema,
       [],
       { scalars: { Date: 'Date' } },
       {
         outputFile: 'graphql.ts',
       }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(content).not.toBeSimilarStringTo(`
+    expect(content.content).not.toBeSimilarStringTo(`
       export type DirectiveResolvers<ContextType = any> = {};
     `);
   });
@@ -582,8 +583,8 @@ describe('TypeScript Resolvers Plugin', () => {
       }
     `);
 
-    const tsContent = await tsPlugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
-    const resolversContent = await plugin(
+    const tsContent = (await tsPlugin(testSchema, [], {}, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
+    const resolversContent = (await plugin(
       testSchema,
       [],
       {
@@ -593,8 +594,8 @@ describe('TypeScript Resolvers Plugin', () => {
       {
         outputFile: 'graphql.ts',
       }
-    );
-    const content = [
+    )) as Types.ComplexPluginOutput;
+    const content = mergeOutputs([
       tsContent,
       resolversContent,
       `
@@ -620,7 +621,7 @@ describe('TypeScript Resolvers Plugin', () => {
           resolvers
         })
       `,
-    ].join('\n');
+    ]);
 
     validateTs(content);
   });
@@ -649,7 +650,7 @@ describe('TypeScript Resolvers Plugin', () => {
         outputFile: 'graphql.ts',
       }
     );
-    const content = [
+    const content = mergeOutputs([
       tsContent,
       resolversContent,
       `
@@ -675,7 +676,7 @@ describe('TypeScript Resolvers Plugin', () => {
           }
         })
       `,
-    ].join('\n');
+    ]);
 
     validateTs(content);
   });
@@ -699,9 +700,9 @@ describe('TypeScript Resolvers Plugin', () => {
         comment: String
       }
     `);
-    const content = await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
+    const content = (await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
 
-    expect(content).toBeSimilarStringTo(`
+    expect(content.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
         Query: {},
         Post: Post,
@@ -738,16 +739,16 @@ describe('TypeScript Resolvers Plugin', () => {
         subscription: MySubscription
       }
     `);
-    const content = await plugin(
+    const content = (await plugin(
       testSchema,
       [],
       {
         rootValueType: 'MyRoot',
       },
       { outputFile: 'graphql.ts' }
-    );
+    )) as Types.ComplexPluginOutput;
 
-    expect(content).toBeSimilarStringTo(`
+    expect(content.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
         MyQuery: MyRoot,
         Post: Post,
@@ -787,7 +788,7 @@ describe('TypeScript Resolvers Plugin', () => {
       },
       { outputFile: 'graphql.ts' }
     );
-    const content = [
+    const content = mergeOutputs([
       tsContent,
       resolversContent,
       `
@@ -821,7 +822,7 @@ describe('TypeScript Resolvers Plugin', () => {
           },
         };
       `,
-    ].join('\n');
+    ]);
 
     validateTs(content);
   });
@@ -837,9 +838,9 @@ describe('TypeScript Resolvers Plugin', () => {
       }
     `);
 
-    const result = await plugin(schemaWithNoImplementors, [], {}, { outputFile: '' });
+    const result = (await plugin(schemaWithNoImplementors, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(result).toBeSimilarStringTo(`
+    expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType = ResolversTypes['Node']> = {
         __resolveType: TypeResolveFn<null, ParentType, ContextType>,
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,

--- a/packages/plugins/typescript/stencil-apollo/src/index.ts
+++ b/packages/plugins/typescript/stencil-apollo/src/index.ts
@@ -46,7 +46,10 @@ export const plugin: PluginFunction<StencilApolloRawPluginConfig> = (schema: Gra
   const visitor = new StencilApolloVisitor(allFragments, config) as any;
   const visitorResult = visit(allAst, { leave: visitor });
 
-  return [visitor.getImports(), visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n');
+  return {
+    prepend: visitor.getImports(),
+    content: [, visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n'),
+  };
 };
 
 export const validate: PluginValidateFn<any> = async (schema: GraphQLSchema, documents: Types.DocumentFile[], config: StencilApolloRawPluginConfig, outputFile: string) => {

--- a/packages/plugins/typescript/stencil-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/stencil-apollo/src/visitor.ts
@@ -18,7 +18,7 @@ export class StencilApolloVisitor extends ClientSideBaseVisitor<StencilApolloRaw
     autoBind(this);
   }
 
-  public getImports(): string {
+  public getImports(): string[] {
     const baseImports = super.getImports();
     const imports = [];
     const hasOperations = this._collectedOperations.length > 0;
@@ -34,7 +34,7 @@ export class StencilApolloVisitor extends ClientSideBaseVisitor<StencilApolloRaw
       imports.push(`import * as StencilApollo from 'stencil-apollo';`);
     }
 
-    return [baseImports, ...imports].join('\n');
+    return [...baseImports, ...imports];
   }
 
   private _buildOperationFunctionalComponent(node: OperationDefinitionNode, documentVariableName: string, operationType: string, operationResultType: string, operationVariablesTypes: string): string {

--- a/packages/plugins/typescript/stencil-apollo/tests/stencil-apollo.spec.ts
+++ b/packages/plugins/typescript/stencil-apollo/tests/stencil-apollo.spec.ts
@@ -3,6 +3,7 @@ import { plugin, StencilComponentType } from '../src/index';
 import { buildClientSchema } from 'graphql';
 import gql from 'graphql-tag';
 import { readFileSync } from 'fs';
+import { Types } from '@graphql-codegen/plugin-helpers';
 
 describe('Components', () => {
   const schema = buildClientSchema(JSON.parse(readFileSync('../../../../dev-test/githunt/schema.json').toString()));
@@ -23,12 +24,10 @@ describe('Components', () => {
       }
     `;
 
-    const content = await plugin(schema, [{ filePath: '', content: documents }], { componentType: StencilComponentType.class }, { outputFile: '' });
+    const content = (await plugin(schema, [{ filePath: '', content: documents }], { componentType: StencilComponentType.class }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(content).toBeSimilarStringTo(`
-        import 'stencil-apollo';
-        import { Component, Prop } from '@stencil/core';
-      `);
+    expect(content.prepend).toContain(`import 'stencil-apollo';`);
+    expect(content.prepend).toContain(`import { Component, Prop } from '@stencil/core';`);
   });
 
   it('should generate Functional Component', async () => {
@@ -48,7 +47,7 @@ describe('Components', () => {
       }
     `;
 
-    const content = await plugin(schema, [{ filePath: '', content: documents }], { componentType: StencilComponentType.functional }, { outputFile: '' });
+    const { content } = (await plugin(schema, [{ filePath: '', content: documents }], { componentType: StencilComponentType.functional }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
     expect(content).toBeSimilarStringTo(`
         export type FeedProps = {
@@ -83,7 +82,7 @@ describe('Components', () => {
       }
     `;
 
-    const content = await plugin(schema, [{ filePath: '', content: documents }], { componentType: StencilComponentType.class }, { outputFile: '' });
+    const { content } = (await plugin(schema, [{ filePath: '', content: documents }], { componentType: StencilComponentType.class }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
     expect(content).toBeSimilarStringTo(`
             @Component({

--- a/packages/plugins/typescript/typescript/src/index.ts
+++ b/packages/plugins/typescript/typescript/src/index.ts
@@ -106,7 +106,10 @@ export const plugin: PluginFunction<TypeScriptPluginConfig> = (schema: GraphQLSc
   const introspectionDefinitions = includeIntrospectionDefinitions(schema, documents, config);
   const scalars = visitor.scalarsDefinition;
 
-  return [visitor.getEnumsImports(), maybeValue, scalars, ...visitorResult.definitions, ...introspectionDefinitions].join('\n');
+  return {
+    prepend: [...visitor.getEnumsImports(), maybeValue],
+    content: [scalars, ...visitorResult.definitions, ...introspectionDefinitions].join('\n'),
+  };
 };
 
 function includeIntrospectionDefinitions(schema: GraphQLSchema, documents: Types.DocumentFile[], config: TypeScriptPluginConfig): string[] {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1,3 +1,4 @@
+import { Types } from '@graphql-codegen/plugin-helpers';
 import '@graphql-codegen/testing';
 import { buildSchema, parse } from 'graphql';
 import { validateTs } from './validate';
@@ -8,8 +9,8 @@ describe('TypeScript', () => {
     const schema = buildSchema(/* GraphQL */ `
       scalar A
     `);
-    const result = await plugin(schema, [], {}, { outputFile: '' });
-    expect(result).toBeSimilarStringTo('export type Maybe<T> =');
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    expect(result.prepend).toBeSimilarStringTo('export type Maybe<T> =');
   });
 
   describe('description to comment', () => {
@@ -18,9 +19,9 @@ describe('TypeScript', () => {
         "My custom scalar"
         scalar A
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       /** All built-in and custom scalars, mapped to their actual values */
       export type Scalars = {
           ID: string,
@@ -41,9 +42,9 @@ describe('TypeScript', () => {
           f: String
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** MyInput */
         export type MyInput`);
     });
@@ -56,9 +57,9 @@ describe('TypeScript', () => {
           f: String!
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** MyInput */
         export type MyInput = {
           /** f is something */
@@ -76,9 +77,9 @@ describe('TypeScript', () => {
           f: String!
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** MyInput
          * multiline
          */
@@ -97,9 +98,9 @@ describe('TypeScript', () => {
           id: ID
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** my union */
         export type A = `);
     });
@@ -115,13 +116,13 @@ describe('TypeScript', () => {
           id: ID
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** this is b */
         export type B = `);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         /** this is c */
         export type C = `);
     });
@@ -133,9 +134,9 @@ describe('TypeScript', () => {
           id: ID
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type B = {
         __typename?: 'B',
         /** the id */
@@ -150,9 +151,9 @@ describe('TypeScript', () => {
           id: ID!
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type Node = {
         __typename?: 'Node',
         /** the id */
@@ -170,9 +171,9 @@ describe('TypeScript', () => {
           B
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       /** custom enum */
       export enum MyEnum {
         /** this is a */
@@ -191,9 +192,9 @@ describe('TypeScript', () => {
           My_Value
         }
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export enum MyEnum {
         ABC = 'A_B_C',
         XYZ = 'X_Y_Z',
@@ -212,9 +213,9 @@ describe('TypeScript', () => {
           B
         }
       `);
-      const result = await plugin(schema, [], { enumsAsTypes: true }, { outputFile: '' });
+      const result = (await plugin(schema, [], { enumsAsTypes: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       /** custom enum */
       export type MyEnum =
         /** this is a */
@@ -231,9 +232,9 @@ describe('TypeScript', () => {
         f: String!
       }`);
 
-      const result = await plugin(schema, [], { immutableTypes: true }, { outputFile: '' });
+      const result = (await plugin(schema, [], { immutableTypes: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type MyInput = {
         readonly f: Scalars['String'],
       };`);
@@ -252,9 +253,9 @@ describe('TypeScript', () => {
         count: Int! @default(value: 1)
       }`);
 
-      const result = await plugin(schema, [], {}, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`export type Any = Scalars['String'] | Scalars['Int'] | Scalars['Float'] | Scalars['ID'];`);
-      expect(result).toBeSimilarStringTo(`
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`export type Any = Scalars['String'] | Scalars['Int'] | Scalars['Float'] | Scalars['ID'];`);
+      expect(result.content).toBeSimilarStringTo(`
       export type CardEdge = {
         __typename?: 'CardEdge',
         count: Scalars['Int'],
@@ -270,9 +271,9 @@ describe('TypeScript', () => {
           foo: String
           bar: String!
         }`);
-      const result = await plugin(schema, [], { avoidOptionals: true }, { outputFile: '' });
+      const result = (await plugin(schema, [], { avoidOptionals: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
           __typename?: 'MyType',
           foo: Maybe<Scalars['String']>,
@@ -287,9 +288,9 @@ describe('TypeScript', () => {
         type MyType {
           foo: [String!]!
         }`);
-      const result = await plugin(schema, [], { immutableTypes: true }, { outputFile: '' });
+      const result = (await plugin(schema, [], { immutableTypes: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
           __typename?: 'MyType',
           readonly foo: ReadonlyArray<Scalars['String']>,
@@ -303,9 +304,9 @@ describe('TypeScript', () => {
       enum MyEnum {
         A
       }`);
-      const result = await plugin(schema, [], { constEnums: true }, { outputFile: '' });
+      const result = (await plugin(schema, [], { constEnums: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export const enum MyEnum {
         A = 'A'
       };
@@ -319,9 +320,9 @@ describe('TypeScript', () => {
         A
         B
       }`);
-      const result = await plugin(schema, [], { enumsAsTypes: true }, { outputFile: '' });
+      const result = (await plugin(schema, [], { enumsAsTypes: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type MyEnum = 'A' | 'B';
     `);
       validateTs(result);
@@ -333,9 +334,9 @@ describe('TypeScript', () => {
         A
         B
       }`);
-      const result = await plugin(schema, [], { enumValues: { MyEnum: { A: 'BOOP' } }, enumsAsTypes: true }, { outputFile: '' });
+      const result = (await plugin(schema, [], { enumValues: { MyEnum: { A: 'BOOP' } }, enumsAsTypes: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type MyEnum = 'BOOP' | 'B';
     `);
       validateTs(result);
@@ -351,7 +352,7 @@ describe('TypeScript', () => {
           foo(a: String!, b: String, c: [String], d: [Int!]!): Foo
         }
       `);
-      const result = await plugin(
+      const result = (await plugin(
         schema,
         [],
         {
@@ -361,16 +362,16 @@ describe('TypeScript', () => {
           },
         },
         { outputFile: '' }
-      );
+      )) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export enum foo {
           YES = 'YES',
           NO = 'NO'
         }
       `);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type mytypefooargs = {
           a: Scalars['String'],
           b?: Maybe<Scalars['String']>,
@@ -378,7 +379,7 @@ describe('TypeScript', () => {
           d: Array<Scalars['Int']>
         };
     `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type mytype = {
           __typename?: 'MyType',
           foo?: Maybe<foo>,
@@ -398,7 +399,7 @@ describe('TypeScript', () => {
           foo(a: String!, b: String, c: [String], d: [Int!]!): Foo
         }
       `);
-      const result = await plugin(
+      const result = (await plugin(
         schema,
         [],
         {
@@ -407,9 +408,9 @@ describe('TypeScript', () => {
           },
         },
         { outputFile: '' }
-      );
+      )) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export enum Foo {
         yes = 'YES',
         no = 'NO'
@@ -426,7 +427,7 @@ describe('TypeScript', () => {
           foo(a: String!, b: String, c: [String], d: [Int!]!): Foo
         }
       `);
-      const result = await plugin(
+      const result = (await plugin(
         schema,
         [],
         {
@@ -436,16 +437,16 @@ describe('TypeScript', () => {
           },
         },
         { outputFile: '' }
-      );
+      )) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export enum Foo {
           yes = 'YES',
           no = 'NO'
         }
       `);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyTypefooArgs = {
           a: Scalars['String'],
           b?: Maybe<Scalars['String']>,
@@ -454,7 +455,7 @@ describe('TypeScript', () => {
         };
       `);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
           __typename?: 'MyType',
           foo?: Maybe<Foo>,
@@ -488,16 +489,16 @@ describe('TypeScript', () => {
         }
       `);
 
-      const content = await plugin(
+      const result = (await plugin(
         testSchema,
         [{ filePath: '', content: query }],
         {},
         {
           outputFile: 'graphql.ts',
         }
-      );
+      )) as Types.ComplexPluginOutput;
 
-      expect(content).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       /** An enum describing what kind of type a given \`__Type\` is. */
       export enum __TypeKind {
         /** Indicates this type is a scalar. */
@@ -528,9 +529,9 @@ describe('TypeScript', () => {
         foo: String
         bar: String!
       }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type Scalars = {
         ID: string,
         String: string,
@@ -539,7 +540,7 @@ describe('TypeScript', () => {
         Float: number,
       };`);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type MyType = {
         __typename?: 'MyType',
         foo?: Maybe<Scalars['String']>,
@@ -556,9 +557,9 @@ describe('TypeScript', () => {
         foo: String
         bar: MyScalar!
       }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type Scalars = {
         ID: string,
         String: string,
@@ -568,7 +569,7 @@ describe('TypeScript', () => {
         MyScalar: any,
       };`);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type MyType = {
         __typename?: 'MyType',
         foo?: Maybe<Scalars['String']>,
@@ -585,9 +586,9 @@ describe('TypeScript', () => {
         foo: String
         bar: MyScalar!
       }`);
-      const result = await plugin(schema, [], { scalars: { MyScalar: 'Date' } }, { outputFile: '' });
+      const result = (await plugin(schema, [], { scalars: { MyScalar: 'Date' } }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type Scalars = {
         ID: string,
         String: string,
@@ -597,7 +598,7 @@ describe('TypeScript', () => {
         MyScalar: Date,
       };`);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type MyType = {
         __typename?: 'MyType',
         foo?: Maybe<Scalars['String']>,
@@ -614,9 +615,9 @@ describe('TypeScript', () => {
           foo: String
           bar: String!
         }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
           __typename?: 'MyType',
           foo?: Maybe<Scalars['String']>,
@@ -636,15 +637,15 @@ describe('TypeScript', () => {
           foo: String!
         }
         `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
           __typename?: 'MyInterface',
           foo: Scalars['String'],
         };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = MyInterface & {
           __typename?: 'MyType',
           foo: Scalars['String'],
@@ -668,21 +669,21 @@ describe('TypeScript', () => {
           bar: String!
         }
         `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
           __typename?: 'MyInterface',
           foo: Scalars['String'],
         };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyOtherInterface = {
           __typename?: 'MyOtherInterface',
           bar: Scalars['String'],
         };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = MyInterface & MyOtherInterface & {
           __typename?: 'MyType',
           foo: Scalars['String'],
@@ -700,15 +701,15 @@ describe('TypeScript', () => {
 
         type MyType implements MyInterface
         `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
           __typename?: 'MyInterface',
           foo: Scalars['String'],
         };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = MyInterface & {
           __typename?: 'MyType',
         };
@@ -726,15 +727,15 @@ describe('TypeScript', () => {
           bar: String!
         }
         `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
           __typename?: 'MyType',
           foo: MyOtherType,
         };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyOtherType = {
           __typename?: 'MyOtherType',
           bar: Scalars['String'],
@@ -757,9 +758,9 @@ describe('TypeScript', () => {
 
       union MyUnion = MyType | MyOtherType
       `);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type MyUnion = MyType | MyOtherType;
     `);
       validateTs(result);
@@ -773,9 +774,9 @@ describe('TypeScript', () => {
           foo: String
           bar: String!
         }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
           __typename?: 'MyInterface',
           foo?: Maybe<Scalars['String']>,
@@ -795,12 +796,12 @@ describe('TypeScript', () => {
         directive @universal on OBJECT | FIELD_DEFINITION | ENUM_VALUE
       `);
 
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).not.toContain('simple');
-      expect(result).not.toContain('withArguments');
-      expect(result).not.toContain('objSimple');
-      expect(result).not.toContain('universal');
+      expect(result.content).not.toContain('simple');
+      expect(result.content).not.toContain('withArguments');
+      expect(result.content).not.toContain('objSimple');
+      expect(result.content).not.toContain('universal');
       validateTs(result);
     });
   });
@@ -808,9 +809,9 @@ describe('TypeScript', () => {
   describe('Naming Convention & Types Prefix', () => {
     it('Should use custom namingConvention for type name and args typename', async () => {
       const schema = buildSchema(`type MyType { foo(a: String!, b: String, c: [String], d: [Int!]!): String }`);
-      const result = await plugin(schema, [], { namingConvention: 'change-case#lowerCase' }, { outputFile: '' });
+      const result = (await plugin(schema, [], { namingConvention: 'change-case#lowerCase' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type mytypefooargs = {
           a: Scalars['String'],
           b?: Maybe<Scalars['String']>,
@@ -818,7 +819,7 @@ describe('TypeScript', () => {
           d: Array<Scalars['Int']>
         };
     `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type mytype = {
           __typename?: 'MyType',
           foo?: Maybe<Scalars['String']>,
@@ -830,9 +831,9 @@ describe('TypeScript', () => {
 
     it('Should use custom namingConvention and add custom prefix', async () => {
       const schema = buildSchema(`type MyType { foo(a: String!, b: String, c: [String], d: [Int!]!): String }`);
-      const result = await plugin(schema, [], { namingConvention: 'change-case#lowerCase', typesPrefix: 'I' }, { outputFile: '' });
+      const result = (await plugin(schema, [], { namingConvention: 'change-case#lowerCase', typesPrefix: 'I' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type Imytypefooargs = {
           a: Scalars['String'],
           b?: Maybe<Scalars['String']>,
@@ -841,7 +842,7 @@ describe('TypeScript', () => {
         };
       `);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type Imytype = {
           __typename?: 'MyType',
           foo?: Maybe<Scalars['String']>,
@@ -894,16 +895,16 @@ describe('TypeScript', () => {
   `);
 
     it('Should generate correct values when using links between types - lowerCase', async () => {
-      const result = await plugin(schema, [], { namingConvention: 'change-case#lowerCase' }, { outputFile: '' });
+      const result = (await plugin(schema, [], { namingConvention: 'change-case#lowerCase' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export enum myenum {
           a = 'A',
           b = 'B',
           c = 'C'
         }
         `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type mytype = {
           __typename?: 'MyType',
           f?: Maybe<Scalars['String']>,
@@ -912,40 +913,40 @@ describe('TypeScript', () => {
           myOtherField?: Maybe<Scalars['String']>,
         };
         `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type my_type = {
           __typename?: 'My_Type',
           linkTest?: Maybe<mytype>,
         };
         `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type myunion = my_type | mytype;
         `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type some_interface = {
           __typename?: 'Some_Interface',
           id: Scalars['ID'],
         };
         `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type impl1 = some_interface & {
           __typename?: 'Impl1',
           id: Scalars['ID'],
         };
         `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type impl_2 = some_interface & {
           __typename?: 'Impl_2',
           id: Scalars['ID'],
         };
         `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type impl_3 = some_interface & {
           __typename?: 'impl_3',
           id: Scalars['ID'],
         };
         `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type query = {
           __typename?: 'Query',
           something?: Maybe<myunion>,
@@ -957,16 +958,16 @@ describe('TypeScript', () => {
     });
 
     it('Should generate correct values when using links between types - pascalCase (default)', async () => {
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export enum MyEnum {
         A = 'A',
         B = 'B',
         C = 'C'
       }
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type MyType = {
         __typename?: 'MyType',
         f?: Maybe<Scalars['String']>,
@@ -975,40 +976,40 @@ describe('TypeScript', () => {
         myOtherField?: Maybe<Scalars['String']>,
       };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type My_Type = {
         __typename?: 'My_Type',
         linkTest?: Maybe<MyType>,
       };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type MyUnion = My_Type | MyType;
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type Some_Interface = {
         __typename?: 'Some_Interface',
         id: Scalars['ID'],
       };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type Impl1 = Some_Interface & {
         __typename?: 'Impl1',
         id: Scalars['ID'],
       };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type Impl_2 = Some_Interface & {
         __typename?: 'Impl_2',
         id: Scalars['ID'],
       };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type Impl_3 = Some_Interface & {
         __typename?: 'impl_3',
         id: Scalars['ID'],
       };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type Query = {
         __typename?: 'Query',
         something?: Maybe<MyUnion>,
@@ -1020,16 +1021,16 @@ describe('TypeScript', () => {
     });
 
     it('Should generate correct values when using links between types - pascalCase (default) with custom prefix', async () => {
-      const result = await plugin(schema, [], { typesPrefix: 'I' }, { outputFile: '' });
+      const result = (await plugin(schema, [], { typesPrefix: 'I' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export enum IMyEnum {
         A = 'A',
         B = 'B',
         C = 'C'
       }`);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type IMyType = {
         __typename?: 'MyType',
         f?: Maybe<Scalars['String']>,
@@ -1037,38 +1038,38 @@ describe('TypeScript', () => {
         b_a_r?: Maybe<Scalars['String']>,
         myOtherField?: Maybe<Scalars['String']>,
       };`);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type IMy_Type = {
         __typename?: 'My_Type',
         linkTest?: Maybe<IMyType>,
       };
   `);
-      expect(result).toBeSimilarStringTo(`export type IMyUnion = IMy_Type | IMyType;`);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`export type IMyUnion = IMy_Type | IMyType;`);
+      expect(result.content).toBeSimilarStringTo(`
       export type ISome_Interface = {
         __typename?: 'Some_Interface',
         id: Scalars['ID'],
       };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type IImpl1 = ISome_Interface & {
         __typename?: 'Impl1',
         id: Scalars['ID'],
       };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type IImpl_2 = ISome_Interface & {
         __typename?: 'Impl_2',
         id: Scalars['ID'],
       };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type IImpl_3 = ISome_Interface & {
         __typename?: 'impl_3',
         id: Scalars['ID'],
       };
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type IQuery = {
         __typename?: 'Query',
         something?: Maybe<IMyUnion>,
@@ -1084,9 +1085,9 @@ describe('TypeScript', () => {
     it('Should generate correctly types for field arguments - with basic fields', async () => {
       const schema = buildSchema(`type MyType { foo(a: String!, b: String, c: [String], d: [Int!]!): String }`);
 
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
           a: Scalars['String'],
           b?: Maybe<Scalars['String']>,
@@ -1100,9 +1101,9 @@ describe('TypeScript', () => {
 
     it('Should generate correctly types for field arguments - with default value', async () => {
       const schema = buildSchema(`type MyType { foo(a: String = "default", b: String! = "default", c: String): String }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
           a: Scalars['String'],
           b: Scalars['String'],
@@ -1115,9 +1116,9 @@ describe('TypeScript', () => {
 
     it('Should generate correctly types for field arguments - with input type', async () => {
       const schema = buildSchema(`input MyInput { f: String } type MyType { foo(a: MyInput, b: MyInput!, c: [MyInput], d: [MyInput]!, e: [MyInput!]!): String }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
           a?: Maybe<MyInput>,
           b: MyInput,
@@ -1132,15 +1133,15 @@ describe('TypeScript', () => {
 
     it('Should add custom prefix for mutation arguments', async () => {
       const schema = buildSchema(`input Input { name: String } type Mutation { foo(id: ID, input: Input): String }`);
-      const result = await plugin(schema, [], { typesPrefix: 'T' }, { outputFile: '' });
+      const result = (await plugin(schema, [], { typesPrefix: 'T' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type TInput = {
           name?: Maybe<Scalars['String']>,
         };
       `);
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type TMutation = {
           __typename?: 'Mutation',
           foo?: Maybe<Scalars['String']>,
@@ -1170,9 +1171,9 @@ describe('TypeScript', () => {
           books: [Book!]!
         }
       `);
-      const result = await plugin(testSchema, [], {}, { outputFile: '' });
+      const result = (await plugin(testSchema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export type NodeTextArgs = {
           arg1: Scalars['String'],
           arg2?: Maybe<Scalars['String']>
@@ -1185,9 +1186,9 @@ describe('TypeScript', () => {
   describe('Enum', () => {
     it('Should build basic enum correctly', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
-      const result = await plugin(schema, [], {}, { outputFile: '' });
+      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export enum MyEnum {
           A = 'A',
           B = 'B',
@@ -1200,9 +1201,9 @@ describe('TypeScript', () => {
 
     it('Should build enum correctly with custom values', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
-      const result = await plugin(schema, [], { enumValues: { MyEnum: { A: 'SomeValue', B: 'TEST' } } }, { outputFile: '' });
+      const result = (await plugin(schema, [], { enumValues: { MyEnum: { A: 'SomeValue', B: 'TEST' } } }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
         export enum MyEnum {
           A = 'SomeValue',
           B = 'TEST',
@@ -1215,20 +1216,20 @@ describe('TypeScript', () => {
 
     it('Should build enum correctly with custom imported enum', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
-      const result = await plugin(schema, [], { enumValues: { MyEnum: './my-file#MyEnum' } }, { outputFile: '' });
+      const result = (await plugin(schema, [], { enumValues: { MyEnum: './my-file#MyEnum' } }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).not.toContain(`export enum MyEnum`);
-      expect(result).toContain(`import { MyEnum } from './my-file';`);
+      expect(result.content).not.toContain(`export enum MyEnum`);
+      expect(result.prepend).toContain(`import { MyEnum } from './my-file';`);
 
       validateTs(result);
     });
 
     it('Should build enum correctly with custom imported enum with different name', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
-      const result = await plugin(schema, [], { enumValues: { MyEnum: './my-file#MyCustomEnum' } }, { outputFile: '' });
+      const result = (await plugin(schema, [], { enumValues: { MyEnum: './my-file#MyCustomEnum' } }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-      expect(result).not.toContain(`export enum MyEnum`);
-      expect(result).toContain(`import { MyCustomEnum as MyEnum } from './my-file';`);
+      expect(result.content).not.toContain(`export enum MyEnum`);
+      expect(result.prepend).toContain(`import { MyCustomEnum as MyEnum } from './my-file';`);
 
       validateTs(result);
     });
@@ -1260,7 +1261,7 @@ describe('TypeScript', () => {
       }
     `);
 
-    const content = await plugin(schema, [], {}, { outputFile: '' });
+    const content = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
     expect(content).not.toContainEqual('[object Object]');
 
@@ -1289,10 +1290,10 @@ describe('TypeScript', () => {
       }
     `);
 
-    const content = await plugin(schema, [], {}, { outputFile: '' });
-    expect(content).toContain('__typename');
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    expect(result.content).toContain('__typename');
 
-    validateTs(content);
+    validateTs(result);
   });
 
   it('should not contain __typename', async () => {
@@ -1317,9 +1318,9 @@ describe('TypeScript', () => {
       }
     `);
 
-    const content = await plugin(schema, [], { skipTypename: true }, { outputFile: '' });
-    expect(content).not.toContain('__typename');
+    const result = (await plugin(schema, [], { skipTypename: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
+    expect(result.content).not.toContain('__typename');
 
-    validateTs(content);
+    validateTs(result);
   });
 });

--- a/packages/plugins/typescript/typescript/tests/validate.ts
+++ b/packages/plugins/typescript/typescript/tests/validate.ts
@@ -1,8 +1,9 @@
+import { Types } from '@graphql-codegen/plugin-helpers';
 import * as ts from 'typescript';
 import * as path from 'path';
 
 export function validateTs(
-  contents: string,
+  pluginOutput: Types.PluginOutput,
   options: ts.CompilerOptions = {
     noEmitOnError: true,
     noImplicitAny: true,
@@ -39,6 +40,7 @@ export function validateTs(
     options.strictFunctionTypes = true;
   }
 
+  const contents: string = typeof pluginOutput === 'string' ? pluginOutput : [...(pluginOutput.prepend || []), pluginOutput.content, ...(pluginOutput.append || [])].join('\n');
   const testFile = `test-file.${isTsx ? 'tsx' : 'ts'}`;
   const result = ts.createSourceFile(testFile, contents, ts.ScriptTarget.ES2016, false, isTsx ? ts.ScriptKind.TSX : undefined);
 

--- a/packages/plugins/typescript/urql/src/index.ts
+++ b/packages/plugins/typescript/urql/src/index.ts
@@ -68,7 +68,10 @@ export const plugin: PluginFunction<UrqlRawPluginConfig> = (schema: GraphQLSchem
   const visitor = new UrqlVisitor(allFragments, config) as any;
   const visitorResult = visit(allAst, { leave: visitor });
 
-  return [visitor.getImports(), visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n');
+  return {
+    prepend: visitor.getImports(),
+    content: [visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n'),
+  };
 };
 
 export const validate: PluginValidateFn<any> = async (schema: GraphQLSchema, documents: Types.DocumentFile[], config: UrqlRawPluginConfig, outputFile: string) => {

--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -1,4 +1,4 @@
-import { ClientSideBaseVisitor, ClientSideBasePluginConfig, LoadedFragment, getConfigValue } from '@graphql-codegen/visitor-plugin-common';
+import { ClientSideBaseVisitor, ClientSideBasePluginConfig, LoadedFragment, getConfigValue, OMIT_TYPE } from '@graphql-codegen/visitor-plugin-common';
 import { UrqlRawPluginConfig } from './index';
 import * as autoBind from 'auto-bind';
 import { OperationDefinitionNode, Kind } from 'graphql';
@@ -21,7 +21,7 @@ export class UrqlVisitor extends ClientSideBaseVisitor<UrqlRawPluginConfig, Urql
     autoBind(this);
   }
 
-  public getImports(): string {
+  public getImports(): string[] {
     const baseImports = super.getImports();
     const imports = [];
     const hasOperations = this._collectedOperations.length > 0;
@@ -38,9 +38,9 @@ export class UrqlVisitor extends ClientSideBaseVisitor<UrqlRawPluginConfig, Urql
       imports.push(`import * as Urql from '${this.config.urqlImportFrom || 'urql'}';`);
     }
 
-    imports.push(`export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>`);
+    imports.push(OMIT_TYPE);
 
-    return [baseImports, ...imports].join('\n');
+    return [...baseImports, ...imports];
   }
 
   private _buildComponent(node: OperationDefinitionNode, documentVariableName: string, operationType: string, operationResultType: string, operationVariablesTypes: string): string {

--- a/packages/utils/plugins-helpers/src/index.ts
+++ b/packages/utils/plugins-helpers/src/index.ts
@@ -1,3 +1,4 @@
 export { resolveExternalModuleAndFn } from './resolve-external-module-and-fn';
 export { toPascalCase } from './to-pascal-case';
 export * from './types';
+export * from './utils';

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -1,4 +1,5 @@
 import { GraphQLSchema, DocumentNode } from 'graphql';
+import { object } from 'prop-types';
 
 export namespace Types {
   export interface GenerateOptions {
@@ -100,6 +101,13 @@ export namespace Types {
       globalIdentifier?: string;
     };
   }
+
+  export type ComplexPluginOutput = { content: string; prepend?: string[]; append?: string[] };
+  export type PluginOutput = string | ComplexPluginOutput;
+}
+
+export function isComplexPluginOutput(obj: Types.PluginOutput): obj is Types.ComplexPluginOutput {
+  return typeof obj === 'object' && obj.content && typeof obj.content === 'string';
 }
 
 export type PluginFunction<T = any> = (
@@ -111,7 +119,7 @@ export type PluginFunction<T = any> = (
     allPlugins?: Types.ConfiguredPlugin[];
     [key: string]: any;
   }
-) => Types.Promisable<string>;
+) => Types.Promisable<Types.PluginOutput>;
 
 export type PluginValidateFn<T = any> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: T, outputFile: string, allPlugins: Types.ConfiguredPlugin[]) => Types.Promisable<void>;
 

--- a/packages/utils/plugins-helpers/src/utils.ts
+++ b/packages/utils/plugins-helpers/src/utils.ts
@@ -1,0 +1,19 @@
+import { Types } from './types';
+
+export function mergeOutputs(content: Types.PluginOutput | Array<Types.PluginOutput>): string {
+  let result: Types.ComplexPluginOutput = { content: '', prepend: [], append: [] };
+
+  if (Array.isArray(content)) {
+    content.forEach(item => {
+      if (typeof item === 'string') {
+        result.content += item;
+      } else {
+        result.content += item.content;
+        result.prepend.push(...(item.prepend || []));
+        result.append.push(...(item.append || []));
+      }
+    });
+  }
+
+  return [...result.prepend, result.content, ...result.append].join('\n');
+}


### PR DESCRIPTION
This PR allows plugins to return a complex type instead of just `string`. 
Now each plugin can return also array of strings to append and array of string to prepend to the final output of each out files.

This will resolve the following:
- [x] https://github.com/dotansimha/graphql-code-generator/issues/1800 
- [x] https://github.com/dotansimha/graphql-code-generator/issues/1117
- [x] Output will look better, because all general types and all imports will be in the top of the generated file. (will also resolve issues related to eslins imports-order)
