### PR TITLE
Fix HOC data props with custom type names

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -62,7 +62,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
   }
 
   private _buildHocProps(operationName: string, operationType: string): string {
-    const typeVariableName = this.convertName(operationName + toPascalCase(operationType));
+    const typeVariableName = this.convertName(operationName + toPascalCase(operationType) + this._parsedConfig.operationResultSuffix);
     const variablesVarName = this.convertName(operationName + toPascalCase(operationType) + 'Variables');
     const argType = operationType === 'mutation' ? 'MutateProps' : 'DataProps';
 

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -606,6 +606,22 @@ query MyFeed {
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should generate HOC props with correct operation result type name', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        { operationResultSuffix: 'Response' },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`export type TestProps<TChildProps = {}> = Partial<ReactApollo.DataProps<TestQueryResponse, TestQueryVariables>> & TChildProps;`);
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should not generate HOCs', async () => {
       const docs = [{ filePath: '', content: basicDoc }];
       const content = (await plugin(


### PR DESCRIPTION
This PR addresses the following issue: #2160 

When custom operation result type name is specified by `operationResultSuffix` config option, React Apollo HOC props are generated with a wrong operation type name. This PR fixes the way HOC props are generated.

Expected example (with `operationResultSuffix` set to `Response`): 
```javascript
export type BooksProps<TChildProps = {}> = Partial<
  ReactApollo.DataProps<BooksQueryResponse, BooksQueryVariables>
> &
  TChildProps;
```