### PR TITLE
Add typescript type graphql plugin

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -23,7 +23,7 @@ export interface NamingConventionMap {
 
 export type LoadedFragment<AdditionalFields = {}> = { name: string; onType: string; node: FragmentDefinitionNode; isExternal: boolean; importFrom?: string | null } & AdditionalFields;
 
-export type DeclarationKind = 'type' | 'interface';
+export type DeclarationKind = 'type' | 'interface' | 'class' | 'abstract class';
 
 export interface DeclarationKindConfig {
   scalar?: DeclarationKind;

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -104,6 +104,7 @@ export function transformComment(comment: string | StringValueNode, indentLevel 
 }
 
 export class DeclarationBlock {
+  _decorator = null;
   _export = false;
   _name = null;
   _kind = null;
@@ -121,6 +122,12 @@ export class DeclarationBlock {
       enumNameValueSeparator: ':',
       ...this._config,
     };
+  }
+
+  withDecorator(decorator: string): DeclarationBlock {
+    this._decorator = decorator;
+
+    return this;
   }
 
   export(exp = true): DeclarationBlock {
@@ -171,6 +178,10 @@ export class DeclarationBlock {
 
   public get string(): string {
     let result = '';
+
+    if (this._decorator) {
+      result += this._decorator + '\n';
+    }
 
     if (this._export) {
       result += 'export ';

--- a/packages/plugins/typescript/type-graphql/.gitignore
+++ b/packages/plugins/typescript/type-graphql/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+dist
+temp
+yarn-error.log

--- a/packages/plugins/typescript/type-graphql/.npmignore
+++ b/packages/plugins/typescript/type-graphql/.npmignore
@@ -1,0 +1,4 @@
+src
+node_modules
+tests
+!dist

--- a/packages/plugins/typescript/type-graphql/package.json
+++ b/packages/plugins/typescript/type-graphql/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@graphql-codegen/typescript-type-graphql",
+  "version": "1.4.0",
+  "description": "GraphQL Code Generator plugin for generating TypeGraphQL compatible TypeScript types",
+  "repository": "git@github.com:dotansimha/graphql-code-generator.git",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc -m esnext --outDir dist/esnext && tsc -m commonjs --outDir dist/commonjs",
+    "test": "jest --config ../../../../jest.config.js"
+  },
+  "dependencies": {
+    "@graphql-codegen/typescript": "1.4.0",
+    "@graphql-codegen/plugin-helpers": "1.4.0",
+    "@graphql-codegen/visitor-plugin-common": "1.4.0",
+    "tslib": "1.10.0"
+  },
+  "devDependencies": {
+    "@graphql-codegen/testing": "1.4.0",
+    "graphql": "14.4.2",
+    "jest": "24.8.0",
+    "ts-jest": "24.0.2",
+    "typescript": "3.5.3"
+  },
+  "peerDependencies": {
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
+  },
+  "sideEffects": false,
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esnext/index.js",
+  "typings": "dist/esnext/index.d.ts",
+  "typescript": {
+    "definition": "dist/esnext/index.d.ts"
+  },
+  "jest-junit": {
+    "outputDirectory": "../../../../test-results/typescript-type-graphql"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/typescript/type-graphql/src/index.ts
+++ b/packages/plugins/typescript/type-graphql/src/index.ts
@@ -1,0 +1,32 @@
+import { Types, PluginFunction } from '@graphql-codegen/plugin-helpers';
+import { parse, printSchema, visit, GraphQLSchema, TypeInfo, GraphQLNamedType, visitWithTypeInfo, getNamedType, isIntrospectionType, DocumentNode, printIntrospectionSchema, isObjectType } from 'graphql';
+import { TypeGraphQLVisitor } from './visitor';
+import { TsIntrospectionVisitor, includeIntrospectionDefinitions, TypeScriptPluginConfig } from '@graphql-codegen/typescript';
+export * from './visitor';
+
+export interface TypeGraphQLPluginConfig extends TypeScriptPluginConfig {}
+
+const TYPE_GRAPHQL_IMPORT = `import * as TypeGraphQL from 'type-graphql';`;
+const DECORATOR_FIX = `type FixDecorator<T> = T;`;
+const isDefinitionInterface = (definition: string) => definition.indexOf('@TypeGraphQL.InterfaceType()') !== -1;
+
+export const plugin: PluginFunction<TypeGraphQLPluginConfig> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: TypeGraphQLPluginConfig) => {
+  const visitor = new TypeGraphQLVisitor(schema, config);
+  const printedSchema = printSchema(schema);
+  const astNode = parse(printedSchema);
+  const maybeValue = `export type Maybe<T> = ${visitor.config.maybeValue};`;
+  const visitorResult = visit(astNode, { leave: visitor });
+  const introspectionDefinitions = includeIntrospectionDefinitions(schema, documents, config);
+  const scalars = visitor.scalarsDefinition;
+
+  let definitions = visitorResult.definitions;
+  // Sort output by interfaces first, classes last to prevent TypeScript errors
+  definitions.sort((definition1, definition2) => (isDefinitionInterface(definition1) ? -1 : 1));
+
+  return {
+    prepend: [...visitor.getEnumsImports(), maybeValue, TYPE_GRAPHQL_IMPORT, DECORATOR_FIX],
+    content: [scalars, ...definitions, ...introspectionDefinitions].join('\n'),
+  };
+};
+
+export { TypeGraphQLVisitor, TsIntrospectionVisitor };

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -1,0 +1,107 @@
+import { transformComment, wrapWithSingleQuotes, DeclarationBlock, indent, BaseTypesVisitor, ParsedTypesConfig } from '@graphql-codegen/visitor-plugin-common';
+import { TypeGraphQLPluginConfig } from './index';
+import * as autoBind from 'auto-bind';
+import { FieldDefinitionNode, NamedTypeNode, ListTypeNode, NonNullTypeNode, EnumTypeDefinitionNode, Kind, InputValueDefinitionNode, GraphQLSchema, ObjectTypeDefinitionNode, InterfaceTypeDefinitionNode } from 'graphql';
+import { TypeScriptOperationVariablesToObject, TypeScriptPluginParsedConfig, TsVisitor } from '@graphql-codegen/typescript';
+import { AvoidOptionalsConfig } from '@graphql-codegen/typescript';
+
+export interface TypeGraphQLPluginParsedConfig extends TypeScriptPluginParsedConfig {
+  avoidOptionals: AvoidOptionalsConfig;
+  constEnums: boolean;
+  enumsAsTypes: boolean;
+  immutableTypes: boolean;
+  maybeValue: string;
+}
+
+const MAYBE_REGEX = /^Maybe<(.*?)>$/;
+const ARRAY_REGEX = /^Array<(.*?)>$/;
+const SCALAR_REGEX = /^Scalars\['(.*?)'\]$/;
+const GRAPHQL_TYPES = ['Query', 'Mutation', 'Subscription'];
+
+export class TypeGraphQLVisitor<TRawConfig extends TypeGraphQLPluginConfig = TypeGraphQLPluginConfig, TParsedConfig extends TypeGraphQLPluginParsedConfig = TypeScriptPluginParsedConfig> extends TsVisitor<TRawConfig, TParsedConfig> {
+  constructor(schema: GraphQLSchema, pluginConfig: TRawConfig, additionalConfig: Partial<TParsedConfig> = {}) {
+    super(schema, pluginConfig, {
+      avoidOptionals: pluginConfig.avoidOptionals || false,
+      maybeValue: pluginConfig.maybeValue || 'T | null',
+      constEnums: pluginConfig.constEnums || false,
+      enumsAsTypes: pluginConfig.enumsAsTypes || false,
+      immutableTypes: pluginConfig.immutableTypes || false,
+      declarationKind: {
+        type: 'class',
+        interface: 'abstract class',
+        arguments: 'type',
+        input: 'type',
+        scalar: 'type',
+      },
+      ...(additionalConfig || {}),
+    } as TParsedConfig);
+
+    autoBind(this);
+    this.setArgumentsTransformer(new TypeScriptOperationVariablesToObject(this.scalars, this.convertName, this.config.avoidOptionals.object, this.config.immutableTypes));
+    this.setDeclarationBlockConfig({
+      enumNameValueSeparator: ' =',
+    });
+  }
+
+  ObjectTypeDefinition(node: ObjectTypeDefinitionNode, key: number | string, parent: any): string {
+    const originalNode = parent[key] as ObjectTypeDefinitionNode;
+
+    let declarationBlock = this.getObjectTypeDeclarationBlock(node, originalNode);
+    if (GRAPHQL_TYPES.indexOf((node.name as unknown) as string) === -1) {
+      // Add type-graphql ObjectType decorator
+      const interfaces = originalNode.interfaces.map(i => this.convertName(i));
+      let decoratorOptions = '';
+      if (interfaces.length > 1) {
+        decoratorOptions = `{ implements: [${interfaces.join(', ')}] }`;
+      } else if (interfaces.length === 1) {
+        decoratorOptions = `{ implements: ${interfaces[0]} }`;
+      }
+      declarationBlock = declarationBlock.withDecorator(`@TypeGraphQL.ObjectType(${decoratorOptions})`);
+    }
+
+    return [declarationBlock.string, this.buildArgumentsBlock(originalNode)].filter(f => f).join('\n\n');
+  }
+
+  InterfaceTypeDefinition(node: InterfaceTypeDefinitionNode, key: number | string, parent: any): string {
+    const originalNode = parent[key] as InterfaceTypeDefinitionNode;
+
+    let declarationBlock = this.getInterfaceTypeDeclarationBlock(node, originalNode).withDecorator('@TypeGraphQL.InterfaceType()');
+
+    return [declarationBlock.string, this.buildArgumentsBlock(originalNode)].filter(f => f).join('\n\n');
+  }
+
+  parseType(typeString: string) {
+    const isNullable = !!typeString.match(MAYBE_REGEX);
+    const nonNullableType = typeString.replace(MAYBE_REGEX, '$1');
+    const isArray = !!nonNullableType.match(ARRAY_REGEX);
+    const singularType = nonNullableType.replace(ARRAY_REGEX, '$1');
+    const isScalar = !!singularType.match(SCALAR_REGEX);
+    const type = singularType.replace(SCALAR_REGEX, (match, type) => (global[type] ? type : `TypeGraphQL.${type}`));
+
+    return { type, isNullable, isArray, isScalar };
+  }
+
+  FieldDefinition(node: FieldDefinitionNode, key?: number | string, parent?: any): string {
+    let typeString = (node.type as any) as string;
+    const comment = transformComment((node.description as any) as string, 1);
+
+    const type = this.parseType(typeString);
+    const decorator = '\n' + indent(`@TypeGraphQL.Field(type => ${type.isArray ? `[${type.type}]` : type.type}${type.isNullable ? ', { nullable: true }' : ''})`) + '\n';
+
+    typeString = type.isArray || type.isNullable || type.isScalar ? typeString : `FixDecorator<${typeString}>`;
+
+    return comment + decorator + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}!: ${typeString};`);
+  }
+
+  InputValueDefinition(node: InputValueDefinitionNode, key?: number | string, parent?: any): string {
+    const originalFieldNode = parent[key] as FieldDefinitionNode;
+    const addOptionalSign = !this.config.avoidOptionals.inputValue && originalFieldNode.type.kind !== Kind.NON_NULL_TYPE;
+    const comment = transformComment((node.description as any) as string, 1);
+
+    return comment + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${addOptionalSign ? '?' : ''}: ${node.type},`);
+  }
+
+  EnumTypeDefinition(node: EnumTypeDefinitionNode): string {
+    return super.EnumTypeDefinition(node) + `TypeGraphQL.registerEnumType(${this.convertName(node)}, { name: '${this.convertName(node)}' });\n`;
+  }
+}

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -1,0 +1,133 @@
+import '@graphql-codegen/testing';
+import { Types } from '@graphql-codegen/plugin-helpers';
+import { buildSchema, parse } from 'graphql';
+import { plugin } from '../src/index';
+
+describe('type-graphql', () => {
+  it('should generate type-graphql imports', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      scalar A
+    `);
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.prepend).toContainEqual(`import * as TypeGraphQL from 'type-graphql';`);
+  });
+
+  it('should generate type-graphql enums', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      "custom enum"
+      enum MyEnum {
+        "this is a"
+        A
+        "this is b"
+        B
+      }
+    `);
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+      /** custom enum */
+      export enum MyEnum {
+        /** this is a */
+        A = 'A',
+        /** this is b */
+        B = 'B'
+      }
+      TypeGraphQL.registerEnumType(MyEnum, { name: 'MyEnum' });`);
+  });
+
+  it('should generate type-graphql classes', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type A {
+        id: ID
+        mandatoryId: ID!
+        str: String
+        mandatoryStr: String!
+        bool: Boolean
+        mandatoryBool: Boolean!
+        int: Int
+        mandatoryInt: Int!
+        float: Float
+        mandatoryFloat: Float!
+        b: B
+        mandatoryB: B!
+        arr: [String!]
+        mandatoryArr: [String!]!
+      }
+      type B {
+        id: ID
+      }
+    `);
+
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.ObjectType()
+      export class A {
+        __typename?: 'A';
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
+        @TypeGraphQL.Field(type => TypeGraphQL.ID)
+        mandatoryId!: Scalars['ID'];
+        @TypeGraphQL.Field(type => String, { nullable: true })
+        str!: Maybe<Scalars['String']>;
+        @TypeGraphQL.Field(type => String)
+        mandatoryStr!: Scalars['String'];
+        @TypeGraphQL.Field(type => Boolean, { nullable: true })
+        bool!: Maybe<Scalars['Boolean']>;
+        @TypeGraphQL.Field(type => Boolean)
+        mandatoryBool!: Scalars['Boolean'];
+        @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
+        int!: Maybe<Scalars['Int']>;
+        @TypeGraphQL.Field(type => TypeGraphQL.Int)
+        mandatoryInt!: Scalars['Int'];
+        @TypeGraphQL.Field(type => TypeGraphQL.Float, { nullable: true })
+        float!: Maybe<Scalars['Float']>;
+        @TypeGraphQL.Field(type => TypeGraphQL.Float)
+        mandatoryFloat!: Scalars['Float'];
+        @TypeGraphQL.Field(type => B, { nullable: true })
+        b!: Maybe<B>;
+        @TypeGraphQL.Field(type => B)
+        mandatoryB!: FixDecorator<B>;
+        @TypeGraphQL.Field(type => [String], { nullable: true })
+        arr!: Maybe<Array<Scalars['String']>>;
+        @TypeGraphQL.Field(type => [String])
+        mandatoryArr!: Array<Scalars['String']>;
+      }
+    `);
+  });
+
+  it('should generate type-graphql classes implementing type-graphql interfaces', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Test implements ITest {
+        id: ID
+        mandatoryStr: String!
+      }
+      interface ITest {
+        id: ID
+      }
+    `);
+
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.ObjectType({ implements: ITest })
+      export class Test extends ITest {
+        __typename?: 'Test';
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
+        @TypeGraphQL.Field(type => String)
+        mandatoryStr!: Scalars['String'];
+      }
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.InterfaceType()
+      export abstract class ITest {
+        
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
+      }
+    `);
+  });
+});

--- a/packages/plugins/typescript/type-graphql/tsconfig.json
+++ b/packages/plugins/typescript/type-graphql/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "importHelpers": true,
+    "experimentalDecorators": true,
+    "module": "esnext",
+    "target": "es2018",
+    "lib": ["es6", "esnext", "es2015"],
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "./dist/",
+    "noImplicitAny": false,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "exclude": ["node_modules", "tests", "dist"]
+}

--- a/packages/plugins/typescript/typescript/src/index.ts
+++ b/packages/plugins/typescript/typescript/src/index.ts
@@ -6,7 +6,7 @@ import { TsIntrospectionVisitor } from './introspection-visitor';
 import { AvoidOptionalsConfig } from './types';
 export * from './typescript-variables-to-object';
 export * from './visitor';
-export * from './visitor';
+export { AvoidOptionalsConfig } from './types';
 
 export interface TypeScriptPluginConfig extends RawTypesConfig {
   /**
@@ -126,7 +126,7 @@ export const plugin: PluginFunction<TypeScriptPluginConfig> = (schema: GraphQLSc
   };
 };
 
-function includeIntrospectionDefinitions(schema: GraphQLSchema, documents: Types.DocumentFile[], config: TypeScriptPluginConfig): string[] {
+export function includeIntrospectionDefinitions(schema: GraphQLSchema, documents: Types.DocumentFile[], config: TypeScriptPluginConfig): string[] {
   const typeInfo = new TypeInfo(schema);
   const usedTypes: GraphQLNamedType[] = [];
   const documentsVisitor = visitWithTypeInfo(typeInfo, {

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -32,7 +32,7 @@ export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPlu
     });
   }
 
-  private clearOptional(str: string): string {
+  protected clearOptional(str: string): string {
     if (str.startsWith('Maybe')) {
       return str.replace(/Maybe<(.*?)>$/, '$1');
     }


### PR DESCRIPTION
This is a plugin that generates type-graphql types, loosely based on the typescript plugin. See PR #2173 for more details.