### PR TITLE
Improve performance by not building schema AST over and over

### DIFF
--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -16,7 +16,7 @@ export async function executeCodegen(config: Types.Config): Promise<Types.FileOu
   function wrapTask(task: () => void | Promise<void>, source?: string) {
     return async () => {
       try {
-        await task();
+        await Promise.resolve(task());
       } catch (error) {
         if (source && !(error instanceof GraphQLError)) {
           error.source = source;

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -5,7 +5,7 @@ import { normalizeOutputParam, normalizeInstanceOrArray, normalizeConfig } from 
 import { prettify } from './utils/prettier';
 import { Renderer } from './utils/listr-renderer';
 import { loadSchema, loadDocuments } from './load';
-import { GraphQLError, DocumentNode } from 'graphql';
+import { GraphQLError, DocumentNode, buildASTSchema } from 'graphql';
 import { getPluginByName } from './plugins';
 import { getPresetByName } from './presets';
 import { debugLog } from './utils/debugging';
@@ -221,6 +221,7 @@ export async function executeCodegen(config: Types.Config): Promise<Types.FileOu
                           presetConfig: outputConfig.presetConfig || {},
                           plugins: normalizedPluginsArray,
                           schema: outputSchema,
+                          schemaAst: buildASTSchema(outputSchema),
                           documents: outputDocuments,
                           config: mergedConfig,
                           pluginMap,
@@ -231,6 +232,7 @@ export async function executeCodegen(config: Types.Config): Promise<Types.FileOu
                             filename,
                             plugins: normalizedPluginsArray,
                             schema: outputSchema,
+                            schemaAst: buildASTSchema(outputSchema),
                             documents: outputDocuments,
                             config: mergedConfig,
                             pluginMap,
@@ -238,13 +240,15 @@ export async function executeCodegen(config: Types.Config): Promise<Types.FileOu
                         ];
                       }
 
-                      for (const outputArgs of outputs) {
+                      const process = async (outputArgs: Types.GenerateOptions) => {
                         const output = await codegen(outputArgs);
                         result.push({
                           filename: outputArgs.filename,
                           content: await prettify(filename, output),
                         });
-                      }
+                      };
+
+                      await Promise.all(outputs.map(process));
                     }, filename),
                   },
                 ],

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -1,5 +1,5 @@
 import { Types, isComplexPluginOutput } from '@graphql-codegen/plugin-helpers';
-import { DocumentNode, visit } from 'graphql';
+import { DocumentNode, visit, buildASTSchema } from 'graphql';
 import { mergeSchemas } from './merge-schemas';
 import { executePlugin } from './execute-plugin';
 import { DetailedError } from './errors';
@@ -16,9 +16,19 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
   const pluginPackages = Object.keys(options.pluginMap).map(key => options.pluginMap[key]);
 
   // merged schema with parts added by plugins
+  let schemaChanged = false;
   const schema = pluginPackages.reduce((schema, plugin) => {
-    return !plugin.addToSchema ? schema : mergeSchemas([schema, plugin.addToSchema]);
+    if (!plugin.addToSchema) {
+      return schema;
+    }
+
+    schemaChanged = true;
+    return mergeSchemas([schema, plugin.addToSchema]);
   }, options.schema);
+
+  if (schemaChanged) {
+    options.schemaAst = buildASTSchema(schema);
+  }
 
   const prepend: Set<string> = new Set<string>();
   const append: Set<string> = new Set<string>();

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -39,6 +39,7 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
                 ...(pluginConfig as object),
               },
         schema,
+        schemaAst: options.schemaAst,
         documents: options.documents,
         outputFilename: options.filename,
         allPlugins: options.plugins,

--- a/packages/graphql-codegen-core/src/execute-plugin.ts
+++ b/packages/graphql-codegen-core/src/execute-plugin.ts
@@ -7,6 +7,7 @@ export interface ExecutePluginOptions {
   name: string;
   config: Types.PluginConfig;
   schema: DocumentNode;
+  schemaAst?: GraphQLSchema;
   documents: Types.DocumentFile[];
   outputFilename: string;
   allPlugins: Types.ConfiguredPlugin[];
@@ -30,7 +31,7 @@ export async function executePlugin(options: ExecutePluginOptions, plugin: Codeg
     );
   }
 
-  const outputSchema: GraphQLSchema = buildASTSchema(options.schema);
+  const outputSchema: GraphQLSchema = options.schemaAst || buildASTSchema(options.schema);
   const documents = options.documents || [];
 
   if (outputSchema && documents.length > 0) {
@@ -51,8 +52,10 @@ export async function executePlugin(options: ExecutePluginOptions, plugin: Codeg
     }
   }
 
-  return plugin.plugin(outputSchema, documents, options.config, {
-    outputFile: options.outputFilename,
-    allPlugins: options.allPlugins,
-  });
+  return await Promise.resolve(
+    plugin.plugin(outputSchema, documents, options.config, {
+      outputFile: options.outputFilename,
+      allPlugins: options.allPlugins,
+    })
+  );
 }

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -162,6 +162,7 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
           pluginMap,
           config,
           schema: options.schema,
+          schemaAst: options.schemaAst,
           documents: [documentFile],
         };
       })

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -6,6 +6,7 @@ export namespace Types {
     filename: string;
     plugins: Types.ConfiguredPlugin[];
     schema: DocumentNode;
+    schemaAst?: GraphQLSchema;
     documents: Types.DocumentFile[];
     config: { [key: string]: any };
     pluginMap: {
@@ -64,6 +65,7 @@ export namespace Types {
     baseOutputDir: string;
     plugins: Types.ConfiguredPlugin[];
     schema: DocumentNode;
+    schemaAst?: GraphQLSchema;
     documents: Types.DocumentFile[];
     config: { [key: string]: any };
     pluginMap: {


### PR DESCRIPTION
Each plugin being executed was generating an AST of the schema over and over again, which was especially painful when using `near-operations-file`.

With this change the AST is built early, and only rebuilt in situations where it isn't passed to the plugin for whatever reason, or a plugin changes the schema.

In my project it decreased execution time from 10s to 4s (250%)

Before
![image](https://user-images.githubusercontent.com/2027834/60302393-1d463400-9934-11e9-98c5-f7abb24bfd9d.png)

After
![image](https://user-images.githubusercontent.com/2027834/60302408-22a37e80-9934-11e9-9aae-709e04fb36c7.png)

There's probably still more that could be done, but this takes care of the worst bits

Addresses the performance issues mentioned on #2069