### PR TITLE
Import path module as variable instead of default in watcher

### DIFF
--- a/packages/graphql-codegen-cli/src/utils/watcher.ts
+++ b/packages/graphql-codegen-cli/src/utils/watcher.ts
@@ -6,7 +6,7 @@ import * as isGlob from 'is-glob';
 import * as logSymbols from 'log-symbols';
 import { debugLog } from './debugging';
 import { getLogger } from './logger';
-import path from 'path';
+import * as path from 'path';
 
 function log(msg: string) {
   // double spaces to inline the message with Listr


### PR DESCRIPTION
The usage later on gets transpiled by TypeScript into:
```javascript
ignored.push(path_1.default.join(entry.filename, '**', '*' + extension));
```
Note the `default`, which is incorrect for a commonjs module and causes a crash.

This PR fixes that