### PR TITLE
Incorrect example in write-your-plugin

### DIFF
--- a/docs/custom-codegen/write-your-plugin.md
+++ b/docs/custom-codegen/write-your-plugin.md
@@ -62,7 +62,7 @@ module.exports = {
   plugin: (schema, documents, config, info) => {
     return documents
       .map(doc => {
-        const docsNames = doc.definitions.map(def => def.name.value);
+        const docsNames = doc.content.definitions.map(def => def.name.value);
 
         return `File ${doc.filePath} contains: ${docsNames.join(', ')}`;
       })


### PR DESCRIPTION
In the description just above you state that documents is an array of type `{ filePath: string, content: DocumentNode }` but then in the subsequent example `definitions` is accessed directly instead of first via `content`.