### PR TITLE
Add variables type parameter to Urql.useMutation hook

### DIFF
--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -66,7 +66,7 @@ export const ${componentName} = (props: Omit<Urql.${operationType}Props<${generi
     if (operationType === 'Mutation') {
       return `
 export function use${operationName}() {
-  return Urql.use${operationType}<${operationResultType}>(${documentVariableName});
+  return Urql.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName});
 };`;
     }
     return `

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -349,7 +349,7 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-      export const TestComponent = (props: Omit<Urql.QueryProps<TestQuery, TestQueryVariables>,  'query'> & { variables?: TestQueryVariables }) => 
+      export const TestComponent = (props: Omit<Urql.QueryProps<TestQuery, TestQueryVariables>,  'query'> & { variables?: TestQueryVariables }) =>
       (
           <Urql.Query {...props} query={TestDocument} />
       );
@@ -521,7 +521,7 @@ export function useFeedQuery(options: Omit<Urql.UseQueryArgs<FeedQueryVariables>
 
       expect(content.content).toBeSimilarStringTo(`
 export function useSubmitRepositoryMutation() {
-  return Urql.useMutation<SubmitRepositoryMutation>(SubmitRepositoryDocument);
+  return Urql.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument);
 };`);
       await validateTypeScript(content, schema, docs, {});
     });


### PR DESCRIPTION
First of all, thank you for making a great tool.

Here is simple patch for add variables type to useMutation hooks so to be specified type instead of `object`

```ts
export declare const useMutation: <T = any, V = object>(query: string | DocumentNode) => [UseMutationState<T>, (variables?: V | undefined) => Promise<OperationResult<T>>];
```