### PR TITLE
Guard against duplicate fragment names in near-operations-file

### DIFF
--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -155,6 +155,23 @@ describe('near-operation-file preset', () => {
     expect(result.map(o => o.plugins)[0]).toEqual(expect.arrayContaining([{ add: `import * as Types from '../types';\n` }]));
   });
 
+  it('should fail when multiple fragments with the same name are found', () => {
+    expect(() =>
+      preset.buildGeneratesSection({
+        baseOutputDir: './src/',
+        config: {},
+        presetConfig: {
+          cwd: '/some/deep/path',
+          baseTypesPath: 'types.ts',
+        },
+        schema: schemaDocumentNode,
+        documents: [testDocuments[1], testDocuments[1]],
+        plugins: [{ typescript: {} }],
+        pluginMap: { typescript: {} as any },
+      })
+    ).toThrow('Multiple fragments with the name(s) "UserFields" were found.');
+  });
+
   it('Should NOT prepend the "add" plugin with Types import when selection set does not include direct fields', async () => {
     const result = await preset.buildGeneratesSection({
       baseOutputDir: './src/',


### PR DESCRIPTION
Right now if you have multiple fragments with the same name, it will not fail, and you may end up with the wrong fragment being used.

Ideally I would prefer that it figured out using the correct fragment based on the imports in the source file, however that could be pretty complicated.

For now, this will at least prevent you from having duplicate fragment names.