### PR TITLE
Fixes issue where base types file is not referenced

### DIFF
--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -1,5 +1,5 @@
 import { parse, dirname, relative, join, isAbsolute } from 'path';
-import { DocumentNode, visit, FragmentSpreadNode, FragmentDefinitionNode, FieldNode } from 'graphql';
+import { DocumentNode, visit, FragmentSpreadNode, FragmentDefinitionNode, FieldNode, Kind } from 'graphql';
 import { FragmentNameToFile } from './index';
 
 export function appendExtensionToFilePath(baseFilePath: string, extension: string) {
@@ -74,7 +74,7 @@ export function isUsingTypes(document: DocumentNode): boolean {
       Field: (node: FieldNode) => {
         const selections = node.selectionSet ? node.selectionSet.selections || [] : [];
 
-        if (selections.length === 0) {
+        if (selections.length === 0 || selections[0].kind === Kind.FRAGMENT_SPREAD) {
           foundFields++;
         }
       },

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -27,6 +27,13 @@ describe('near-operation-file preset', () => {
       }
     }
   `);
+  const minimalOperationAst = parse(/* GraphQL */ `
+    query {
+      user {
+        ...UserFields
+      }
+    }
+  `);
   const fragmentAst = parse(/* GraphQL */ `
     fragment UserFields on User {
       id
@@ -124,6 +131,23 @@ describe('near-operation-file preset', () => {
       },
       schema: schemaDocumentNode,
       documents: testDocuments.slice(0, 2),
+      plugins: [{ typescript: {} }],
+      pluginMap: { typescript: {} as any },
+    });
+
+    expect(result.map(o => o.plugins)[0]).toEqual(expect.arrayContaining([{ add: `import * as Types from '../types';\n` }]));
+  });
+
+  it('Should prepend the "add" plugin with the correct import, when only using fragment spread', async () => {
+    const result = await preset.buildGeneratesSection({
+      baseOutputDir: './src/',
+      config: {},
+      presetConfig: {
+        cwd: '/some/deep/path',
+        baseTypesPath: 'types.ts',
+      },
+      schema: schemaDocumentNode,
+      documents: [{ filePath: '/some/deep/path/src/graphql/me-query.graphql', content: minimalOperationAst }, testDocuments[1]],
       plugins: [{ typescript: {} }],
       pluginMap: { typescript: {} as any },
     });


### PR DESCRIPTION
This is a suggestion to fix the issue mentioned in https://github.com/dotansimha/graphql-code-generator/issues/2069#issuecomment-509346480

When a query only contains a fragment spread:
```graphql
query {
  user {
    ...UserFragment
  }
}
```
as opposed to
```graphql
query {
  user {
    id
    ...UserFragment
  }
}
```

The import of the main types file, i.e. `import * as Types from '../types'` was not included.