### PR TITLE
Update add plugin with output section selection

### DIFF
--- a/docs/plugins/add.md
+++ b/docs/plugins/add.md
@@ -10,10 +10,19 @@ You can use this plugin to add custom code, imports, comments and more to your o
 ## Installation
 
     $ yarn add -D @graphql-codegen/add
-    
-    
+
 > Notice that the order of plugins in the yaml config matters.
 > If you need to add something to the top of the file, for example `/* eslint-disable */`, makes sure to place the `add` plugin before the other plugins, so their output won't be on top of the `add` addition.
+
+## Input parameters
+
+To control in which section of output the text will be added, the input can be specified
+as an object. The object takes two parameters:
+
+- `placement`: Optional specification of output section of added text
+  - Input: `'prepend' | 'content' | 'append'`
+  - Default: `'prepend'`
+- `content`: Content to add to file, can be text or an array/list of strings
 
 ## Examples
 
@@ -22,6 +31,13 @@ You can use this plugin to add custom code, imports, comments and more to your o
 generates:
   path/to/file.ts:
     plugins:
-      - add: '// THIS IS A GENERATED FILE'
+      - add: '/* tslint:disable */'
+      - add:
+          content:
+            - ''
+            - 'declare namespace GraphQL {'
+      - add:
+          placement: 'append'
+          content: '}'
       - typescript
 ```

--- a/packages/plugins/other/add/src/index.ts
+++ b/packages/plugins/other/add/src/index.ts
@@ -1,13 +1,34 @@
 import { GraphQLSchema } from 'graphql';
 import { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
 
-export type AddPluginConfig = string | string[];
+type ContentType = string | string[] | { [index: string]: string };
+interface AddPluginParams {
+  placement: string;
+  content: ContentType;
+}
+export type AddPluginConfig = string | AddPluginParams;
+
+const asFileString = (content: ContentType) => {
+  const asArray = Array.isArray(content) ? content : typeof content === 'object' ? Object.keys(content).map(k => content[k]) : [content];
+  return asArray.filter(a => typeof a === 'string');
+};
 
 export const plugin: PluginFunction<AddPluginConfig> = async (schema: GraphQLSchema, documents: Types.DocumentFile[], config: AddPluginConfig): Promise<Types.PluginOutput> => {
-  const asArray = Array.isArray(config) ? config : typeof config === 'object' ? Object.keys(config).map(k => config[k]) : [config];
+  // Will always be object if specified as array or object
+  if (typeof config !== 'object') { return { content: null, prepend: asFileString(config) }; }
+
+  let placement = config.placement;
+  let content = config.content;
+
+  if (placement && placement !== 'prepend' && placement !== 'content' && placement !== 'append') {
+    throw Error('Add plugin, faulty placement option');
+  }
+  if (!placement) { placement = 'prepend'; }
+
+  if (!content) { throw Error('Add plugin, missing content'); }
 
   return {
-    prepend: asArray.filter(a => a),
     content: null,
+    [placement]: asFileString(content),
   };
 };


### PR DESCRIPTION
Add functionality to add plugin so that it is possible to select which output section the text should end up in.

This supports such use cases such as wrapping the output in a namespace, etc.