### PR TITLE
Allow specifying customModulePathPrefix with typescript-graphql-files-modules plugin

### DIFF
--- a/packages/plugins/typescript/graphql-files-modules/tests/graphql-files-modules.spec.ts
+++ b/packages/plugins/typescript/graphql-files-modules/tests/graphql-files-modules.spec.ts
@@ -177,4 +177,33 @@ describe('graphql-codegen typescript-graphql-files-modules', () => {
     `);
     validateTs(result);
   });
+
+  it('Should generate simple module with a custom path prefix', async () => {
+    const result = await plugin(
+      null,
+      [
+        {
+          filePath: 'some/file/my-query.graphql',
+          content: parse(/* GraphQL */ `
+            query MyQuery {
+              field
+            }
+          `),
+        },
+      ],
+      { modulePathPrefix: 'api/' },
+      { outputFile: '' }
+    );
+
+    expect(result).toBeSimilarStringTo(`
+      declare module '*/api/my-query.graphql' {
+        import { DocumentNode } from 'graphql';
+        const defaultDocument: DocumentNode;
+        export const MyQuery: DocumentNode;
+      
+        export default defaultDocument;
+      }
+    `);
+    validateTs(result);
+  });
 });


### PR DESCRIPTION
This change would allow specifying a `customModulePathPrefix` when using the `typescript-graphql-files-modules` plugin to generate typings for GraphQL files.

Consider the following project structure:

```
/src
 /api
   /user-service
     queries.graphql
     mutations.graphql
     schema.graphql
     fragments.graphql
   /message-service
     queries.graphql
     mutations.graphql
     schema.graphql
     fragments.graphql
  index.ts
codegen.yml
```

Currently all files generated using the plugin have the following format. The generic module definition glob makes type discovery with intellisense difficult.

```typescript
module "*/FILE_NAME.graphql" { ... }
```

With the changes in place, using the following config would allow for a more specific module definition path.

```yaml
# ...
generates: ./src/api/user-service/queries.d.ts
  schema: ./src/api/user-service/schema.graphql
  documents: ./src/api/user-service/*.graphql
  plugins:
    - typescript-graphql-files-modules
  config:
    customModulePathPrefix: api/user-service/
```

```typescript
module "*/api/user-service/queries.graphql" { ... }
```
