### PR TITLE
Update documentation for `skipTypename` and `nonOptionalTypename`

### DIFF
--- a/docs/generated-config/base-documents-visitor.md
+++ b/docs/generated-config/base-documents-visitor.md
@@ -1,10 +1,21 @@
 ### skipTypename (`boolean`, default value: `false`)
 
-Automatically adds `__typename` field to the generated types, even when they are not specified in the selection set.
+When `false`, automatically adds an optional `__typename` field to the generated types, even when not specified in the selection set.
 
 #### Usage Example
 
 ```yml
 config:
   skipTypename: true
+```
+
+### nonOptionalTypename (`boolean`, default value: `false`)
+
+When `true`, makes the `__typename` field non-optional on generated types, even when not specified in the selection set.
+
+#### Usage Example
+
+```yml
+config:
+  nonOptionalTypename: true
 ```


### PR DESCRIPTION
This adds documentation for `nonOptionalTypename` (introduced in https://github.com/dotansimha/graphql-code-generator/pull/1879) and clarifies the behavior of `skipTypename` a bit.

I _think_ I put this in the right markdown document, given that `skipTypename` is also here, but happy to relocate if there's a better place 🙂 