### PR TITLE
Fix external enums to be re-exported from the generated file

### DIFF
--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -78,7 +78,7 @@ export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPlu
 
     // In case of mapped external enum string
     if (this.config.enumValues[enumName] && this.config.enumValues[enumName].sourceFile) {
-      return null;
+      return `export { ${this.config.enumValues[enumName].typeIdentifier} };\n`;
     }
 
     if (this.config.enumsAsTypes) {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1573,6 +1573,26 @@ describe('TypeScript', () => {
 
       validateTs(result);
     });
+
+    it('Should re-export external enums', async () => {
+      const schema = buildSchema(`enum MyEnum { A, B, C } enum MyEnum2 { X, Y, Z }`);
+      const result = (await plugin(schema, [], { enumValues: { MyEnum: './my-file#MyEnum', MyEnum2: './my-file#MyEnum2X' } }, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+      expect(result.content).toContain(`export { MyEnum };`);
+      expect(result.content).toContain(`export { MyEnum2 };`);
+
+      validateTs(result);
+    });
+
+    it('Should re-export external enums when single file option used', async () => {
+      const schema = buildSchema(`enum MyEnum { A, B, C } enum MyEnum2 { X, Y, Z }`);
+      const result = (await plugin(schema, [], { enumValues: './my-file' }, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+      expect(result.content).toContain(`export { MyEnum };`);
+      expect(result.content).toContain(`export { MyEnum2 };`);
+
+      validateTs(result);
+    });
   });
 
   it('should not have [object Object]', async () => {


### PR DESCRIPTION
Related #2206.

It works but I'm not sure if the approach is correct. Maybe there should be `getEnumsExports` method in `BaseTypesVisitor` (to complement `getEnumsImports`)?