### PR TITLE
Fix relative imports generation in `near-operation-file` preset

### DIFF
--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -117,11 +117,13 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
       return prev;
     }, {});
 
+    const absTypesPath = resolve(baseDir, join(options.baseOutputDir, options.presetConfig.baseTypesPath));
+
     return options.documents
       .map<Types.GenerateOptions | null>(documentFile => {
-        const absTypesPath = resolve(baseDir, join(options.baseOutputDir, options.presetConfig.baseTypesPath));
-        const absFilePath = appendExtensionToFilePath(documentFile.filePath, extension);
-        const relativeImportPath = resolveRelativeImport(absFilePath, absTypesPath);
+        const generatedFilePath = appendExtensionToFilePath(documentFile.filePath, extension);
+        const absGeneratedFilePath = resolve(baseDir, generatedFilePath);
+        const relativeImportPath = resolveRelativeImport(absGeneratedFilePath, absTypesPath);
         const fragmentsInUse = extractExternalFragmentsInUse(documentFile.content, fragmentNameToFile);
         const plugins = [...options.plugins];
 
@@ -135,7 +137,8 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
           const fragmentDetails = fragmentNameToFile[fragmentName];
 
           if (fragmentDetails) {
-            const fragmentImportPath = resolveRelativeImport(absFilePath, fragmentDetails.filePath);
+            const absFragmentFilePath = resolve(baseDir, fragmentDetails.filePath);
+            const fragmentImportPath = resolveRelativeImport(absGeneratedFilePath, absFragmentFilePath);
 
             plugins.unshift({
               add: `import { ${fragmentDetails.importName} } from '${fragmentImportPath}';`,
@@ -154,7 +157,7 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
         plugins.unshift({ add: `import * as ${importTypesNamespace} from '${relativeImportPath}';\n` });
 
         return {
-          filename: absFilePath,
+          filename: generatedFilePath,
           plugins,
           pluginMap,
           config,

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -1,17 +1,17 @@
-import { parse, dirname, relative } from 'path';
+import { parse, dirname, relative, join } from 'path';
 import { DocumentNode, visit, FragmentSpreadNode, FragmentDefinitionNode } from 'graphql';
 import { FragmentNameToFile } from './index';
 
 export function appendExtensionToFilePath(baseFilePath: string, extension: string) {
   const parsedPath = parse(baseFilePath);
 
-  return parsedPath.dir + '/' + parsedPath.name + extension;
+  return join(parsedPath.dir, parsedPath.name + extension).replace(/\\/g, '/');
 }
 
 export function clearExtension(path: string): string {
   const parsedPath = parse(path);
 
-  return parsedPath.dir + '/' + parsedPath.name;
+  return join(parsedPath.dir, parsedPath.name).replace(/\\/g, '/');
 }
 
 export function extractExternalFragmentsInUse(documentNode: DocumentNode | FragmentDefinitionNode, fragmentNameToFile: FragmentNameToFile, result: Set<string> = new Set(), ignoreList: Set<string> = new Set()): Set<string> {
@@ -39,7 +39,7 @@ export function extractExternalFragmentsInUse(documentNode: DocumentNode | Fragm
 
 export function fixLocalFile(path: string): string {
   if (!path.startsWith('..') && !path.startsWith('&&')) {
-    return `.${path}`;
+    return `./${path}`;
   }
 
   return path;

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -1,17 +1,17 @@
-import { parse, dirname, relative, sep } from 'path';
+import { parse, dirname, relative } from 'path';
 import { DocumentNode, visit, FragmentSpreadNode, FragmentDefinitionNode } from 'graphql';
 import { FragmentNameToFile } from './index';
 
 export function appendExtensionToFilePath(baseFilePath: string, extension: string) {
   const parsedPath = parse(baseFilePath);
 
-  return parsedPath.dir + sep + parsedPath.name + extension;
+  return parsedPath.dir + '/' + parsedPath.name + extension;
 }
 
 export function clearExtension(path: string): string {
   const parsedPath = parse(path);
 
-  return parsedPath.dir + sep + parsedPath.name;
+  return parsedPath.dir + '/' + parsedPath.name;
 }
 
 export function extractExternalFragmentsInUse(documentNode: DocumentNode | FragmentDefinitionNode, fragmentNameToFile: FragmentNameToFile, result: Set<string> = new Set(), ignoreList: Set<string> = new Set()): Set<string> {

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -1,4 +1,4 @@
-import { parse, dirname, relative, join } from 'path';
+import { parse, dirname, relative, join, isAbsolute } from 'path';
 import { DocumentNode, visit, FragmentSpreadNode, FragmentDefinitionNode } from 'graphql';
 import { FragmentNameToFile } from './index';
 
@@ -46,5 +46,11 @@ export function fixLocalFile(path: string): string {
 }
 
 export function resolveRelativeImport(from: string, to: string): string {
+  if (!isAbsolute(from)) {
+    throw new Error(`Argument 'from' must be an absolute path, '${from}' given.`);
+  }
+  if (!isAbsolute(to)) {
+    throw new Error(`Argument 'to' must be an absolute path, '${to}' given.`);
+  }
   return fixLocalFile(clearExtension(relative(dirname(from), to)));
 }

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -122,7 +122,7 @@ describe('near-operation-file preset', () => {
         baseTypesPath: 'types.ts',
       },
       schema: schemaDocumentNode,
-      documents: testDocuments,
+      documents: testDocuments.slice(0, 2),
       plugins: [{ typescript: {} }],
       pluginMap: { typescript: {} as any },
     });
@@ -139,7 +139,7 @@ describe('near-operation-file preset', () => {
         baseTypesPath: 'types.ts',
       },
       schema: schemaDocumentNode,
-      documents: testDocuments,
+      documents: testDocuments.slice(0, 2),
       plugins: [{ typescript: {} }],
       pluginMap: { typescript: {} as any },
     });
@@ -156,7 +156,7 @@ describe('near-operation-file preset', () => {
         baseTypesPath: 'types.ts',
       },
       schema: schemaDocumentNode,
-      documents: testDocuments,
+      documents: testDocuments.slice(0, 2),
       plugins: [{ typescript: {} }],
       pluginMap: { typescript: {} as any },
     });
@@ -173,7 +173,7 @@ describe('near-operation-file preset', () => {
         baseTypesPath: 'types.ts',
       },
       schema: schemaDocumentNode,
-      documents: testDocuments,
+      documents: testDocuments.slice(0, 2),
       plugins: [{ typescript: {} }],
       pluginMap: { typescript: {} as any },
     });

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -92,7 +92,7 @@ describe('near-operation-file preset', () => {
       baseOutputDir: './src/',
       config: {},
       presetConfig: {
-        cwd: '/some/deep/path/',
+        cwd: '/some/deep/path',
         baseTypesPath: 'types.ts',
         extension: '.flow.js',
       },
@@ -118,7 +118,7 @@ describe('near-operation-file preset', () => {
       baseOutputDir: './src/',
       config: {},
       presetConfig: {
-        cwd: '/some/deep/path/',
+        cwd: '/some/deep/path',
         baseTypesPath: 'types.ts',
       },
       schema: schemaDocumentNode,
@@ -135,7 +135,7 @@ describe('near-operation-file preset', () => {
       baseOutputDir: './src/',
       config: {},
       presetConfig: {
-        cwd: '/some/deep/path/',
+        cwd: '/some/deep/path',
         baseTypesPath: 'types.ts',
       },
       schema: schemaDocumentNode,
@@ -152,7 +152,7 @@ describe('near-operation-file preset', () => {
       baseOutputDir: './src/',
       config: {},
       presetConfig: {
-        cwd: '/some/deep/path/',
+        cwd: '/some/deep/path',
         baseTypesPath: 'types.ts',
       },
       schema: schemaDocumentNode,
@@ -169,7 +169,7 @@ describe('near-operation-file preset', () => {
       baseOutputDir: './src/',
       config: {},
       presetConfig: {
-        cwd: '/some/deep/path/',
+        cwd: '/some/deep/path',
         baseTypesPath: 'types.ts',
       },
       schema: schemaDocumentNode,

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -130,6 +130,50 @@ describe('near-operation-file preset', () => {
     expect(result.map(o => o.plugins)[0]).toEqual(expect.arrayContaining([{ add: `import * as Types from '../types';\n` }]));
   });
 
+  it('Should prepend the "add" plugin with the correct import (long path)', async () => {
+    const result = await preset.buildGeneratesSection({
+      baseOutputDir: './src/',
+      config: {},
+      presetConfig: {
+        cwd: '/some/deep/path',
+        baseTypesPath: 'types.ts',
+      },
+      schema: schemaDocumentNode,
+      documents: [
+        {
+          filePath: '/some/deep/path/src/graphql/nested/here/me-query.graphql',
+          content: operationAst,
+        },
+        testDocuments[1],
+      ],
+      plugins: [{ typescript: {} }],
+      pluginMap: { typescript: {} as any },
+    });
+    expect(result.map(o => o.plugins)[0]).toEqual(expect.arrayContaining([{ add: `import * as Types from '../../../types';\n` }]));
+  });
+
+  it('Should prepend the "add" plugin with the correct import (siblings)', async () => {
+    const result = await preset.buildGeneratesSection({
+      baseOutputDir: './src/',
+      config: {},
+      presetConfig: {
+        cwd: '/some/deep/path',
+        baseTypesPath: 'types.ts',
+      },
+      schema: schemaDocumentNode,
+      documents: [
+        {
+          filePath: '/some/deep/path/src/me-query.graphql',
+          content: operationAst,
+        },
+        testDocuments[1],
+      ],
+      plugins: [{ typescript: {} }],
+      pluginMap: { typescript: {} as any },
+    });
+    expect(result.map(o => o.plugins)[0]).toEqual(expect.arrayContaining([{ add: `import * as Types from './types';\n` }]));
+  });
+
   it('Should add "add" plugin to plugins map if its not there', async () => {
     const result = await preset.buildGeneratesSection({
       baseOutputDir: './src/',
@@ -188,6 +232,64 @@ describe('near-operation-file preset', () => {
         },
         {
           add: `import { UserFieldsFragment } from './user-fragment.generated';`,
+        },
+      ])
+    );
+  });
+
+  it('Should add import to external fragment when its in use (long path)', async () => {
+    const result = await preset.buildGeneratesSection({
+      baseOutputDir: './src/',
+      config: {},
+      presetConfig: {
+        cwd: '/some/deep/path',
+        baseTypesPath: 'types.ts',
+      },
+      schema: schemaDocumentNode,
+      documents: [
+        {
+          filePath: '/some/deep/path/src/graphql/nested/down/here/me-query.graphql',
+          content: operationAst,
+        },
+        testDocuments[1],
+      ],
+      plugins: [{ typescript: {} }],
+      pluginMap: { typescript: {} as any },
+    });
+
+    expect(result.map(o => o.plugins)[0]).toEqual(
+      expect.arrayContaining([
+        {
+          add: `import { UserFieldsFragment } from '../../../user-fragment.generated';`,
+        },
+      ])
+    );
+  });
+
+  it('Should add import to external fragment when its in use (nested fragment)', async () => {
+    const result = await preset.buildGeneratesSection({
+      baseOutputDir: './src/',
+      config: {},
+      presetConfig: {
+        cwd: '/some/deep/path',
+        baseTypesPath: 'types.ts',
+      },
+      schema: schemaDocumentNode,
+      documents: [
+        testDocuments[0],
+        {
+          filePath: '/some/deep/path/src/graphql/nested/down/here/user-fragment.graphql',
+          content: fragmentAst,
+        },
+      ],
+      plugins: [{ typescript: {} }],
+      pluginMap: { typescript: {} as any },
+    });
+
+    expect(result.map(o => o.plugins)[0]).toEqual(
+      expect.arrayContaining([
+        {
+          add: `import { UserFieldsFragment } from './nested/down/here/user-fragment.generated';`,
         },
       ])
     );


### PR DESCRIPTION
Fixes #1892 (backslashes being used in generated imports on Windows) and also problem with a nested file import where the import would be missing slash after "current directory" dot (`.nested/types` instead of `./nested/types`).

I've used a regex to replace backslashes with slashes. Let me know if you want me to use a library like https://www.npmjs.com/package/normalize-path or https://www.npmjs.com/package/slash instead.