### PR TITLE
fix(typescript-operations): wrong type for variable with default value ( #1934)

### DIFF
--- a/packages/plugins/typescript/operations/src/ts-operation-variables-to-object.ts
+++ b/packages/plugins/typescript/operations/src/ts-operation-variables-to-object.ts
@@ -1,13 +1,6 @@
 import { TypeScriptOperationVariablesToObject as TSOperationVariablesToObject } from '@graphql-codegen/typescript';
 
 export class TypeScriptOperationVariablesToObject extends TSOperationVariablesToObject {
-  protected formatFieldString(fieldName: string, isNonNullType: boolean, hasDefaultValue: boolean): string {
-    if (hasDefaultValue) {
-      return `${fieldName}?`;
-    }
-
-    return super.formatFieldString(fieldName, isNonNullType, hasDefaultValue);
-  }
   protected formatTypeString(fieldType: string, isNonNullType: boolean, hasDefaultValue: boolean): string {
     return fieldType;
   }

--- a/packages/plugins/typescript/operations/src/ts-operation-variables-to-object.ts
+++ b/packages/plugins/typescript/operations/src/ts-operation-variables-to-object.ts
@@ -1,6 +1,13 @@
 import { TypeScriptOperationVariablesToObject as TSOperationVariablesToObject } from '@graphql-codegen/typescript';
 
 export class TypeScriptOperationVariablesToObject extends TSOperationVariablesToObject {
+  protected formatFieldString(fieldName: string, isNonNullType: boolean, hasDefaultValue: boolean): string {
+    if (hasDefaultValue) {
+      return `${fieldName}?`;
+    }
+
+    return super.formatFieldString(fieldName, isNonNullType, hasDefaultValue);
+  }
   protected formatTypeString(fieldType: string, isNonNullType: boolean, hasDefaultValue: boolean): string {
     return fieldType;
   }

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -1282,7 +1282,7 @@ describe('TypeScript Operations Plugin', () => {
 
       expect(content).toBeSimilarStringTo(`
         export type UsersQueryVariables = {
-          reverse: Maybe<Scalars['Boolean']>
+          reverse?: Maybe<Scalars['Boolean']>
         };
       `);
     });

--- a/packages/plugins/typescript/typescript/src/typescript-variables-to-object.ts
+++ b/packages/plugins/typescript/typescript/src/typescript-variables-to-object.ts
@@ -34,11 +34,10 @@ export class TypeScriptOperationVariablesToObject extends OperationVariablesToOb
   }
 
   protected formatFieldString(fieldName: string, isNonNullType: boolean, hasDefaultValue: boolean): string {
-    if ((!hasDefaultValue && isNonNullType) || this._avoidOptionals) {
+    if (!hasDefaultValue && (this._avoidOptionals || isNonNullType)) {
       return fieldName;
-    } else {
-      return `${fieldName}?`;
     }
+    return `${fieldName}?`;
   }
 
   protected formatTypeString(fieldType: string, isNonNullType: boolean, hasDefaultValue: boolean): string {

--- a/packages/plugins/typescript/typescript/src/typescript-variables-to-object.ts
+++ b/packages/plugins/typescript/typescript/src/typescript-variables-to-object.ts
@@ -34,7 +34,7 @@ export class TypeScriptOperationVariablesToObject extends OperationVariablesToOb
   }
 
   protected formatFieldString(fieldName: string, isNonNullType: boolean, hasDefaultValue: boolean): string {
-    if (hasDefaultValue || isNonNullType || this._avoidOptionals) {
+    if ((!hasDefaultValue && isNonNullType) || this._avoidOptionals) {
       return fieldName;
     } else {
       return `${fieldName}?`;
@@ -42,7 +42,7 @@ export class TypeScriptOperationVariablesToObject extends OperationVariablesToOb
   }
 
   protected formatTypeString(fieldType: string, isNonNullType: boolean, hasDefaultValue: boolean): string {
-    if (hasDefaultValue) {
+    if (!hasDefaultValue && isNonNullType) {
       return this.clearOptional(fieldType);
     }
 

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1376,6 +1376,22 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
+    it('Should generate correctly types for field arguments - with default value and avoidOptionals option set to true', async () => {
+      const schema = buildSchema(`type MyType { foo(a: String = "default", b: String! = "default", c: String, d: String!): String }`);
+      const result = (await plugin(schema, [], { avoidOptionals: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type MyTypeFooArgs = {
+          a?: Maybe<Scalars['String']>,
+          b?: Scalars['String'],
+          c: Maybe<Scalars['String']>,
+          d: Scalars['String']
+      };
+    `);
+
+      validateTs(result);
+    });
+
     it('Should generate correctly types for field arguments - with input type', async () => {
       const schema = buildSchema(`input MyInput { f: String } type MyType { foo(a: MyInput, b: MyInput!, c: [MyInput], d: [MyInput]!, e: [MyInput!]!): String }`);
       const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1361,14 +1361,15 @@ describe('TypeScript', () => {
     });
 
     it('Should generate correctly types for field arguments - with default value', async () => {
-      const schema = buildSchema(`type MyType { foo(a: String = "default", b: String! = "default", c: String): String }`);
+      const schema = buildSchema(`type MyType { foo(a: String = "default", b: String! = "default", c: String, d: String!): String }`);
       const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
-          a: Scalars['String'],
-          b: Scalars['String'],
-          c?: Maybe<Scalars['String']>
+          a?: Maybe<Scalars['String']>,
+          b?: Scalars['String'],
+          c?: Maybe<Scalars['String']>,
+          d: Scalars['String']
         };
     `);
 


### PR DESCRIPTION
Related #1934

`typescript-operations` generates false types for operation variables width default values.

Example:

```graphql
query foo($var: String = "test") {
  foo(var: $var)
}
```

**Generated Types:**

```typescript
export type FooQueryVariables = {
  var: Maybe<Scalars['String']>
};
```

**Expected Types:**

```diff
export type FooQueryVariables = {
-  var: Maybe<Scalars['String']>
+  var?: Maybe<Scalars['String']>
};
```

More details can be found in https://github.com/dotansimha/graphql-code-generator/issues/1934