### PR TITLE
Set comment descriptions to false by default

### DIFF
--- a/packages/plugins/other/schema-ast/src/index.ts
+++ b/packages/plugins/other/schema-ast/src/index.ts
@@ -3,7 +3,7 @@ import { PluginFunction, PluginValidateFn, Types } from '@graphql-codegen/plugin
 import { extname } from 'path';
 
 export const plugin: PluginFunction = async (schema: GraphQLSchema): Promise<string> => {
-  return printSchema(schema, { commentDescriptions: true });
+  return printSchema(schema, { commentDescriptions: false });
 };
 
 export const validate: PluginValidateFn<any> = async (schema: GraphQLSchema, documents: Types.DocumentFile[], config: any, outputFile: string, allPlugins: Types.ConfiguredPlugin[]) => {


### PR DESCRIPTION
By setting the comment descriptions to false, comments in the `.graphql` files will also be included in introspection after code generation.

Currently (with the default `true`), comments are not included in introspection.