### PR TITLE
Fixes for resolvers plugins: override optional declaration of args types

### DIFF
--- a/packages/plugins/flow/resolvers/src/flow-util-types.ts
+++ b/packages/plugins/flow/resolvers/src/flow-util-types.ts
@@ -1,0 +1,1 @@
+export const FLOW_REQUIRE_FIELDS_TYPE = `export type $RequireFields<Origin, Keys> = $Diff<Args, Keys> & $ObjMapi<Keys, <Key>(k: Key) => $NonMaybeType<$ElementType<Origin, Key>>>;`;

--- a/packages/plugins/flow/resolvers/src/index.ts
+++ b/packages/plugins/flow/resolvers/src/index.ts
@@ -83,7 +83,7 @@ ${resolverTypeWrapper}
   }
 
   return {
-    prepend: [gqlImports, ...mappersImports],
+    prepend: [gqlImports, ...mappersImports, ...visitor.globalDeclarations],
     content: [header, resolversTypeMapping, resolversParentTypeMapping, ...visitorResult.definitions.filter(d => typeof d === 'string'), getRootResolver(), getAllDirectiveResolvers()].join('\n'),
   };
 };

--- a/packages/plugins/flow/resolvers/src/visitor.ts
+++ b/packages/plugins/flow/resolvers/src/visitor.ts
@@ -1,8 +1,9 @@
 import { FlowResolversPluginConfig } from './index';
-import { ListTypeNode, NamedTypeNode, NonNullTypeNode, GraphQLSchema, ScalarTypeDefinitionNode } from 'graphql';
+import { ListTypeNode, NamedTypeNode, NonNullTypeNode, GraphQLSchema, ScalarTypeDefinitionNode, InputValueDefinitionNode } from 'graphql';
 import * as autoBind from 'auto-bind';
 import { indent, ParsedResolversConfig, BaseResolversVisitor, DeclarationBlock } from '@graphql-codegen/visitor-plugin-common';
 import { FlowOperationVariablesToObject } from '@graphql-codegen/flow';
+import { FLOW_REQUIRE_FIELDS_TYPE } from './flow-util-types';
 
 export interface ParsedFlorResolversConfig extends ParsedResolversConfig {}
 
@@ -15,6 +16,11 @@ export class FlowResolversVisitor extends BaseResolversVisitor<FlowResolversPlug
 
   protected _getScalar(name: string): string {
     return `$ElementType<Scalars, '${name}'>`;
+  }
+
+  protected applyRequireFields(argsType: string, fields: InputValueDefinitionNode[]): string {
+    this._globalDeclarations.add(FLOW_REQUIRE_FIELDS_TYPE);
+    return `$RequireFields<${argsType}, { ${fields.map(f => `${f.name.value}: *`).join(', ')} }>`;
   }
 
   protected buildMapperImport(source: string, types: { identifier: string; asDefault?: boolean }[]): string {

--- a/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
@@ -11,8 +11,22 @@ describe('Flow Resolvers Plugin', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('Default values of args and compatibility with typescript plugin', async () => {
+    const testSchema = buildSchema(/* GraphQL */ `
+      type Query {
+        something(arg: String = "default_value"): String
+      }
+    `);
+
+    const config: any = { noSchemaStitching: true };
+    const result = (await plugin(testSchema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.prepend).toContain(`export type $RequireFields<Origin, Keys> = $Diff<Args, Keys> & $ObjMapi<Keys, <Key>(k: Key) => $NonMaybeType<$ElementType<Origin, Key>>>;`);
+    expect(result.content).toContain(`something?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType, $RequireFields<QuerySomethingArgs, { arg: * }>>,`);
+  });
+
   it('Should generate ResolversParentTypes', () => {
-    const result = plugin(schema, [], {}, { outputFile: '' });
+    const result = plugin(schema, [], {}, { outputFile: '' }) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
       /** Mapping between all available schema types and the resolvers parents */
@@ -72,7 +86,7 @@ describe('Flow Resolvers Plugin', () => {
       {
         rootValueType: 'MyRoot',
         asyncResolverTypes: true,
-      },
+      } as any,
       { outputFile: 'graphql.ts' }
     )) as Types.ComplexPluginOutput;
 

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -273,3 +273,4 @@ export function stripMapperTypeInterpolation(identifier: string): string {
 }
 
 export const OMIT_TYPE = 'export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;';
+export const REQUIRE_FIELDS_TYPE = `export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };`;

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -1,4 +1,4 @@
-import { RawResolversConfig, OMIT_TYPE } from '@graphql-codegen/visitor-plugin-common';
+import { RawResolversConfig } from '@graphql-codegen/visitor-plugin-common';
 import { Types, PluginFunction } from '@graphql-codegen/plugin-helpers';
 import { isScalarType, parse, printSchema, visit, GraphQLSchema } from 'graphql';
 import { TypeScriptResolversVisitor } from './visitor';
@@ -172,7 +172,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   }
 
   return {
-    prepend: [`import { ${imports.join(', ')} } from 'graphql';`, ...mappersImports, OMIT_TYPE],
+    prepend: [`import { ${imports.join(', ')} } from 'graphql';`, ...mappersImports, ...visitor.globalDeclarations],
     content: [header, resolversTypeMapping, resolversParentTypeMapping, ...visitorResult.definitions.filter(d => typeof d === 'string'), getRootResolver(), getAllDirectiveResolvers()].join('\n'),
   };
 };

--- a/packages/plugins/typescript/resolvers/src/visitor.ts
+++ b/packages/plugins/typescript/resolvers/src/visitor.ts
@@ -1,7 +1,7 @@
 import { TypeScriptResolversPluginConfig } from './index';
 import { ListTypeNode, NamedTypeNode, NonNullTypeNode, GraphQLSchema } from 'graphql';
 import * as autoBind from 'auto-bind';
-import { ParsedResolversConfig, BaseResolversVisitor } from '@graphql-codegen/visitor-plugin-common';
+import { ParsedResolversConfig, BaseResolversVisitor, getConfigValue } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptOperationVariablesToObject } from '@graphql-codegen/typescript';
 
 export interface ParsedTypeScriptResolversConfig extends ParsedResolversConfig {
@@ -15,10 +15,10 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<TypeScriptR
     super(
       pluginConfig,
       {
-        avoidOptionals: pluginConfig.avoidOptionals || false,
-        immutableTypes: pluginConfig.immutableTypes || false,
-        useIndexSignature: pluginConfig.useIndexSignature || false,
-      } as any,
+        avoidOptionals: getConfigValue(pluginConfig.avoidOptionals, false),
+        immutableTypes: getConfigValue(pluginConfig.immutableTypes, false),
+        useIndexSignature: getConfigValue(pluginConfig.useIndexSignature, false),
+      } as ParsedTypeScriptResolversConfig,
       schema
     );
     autoBind(this);


### PR DESCRIPTION
When args field has default value, we generate by default the `Args` type with optional and `Maybe`, because `typescript-operations` uses it to set the variables/arguments - and if it has a default value - then it's fine that it's optional.
But, for `typescript-resolvers`, we need to override this behaviour because we would like to tell the backend developers that this field will have a value (because it has a default).

Related: https://github.com/dotansimha/graphql-code-generator/issues/2064