### PR TITLE
Strip all extraneous type import characters

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -269,7 +269,7 @@ export function getRootTypeNames(schema: GraphQLSchema): string[] {
 }
 
 export function stripMapperTypeInterpolation(identifier: string): string {
-  return identifier.includes('{T}') ? identifier.replace(/<.*?>/g, '') : identifier;
+  return identifier.trim().replace(/[^$\w].*$/, '');
 }
 
 export const OMIT_TYPE = 'export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;';


### PR DESCRIPTION
Closes the same issue as https://github.com/dotansimha/graphql-code-generator/pull/1166 that's re-appeared in the refactor.