### PR TITLE
Fix links to @graphql-codegen/typescript

### DIFF
--- a/docs/plugins/typescript-react-apollo.md
+++ b/docs/plugins/typescript-react-apollo.md
@@ -3,7 +3,7 @@ id: typescript-react-apollo
 title: TypeScript React Apollo
 ---
 
-This plugin generates React Apollo components and HOC with TypeScript typings. It extends the basic TypeScript template [`@graphql-codegen/typescript`](typescript-typings) and thus shares a similar configuration.
+This plugin generates React Apollo components and HOC with TypeScript typings. It extends the basic TypeScript template [`@graphql-codegen/typescript`](typescript) and thus shares a similar configuration.
 
 ## Installation
 

--- a/docs/plugins/typescript-stencil-apollo.md
+++ b/docs/plugins/typescript-stencil-apollo.md
@@ -3,7 +3,7 @@ id: typescript-stencil-apollo
 title: TypeScript Stencil Apollo
 ---
 
-This plugin generates Stencil Apollo functional components typings. It extends the basic TypeScript template [`@graphql-codegen/typescript-common`](typescript-typings) and thus shares a similar configuration.
+This plugin generates Stencil Apollo functional components typings. It extends the basic TypeScript template [`@graphql-codegen/typescript`](typescript) and thus shares a similar configuration.
 
 ## Installation
 


### PR DESCRIPTION
This fixes a couple links to the typescript plugin page that currently result in a 404.