### PR TITLE
Update the live demo to include the missing stencil apollo dependency

### DIFF
--- a/website/live-demo/package.json
+++ b/website/live-demo/package.json
@@ -27,6 +27,7 @@
     "@graphql-codegen/typescript-operations": "1.2.0",
     "@graphql-codegen/typescript-react-apollo": "1.2.0",
     "@graphql-codegen/typescript-resolvers": "1.2.0",
+    "@graphql-codegen/typescript-stencil-apollo": "^1.2.0",
     "@graphql-codegen/typescript-urql": "1.2.0",
     "@material-ui/core": "4.0.2",
     "codemirror": "5.47.0",


### PR DESCRIPTION
I think this should fix https://github.com/dotansimha/graphql-code-generator/issues/1959

Just based on the fact that when I tried to run this package locally, it wouldn't run without this dependency