### PR TITLE
Allow codegen to skip schema building when it's not possible

### DIFF
--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -5,10 +5,11 @@ import { normalizeOutputParam, normalizeInstanceOrArray, normalizeConfig } from 
 import { prettify } from './utils/prettier';
 import { Renderer } from './utils/listr-renderer';
 import { loadSchema, loadDocuments } from './load';
-import { GraphQLError, DocumentNode, buildASTSchema } from 'graphql';
+import { GraphQLError, DocumentNode } from 'graphql';
 import { getPluginByName } from './plugins';
 import { getPresetByName } from './presets';
 import { debugLog } from './utils/debugging';
+import { tryToBuildSchema } from './utils/try-to-build-schema';
 
 export const defaultLoader = (mod: string) => import(mod);
 
@@ -214,6 +215,7 @@ export async function executeCodegen(config: Types.Config): Promise<Types.FileOu
                       };
 
                       let outputs: Types.GenerateOptions[] = [];
+                      const builtSchema = tryToBuildSchema(outputSchema);
 
                       if (hasPreset) {
                         outputs = await preset.buildGeneratesSection({
@@ -221,7 +223,7 @@ export async function executeCodegen(config: Types.Config): Promise<Types.FileOu
                           presetConfig: outputConfig.presetConfig || {},
                           plugins: normalizedPluginsArray,
                           schema: outputSchema,
-                          schemaAst: buildASTSchema(outputSchema),
+                          schemaAst: builtSchema,
                           documents: outputDocuments,
                           config: mergedConfig,
                           pluginMap,
@@ -232,7 +234,7 @@ export async function executeCodegen(config: Types.Config): Promise<Types.FileOu
                             filename,
                             plugins: normalizedPluginsArray,
                             schema: outputSchema,
-                            schemaAst: buildASTSchema(outputSchema),
+                            schemaAst: builtSchema,
                             documents: outputDocuments,
                             config: mergedConfig,
                             pluginMap,

--- a/packages/graphql-codegen-cli/src/utils/try-to-build-schema.ts
+++ b/packages/graphql-codegen-cli/src/utils/try-to-build-schema.ts
@@ -1,0 +1,12 @@
+import { DocumentNode, GraphQLSchema, buildASTSchema } from 'graphql';
+import { debugLog } from './debugging';
+
+export function tryToBuildSchema(schema: DocumentNode): GraphQLSchema {
+  try {
+    return buildASTSchema(schema);
+  } catch (e) {
+    debugLog(`Unable to build AST schema from DocumentNode, will try again later...`, e);
+
+    return null;
+  }
+}


### PR DESCRIPTION
Related: https://github.com/dotansimha/graphql-code-generator/issues/2108