### PR TITLE
Use the proper output filename when invoking prettier

### DIFF
--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -242,7 +242,7 @@ export async function executeCodegen(config: Types.Config): Promise<Types.FileOu
                         const output = await codegen(outputArgs);
                         result.push({
                           filename: outputArgs.filename,
-                          content: await prettify(filename, output),
+                          content: await prettify(outputArgs.filename, output),
                         });
                       }
                     }, filename),


### PR DESCRIPTION
When using `near-operation-file` where the configuration doesn't point to a file, prettier was invoked incorrectly

For example, with this:
```yml
 ./packages/app/src:
    preset: near-operation-file
```

The filename passed to prettier was `./packages/app/src` and not the actual generated file name