### PR TITLE
Try to pre-resolve types in order to avoid `Pick`

### DIFF
--- a/dev-test/codegen.yml
+++ b/dev-test/codegen.yml
@@ -63,6 +63,23 @@ generates:
     plugins:
       - typescript
       - typescript-operations
+  ./dev-test/githunt/types.preResolveTypes.ts:
+    schema: ./dev-test/githunt/schema.json
+    documents: ./dev-test/githunt/**/*.graphql
+    config:
+      preResolveTypes: true
+    plugins:
+      - typescript
+      - typescript-operations
+  ./dev-test/githunt/types.preResolveTypes.compatibility.ts:
+    schema: ./dev-test/githunt/schema.json
+    documents: ./dev-test/githunt/**/*.graphql
+    config:
+      preResolveTypes: true
+    plugins:
+      - typescript
+      - typescript-operations
+      - typescript-compatibility
   ./dev-test/githunt/types.enumsAsTypes.ts:
     schema: ./dev-test/githunt/schema.json
     documents: ./dev-test/githunt/**/*.graphql

--- a/dev-test/codegen.yml
+++ b/dev-test/codegen.yml
@@ -120,6 +120,16 @@ generates:
       - typescript
       - typescript-operations
       - typescript-react-apollo
+  ./dev-test/githunt/types.reactApollo.preResolveTypes.tsx:
+    schema: ./dev-test/githunt/schema.json
+    documents: ./dev-test/githunt/**/*.graphql
+    config:
+      preResolveTypes: true
+    plugins:
+      - add: // tslint:disable
+      - typescript
+      - typescript-operations
+      - typescript-react-apollo
   ./dev-test/githunt/types.reactApollo.hooks.tsx:
     schema: ./dev-test/githunt/schema.json
     documents: ./dev-test/githunt/**/*.graphql
@@ -155,6 +165,14 @@ generates:
   ./dev-test/star-wars/types.ts:
     schema: ./dev-test/star-wars/schema.json
     documents: ./dev-test/star-wars/**/*.graphql
+    plugins:
+      - typescript
+      - typescript-operations
+  ./dev-test/star-wars/types.preResolveTypes.ts:
+    schema: ./dev-test/star-wars/schema.json
+    documents: ./dev-test/star-wars/**/*.graphql
+    config:
+      preResolveTypes: true
     plugins:
       - typescript
       - typescript-operations

--- a/dev-test/githunt/types.preResolveTypes.compatibility.ts
+++ b/dev-test/githunt/types.preResolveTypes.compatibility.ts
@@ -1,0 +1,308 @@
+export type Maybe<T> = T | null;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+/** A comment about an entry, submitted by a user */
+export type Comment = {
+  __typename?: 'Comment';
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** The GitHub user who posted the comment */
+  postedBy: User;
+  /** A timestamp of when the comment was posted */
+  createdAt: Scalars['Float'];
+  /** The text of the comment */
+  content: Scalars['String'];
+  /** The repository which this comment is about */
+  repoName: Scalars['String'];
+};
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type Entry = {
+  __typename?: 'Entry';
+  /** Information about the repository from GitHub */
+  repository: Repository;
+  /** The GitHub user who submitted this entry */
+  postedBy: User;
+  /** A timestamp of when the entry was submitted */
+  createdAt: Scalars['Float'];
+  /** The score of this repository, upvotes - downvotes */
+  score: Scalars['Int'];
+  /** The hot score of this repository */
+  hotScore: Scalars['Float'];
+  /** Comments posted about this repository */
+  comments: Array<Maybe<Comment>>;
+  /** The number of comments posted about this repository */
+  commentCount: Scalars['Int'];
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** XXX to be changed */
+  vote: Vote;
+};
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type EntryCommentsArgs = {
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  /** Sort by a combination of freshness and score, using Reddit's algorithm */
+  Hot = 'HOT',
+  /** Newest entries first */
+  New = 'NEW',
+  /** Highest score entries first */
+  Top = 'TOP',
+}
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** Submit a new repository, returns the new submission */
+  submitRepository?: Maybe<Entry>;
+  /** Vote on a repository submission, returns the submission that was voted on */
+  vote?: Maybe<Entry>;
+  /** Comment on a repository, returns the new comment */
+  submitComment?: Maybe<Comment>;
+};
+
+export type MutationSubmitRepositoryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+export type MutationVoteArgs = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+export type MutationSubmitCommentArgs = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+export type Query = {
+  __typename?: 'Query';
+  /** A feed of repository submissions */
+  feed?: Maybe<Array<Maybe<Entry>>>;
+  /** A single entry */
+  entry?: Maybe<Entry>;
+  /** Return the currently logged in user, or null if nobody is logged in */
+  currentUser?: Maybe<User>;
+};
+
+export type QueryFeedArgs = {
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+export type QueryEntryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/** A repository object from the GitHub API. This uses the exact field names returned by the
+ * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
+ */
+export type Repository = {
+  __typename?: 'Repository';
+  /** Just the name of the repository, e.g. GitHunt-API */
+  name: Scalars['String'];
+  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
+  full_name: Scalars['String'];
+  /** The description of the repository */
+  description?: Maybe<Scalars['String']>;
+  /** The link to the repository on GitHub */
+  html_url: Scalars['String'];
+  /** The number of people who have starred this repository on GitHub */
+  stargazers_count: Scalars['Int'];
+  /** The number of open issues on this repository on GitHub */
+  open_issues_count?: Maybe<Scalars['Int']>;
+  /** The owner of this repository on GitHub, e.g. apollostack */
+  owner?: Maybe<User>;
+};
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** Subscription fires on every comment added */
+  commentAdded?: Maybe<Comment>;
+};
+
+export type SubscriptionCommentAddedArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export type User = {
+  __typename?: 'User';
+  /** The name of the user, e.g. apollostack */
+  login: Scalars['String'];
+  /** The URL to a directly embeddable image for this user's avatar */
+  avatar_url: Scalars['String'];
+  /** The URL of this user's GitHub page */
+  html_url: Scalars['String'];
+};
+
+/** XXX to be removed */
+export type Vote = {
+  __typename?: 'Vote';
+  vote_value: Scalars['Int'];
+};
+
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  Up = 'UP',
+  Down = 'DOWN',
+  Cancel = 'CANCEL',
+}
+export type OnCommentAddedSubscriptionVariables = {
+  repoFullName: Scalars['String'];
+};
+
+export type OnCommentAddedSubscription = { __typename?: 'Subscription'; commentAdded: Maybe<{ __typename?: 'Comment'; id: number; createdAt: number; content: string; postedBy: { __typename?: 'User'; login: string; html_url: string } }> };
+
+export type CommentQueryVariables = {
+  repoFullName: Scalars['String'];
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+export type CommentQuery = {
+  __typename?: 'Query';
+  currentUser: Maybe<{ __typename?: 'User'; login: string; html_url: string }>;
+  entry: Maybe<{
+    __typename?: 'Entry';
+    id: number;
+    createdAt: number;
+    commentCount: number;
+    postedBy: { __typename?: 'User'; login: string; html_url: string };
+    comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
+    repository: { __typename?: 'Repository'; full_name: string; html_url: string } & { __typename?: 'Repository'; description: string; open_issues_count: number; stargazers_count: number };
+  }>;
+};
+
+export type CommentsPageCommentFragment = { __typename?: 'Comment'; id: number; createdAt: number; content: string; postedBy: { __typename?: 'User'; login: string; html_url: string } };
+
+export type CurrentUserForProfileQueryVariables = {};
+
+export type CurrentUserForProfileQuery = { __typename?: 'Query'; currentUser: Maybe<{ __typename?: 'User'; login: string; avatar_url: string }> };
+
+export type FeedEntryFragment = {
+  __typename?: 'Entry';
+  id: number;
+  commentCount: number;
+  repository: { __typename?: 'Repository'; full_name: string; html_url: string; owner: Maybe<{ __typename?: 'User'; avatar_url: string }> };
+} & (VoteButtonsFragment & RepoInfoFragment);
+
+export type FeedQueryVariables = {
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+export type FeedQuery = { __typename?: 'Query'; currentUser: Maybe<{ __typename?: 'User'; login: string }>; feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>> };
+
+export type SubmitRepositoryMutationVariables = {
+  repoFullName: Scalars['String'];
+};
+
+export type SubmitRepositoryMutation = { __typename?: 'Mutation'; submitRepository: Maybe<{ __typename?: 'Entry'; createdAt: number }> };
+
+export type RepoInfoFragment = {
+  __typename?: 'Entry';
+  createdAt: number;
+  repository: { __typename?: 'Repository'; description: string; stargazers_count: number; open_issues_count: number };
+  postedBy: { __typename?: 'User'; html_url: string; login: string };
+};
+
+export type SubmitCommentMutationVariables = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+export type SubmitCommentMutation = { __typename?: 'Mutation'; submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment> };
+
+export type VoteButtonsFragment = { __typename?: 'Entry'; score: number; vote: { __typename?: 'Vote'; vote_value: number } };
+
+export type VoteMutationVariables = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+export type VoteMutation = { __typename?: 'Mutation'; vote: Maybe<{ __typename?: 'Entry'; score: number; id: number; vote: { __typename?: 'Vote'; vote_value: number } }> };
+export namespace OnCommentAdded {
+  export type Variables = OnCommentAddedSubscriptionVariables;
+  export type Subscription = OnCommentAddedSubscription;
+  export type CommentAdded = NonNullable<OnCommentAddedSubscription['commentAdded']>;
+  export type PostedBy = (NonNullable<OnCommentAddedSubscription['commentAdded']>)['postedBy'];
+}
+
+export namespace Comment {
+  export type Variables = CommentQueryVariables;
+  export type Query = CommentQuery;
+  export type CurrentUser = NonNullable<CommentQuery['currentUser']>;
+  export type Entry = NonNullable<CommentQuery['entry']>;
+  export type PostedBy = (NonNullable<CommentQuery['entry']>)['postedBy'];
+  export type Comments = CommentsPageCommentFragment;
+  export type Repository = (NonNullable<CommentQuery['entry']>)['repository'];
+  export type RepositoryInlineFragment = { __typename: 'Repository' } & Pick<(NonNullable<CommentQuery['entry']>)['repository'], 'description' | 'open_issues_count' | 'stargazers_count'>;
+}
+
+export namespace CommentsPageComment {
+  export type Fragment = CommentsPageCommentFragment;
+  export type PostedBy = CommentsPageCommentFragment['postedBy'];
+}
+
+export namespace CurrentUserForProfile {
+  export type Variables = CurrentUserForProfileQueryVariables;
+  export type Query = CurrentUserForProfileQuery;
+  export type CurrentUser = NonNullable<CurrentUserForProfileQuery['currentUser']>;
+}
+
+export namespace FeedEntry {
+  export type Fragment = RepoInfoFragment;
+  export type Repository = FeedEntryFragment['repository'];
+  export type Owner = NonNullable<FeedEntryFragment['repository']['owner']>;
+}
+
+export namespace Feed {
+  export type Variables = FeedQueryVariables;
+  export type Query = FeedQuery;
+  export type CurrentUser = NonNullable<FeedQuery['currentUser']>;
+  export type Feed = FeedEntryFragment;
+}
+
+export namespace SubmitRepository {
+  export type Variables = SubmitRepositoryMutationVariables;
+  export type Mutation = SubmitRepositoryMutation;
+  export type SubmitRepository = NonNullable<SubmitRepositoryMutation['submitRepository']>;
+}
+
+export namespace RepoInfo {
+  export type Fragment = RepoInfoFragment;
+  export type Repository = RepoInfoFragment['repository'];
+  export type PostedBy = RepoInfoFragment['postedBy'];
+}
+
+export namespace SubmitComment {
+  export type Variables = SubmitCommentMutationVariables;
+  export type Mutation = SubmitCommentMutation;
+  export type SubmitComment = CommentsPageCommentFragment;
+}
+
+export namespace VoteButtons {
+  export type Fragment = VoteButtonsFragment;
+  export type Vote = VoteButtonsFragment['vote'];
+}
+
+export namespace Vote {
+  export type Variables = VoteMutationVariables;
+  export type Mutation = VoteMutation;
+  export type Vote = NonNullable<VoteMutation['vote']>;
+  export type _Vote = (NonNullable<VoteMutation['vote']>)['vote'];
+}

--- a/dev-test/githunt/types.preResolveTypes.ts
+++ b/dev-test/githunt/types.preResolveTypes.ts
@@ -1,0 +1,237 @@
+export type Maybe<T> = T | null;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+/** A comment about an entry, submitted by a user */
+export type Comment = {
+  __typename?: 'Comment';
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** The GitHub user who posted the comment */
+  postedBy: User;
+  /** A timestamp of when the comment was posted */
+  createdAt: Scalars['Float'];
+  /** The text of the comment */
+  content: Scalars['String'];
+  /** The repository which this comment is about */
+  repoName: Scalars['String'];
+};
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type Entry = {
+  __typename?: 'Entry';
+  /** Information about the repository from GitHub */
+  repository: Repository;
+  /** The GitHub user who submitted this entry */
+  postedBy: User;
+  /** A timestamp of when the entry was submitted */
+  createdAt: Scalars['Float'];
+  /** The score of this repository, upvotes - downvotes */
+  score: Scalars['Int'];
+  /** The hot score of this repository */
+  hotScore: Scalars['Float'];
+  /** Comments posted about this repository */
+  comments: Array<Maybe<Comment>>;
+  /** The number of comments posted about this repository */
+  commentCount: Scalars['Int'];
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** XXX to be changed */
+  vote: Vote;
+};
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type EntryCommentsArgs = {
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  /** Sort by a combination of freshness and score, using Reddit's algorithm */
+  Hot = 'HOT',
+  /** Newest entries first */
+  New = 'NEW',
+  /** Highest score entries first */
+  Top = 'TOP',
+}
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** Submit a new repository, returns the new submission */
+  submitRepository?: Maybe<Entry>;
+  /** Vote on a repository submission, returns the submission that was voted on */
+  vote?: Maybe<Entry>;
+  /** Comment on a repository, returns the new comment */
+  submitComment?: Maybe<Comment>;
+};
+
+export type MutationSubmitRepositoryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+export type MutationVoteArgs = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+export type MutationSubmitCommentArgs = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+export type Query = {
+  __typename?: 'Query';
+  /** A feed of repository submissions */
+  feed?: Maybe<Array<Maybe<Entry>>>;
+  /** A single entry */
+  entry?: Maybe<Entry>;
+  /** Return the currently logged in user, or null if nobody is logged in */
+  currentUser?: Maybe<User>;
+};
+
+export type QueryFeedArgs = {
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+export type QueryEntryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/** A repository object from the GitHub API. This uses the exact field names returned by the
+ * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
+ */
+export type Repository = {
+  __typename?: 'Repository';
+  /** Just the name of the repository, e.g. GitHunt-API */
+  name: Scalars['String'];
+  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
+  full_name: Scalars['String'];
+  /** The description of the repository */
+  description?: Maybe<Scalars['String']>;
+  /** The link to the repository on GitHub */
+  html_url: Scalars['String'];
+  /** The number of people who have starred this repository on GitHub */
+  stargazers_count: Scalars['Int'];
+  /** The number of open issues on this repository on GitHub */
+  open_issues_count?: Maybe<Scalars['Int']>;
+  /** The owner of this repository on GitHub, e.g. apollostack */
+  owner?: Maybe<User>;
+};
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** Subscription fires on every comment added */
+  commentAdded?: Maybe<Comment>;
+};
+
+export type SubscriptionCommentAddedArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export type User = {
+  __typename?: 'User';
+  /** The name of the user, e.g. apollostack */
+  login: Scalars['String'];
+  /** The URL to a directly embeddable image for this user's avatar */
+  avatar_url: Scalars['String'];
+  /** The URL of this user's GitHub page */
+  html_url: Scalars['String'];
+};
+
+/** XXX to be removed */
+export type Vote = {
+  __typename?: 'Vote';
+  vote_value: Scalars['Int'];
+};
+
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  Up = 'UP',
+  Down = 'DOWN',
+  Cancel = 'CANCEL',
+}
+export type OnCommentAddedSubscriptionVariables = {
+  repoFullName: Scalars['String'];
+};
+
+export type OnCommentAddedSubscription = { __typename?: 'Subscription'; commentAdded: Maybe<{ __typename?: 'Comment'; id: number; createdAt: number; content: string; postedBy: { __typename?: 'User'; login: string; html_url: string } }> };
+
+export type CommentQueryVariables = {
+  repoFullName: Scalars['String'];
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+export type CommentQuery = {
+  __typename?: 'Query';
+  currentUser: Maybe<{ __typename?: 'User'; login: string; html_url: string }>;
+  entry: Maybe<{
+    __typename?: 'Entry';
+    id: number;
+    createdAt: number;
+    commentCount: number;
+    postedBy: { __typename?: 'User'; login: string; html_url: string };
+    comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
+    repository: { __typename?: 'Repository'; full_name: string; html_url: string } & { __typename?: 'Repository'; description: string; open_issues_count: number; stargazers_count: number };
+  }>;
+};
+
+export type CommentsPageCommentFragment = { __typename?: 'Comment'; id: number; createdAt: number; content: string; postedBy: { __typename?: 'User'; login: string; html_url: string } };
+
+export type CurrentUserForProfileQueryVariables = {};
+
+export type CurrentUserForProfileQuery = { __typename?: 'Query'; currentUser: Maybe<{ __typename?: 'User'; login: string; avatar_url: string }> };
+
+export type FeedEntryFragment = {
+  __typename?: 'Entry';
+  id: number;
+  commentCount: number;
+  repository: { __typename?: 'Repository'; full_name: string; html_url: string; owner: Maybe<{ __typename?: 'User'; avatar_url: string }> };
+} & (VoteButtonsFragment & RepoInfoFragment);
+
+export type FeedQueryVariables = {
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+export type FeedQuery = { __typename?: 'Query'; currentUser: Maybe<{ __typename?: 'User'; login: string }>; feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>> };
+
+export type SubmitRepositoryMutationVariables = {
+  repoFullName: Scalars['String'];
+};
+
+export type SubmitRepositoryMutation = { __typename?: 'Mutation'; submitRepository: Maybe<{ __typename?: 'Entry'; createdAt: number }> };
+
+export type RepoInfoFragment = {
+  __typename?: 'Entry';
+  createdAt: number;
+  repository: { __typename?: 'Repository'; description: string; stargazers_count: number; open_issues_count: number };
+  postedBy: { __typename?: 'User'; html_url: string; login: string };
+};
+
+export type SubmitCommentMutationVariables = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+export type SubmitCommentMutation = { __typename?: 'Mutation'; submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment> };
+
+export type VoteButtonsFragment = { __typename?: 'Entry'; score: number; vote: { __typename?: 'Vote'; vote_value: number } };
+
+export type VoteMutationVariables = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+export type VoteMutation = { __typename?: 'Mutation'; vote: Maybe<{ __typename?: 'Entry'; score: number; id: number; vote: { __typename?: 'Vote'; vote_value: number } }> };

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -1,0 +1,490 @@
+// tslint:disable
+import gql from 'graphql-tag';
+import * as React from 'react';
+import * as ReactApollo from 'react-apollo';
+export type Maybe<T> = T | null;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
+/** A comment about an entry, submitted by a user */
+export type Comment = {
+  __typename?: 'Comment',
+  /** The SQL ID of this entry */
+  id: Scalars['Int'],
+  /** The GitHub user who posted the comment */
+  postedBy: User,
+  /** A timestamp of when the comment was posted */
+  createdAt: Scalars['Float'],
+  /** The text of the comment */
+  content: Scalars['String'],
+  /** The repository which this comment is about */
+  repoName: Scalars['String'],
+};
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type Entry = {
+  __typename?: 'Entry',
+  /** Information about the repository from GitHub */
+  repository: Repository,
+  /** The GitHub user who submitted this entry */
+  postedBy: User,
+  /** A timestamp of when the entry was submitted */
+  createdAt: Scalars['Float'],
+  /** The score of this repository, upvotes - downvotes */
+  score: Scalars['Int'],
+  /** The hot score of this repository */
+  hotScore: Scalars['Float'],
+  /** Comments posted about this repository */
+  comments: Array<Maybe<Comment>>,
+  /** The number of comments posted about this repository */
+  commentCount: Scalars['Int'],
+  /** The SQL ID of this entry */
+  id: Scalars['Int'],
+  /** XXX to be changed */
+  vote: Vote,
+};
+
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type EntryCommentsArgs = {
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
+};
+
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  /** Sort by a combination of freshness and score, using Reddit's algorithm */
+  Hot = 'HOT',
+  /** Newest entries first */
+  New = 'NEW',
+  /** Highest score entries first */
+  Top = 'TOP'
+}
+
+export type Mutation = {
+  __typename?: 'Mutation',
+  /** Submit a new repository, returns the new submission */
+  submitRepository?: Maybe<Entry>,
+  /** Vote on a repository submission, returns the submission that was voted on */
+  vote?: Maybe<Entry>,
+  /** Comment on a repository, returns the new comment */
+  submitComment?: Maybe<Comment>,
+};
+
+
+export type MutationSubmitRepositoryArgs = {
+  repoFullName: Scalars['String']
+};
+
+
+export type MutationVoteArgs = {
+  repoFullName: Scalars['String'],
+  type: VoteType
+};
+
+
+export type MutationSubmitCommentArgs = {
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
+};
+
+export type Query = {
+  __typename?: 'Query',
+  /** A feed of repository submissions */
+  feed?: Maybe<Array<Maybe<Entry>>>,
+  /** A single entry */
+  entry?: Maybe<Entry>,
+  /** Return the currently logged in user, or null if nobody is logged in */
+  currentUser?: Maybe<User>,
+};
+
+
+export type QueryFeedArgs = {
+  type: FeedType,
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
+};
+
+
+export type QueryEntryArgs = {
+  repoFullName: Scalars['String']
+};
+
+/** A repository object from the GitHub API. This uses the exact field names returned by the
+ * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
+ */
+export type Repository = {
+  __typename?: 'Repository',
+  /** Just the name of the repository, e.g. GitHunt-API */
+  name: Scalars['String'],
+  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
+  full_name: Scalars['String'],
+  /** The description of the repository */
+  description?: Maybe<Scalars['String']>,
+  /** The link to the repository on GitHub */
+  html_url: Scalars['String'],
+  /** The number of people who have starred this repository on GitHub */
+  stargazers_count: Scalars['Int'],
+  /** The number of open issues on this repository on GitHub */
+  open_issues_count?: Maybe<Scalars['Int']>,
+  /** The owner of this repository on GitHub, e.g. apollostack */
+  owner?: Maybe<User>,
+};
+
+export type Subscription = {
+  __typename?: 'Subscription',
+  /** Subscription fires on every comment added */
+  commentAdded?: Maybe<Comment>,
+};
+
+
+export type SubscriptionCommentAddedArgs = {
+  repoFullName: Scalars['String']
+};
+
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export type User = {
+  __typename?: 'User',
+  /** The name of the user, e.g. apollostack */
+  login: Scalars['String'],
+  /** The URL to a directly embeddable image for this user's avatar */
+  avatar_url: Scalars['String'],
+  /** The URL of this user's GitHub page */
+  html_url: Scalars['String'],
+};
+
+/** XXX to be removed */
+export type Vote = {
+  __typename?: 'Vote',
+  vote_value: Scalars['Int'],
+};
+
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  Up = 'UP',
+  Down = 'DOWN',
+  Cancel = 'CANCEL'
+}
+export type OnCommentAddedSubscriptionVariables = {
+  repoFullName: Scalars['String']
+};
+
+
+export type OnCommentAddedSubscription = { __typename?: 'Subscription', commentAdded: Maybe<{ __typename?: 'Comment', id: number, createdAt: number, content: string, postedBy: { __typename?: 'User', login: string, html_url: string } }> };
+
+export type CommentQueryVariables = {
+  repoFullName: Scalars['String'],
+  limit?: Maybe<Scalars['Int']>,
+  offset?: Maybe<Scalars['Int']>
+};
+
+
+export type CommentQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, commentCount: number, postedBy: { __typename?: 'User', login: string, html_url: string }, comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository', full_name: string, html_url: string } & { __typename?: 'Repository', description: string, open_issues_count: number, stargazers_count: number }) }> };
+
+export type CommentsPageCommentFragment = { __typename?: 'Comment', id: number, createdAt: number, content: string, postedBy: { __typename?: 'User', login: string, html_url: string } };
+
+export type CurrentUserForProfileQueryVariables = {};
+
+
+export type CurrentUserForProfileQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, avatar_url: string }> };
+
+export type FeedEntryFragment = ({ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', full_name: string, html_url: string, owner: Maybe<{ __typename?: 'User', avatar_url: string }> } } & (VoteButtonsFragment & RepoInfoFragment));
+
+export type FeedQueryVariables = {
+  type: FeedType,
+  offset?: Maybe<Scalars['Int']>,
+  limit?: Maybe<Scalars['Int']>
+};
+
+
+export type FeedQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string }>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> };
+
+export type SubmitRepositoryMutationVariables = {
+  repoFullName: Scalars['String']
+};
+
+
+export type SubmitRepositoryMutation = { __typename?: 'Mutation', submitRepository: Maybe<{ __typename?: 'Entry', createdAt: number }> };
+
+export type RepoInfoFragment = { __typename?: 'Entry', createdAt: number, repository: { __typename?: 'Repository', description: string, stargazers_count: number, open_issues_count: number }, postedBy: { __typename?: 'User', html_url: string, login: string } };
+
+export type SubmitCommentMutationVariables = {
+  repoFullName: Scalars['String'],
+  commentContent: Scalars['String']
+};
+
+
+export type SubmitCommentMutation = { __typename?: 'Mutation', submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> };
+
+export type VoteButtonsFragment = { __typename?: 'Entry', score: number, vote: { __typename?: 'Vote', vote_value: number } };
+
+export type VoteMutationVariables = {
+  repoFullName: Scalars['String'],
+  type: VoteType
+};
+
+
+export type VoteMutation = { __typename?: 'Mutation', vote: Maybe<{ __typename?: 'Entry', score: number, id: number, vote: { __typename?: 'Vote', vote_value: number } }> };
+export const CommentsPageCommentFragmentDoc = gql`
+    fragment CommentsPageComment on Comment {
+  id
+  postedBy {
+    login
+    html_url
+  }
+  createdAt
+  content
+}
+    `;
+export const VoteButtonsFragmentDoc = gql`
+    fragment VoteButtons on Entry {
+  score
+  vote {
+    vote_value
+  }
+}
+    `;
+export const RepoInfoFragmentDoc = gql`
+    fragment RepoInfo on Entry {
+  createdAt
+  repository {
+    description
+    stargazers_count
+    open_issues_count
+  }
+  postedBy {
+    html_url
+    login
+  }
+}
+    `;
+export const FeedEntryFragmentDoc = gql`
+    fragment FeedEntry on Entry {
+  id
+  commentCount
+  repository {
+    full_name
+    html_url
+    owner {
+      avatar_url
+    }
+  }
+  ...VoteButtons
+  ...RepoInfo
+}
+    ${VoteButtonsFragmentDoc}
+${RepoInfoFragmentDoc}`;
+export const OnCommentAddedDocument = gql`
+    subscription onCommentAdded($repoFullName: String!) {
+  commentAdded(repoFullName: $repoFullName) {
+    id
+    postedBy {
+      login
+      html_url
+    }
+    createdAt
+    content
+  }
+}
+    `;
+export type OnCommentAddedComponentProps = Omit<ReactApollo.SubscriptionProps<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>, 'subscription'>;
+
+    export const OnCommentAddedComponent = (props: OnCommentAddedComponentProps) => (
+      <ReactApollo.Subscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables> subscription={OnCommentAddedDocument} {...props} />
+    );
+    
+export type OnCommentAddedProps<TChildProps = {}> = Partial<ReactApollo.DataProps<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>> & TChildProps;
+export function withOnCommentAdded<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
+  TProps,
+  OnCommentAddedSubscription,
+  OnCommentAddedSubscriptionVariables,
+  OnCommentAddedProps<TChildProps>>) {
+    return ReactApollo.withSubscription<TProps, OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables, OnCommentAddedProps<TChildProps>>(OnCommentAddedDocument, {
+      alias: 'withOnCommentAdded',
+      ...operationOptions
+    });
+};
+export const CommentDocument = gql`
+    query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
+  currentUser {
+    login
+    html_url
+  }
+  entry(repoFullName: $repoFullName) {
+    id
+    postedBy {
+      login
+      html_url
+    }
+    createdAt
+    comments(limit: $limit, offset: $offset) {
+      ...CommentsPageComment
+    }
+    commentCount
+    repository {
+      full_name
+      html_url
+      ... on Repository {
+        description
+        open_issues_count
+        stargazers_count
+      }
+    }
+  }
+}
+    ${CommentsPageCommentFragmentDoc}`;
+export type CommentComponentProps = Omit<ReactApollo.QueryProps<CommentQuery, CommentQueryVariables>, 'query'> & ({ variables: CommentQueryVariables; skip?: false; } | { skip: true; });
+
+    export const CommentComponent = (props: CommentComponentProps) => (
+      <ReactApollo.Query<CommentQuery, CommentQueryVariables> query={CommentDocument} {...props} />
+    );
+    
+export type CommentProps<TChildProps = {}> = Partial<ReactApollo.DataProps<CommentQuery, CommentQueryVariables>> & TChildProps;
+export function withComment<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
+  TProps,
+  CommentQuery,
+  CommentQueryVariables,
+  CommentProps<TChildProps>>) {
+    return ReactApollo.withQuery<TProps, CommentQuery, CommentQueryVariables, CommentProps<TChildProps>>(CommentDocument, {
+      alias: 'withComment',
+      ...operationOptions
+    });
+};
+export const CurrentUserForProfileDocument = gql`
+    query CurrentUserForProfile {
+  currentUser {
+    login
+    avatar_url
+  }
+}
+    `;
+export type CurrentUserForProfileComponentProps = Omit<ReactApollo.QueryProps<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>, 'query'>;
+
+    export const CurrentUserForProfileComponent = (props: CurrentUserForProfileComponentProps) => (
+      <ReactApollo.Query<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables> query={CurrentUserForProfileDocument} {...props} />
+    );
+    
+export type CurrentUserForProfileProps<TChildProps = {}> = Partial<ReactApollo.DataProps<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>> & TChildProps;
+export function withCurrentUserForProfile<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
+  TProps,
+  CurrentUserForProfileQuery,
+  CurrentUserForProfileQueryVariables,
+  CurrentUserForProfileProps<TChildProps>>) {
+    return ReactApollo.withQuery<TProps, CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables, CurrentUserForProfileProps<TChildProps>>(CurrentUserForProfileDocument, {
+      alias: 'withCurrentUserForProfile',
+      ...operationOptions
+    });
+};
+export const FeedDocument = gql`
+    query Feed($type: FeedType!, $offset: Int, $limit: Int) {
+  currentUser {
+    login
+  }
+  feed(type: $type, offset: $offset, limit: $limit) {
+    ...FeedEntry
+  }
+}
+    ${FeedEntryFragmentDoc}`;
+export type FeedComponentProps = Omit<ReactApollo.QueryProps<FeedQuery, FeedQueryVariables>, 'query'> & ({ variables: FeedQueryVariables; skip?: false; } | { skip: true; });
+
+    export const FeedComponent = (props: FeedComponentProps) => (
+      <ReactApollo.Query<FeedQuery, FeedQueryVariables> query={FeedDocument} {...props} />
+    );
+    
+export type FeedProps<TChildProps = {}> = Partial<ReactApollo.DataProps<FeedQuery, FeedQueryVariables>> & TChildProps;
+export function withFeed<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
+  TProps,
+  FeedQuery,
+  FeedQueryVariables,
+  FeedProps<TChildProps>>) {
+    return ReactApollo.withQuery<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps>>(FeedDocument, {
+      alias: 'withFeed',
+      ...operationOptions
+    });
+};
+export const SubmitRepositoryDocument = gql`
+    mutation submitRepository($repoFullName: String!) {
+  submitRepository(repoFullName: $repoFullName) {
+    createdAt
+  }
+}
+    `;
+export type SubmitRepositoryMutationFn = ReactApollo.MutationFn<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
+export type SubmitRepositoryComponentProps = Omit<ReactApollo.MutationProps<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>, 'mutation'>;
+
+    export const SubmitRepositoryComponent = (props: SubmitRepositoryComponentProps) => (
+      <ReactApollo.Mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> mutation={SubmitRepositoryDocument} {...props} />
+    );
+    
+export type SubmitRepositoryProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>> & TChildProps;
+export function withSubmitRepository<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
+  TProps,
+  SubmitRepositoryMutation,
+  SubmitRepositoryMutationVariables,
+  SubmitRepositoryProps<TChildProps>>) {
+    return ReactApollo.withMutation<TProps, SubmitRepositoryMutation, SubmitRepositoryMutationVariables, SubmitRepositoryProps<TChildProps>>(SubmitRepositoryDocument, {
+      alias: 'withSubmitRepository',
+      ...operationOptions
+    });
+};
+export const SubmitCommentDocument = gql`
+    mutation submitComment($repoFullName: String!, $commentContent: String!) {
+  submitComment(repoFullName: $repoFullName, commentContent: $commentContent) {
+    ...CommentsPageComment
+  }
+}
+    ${CommentsPageCommentFragmentDoc}`;
+export type SubmitCommentMutationFn = ReactApollo.MutationFn<SubmitCommentMutation, SubmitCommentMutationVariables>;
+export type SubmitCommentComponentProps = Omit<ReactApollo.MutationProps<SubmitCommentMutation, SubmitCommentMutationVariables>, 'mutation'>;
+
+    export const SubmitCommentComponent = (props: SubmitCommentComponentProps) => (
+      <ReactApollo.Mutation<SubmitCommentMutation, SubmitCommentMutationVariables> mutation={SubmitCommentDocument} {...props} />
+    );
+    
+export type SubmitCommentProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<SubmitCommentMutation, SubmitCommentMutationVariables>> & TChildProps;
+export function withSubmitComment<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
+  TProps,
+  SubmitCommentMutation,
+  SubmitCommentMutationVariables,
+  SubmitCommentProps<TChildProps>>) {
+    return ReactApollo.withMutation<TProps, SubmitCommentMutation, SubmitCommentMutationVariables, SubmitCommentProps<TChildProps>>(SubmitCommentDocument, {
+      alias: 'withSubmitComment',
+      ...operationOptions
+    });
+};
+export const VoteDocument = gql`
+    mutation vote($repoFullName: String!, $type: VoteType!) {
+  vote(repoFullName: $repoFullName, type: $type) {
+    score
+    id
+    vote {
+      vote_value
+    }
+  }
+}
+    `;
+export type VoteMutationFn = ReactApollo.MutationFn<VoteMutation, VoteMutationVariables>;
+export type VoteComponentProps = Omit<ReactApollo.MutationProps<VoteMutation, VoteMutationVariables>, 'mutation'>;
+
+    export const VoteComponent = (props: VoteComponentProps) => (
+      <ReactApollo.Mutation<VoteMutation, VoteMutationVariables> mutation={VoteDocument} {...props} />
+    );
+    
+export type VoteProps<TChildProps = {}> = Partial<ReactApollo.MutateProps<VoteMutation, VoteMutationVariables>> & TChildProps;
+export function withVote<TProps, TChildProps = {}>(operationOptions?: ReactApollo.OperationOption<
+  TProps,
+  VoteMutation,
+  VoteMutationVariables,
+  VoteProps<TChildProps>>) {
+    return ReactApollo.withMutation<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps>>(VoteDocument, {
+      alias: 'withVote',
+      ...operationOptions
+    });
+};

--- a/dev-test/star-wars/types.preResolveTypes.ts
+++ b/dev-test/star-wars/types.preResolveTypes.ts
@@ -1,0 +1,330 @@
+export type Maybe<T> = T | null;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+};
+
+/** A character from the Star Wars universe */
+export type Character = {
+  /** The ID of the character */
+  id: Scalars['ID'],
+  /** The name of the character */
+  name: Scalars['String'],
+  /** The friends of the character, or an empty list if they have none */
+  friends?: Maybe<Array<Maybe<Character>>>,
+  /** The friends of the character exposed as a connection with edges */
+  friendsConnection: FriendsConnection,
+  /** The movies this character appears in */
+  appearsIn: Array<Maybe<Episode>>,
+};
+
+
+/** A character from the Star Wars universe */
+export type CharacterFriendsConnectionArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['ID']>
+};
+
+/** The input object sent when passing a color */
+export type ColorInput = {
+  red: Scalars['Int'],
+  green: Scalars['Int'],
+  blue: Scalars['Int'],
+};
+
+/** An autonomous mechanical character in the Star Wars universe */
+export type Droid = Character & {
+  __typename?: 'Droid',
+  /** The ID of the droid */
+  id: Scalars['ID'],
+  /** What others call this droid */
+  name: Scalars['String'],
+  /** This droid's friends, or an empty list if they have none */
+  friends?: Maybe<Array<Maybe<Character>>>,
+  /** The friends of the droid exposed as a connection with edges */
+  friendsConnection: FriendsConnection,
+  /** The movies this droid appears in */
+  appearsIn: Array<Maybe<Episode>>,
+  /** This droid's primary function */
+  primaryFunction?: Maybe<Scalars['String']>,
+};
+
+
+/** An autonomous mechanical character in the Star Wars universe */
+export type DroidFriendsConnectionArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['ID']>
+};
+
+/** The episodes in the Star Wars trilogy */
+export enum Episode {
+  /** Star Wars Episode IV: A New Hope, released in 1977. */
+  Newhope = 'NEWHOPE',
+  /** Star Wars Episode V: The Empire Strikes Back, released in 1980. */
+  Empire = 'EMPIRE',
+  /** Star Wars Episode VI: Return of the Jedi, released in 1983. */
+  Jedi = 'JEDI'
+}
+
+/** A connection object for a character's friends */
+export type FriendsConnection = {
+  __typename?: 'FriendsConnection',
+  /** The total number of friends */
+  totalCount?: Maybe<Scalars['Int']>,
+  /** The edges for each of the character's friends. */
+  edges?: Maybe<Array<Maybe<FriendsEdge>>>,
+  /** A list of the friends, as a convenience when edges are not needed. */
+  friends?: Maybe<Array<Maybe<Character>>>,
+  /** Information for paginating this connection */
+  pageInfo: PageInfo,
+};
+
+/** An edge object for a character's friends */
+export type FriendsEdge = {
+  __typename?: 'FriendsEdge',
+  /** A cursor used for pagination */
+  cursor: Scalars['ID'],
+  /** The character represented by this friendship edge */
+  node?: Maybe<Character>,
+};
+
+/** A humanoid creature from the Star Wars universe */
+export type Human = Character & {
+  __typename?: 'Human',
+  /** The ID of the human */
+  id: Scalars['ID'],
+  /** What this human calls themselves */
+  name: Scalars['String'],
+  /** The home planet of the human, or null if unknown */
+  homePlanet?: Maybe<Scalars['String']>,
+  /** Height in the preferred unit, default is meters */
+  height?: Maybe<Scalars['Float']>,
+  /** Mass in kilograms, or null if unknown */
+  mass?: Maybe<Scalars['Float']>,
+  /** This human's friends, or an empty list if they have none */
+  friends?: Maybe<Array<Maybe<Character>>>,
+  /** The friends of the human exposed as a connection with edges */
+  friendsConnection: FriendsConnection,
+  /** The movies this human appears in */
+  appearsIn: Array<Maybe<Episode>>,
+  /** A list of starships this person has piloted, or an empty list if none */
+  starships?: Maybe<Array<Maybe<Starship>>>,
+};
+
+
+/** A humanoid creature from the Star Wars universe */
+export type HumanHeightArgs = {
+  unit?: Maybe<LengthUnit>
+};
+
+
+/** A humanoid creature from the Star Wars universe */
+export type HumanFriendsConnectionArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['ID']>
+};
+
+/** Units of height */
+export enum LengthUnit {
+  /** The standard unit around the world */
+  Meter = 'METER',
+  /** Primarily used in the United States */
+  Foot = 'FOOT'
+}
+
+/** The mutation type, represents all updates we can make to our data */
+export type Mutation = {
+  __typename?: 'Mutation',
+  createReview?: Maybe<Review>,
+};
+
+
+/** The mutation type, represents all updates we can make to our data */
+export type MutationCreateReviewArgs = {
+  episode?: Maybe<Episode>,
+  review: ReviewInput
+};
+
+/** Information for paginating this connection */
+export type PageInfo = {
+  __typename?: 'PageInfo',
+  startCursor?: Maybe<Scalars['ID']>,
+  endCursor?: Maybe<Scalars['ID']>,
+  hasNextPage: Scalars['Boolean'],
+};
+
+/** The query type, represents all of the entry points into our object graph */
+export type Query = {
+  __typename?: 'Query',
+  hero?: Maybe<Character>,
+  reviews?: Maybe<Array<Maybe<Review>>>,
+  search?: Maybe<Array<Maybe<SearchResult>>>,
+  character?: Maybe<Character>,
+  droid?: Maybe<Droid>,
+  human?: Maybe<Human>,
+  starship?: Maybe<Starship>,
+};
+
+
+/** The query type, represents all of the entry points into our object graph */
+export type QueryHeroArgs = {
+  episode?: Maybe<Episode>
+};
+
+
+/** The query type, represents all of the entry points into our object graph */
+export type QueryReviewsArgs = {
+  episode: Episode
+};
+
+
+/** The query type, represents all of the entry points into our object graph */
+export type QuerySearchArgs = {
+  text?: Maybe<Scalars['String']>
+};
+
+
+/** The query type, represents all of the entry points into our object graph */
+export type QueryCharacterArgs = {
+  id: Scalars['ID']
+};
+
+
+/** The query type, represents all of the entry points into our object graph */
+export type QueryDroidArgs = {
+  id: Scalars['ID']
+};
+
+
+/** The query type, represents all of the entry points into our object graph */
+export type QueryHumanArgs = {
+  id: Scalars['ID']
+};
+
+
+/** The query type, represents all of the entry points into our object graph */
+export type QueryStarshipArgs = {
+  id: Scalars['ID']
+};
+
+/** Represents a review for a movie */
+export type Review = {
+  __typename?: 'Review',
+  /** The number of stars this review gave, 1-5 */
+  stars: Scalars['Int'],
+  /** Comment about the movie */
+  commentary?: Maybe<Scalars['String']>,
+};
+
+/** The input object sent when someone is creating a new review */
+export type ReviewInput = {
+  /** 0-5 stars */
+  stars: Scalars['Int'],
+  /** Comment about the movie, optional */
+  commentary?: Maybe<Scalars['String']>,
+  /** Favorite color, optional */
+  favoriteColor?: Maybe<ColorInput>,
+};
+
+export type SearchResult = Human | Droid | Starship;
+
+export type Starship = {
+  __typename?: 'Starship',
+  /** The ID of the starship */
+  id: Scalars['ID'],
+  /** The name of the starship */
+  name: Scalars['String'],
+  /** Length of the starship, along the longest axis */
+  length?: Maybe<Scalars['Float']>,
+};
+
+
+export type StarshipLengthArgs = {
+  unit?: Maybe<LengthUnit>
+};
+export type CreateReviewForEpisodeMutationVariables = {
+  episode: Episode,
+  review: ReviewInput
+};
+
+
+export type CreateReviewForEpisodeMutation = { __typename?: 'Mutation', createReview: Maybe<{ __typename?: 'Review', stars: number, commentary: string }> };
+
+export type HeroAndFriendsNamesQueryVariables = {
+  episode?: Maybe<Episode>
+};
+
+
+export type HeroAndFriendsNamesQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human' | 'Droid', name: string, friends: Maybe<Array<Maybe<{ __typename?: 'Human' | 'Droid', name: string }>>> }> };
+
+export type HeroAppearsInQueryVariables = {};
+
+
+export type HeroAppearsInQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human' | 'Droid', name: string, appearsIn: Episode }> };
+
+export type HeroDetailsQueryVariables = {
+  episode?: Maybe<Episode>
+};
+
+
+export type HeroDetailsQuery = { __typename?: 'Query', hero: Maybe<({ __typename?: 'Human' | 'Droid', name: string } & ({ __typename?: 'Human', height: number } | { __typename?: 'Droid', primaryFunction: string }))> };
+
+export type HeroDetailsWithFragmentQueryVariables = {
+  episode?: Maybe<Episode>
+};
+
+
+export type HeroDetailsWithFragmentQuery = { __typename?: 'Query', hero: Maybe<({ __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> };
+
+export type HeroDetailsFragment = ({ __typename?: 'Human' | 'Droid', name: string } & ({ __typename?: 'Human', height: number } | { __typename?: 'Droid', primaryFunction: string }));
+
+export type HeroNameQueryVariables = {
+  episode?: Maybe<Episode>
+};
+
+
+export type HeroNameQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human' | 'Droid', name: string }> };
+
+export type HeroNameConditionalInclusionQueryVariables = {
+  episode?: Maybe<Episode>,
+  includeName: Scalars['Boolean']
+};
+
+
+export type HeroNameConditionalInclusionQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human' | 'Droid', name: string }> };
+
+export type HeroNameConditionalExclusionQueryVariables = {
+  episode?: Maybe<Episode>,
+  skipName: Scalars['Boolean']
+};
+
+
+export type HeroNameConditionalExclusionQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human' | 'Droid', name: string }> };
+
+export type HeroParentTypeDependentFieldQueryVariables = {
+  episode?: Maybe<Episode>
+};
+
+
+export type HeroParentTypeDependentFieldQuery = { __typename?: 'Query', hero: Maybe<({ __typename?: 'Human' | 'Droid', name: string } & ({ __typename?: 'Human', friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid', name: string } & { __typename?: 'Human', height: number })>>> } | { __typename?: 'Droid', friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid', name: string } & { __typename?: 'Human', height: number })>>> }))> };
+
+export type HeroTypeDependentAliasedFieldQueryVariables = {
+  episode?: Maybe<Episode>
+};
+
+
+export type HeroTypeDependentAliasedFieldQuery = { __typename?: 'Query', hero: Maybe<({ __typename?: 'Human' | 'Droid' } & ({ __typename?: 'Human', property: string } | { __typename?: 'Droid', property: string }))> };
+
+export type HumanWithNullHeightQueryVariables = {};
+
+
+export type HumanWithNullHeightQuery = { __typename?: 'Query', human: Maybe<{ __typename?: 'Human', name: string, mass: number }> };
+
+export type TwoHeroesQueryVariables = {};
+
+
+export type TwoHeroesQuery = { __typename?: 'Query', r2: Maybe<{ __typename?: 'Human' | 'Droid', name: string }>, luke: Maybe<{ __typename?: 'Human' | 'Droid', name: string }> };

--- a/packages/plugins/flow/operations/src/flow-selection-set-to-object.ts
+++ b/packages/plugins/flow/operations/src/flow-selection-set-to-object.ts
@@ -8,17 +8,18 @@ export class FlowSelectionSetToObject extends SelectionSetToObject {
     _schema: GraphQLSchema,
     _convertName: ConvertNameFn,
     _addTypename: boolean,
+    _preResolveTypes: boolean,
     _nonOptionalTypename: boolean,
     _loadedFragments: LoadedFragment[],
     private _visitorConfig: FlowDocumentsParsedConfig,
     _parentSchemaType?: GraphQLNamedType,
     _selectionSet?: SelectionSetNode
   ) {
-    super(_scalars, _schema, _convertName, _addTypename, _nonOptionalTypename, _loadedFragments, _visitorConfig.namespacedImportName, _parentSchemaType, _selectionSet);
+    super(_scalars, _schema, _convertName, _addTypename, _preResolveTypes, _nonOptionalTypename, _loadedFragments, _visitorConfig.namespacedImportName, _parentSchemaType, _selectionSet);
   }
 
   public createNext(parentSchemaType: GraphQLNamedType, selectionSet: SelectionSetNode): SelectionSetToObject {
-    return new FlowSelectionSetToObject(this._scalars, this._schema, this._convertName, this._addTypename, this._nonOptionalTypename, this._loadedFragments, this._visitorConfig, parentSchemaType, selectionSet);
+    return new FlowSelectionSetToObject(this._scalars, this._schema, this._convertName, this._addTypename, this._preResolveTypes, this._nonOptionalTypename, this._loadedFragments, this._visitorConfig, parentSchemaType, selectionSet);
   }
 
   protected buildPrimitiveFields(parentName: string, fields: PrimitiveField[]): string | null {

--- a/packages/plugins/flow/operations/src/visitor.ts
+++ b/packages/plugins/flow/operations/src/visitor.ts
@@ -20,7 +20,7 @@ export class FlowDocumentsVisitor extends BaseDocumentsVisitor<FlowDocumentsPlug
       schema
     );
 
-    this.setSelectionSetHandler(new FlowSelectionSetToObject(this.scalars, this.schema, this.convertName, this.config.addTypename, this.config.nonOptionalTypename, allFragments, this.config));
+    this.setSelectionSetHandler(new FlowSelectionSetToObject(this.scalars, this.schema, this.convertName, this.config.addTypename, this.config.preResolveTypes, this.config.nonOptionalTypename, allFragments, this.config));
     this.setVariablesTransformer(new FlowOperationVariablesToObject(this.scalars, this.convertName, this.config.namespacedImportName));
   }
 }

--- a/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
@@ -1,7 +1,7 @@
 import { ScalarsMap, ConvertOptions, LoadedFragment } from './types';
 import * as autoBind from 'auto-bind';
 import { DEFAULT_SCALARS } from './scalars';
-import { toPascalCase, DeclarationBlock, DeclarationBlockConfig, buildScalars } from './utils';
+import { toPascalCase, DeclarationBlock, DeclarationBlockConfig, buildScalars, getConfigValue } from './utils';
 import { GraphQLSchema, FragmentDefinitionNode, GraphQLObjectType, OperationDefinitionNode, VariableDefinitionNode, OperationTypeNode, ASTNode } from 'graphql';
 import { SelectionSetToObject } from './selection-set-to-object';
 import { OperationVariablesToObject } from './variables-to-object';
@@ -20,10 +20,12 @@ function getRootType(operation: OperationTypeNode, schema: GraphQLSchema) {
 
 export interface ParsedDocumentsConfig extends ParsedConfig {
   addTypename: boolean;
+  preResolveTypes: boolean;
   globalNamespace: boolean;
 }
 
 export interface RawDocumentsConfig extends RawConfig {
+  preResolveTypes?: boolean;
   globalNamespace?: boolean;
 }
 
@@ -36,10 +38,11 @@ export class BaseDocumentsVisitor<TRawConfig extends RawDocumentsConfig = RawDoc
     super(
       rawConfig,
       {
+        preResolveTypes: getConfigValue(rawConfig.preResolveTypes, false),
         addTypename: !rawConfig.skipTypename,
         globalNamespace: !!rawConfig.globalNamespace,
         ...((additionalConfig || {}) as any),
-      } as any,
+      },
       buildScalars(_schema, scalars)
     );
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
@@ -25,7 +25,33 @@ export interface ParsedDocumentsConfig extends ParsedConfig {
 }
 
 export interface RawDocumentsConfig extends RawConfig {
+  /**
+   * @name preResolveTypes
+   * @type boolean
+   * @default false
+   * @description Avoid using `Pick` and resolve the actual primitive type of all selection set.
+   *
+   * @example
+   * ```yml
+   * plugins
+   *   config:
+   *     preResolveTypes: true
+   * ```
+   */
   preResolveTypes?: boolean;
+  /**
+   * @name globalNamespace
+   * @type boolean
+   * @default false
+   * @description Puts all generated code under `global` namespace. Useful for Stencil integration.
+   *
+   * @example
+   * ```yml
+   * plugins
+   *   config:
+   *     globalNamespace: true
+   * ```
+   */
   globalNamespace?: boolean;
 }
 

--- a/packages/plugins/typescript/compatibility/src/index.ts
+++ b/packages/plugins/typescript/compatibility/src/index.ts
@@ -42,6 +42,14 @@ export interface CompatabilityPluginRawConfig extends RawConfig {
    * ```
    */
   strict?: boolean;
+  /**
+   * @name preResolveTypes
+   * @type boolean
+   * @description Avoid using `Pick` in `typescript-operations` and make sure to optimize this package as well.
+   * @default false
+   *
+   */
+  preResolveTypes?: boolean;
 }
 
 const REACT_APOLLO_PLUGIN_NAME = 'typescript-react-apollo';

--- a/packages/plugins/typescript/compatibility/src/visitor.ts
+++ b/packages/plugins/typescript/compatibility/src/visitor.ts
@@ -8,6 +8,7 @@ export interface CompatabilityPluginConfig extends ParsedConfig {
   reactApollo: any;
   noNamespaces: boolean;
   strict: boolean;
+  preResolveTypes: boolean;
 }
 
 export class CompatabilityPluginVisitor extends BaseVisitor<CompatabilityPluginRawConfig, CompatabilityPluginConfig> {
@@ -15,6 +16,7 @@ export class CompatabilityPluginVisitor extends BaseVisitor<CompatabilityPluginR
     super(rawConfig, {
       reactApollo: options.reactApollo,
       noNamespaces: getConfigValue<boolean>(rawConfig.noNamespaces, false),
+      preResolveTypes: getConfigValue<boolean>(rawConfig.preResolveTypes, false),
       strict: getConfigValue<boolean>(rawConfig.strict, false),
     } as any);
   }
@@ -42,7 +44,7 @@ export class CompatabilityPluginVisitor extends BaseVisitor<CompatabilityPluginR
       },
     };
 
-    selectionSetToTypes(typesPrefix, this, this._schema, typeName, baseName, node.operation, node.selectionSet, selectionSetTypes);
+    selectionSetToTypes(typesPrefix, this, this._schema, typeName, baseName, node.operation, node.selectionSet, this.config.preResolveTypes, selectionSetTypes);
 
     return selectionSetTypes;
   }
@@ -53,7 +55,7 @@ export class CompatabilityPluginVisitor extends BaseVisitor<CompatabilityPluginR
     const typesPrefix = this.config.noNamespaces ? this.convertName(node.name.value) : '';
     const selectionSetTypes: SelectionSetToObjectResult = {};
 
-    selectionSetToTypes(typesPrefix, this, this._schema, typeName, baseName, 'fragment', node.selectionSet, selectionSetTypes);
+    selectionSetToTypes(typesPrefix, this, this._schema, typeName, baseName, 'fragment', node.selectionSet, this.config.preResolveTypes, selectionSetTypes);
 
     return selectionSetTypes;
   }

--- a/packages/plugins/typescript/operations/src/ts-selection-set-to-object.ts
+++ b/packages/plugins/typescript/operations/src/ts-selection-set-to-object.ts
@@ -8,17 +8,18 @@ export class TypeScriptSelectionSetToObject extends SelectionSetToObject {
     _schema: GraphQLSchema,
     _convertName: ConvertNameFn,
     _addTypename: boolean,
+    _preResolveTypes: boolean,
     _nonOptionalTypename: boolean,
     _loadedFragments: LoadedFragment[],
     private _config: TypeScriptDocumentsParsedConfig,
     _parentSchemaType?: GraphQLNamedType,
     _selectionSet?: SelectionSetNode
   ) {
-    super(_scalars, _schema, _convertName, _addTypename, _nonOptionalTypename, _loadedFragments, _config.namespacedImportName, _parentSchemaType, _selectionSet);
+    super(_scalars, _schema, _convertName, _addTypename, _preResolveTypes, _nonOptionalTypename, _loadedFragments, _config.namespacedImportName, _parentSchemaType, _selectionSet);
   }
 
   public createNext(parentSchemaType: GraphQLNamedType, selectionSet: SelectionSetNode): SelectionSetToObject {
-    return new TypeScriptSelectionSetToObject(this._scalars, this._schema, this._convertName, this._addTypename, this._nonOptionalTypename, this._loadedFragments, this._config, parentSchemaType, selectionSet);
+    return new TypeScriptSelectionSetToObject(this._scalars, this._schema, this._convertName, this._addTypename, this._preResolveTypes, this._nonOptionalTypename, this._loadedFragments, this._config, parentSchemaType, selectionSet);
   }
 
   private clearOptional(str: string): string {

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -21,7 +21,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<TypeScriptD
       schema
     );
 
-    this.setSelectionSetHandler(new TypeScriptSelectionSetToObject(this.scalars, this.schema, this.convertName, this.config.addTypename, this.config.nonOptionalTypename, allFragments, this.config));
+    this.setSelectionSetHandler(new TypeScriptSelectionSetToObject(this.scalars, this.schema, this.convertName, this.config.addTypename, this.config.preResolveTypes, this.config.nonOptionalTypename, allFragments, this.config));
     this.setVariablesTransformer(new TypeScriptOperationVariablesToObject(this.scalars, this.convertName, this.config.avoidOptionals, this.config.immutableTypes, this.config.namespacedImportName));
   }
 }

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -827,6 +827,34 @@ describe('TypeScript Operations Plugin', () => {
       validate(result, config, gitHuntSchema);
     });
 
+    it('Should build a basic selection set based on basic query on GitHub schema with preResolveTypes=true', async () => {
+      const ast = parse(/* GraphQL */ `
+        query me($repoFullName: String!) {
+          currentUser {
+            login
+            html_url
+          }
+          entry(repoFullName: $repoFullName) {
+            id
+            postedBy {
+              login
+              html_url
+            }
+            createdAt
+          }
+        }
+      `);
+      const config = { preResolveTypes: true };
+      const result = await plugin(gitHuntSchema, [{ filePath: 'test-file.ts', content: ast }], config, {
+        outputFile: '',
+      });
+
+      expect(result).toBeSimilarStringTo(
+        `export type MeQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, postedBy: { __typename?: 'User', login: string, html_url: string } }> };`
+      );
+      validate(result, config, gitHuntSchema);
+    });
+
     it('Should build a basic selection set based on basic query', async () => {
       const ast = parse(`
         query dummy {

--- a/website/live-demo/src/examples.ts
+++ b/website/live-demo/src/examples.ts
@@ -81,6 +81,18 @@ export const EXAMPLES: { [name: string]: Example } = {
     schema: TS_SCHEMA,
     documents: TS_QUERY,
   },
+  'typescript-operations-no-pick': {
+    name: 'TypeScript Operations (without Pick)',
+    config: `generates:
+  client-types.ts:
+    config:
+      preResolveTypes: true
+    plugins:
+      - typescript
+      - typescript-operations`,
+    schema: TS_SCHEMA,
+    documents: TS_QUERY,
+  },
   'typescript-operations-compatibility': {
     name: 'TypeScript Operations with 0.18 Compatibility',
     config: `generates:

--- a/website/live-demo/src/generate.ts
+++ b/website/live-demo/src/generate.ts
@@ -8,6 +8,7 @@ export async function generate(config: string, schema: string, documents?: strin
     const { generates, ...rootConfig } = safeLoad(cleanTabs);
     const filename = Object.keys(generates)[0];
     const plugins = normalizeConfig(generates[filename].plugins || generates[filename]);
+    const outputConfig = generates[filename].config;
     const { codegen } = await import('@graphql-codegen/core');
     const { parse } = await import('graphql');
     const pluginMap: any = {};
@@ -16,6 +17,11 @@ export async function generate(config: string, schema: string, documents?: strin
       const pluginName = Object.keys(pluginElement)[0];
       pluginMap[pluginName] = await pluginLoaderMap[pluginName]();
     }
+
+    const mergedConfig = {
+      ...rootConfig,
+      ...outputConfig,
+    };
 
     return await codegen({
       filename,
@@ -29,9 +35,7 @@ export async function generate(config: string, schema: string, documents?: strin
             },
           ]
         : [],
-      config: {
-        ...rootConfig,
-      },
+      config: mergedConfig,
       pluginMap,
     });
   } catch (e) {


### PR DESCRIPTION
A solution for: https://github.com/dotansimha/graphql-code-generator/issues/1904 

It still requires `typescript` as a dependency, but now `typescript-operations` can use `preResolveTypes: true` in order to generate `field: string` instead of `field: Pick<BaseType, 'field'>`.

Required `typescript-compatibility` minor changes because of the needs to eliminate `Maybe` when building the intermediate types.