### PR TITLE
Add type-graphql support

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -184,8 +184,8 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
 
   getObjectTypeDeclarationBlock(node: ObjectTypeDefinitionNode, originalNode: ObjectTypeDefinitionNode): DeclarationBlock {
     const optionalTypename = this.config.nonOptionalTypename ? '__typename' : '__typename?';
-    const allFields = [...(this.config.addTypename ? [indent(`${optionalTypename}: '${node.name}',`)] : []), ...node.fields];
     const { type } = this._parsedConfig.declarationKind;
+    const allFields = [...(this.config.addTypename ? [indent(`${optionalTypename}: '${node.name}'${type === 'class' ? ';' : ','}`)] : []), ...node.fields];
 
     const buildInterfaces = () => {
       if (!originalNode.interfaces || !node.interfaces.length) {

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -218,8 +218,8 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
     return [this.getObjectTypeDeclarationBlock(node, originalNode).string, this.buildArgumentsBlock(originalNode)].filter(f => f).join('\n\n');
   }
 
-  InterfaceTypeDefinition(node: InterfaceTypeDefinitionNode, key: number | string, parent: any): string {
-    const argumentsBlock = this.buildArgumentsBlock(parent[key] as InterfaceTypeDefinitionNode);
+  getInterfaceTypeDeclarationBlock(node: InterfaceTypeDefinitionNode, originalNode: InterfaceTypeDefinitionNode): DeclarationBlock {
+    const argumentsBlock = this.buildArgumentsBlock(originalNode);
 
     let declarationBlock = new DeclarationBlock(this._declarationBlockConfig)
       .export()
@@ -227,9 +227,13 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
       .withName(this.convertName(node))
       .withComment((node.description as any) as string);
 
-    const interfaceDefinition = declarationBlock.withBlock(node.fields.join('\n')).string;
+    return declarationBlock.withBlock(node.fields.join('\n'));
+  }
 
-    return [interfaceDefinition, argumentsBlock].filter(f => f).join('\n\n');
+  InterfaceTypeDefinition(node: InterfaceTypeDefinitionNode, key: number | string, parent: any): string {
+    const originalNode = parent[key] as InterfaceTypeDefinitionNode;
+
+    return [this.getInterfaceTypeDeclarationBlock(node, originalNode).string, this.buildArgumentsBlock(originalNode)].filter(f => f).join('\n\n');
   }
 
   ScalarTypeDefinition(node: ScalarTypeDefinitionNode): string {

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -23,7 +23,7 @@ export interface NamingConventionMap {
 
 export type LoadedFragment<AdditionalFields = {}> = { name: string; onType: string; node: FragmentDefinitionNode; isExternal: boolean; importFrom?: string | null } & AdditionalFields;
 
-export type DeclarationKind = 'type' | 'interface';
+export type DeclarationKind = 'type' | 'interface' | 'class' | 'abstract class';
 
 export interface DeclarationKindConfig {
   scalar?: DeclarationKind;

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -104,6 +104,7 @@ export function transformComment(comment: string | StringValueNode, indentLevel 
 }
 
 export class DeclarationBlock {
+  _decorator = null;
   _export = false;
   _name = null;
   _kind = null;
@@ -121,6 +122,12 @@ export class DeclarationBlock {
       enumNameValueSeparator: ':',
       ...this._config,
     };
+  }
+
+  withDecorator(decorator: string): DeclarationBlock {
+    this._decorator = decorator;
+
+    return this;
   }
 
   export(exp = true): DeclarationBlock {
@@ -171,6 +178,10 @@ export class DeclarationBlock {
 
   public get string(): string {
     let result = '';
+
+    if (this._decorator) {
+      result += this._decorator + '\n';
+    }
 
     if (this._export) {
       result += 'export ';

--- a/packages/plugins/typescript/typescript/src/index.ts
+++ b/packages/plugins/typescript/typescript/src/index.ts
@@ -114,6 +114,8 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
   outputTypeGraphQL?: boolean;
 }
 
+const TYPE_GRAPHQL_IMPORT = `import * as TypeGraphQL from 'type-graphql';`;
+
 export const plugin: PluginFunction<TypeScriptPluginConfig> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: TypeScriptPluginConfig) => {
   const visitor = new TsVisitor(schema, config);
   const printedSchema = printSchema(schema);
@@ -124,7 +126,7 @@ export const plugin: PluginFunction<TypeScriptPluginConfig> = (schema: GraphQLSc
   const scalars = visitor.scalarsDefinition;
 
   return {
-    prepend: [...visitor.getEnumsImports(), maybeValue],
+    prepend: [...visitor.getEnumsImports(), maybeValue, ...(config.outputTypeGraphQL ? [TYPE_GRAPHQL_IMPORT] : [])],
     content: [scalars, ...visitorResult.definitions, ...introspectionDefinitions].join('\n'),
   };
 };

--- a/packages/plugins/typescript/typescript/src/index.ts
+++ b/packages/plugins/typescript/typescript/src/index.ts
@@ -95,6 +95,23 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    * ```
    */
   maybeValue?: string;
+  /**
+   * @name outputTypeGraphQL
+   * @type boolean
+   * @description Output objects compatible with type-graphql
+   * @default false
+   *
+   * @example
+   * * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    outputTypeGraphQL: true
+   * ```
+   */
+  outputTypeGraphQL?: boolean;
 }
 
 export const plugin: PluginFunction<TypeScriptPluginConfig> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: TypeScriptPluginConfig) => {

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -15,6 +15,7 @@ export interface TypeScriptPluginParsedConfig extends ParsedTypesConfig {
 
 const MAYBE_REGEX = /^Maybe<(.*?)>$/;
 const ARRAY_REGEX = /^Array<(.*?)>$/;
+const GRAPHQL_TYPES = ['Query', 'Mutation', 'Subscription'];
 
 export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPluginConfig, TParsedConfig extends TypeScriptPluginParsedConfig = TypeScriptPluginParsedConfig> extends BaseTypesVisitor<TRawConfig, TParsedConfig> {
   constructor(schema: GraphQLSchema, pluginConfig: TRawConfig, additionalConfig: Partial<TParsedConfig> = {}) {
@@ -76,7 +77,8 @@ export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPlu
     const originalNode = parent[key] as ObjectTypeDefinitionNode;
 
     let declarationBlock = this.getObjectTypeDeclarationBlock(node, originalNode);
-    if (this.config.outputTypeGraphQL) {
+    if (this.config.outputTypeGraphQL && GRAPHQL_TYPES.indexOf((node.name as unknown) as string) === -1) {
+      // Add type-graphql ObjectType decorator
       const interfaces = originalNode.interfaces.map(i => this.convertName(i));
       let decoratorOptions = '';
       if (interfaces.length > 1) {

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -86,7 +86,7 @@ export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPlu
     const comment = transformComment((node.description as any) as string, 1);
     let decorator = '';
     if (super.config.outputTypeGraphQL) {
-      const typeGraphQLType = typeString.replace(MAYBE_REGEX, '$1').replace(/Scalars\['(.*?)'\]$/, 'TypeGraphQL.$1');
+      const typeGraphQLType = typeString.replace(MAYBE_REGEX, '$1').replace(/Scalars\['(.*?)'\]$/, (match, type) => (global[type] ? type : `TypeGraphQL.${type}`));
       const nullable = !!typeString.match(MAYBE_REGEX);
 
       decorator = '\n' + indent(`@TypeGraphQL.Field(type => ${typeGraphQLType}${nullable ? ', { nullable: true }' : ''})`) + '\n';

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1746,7 +1746,7 @@ describe('TypeScript', () => {
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.ObjectType()
       export class A {
-        __typename?: 'A',
+        __typename?: 'A';
 
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
         id!: Maybe<Scalars['ID']>;
@@ -1789,6 +1789,50 @@ describe('TypeScript', () => {
 
         @TypeGraphQL.Field(type => [String])
         mandatoryArr!: Array<Scalars['String']>;
+      }
+    `);
+  });
+
+  it('should generate type-graphql classes implementing type-graphql interfaces', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Test implements ITest {
+        id: ID
+        mandatoryStr: String!
+      }
+
+      interface ITest {
+        id: ID
+      }
+    `);
+
+    const result = (await plugin(
+      schema,
+      [],
+      {
+        outputTypeGraphQL: true,
+      },
+      { outputFile: '' }
+    )) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.ObjectType({ implements: ITest })
+      export class Test extends ITest {
+        __typename?: 'Test';
+
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
+
+        @TypeGraphQL.Field(type => String)
+        mandatoryStr!: Scalars['String'];
+      }
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.InterfaceType()
+      export abstract class ITest {
+        
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
       }
     `);
   });

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1752,16 +1752,16 @@ describe('TypeScript', () => {
         @TypeGraphQL.Field(type => TypeGraphQL.ID)
         mandatoryId!: Scalars['ID'];
 
-        @TypeGraphQL.Field(type => TypeGraphQL.String, { nullable: true })
+        @TypeGraphQL.Field(type => String, { nullable: true })
         str!: Maybe<Scalars['String']>;
 
-        @TypeGraphQL.Field(type => TypeGraphQL.String)
+        @TypeGraphQL.Field(type => String)
         mandatoryStr!: Scalars['String'];
 
-        @TypeGraphQL.Field(type => TypeGraphQL.Boolean, { nullable: true })
+        @TypeGraphQL.Field(type => Boolean, { nullable: true })
         bool!: Maybe<Scalars['Boolean']>;
 
-        @TypeGraphQL.Field(type => TypeGraphQL.Boolean)
+        @TypeGraphQL.Field(type => Boolean)
         mandatoryBool!: Scalars['Boolean'];
 
         @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
@@ -1781,8 +1781,7 @@ describe('TypeScript', () => {
 
         @TypeGraphQL.Field(type => B)
         mandatoryB!: B;
-
-        
+      }
     `);
   });
 });

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1663,4 +1663,35 @@ describe('TypeScript', () => {
 
     validateTs(result);
   });
+
+  it('should generate type-graphql enums', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      "custom enum"
+      enum MyEnum {
+        "this is a"
+        A
+        "this is b"
+        B
+      }
+    `);
+    const result = (await plugin(
+      schema,
+      [],
+      {
+        outputTypeGraphQL: true,
+      },
+      { outputFile: '' }
+    )) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+      /** custom enum */
+      export enum MyEnum {
+        /** this is a */
+        A = 'A',
+        /** this is b */
+        B = 'B'
+      }
+      registerEnumType(MyEnum, { name: 'MyEnum' });`);
+    validateTs(result);
+  });
 });

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1664,6 +1664,22 @@ describe('TypeScript', () => {
     validateTs(result);
   });
 
+  it('should generate type-graphql imports', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      scalar A
+    `);
+    const result = (await plugin(
+      schema,
+      [],
+      {
+        outputTypeGraphQL: true,
+      },
+      { outputFile: '' }
+    )) as Types.ComplexPluginOutput;
+
+    expect(result.prepend).toContainEqual(`import * as TypeGraphQL from 'type-graphql';`);
+  });
+
   it('should generate type-graphql enums', async () => {
     const schema = buildSchema(/* GraphQL */ `
       "custom enum"

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1725,6 +1725,8 @@ describe('TypeScript', () => {
         mandatoryFloat: Float!
         b: B
         mandatoryB: B!
+        arr: [String!]
+        mandatoryArr: [String!]!
       }
 
       type B {
@@ -1781,6 +1783,12 @@ describe('TypeScript', () => {
 
         @TypeGraphQL.Field(type => B)
         mandatoryB!: B;
+
+        @TypeGraphQL.Field(type => [String], { nullable: true })
+        arr!: Maybe<Array<Scalars['String']>>;
+
+        @TypeGraphQL.Field(type => [String])
+        mandatoryArr!: Array<Scalars['String']>;
       }
     `);
   });

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1691,7 +1691,82 @@ describe('TypeScript', () => {
         /** this is b */
         B = 'B'
       }
-      registerEnumType(MyEnum, { name: 'MyEnum' });`);
-    validateTs(result);
+      TypeGraphQL.registerEnumType(MyEnum, { name: 'MyEnum' });`);
+  });
+
+  it('should generate type-graphql classes', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type A {
+        id: ID
+        mandatoryId: ID!
+        str: String
+        mandatoryStr: String!
+        bool: Boolean
+        mandatoryBool: Boolean!
+        int: Int
+        mandatoryInt: Int!
+        float: Float
+        mandatoryFloat: Float!
+        b: B
+        mandatoryB: B!
+      }
+
+      type B {
+        id: ID
+      }
+    `);
+
+    const result = (await plugin(
+      schema,
+      [],
+      {
+        outputTypeGraphQL: true,
+      },
+      { outputFile: '' }
+    )) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.ObjectType()
+      export class A {
+        __typename?: 'A',
+
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
+
+        @TypeGraphQL.Field(type => TypeGraphQL.ID)
+        mandatoryId!: Scalars['ID'];
+
+        @TypeGraphQL.Field(type => TypeGraphQL.String, { nullable: true })
+        str!: Maybe<Scalars['String']>;
+
+        @TypeGraphQL.Field(type => TypeGraphQL.String)
+        mandatoryStr!: Scalars['String'];
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Boolean, { nullable: true })
+        bool!: Maybe<Scalars['Boolean']>;
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Boolean)
+        mandatoryBool!: Scalars['Boolean'];
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
+        int!: Maybe<Scalars['Int']>;
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Int)
+        mandatoryInt!: Scalars['Int'];
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Float, { nullable: true })
+        float!: Maybe<Scalars['Float']>;
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Float)
+        mandatoryFloat!: Scalars['Float'];
+
+        @TypeGraphQL.Field(type => B, { nullable: true })
+        b!: Maybe<B>;
+
+        @TypeGraphQL.Field(type => B)
+        mandatoryB!: B;
+
+        
+    `);
   });
 });


### PR DESCRIPTION
Following my issue in #1668, I have extended the @graphql-code-generator/typescript plugin with an extra flag `outputTypeGraphQL` that will output type-graphql classes instead of interfaces/types, and register any emitted enums with type-graphql. This enables exposing the types generated by graphql-code-generator in a downstream GraphQL server.

I have tested it on my own code and it works, outside of a nasty issue where the reflection metadata code generated by the TypeScript compiler will try to reference a class that is defined later in the generated file, crashing the application using the generated types. I have found similar issues concerning this functionality [here](https://github.com/19majkel94/type-graphql/issues/130), [here](https://github.com/rbuckton/reflect-metadata/issues/12) and [here](https://github.com/Microsoft/TypeScript/issues/4521). I have contemplated a couple of solutions to this issue:

- Output graphql-code-generator types into separate files. This cannot be accomplished without quite a bit of refactoring in graphql-code-generator. It will work by fixing the commonjs limitation described in [this type-graphql issue](https://github.com/19majkel94/type-graphql/issues/130).
- Use a Webpack/Babel postprocessing plug-in to move all emitted decorators below the required class definition. This is a manual process done by the end user.
- A ridiculously simple solution is to define a type `type FixDecorator<T> = T;`, and then defining all fields using `field: FixDecorator<ReferencedClass>;` rather than `field: ReferencedClass`. This makes the TypeScript compiler output `Object` as the type in the emitted metadata, fixing the missing reference.

Any thoughts on how to solve this issue are greatly appreciated. I will also be opening an issue on the type-graphql GitHub.