### PR TITLE
Fix QueryHookOptions for @apollo/react-hooks

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -128,7 +128,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
 
     this.imports.add(this.getReactApolloHooksImport());
     return `
-export function use${operationName}(baseOptions?: ReactApolloHooks.${operationType}HookOptions<${node.operation !== 'query' ? `${operationResultType}, ` : ''}${operationVariablesTypes}>) {
+export function use${operationName}(baseOptions?: ReactApolloHooks.${operationType}HookOptions<${this.config.hooksImportFrom === '@apollo/react-hooks' || node.operation !== 'query' ? `${operationResultType}, ` : ''}${operationVariablesTypes}>) {
   return ReactApolloHooks.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, baseOptions);
 };`;
   }


### PR DESCRIPTION
Implements the solution as suggested by @dotansimha in https://github.com/dotansimha/graphql-code-generator/issues/1863#issuecomment-496586940

It checks whether `hooksImportFrom` is set to `@apollo/react-hooks`, if so, it outputs the signature that `@apollo/react-hooks` expects, otherwise it defaults to the signature that is compatible with `react-apollo-hooks`.

One quick thing to mention, I tested this change rather quickly by manually editing the visitor in my node_modules, let me know if somethings not right!