### PR TITLE
fix(typescript/flow-operations): generate correct union/interface type definitions

### DIFF
--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -75,24 +75,24 @@ describe('Flow Operations Plugin', () => {
 
   describe('Naming Convention & Types Prefix', () => {
     it('Should allow custom naming and point to the correct type', async () => {
-      const ast = parse(`
-      query notifications {
-        notifications {
-          id
+      const ast = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            id
 
-          ... on TextNotification {
-            text
-          }
+            ... on TextNotification {
+              text
+            }
 
-          ... on ImageNotification {
-            imageUrl
-            metadata {
-              createdBy
+            ... on ImageNotification {
+              imageUrl
+              metadata {
+                createdBy
+              }
             }
           }
         }
-      }
-  `);
+      `);
       const result = await plugin(
         schema,
         [
@@ -105,31 +105,38 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(
-        `export type notificationsquery = ({ __typename?: 'Query' } & { notifications: Array<({ __typename?: 'TextNotification' | 'ImageNotification' } & $Pick<notifiction, { id: * }> & (({ __typename?: 'TextNotification' } & $Pick<textnotification, { text: * }>) | ({ __typename?: 'ImageNotification' } & $Pick<imagenotification, { imageUrl: * }> & { metadata: ({ __typename?: 'ImageMetadata' } & $Pick<imagemetadata, { createdBy: * }>) })))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type notificationsquery = ({ __typename?: 'Query' } & { notifications: Array<(
+          { __typename?: 'TextNotification' }
+          & $Pick<textnotification, { text: *, id: * }>
+        ) | (
+          { __typename?: 'ImageNotification' }
+          & $Pick<imagenotification, { imageUrl: *, id: * }>
+          & { metadata: ({ __typename?: 'ImageMetadata' } & $Pick<imagemetadata, { createdBy: * }>) }
+        )> });
+      `);
       validateFlow(result);
     });
 
     it('Should allow custom naming and point to the correct type - with custom prefix', async () => {
-      const ast = parse(`
-      query notifications {
-        notifications {
-          id
+      const ast = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            id
 
-          ... on TextNotification {
-            text
-          }
+            ... on TextNotification {
+              text
+            }
 
-          ... on ImageNotification {
-            imageUrl
-            metadata {
-              createdBy
+            ... on ImageNotification {
+              imageUrl
+              metadata {
+                createdBy
+              }
             }
           }
         }
-      }
-  `);
+      `);
       const result = await plugin(
         schema,
         [
@@ -143,9 +150,16 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`export type inotificationsqueryvariables = {};`);
-      expect(result).toBeSimilarStringTo(
-        `export type inotificationsquery = ({ __typename?: 'Query' } & { notifications: Array<({ __typename?: 'TextNotification' | 'ImageNotification' } & $Pick<inotifiction, { id: * }> & (({ __typename?: 'TextNotification' } & $Pick<itextnotification, { text: * }>) | ({ __typename?: 'ImageNotification' } & $Pick<iimagenotification, { imageUrl: * }> & { metadata: ({ __typename?: 'ImageMetadata' } & $Pick<iimagemetadata, { createdBy: * }>) })))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type inotificationsquery = ({ __typename?: 'Query' } & { notifications: Array<(
+          { __typename?: 'TextNotification' }
+          & $Pick<itextnotification, { text: *, id: * }>
+        ) | (
+          { __typename?: 'ImageNotification' }
+          & $Pick<iimagenotification, { imageUrl: *, id: * }>
+          & { metadata: ({ __typename?: 'ImageMetadata' } & $Pick<iimagemetadata, { createdBy: * }>) }
+        )> });
+      `);
       validateFlow(result);
     });
   });
@@ -238,7 +252,7 @@ describe('Flow Operations Plugin', () => {
     });
 
     it('Should add __typename correctly when unions are in use', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query unionTest {
           unionTest {
             ... on User {
@@ -250,7 +264,7 @@ describe('Flow Operations Plugin', () => {
             }
           }
         }
-    `);
+      `);
       const result = await plugin(
         schema,
         [
@@ -263,12 +277,20 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type UnionTestQuery = ({ __typename?: 'Query' } & { unionTest: ?(({ __typename?: 'User' } & $Pick<User, { id: * }>) | ({ __typename?: 'Profile' } & $Pick<Profile, { age: * }>)) });`);
+      expect(result).toBeSimilarStringTo(`
+        export type UnionTestQuery = ({ __typename?: 'Query' } & { unionTest: ?(
+          { __typename?: 'User' }
+          & $Pick<User, { id: * }>
+        ) | (
+          { __typename?: 'Profile' }
+          & $Pick<Profile, { age: * }>
+        ) });
+      `);
       validateFlow(result);
     });
 
     it('Should add non optional __typename when specified in config', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query unionTest {
           unionTest {
             ... on User {
@@ -280,7 +302,7 @@ describe('Flow Operations Plugin', () => {
             }
           }
         }
-    `);
+      `);
       const result = await plugin(
         schema,
         [
@@ -293,12 +315,20 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type UnionTestQuery = ({ __typename: 'Query' } & { unionTest: ?(({ __typename: 'User' } & $Pick<User, { id: * }>) | ({ __typename: 'Profile' } & $Pick<Profile, { age: * }>)) });`);
+      expect(result).toBeSimilarStringTo(`
+        export type UnionTestQuery = ({ __typename: 'Query' } & { unionTest: ?(
+          { __typename: 'User' }
+          & $Pick<User, { id: * }>
+        ) | (
+          { __typename: 'Profile' }
+          & $Pick<Profile, { age: * }>
+        ) });
+      `);
       validateFlow(result);
     });
 
     it('Should add __typename correctly when interfaces are in use', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query notifications {
           notifications {
             id
@@ -306,7 +336,7 @@ describe('Flow Operations Plugin', () => {
             ... on TextNotification {
               text
             }
-  
+
             ... on ImageNotification {
               imageUrl
               metadata {
@@ -315,7 +345,7 @@ describe('Flow Operations Plugin', () => {
             }
           }
         }
-    `);
+      `);
       const result = await plugin(
         schema,
         [
@@ -327,9 +357,16 @@ describe('Flow Operations Plugin', () => {
         {},
         { outputFile: '' }
       );
-      expect(result).toBeSimilarStringTo(
-        `export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<({ __typename?: 'TextNotification' | 'ImageNotification' } & $Pick<Notifiction, { id: * }> & (({ __typename?: 'TextNotification' } & $Pick<TextNotification, { text: * }>) | ({ __typename?: 'ImageNotification' } & $Pick<ImageNotification, { imageUrl: * }> & { metadata: ({ __typename?: 'ImageMetadata' } & $Pick<ImageMetadata, { createdBy: * }>) })))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<(
+          { __typename?: 'TextNotification' }
+          & $Pick<TextNotification, { text: *, id: * }>
+        ) | (
+          { __typename?: 'ImageNotification' }
+          & $Pick<ImageNotification, { imageUrl: *, id: * }>
+          & { metadata: ({ __typename?: 'ImageMetadata' } & $Pick<ImageMetadata, { createdBy: * }>) }
+        )> });
+      `);
       validateFlow(result);
     });
   });
@@ -490,24 +527,24 @@ describe('Flow Operations Plugin', () => {
     });
 
     it('Should support interfaces correctly when used with inline fragments', async () => {
-      const ast = parse(`
-      query notifications {
-        notifications {
-          id
+      const ast = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            id
 
-          ... on TextNotification {
-            text
-          }
+            ... on TextNotification {
+              text
+            }
 
-          ... on ImageNotification {
-            imageUrl
-            metadata {
-              createdBy
+            ... on ImageNotification {
+              imageUrl
+              metadata {
+                createdBy
+              }
             }
           }
         }
-      }
-    `);
+      `);
       const result = await plugin(
         schema,
         [
@@ -520,14 +557,19 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(
-        'export type NotificationsQuery = { notifications: Array<($Pick<Notifiction, { id: * }> & ($Pick<TextNotification, { text: * }> | ($Pick<ImageNotification, { imageUrl: * }> & { metadata: $Pick<ImageMetadata, { createdBy: * }> })))> };'
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type NotificationsQuery = { notifications: Array<(
+          $Pick<TextNotification, { text: *, id: * }>
+        ) | (
+          $Pick<ImageNotification, { imageUrl: *, id: * }>
+          & { metadata: $Pick<ImageMetadata, { createdBy: * }> }
+        )> };
+      `);
       validateFlow(result);
     });
 
     it('Should support union correctly when used with inline fragments', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query unionTest {
           unionTest {
             ... on User {
@@ -539,7 +581,7 @@ describe('Flow Operations Plugin', () => {
             }
           }
         }
-    `);
+      `);
       const result = await plugin(
         schema,
         [
@@ -552,12 +594,18 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type UnionTestQuery = { unionTest: ?($Pick<User, { id: * }> | $Pick<Profile, { age: * }>) };`);
+      expect(result).toBeSimilarStringTo(`
+        export type UnionTestQuery = { unionTest: ?(
+          $Pick<User, { id: * }>
+        ) | (
+          $Pick<Profile, { age: * }>
+        ) };
+      `);
       validateFlow(result);
     });
 
     it('Should support inline fragments', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query currentUser {
           me {
             id
@@ -569,7 +617,7 @@ describe('Flow Operations Plugin', () => {
             }
           }
         }
-    `);
+      `);
       const result = await plugin(
         schema,
         [
@@ -582,7 +630,12 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type CurrentUserQuery = { me: ?($Pick<User, { id: * }> & ($Pick<User, { username: * }> & { profile: ?$Pick<Profile, { age: * }> })) };`);
+      expect(result).toBeSimilarStringTo(`
+        export type CurrentUserQuery = { me: ?(
+          $Pick<User, { username: *, id: * }>
+          & { profile: ?$Pick<Profile, { age: * }> }
+        ) };
+      `);
       validateFlow(result);
     });
 

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -106,14 +106,20 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type notificationsquery = ({ __typename?: 'Query' } & { notifications: Array<(
-          { __typename?: 'TextNotification' }
-          & $Pick<textnotification, { text: *, id: * }>
-        ) | (
-          { __typename?: 'ImageNotification' }
-          & $Pick<imagenotification, { imageUrl: *, id: * }>
-          & { metadata: ({ __typename?: 'ImageMetadata' } & $Pick<imagemetadata, { createdBy: * }>) }
-        )> });
+        export type notificationsquery = (
+          { __typename?: 'Query' }
+          & { notifications: Array<(
+            { __typename?: 'TextNotification' }
+            & $Pick<textnotification, { text: *, id: * }>
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & $Pick<imagenotification, { imageUrl: *, id: * }>
+            & { metadata: (
+              { __typename?: 'ImageMetadata' }
+              & $Pick<imagemetadata, { createdBy: * }>
+            ) }
+          )> }
+        );
       `);
       validateFlow(result);
     });
@@ -151,14 +157,20 @@ describe('Flow Operations Plugin', () => {
 
       expect(result).toBeSimilarStringTo(`export type inotificationsqueryvariables = {};`);
       expect(result).toBeSimilarStringTo(`
-        export type inotificationsquery = ({ __typename?: 'Query' } & { notifications: Array<(
-          { __typename?: 'TextNotification' }
-          & $Pick<itextnotification, { text: *, id: * }>
-        ) | (
-          { __typename?: 'ImageNotification' }
-          & $Pick<iimagenotification, { imageUrl: *, id: * }>
-          & { metadata: ({ __typename?: 'ImageMetadata' } & $Pick<iimagemetadata, { createdBy: * }>) }
-        )> });
+        export type inotificationsquery = (
+          { __typename?: 'Query' }
+          & { notifications: Array<(
+            { __typename?: 'TextNotification' }
+            & $Pick<itextnotification, { text: *, id: * }>
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & $Pick<iimagenotification, { imageUrl: *, id: * }>
+            & { metadata: (
+              { __typename?: 'ImageMetadata' }
+              & $Pick<iimagemetadata, { createdBy: * }>
+            ) }
+          )> }
+        );
       `);
       validateFlow(result);
     });
@@ -187,7 +199,7 @@ describe('Flow Operations Plugin', () => {
     });
 
     it('Should add __typename as non-optional when explicitly specified', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query {
           __typename
           dummy
@@ -204,12 +216,17 @@ describe('Flow Operations Plugin', () => {
         {},
         { outputFile: '' }
       );
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = ({ __typename: 'Query' } & $Pick<Query, { dummy: * }>);`);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_Query = (
+          { __typename: 'Query' }
+          & $Pick<Query, { dummy: * }>
+        );
+      `);
       validateFlow(result);
     });
 
     it('Should add __typename as optional when its not specified', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query {
           dummy
         }
@@ -225,12 +242,17 @@ describe('Flow Operations Plugin', () => {
         {},
         { outputFile: '' }
       );
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = ({ __typename?: 'Query' } & $Pick<Query, { dummy: * }>);`);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_Query = (
+          { __typename?: 'Query' }
+          & $Pick<Query, { dummy: * }>
+        );
+      `);
       validateFlow(result);
     });
 
     it('Should add __typename as non-optional when its explictly specified, even if skipTypename is true', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query {
           __typename
           dummy
@@ -247,7 +269,12 @@ describe('Flow Operations Plugin', () => {
         { skipTypename: true },
         { outputFile: '' }
       );
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = ({ __typename: 'Query' } & $Pick<Query, { dummy: * }>);`);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_Query = (
+          { __typename: 'Query' }
+          & $Pick<Query, { dummy: * }>
+        );
+      `);
       validateFlow(result);
     });
 
@@ -278,13 +305,16 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type UnionTestQuery = ({ __typename?: 'Query' } & { unionTest: ?(
-          { __typename?: 'User' }
-          & $Pick<User, { id: * }>
-        ) | (
-          { __typename?: 'Profile' }
-          & $Pick<Profile, { age: * }>
-        ) });
+        export type UnionTestQuery = (
+          { __typename?: 'Query' }
+          & { unionTest: ?(
+            { __typename?: 'User' }
+            & $Pick<User, { id: * }>
+          ) | (
+            { __typename?: 'Profile' }
+            & $Pick<Profile, { age: * }>
+          ) }
+        );
       `);
       validateFlow(result);
     });
@@ -316,13 +346,16 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type UnionTestQuery = ({ __typename: 'Query' } & { unionTest: ?(
-          { __typename: 'User' }
-          & $Pick<User, { id: * }>
-        ) | (
-          { __typename: 'Profile' }
-          & $Pick<Profile, { age: * }>
-        ) });
+        export type UnionTestQuery = (
+          { __typename: 'Query' }
+          & { unionTest: ?(
+            { __typename: 'User' }
+            & $Pick<User, { id: * }>
+          ) | (
+            { __typename: 'Profile' }
+            & $Pick<Profile, { age: * }>
+          ) }
+        );
       `);
       validateFlow(result);
     });
@@ -358,14 +391,20 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(`
-        export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<(
-          { __typename?: 'TextNotification' }
-          & $Pick<TextNotification, { text: *, id: * }>
-        ) | (
-          { __typename?: 'ImageNotification' }
-          & $Pick<ImageNotification, { imageUrl: *, id: * }>
-          & { metadata: ({ __typename?: 'ImageMetadata' } & $Pick<ImageMetadata, { createdBy: * }>) }
-        )> });
+        export type NotificationsQuery = (
+          { __typename?: 'Query' }
+          & { notifications: Array<(
+            { __typename?: 'TextNotification' }
+            & $Pick<TextNotification, { text: *, id: * }>
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & $Pick<ImageNotification, { imageUrl: *, id: * }>
+            & { metadata: (
+              { __typename?: 'ImageMetadata' }
+              & $Pick<ImageMetadata, { createdBy: * }>
+            ) }
+          )> }
+        );
       `);
       validateFlow(result);
     });
@@ -459,7 +498,7 @@ describe('Flow Operations Plugin', () => {
     });
 
     it('Should support fragment spread correctly with simple type with other fields', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         fragment UserFields on User {
           id
           profile {
@@ -473,7 +512,7 @@ describe('Flow Operations Plugin', () => {
             username
           }
         }
-    `);
+      `);
       const result = await plugin(
         schema,
         [
@@ -486,12 +525,16 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type MeQuery = { me: ?($Pick<User, { username: * }> & UserFieldsFragment) };`);
+      expect(result).toBeSimilarStringTo(`
+        export type MeQuery = { me: ?$Pick<User, { username: * }>
+          & UserFieldsFragment
+        };
+      `);
       validateFlow(result);
     });
 
     it('Should support fragment spread correctly with multiple fragment spread', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         fragment UserFields on User {
           id
         }
@@ -509,7 +552,8 @@ describe('Flow Operations Plugin', () => {
             username
           }
         }
-    `);
+      `);
+
       const result = await plugin(
         schema,
         [
@@ -522,7 +566,12 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type MeQuery = { me: ?($Pick<User, { username: * }> & (UserFieldsFragment & UserProfileFragment)) };`);
+      expect(result).toBeSimilarStringTo(`
+        export type MeQuery = { me: ?$Pick<User, { username: * }>
+          & UserFieldsFragment
+          & UserProfileFragment 
+        };
+      `);
       validateFlow(result);
     });
 
@@ -558,9 +607,7 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type NotificationsQuery = { notifications: Array<(
-          $Pick<TextNotification, { text: *, id: * }>
-        ) | (
+        export type NotificationsQuery = { notifications: Array<$Pick<TextNotification, { text: *, id: * }> | (
           $Pick<ImageNotification, { imageUrl: *, id: * }>
           & { metadata: $Pick<ImageMetadata, { createdBy: * }> }
         )> };
@@ -595,11 +642,7 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type UnionTestQuery = { unionTest: ?(
-          $Pick<User, { id: * }>
-        ) | (
-          $Pick<Profile, { age: * }>
-        ) };
+        export type UnionTestQuery = { unionTest: ?$Pick<User, { id: * }> | $Pick<Profile, { age: * }> };
       `);
       validateFlow(result);
     });
@@ -640,7 +683,7 @@ describe('Flow Operations Plugin', () => {
     });
 
     it('Should build a basic selection set based on basic query on GitHub schema', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query me($repoFullName: String!) {
           currentUser {
             login
@@ -672,12 +715,17 @@ describe('Flow Operations Plugin', () => {
           repoFullName: $ElementType<Scalars, 'String'>
         };`
       );
-      expect(result).toBeSimilarStringTo(`export type MeQuery = { currentUser: ?$Pick<User, { login: *, html_url: * }>, entry: ?($Pick<Entry, { id: *, createdAt: * }> & { postedBy: $Pick<User, { login: *, html_url: * }> }) };`);
+      expect(result).toBeSimilarStringTo(`
+        export type MeQuery = { currentUser: ?$Pick<User, { login: *, html_url: * }>, entry: ?(
+          $Pick<Entry, { id: *, createdAt: * }>
+          & { postedBy: $Pick<User, { login: *, html_url: * }> }
+        ) };
+      `);
       validateFlow(result);
     });
 
     it('Should build a basic selection set based on basic query', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query dummy {
           dummy
         }
@@ -698,7 +746,7 @@ describe('Flow Operations Plugin', () => {
     });
 
     it('Should build a basic selection set based on basic query with field aliasing for basic scalar', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query dummy {
           customName: dummy
           customName2: dummyWithType {
@@ -718,12 +766,17 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type DummyQuery = ({ customName: $ElementType<Query, 'dummy'> } & { customName2: ?$Pick<Profile, { age: * }> });`);
+      expect(result).toBeSimilarStringTo(`
+        export type DummyQuery = (
+          { customName: $ElementType<Query, 'dummy'> }
+          & { customName2: ?$Pick<Profile, { age: * }> }
+        );
+      `);
       validateFlow(result);
     });
 
     it('Should build a basic selection set based on a query with inner fields', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query currentUser {
           me {
             id
@@ -747,7 +800,12 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type CurrentUserQuery = { me: ?($Pick<User, { id: *, username: *, role: * }> & { profile: ?$Pick<Profile, { age: * }> }) };`);
+      expect(result).toBeSimilarStringTo(`
+        export type CurrentUserQuery = { me: ?(
+          $Pick<User, { id: *, username: *, role: * }>
+          & { profile: ?$Pick<Profile, { age: * }> }
+        ) };
+      `);
 
       validateFlow(result);
     });
@@ -755,7 +813,7 @@ describe('Flow Operations Plugin', () => {
 
   describe('Fragment Definition', () => {
     it('Should build fragment definition correctly - with name and selection set', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         fragment UserFields on User {
           id
           username
@@ -776,14 +834,19 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type UserFieldsFragment = ($Pick<User, { id: *, username: * }> & { profile: ?$Pick<Profile, { age: * }> });`);
+      expect(result).toBeSimilarStringTo(`
+        export type UserFieldsFragment = (
+          $Pick<User, { id: *, username: * }>
+          & { profile: ?$Pick<Profile, { age: * }> }
+        );
+      `);
       validateFlow(result);
     });
   });
 
   describe('Operation Definition', () => {
     it('Should detect Mutation correctly', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         mutation login {
           login(username: "1", password: "2") {
             id
@@ -806,7 +869,12 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type LoginMutation = { login: ?($Pick<User, { id: *, username: * }> & { profile: ?$Pick<Profile, { age: * }> }) };`);
+      expect(result).toBeSimilarStringTo(`
+        export type LoginMutation = { login: ?(
+          $Pick<User, { id: *, username: * }>
+          & { profile: ?$Pick<Profile, { age: * }> }
+        ) };
+      `);
       validateFlow(result);
     });
 
@@ -913,7 +981,7 @@ describe('Flow Operations Plugin', () => {
 
   describe('Output options', () => {
     it('Should respect flow option useFlowExactObjects', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query currentUser {
           me {
             id
@@ -937,13 +1005,18 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type CurrentUserQuery = {| me: ?($Pick<User, {| id: *, username: *, role: * |}> & {| profile: ?$Pick<Profile, {| age: * |}> |}) |};`);
+      expect(result).toBeSimilarStringTo(`
+        export type CurrentUserQuery = {| me: ?(
+          $Pick<User, {| id: *, username: *, role: * |}>
+          & {| profile: ?$Pick<Profile, {| age: * |}> |}
+        ) |};
+      `);
 
       validateFlow(result);
     });
 
     it('Should respect flow option useFlowReadOnlyTypes', async () => {
-      const ast = parse(`
+      const ast = parse(/* GraphQL */ `
         query currentUser {
           me {
             id
@@ -966,7 +1039,12 @@ describe('Flow Operations Plugin', () => {
         { skipTypename: true, useFlowReadOnlyTypes: true },
         { outputFile: '' }
       );
-      expect(result).toBeSimilarStringTo(`export type CurrentUserQuery = { +me: ?($Pick<User, { +id: *, +username: *, +role: * }> & { +profile: ?$Pick<Profile, { +age: * }> }) };`);
+      expect(result).toBeSimilarStringTo(`
+        export type CurrentUserQuery = { +me: ?(
+          $Pick<User, { +id: *, +username: *, +role: * }>
+          & { +profile: ?$Pick<Profile, { +age: * }> }
+        ) };
+      `);
 
       validateFlow(result);
     });

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -13,7 +13,6 @@ import {
   GraphQLField,
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
-  isScalarType,
   GraphQLInterfaceType,
   SelectionNode,
   isListType,
@@ -21,7 +20,7 @@ import {
   GraphQLOutputType,
   isAbstractType,
 } from 'graphql';
-import { getBaseType, quoteIfNeeded, isRootType, getBaseTypeNode } from './utils';
+import { getBaseType } from './utils';
 import { ScalarsMap, ConvertNameFn, LoadedFragment } from './types';
 import { GraphQLObjectType, GraphQLNonNull, GraphQLList } from 'graphql';
 import { BaseVisitorConvertOptions } from './base-visitor';
@@ -100,68 +99,9 @@ export class SelectionSetToObject {
     throw new Error(`You must override wrapTypeWithModifiers in your SelectionSetToObject implementation!`);
   }
 
-  _collectField(field: FieldNode) {
-    if (field.name.value === '__typename') {
-      this._queriedForTypename = true;
-
-      return;
-    }
-
-    if (isObjectType(this._parentSchemaType) || isInterfaceType(this._parentSchemaType)) {
-      let schemaField: GraphQLField<any, any>;
-
-      if (isRootType(this._parentSchemaType, this._schema) && isMetadataFieldName(field.name.value)) {
-        schemaField = metadataFieldMap[field.name.value];
-      } else {
-        schemaField = this._parentSchemaType.getFields()[field.name.value];
-      }
-
-      const rawType = schemaField.type as any;
-      const baseType = getBaseType(rawType);
-
-      if (!baseType) {
-        throw new Error(`Unable to find a type called "${rawType}" in your schema!`);
-      }
-
-      const typeName = baseType.name;
-
-      if (this._scalars[typeName] || isEnumType(baseType) || isScalarType(baseType)) {
-        if (field.alias && field.alias.value) {
-          this._primitiveAliasedFields.push({
-            fieldName: field.name.value,
-            alias: field.alias.value,
-          });
-        } else {
-          this._primitiveFields.push(field.name.value);
-        }
-      } else {
-        const selectionSetToObject = this.createNext(baseType, field.selectionSet);
-
-        this._linksFields.push({
-          alias: field.alias ? field.alias.value : null,
-          name: field.name.value,
-          type: typeName,
-          selectionSet: this.wrapTypeWithModifiers(selectionSetToObject.string, rawType),
-        });
-      }
-    }
-  }
-
-  _collectFragmentSpread(node: FragmentSpreadNode) {
-    const loadedFragment = this._loadedFragments.find(f => f.name === node.name.value);
-
-    if (!loadedFragment) {
-      throw new Error(`Unable to find fragment matching then name "${node.name.value}"! Please make sure it's loaded.`);
-    }
-
-    if (!this._fragments[loadedFragment.onType]) {
-      this._fragments[loadedFragment.onType] = [];
-    }
-
-    const fragmentSuffix = this._dedupeOperationSuffix && node.name.value.toLowerCase().endsWith('fragment') ? '' : 'Fragment';
-    this._fragments[loadedFragment.onType].push(this._convertName(node.name.value, { useTypesPrefix: true, suffix: fragmentSuffix }));
-  }
-
+  /**
+   * traverse the inline fragment nodes recursively for colleting the selectionSets on each type
+   */
   _collectInlineFragments(parentType: GraphQLNamedType, nodes: InlineFragmentNode[], types: Map<string, SelectionNode[]>) {
     if (isListType(parentType) || isNonNullType(parentType)) {
       return this._collectInlineFragments(parentType.ofType, nodes, types);
@@ -190,7 +130,7 @@ export class SelectionSetToObject {
         }
       }
     } else if (isInterfaceType(parentType)) {
-      const possibleTypes = this._schema.getPossibleTypes(parentType);
+      const possibleTypes = this._getPossibleTypes(parentType);
 
       for (const node of nodes) {
         const onType = node.typeCondition.name.value;
@@ -245,7 +185,7 @@ export class SelectionSetToObject {
 
           this._collectInlineFragments(schemaType, node.selectionSet.selections.filter(selection => selection.kind === 'InlineFragment') as InlineFragmentNode[], types);
         } else if (isInterfaceType(schemaType)) {
-          const possibleInterfaceTypes = this._schema.getPossibleTypes(schemaType);
+          const possibleInterfaceTypes = this._getPossibleTypes(schemaType);
           for (const possibleType of possibleTypes) {
             if (possibleInterfaceTypes.find(possibleInterfaceType => possibleInterfaceType.name === possibleType.name)) {
               let typeSelections = types.get(possibleType.name);
@@ -264,24 +204,7 @@ export class SelectionSetToObject {
     }
   }
 
-  _collectInlineFragment(node: InlineFragmentNode) {
-    const onType = node.typeCondition.name.value;
-    const schemaType = this._schema.getType(onType);
-
-    if (!schemaType) {
-      throw new Error(`Inline fragment refernces a GraphQL type "${onType}" that does not exists in your schema!`);
-    }
-
-    const selectionSet = this.createNext(schemaType, node.selectionSet);
-
-    if (!this._fragments[onType]) {
-      this._fragments[onType] = [];
-    }
-
-    this._fragments[onType].push(selectionSet.string);
-  }
-
-  protected _getPossibleTypes(type: GraphQLNamedType = this._parentSchemaType): Array<GraphQLObjectType> {
+  protected _getPossibleTypes(type: GraphQLNamedType): Array<GraphQLObjectType> {
     if (isListType(type) || isNonNullType(type)) {
       return this._getPossibleTypes(type.ofType);
     } else if (isObjectType(type)) {
@@ -290,6 +213,24 @@ export class SelectionSetToObject {
       return this._schema.getPossibleTypes(type) as Array<GraphQLObjectType>;
     }
     return [];
+  }
+
+  protected _createInlineFragmentForFieldNodes(parentType: GraphQLNamedType, fieldNodes: FieldNode[]): InlineFragmentNode {
+    return {
+      kind: Kind.INLINE_FRAGMENT,
+      typeCondition: {
+        kind: Kind.NAMED_TYPE,
+        name: {
+          kind: Kind.NAME,
+          value: parentType.name,
+        },
+      },
+      directives: [],
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: fieldNodes,
+      },
+    };
   }
 
   get string(): string {
@@ -318,148 +259,32 @@ export class SelectionSetToObject {
     }
 
     if (fieldNodes.length) {
-      const fieldInlineFragment: InlineFragmentNode = {
-        kind: Kind.INLINE_FRAGMENT,
-        typeCondition: {
-          kind: Kind.NAMED_TYPE,
-          name: {
-            kind: Kind.NAME,
-            value: this._parentSchemaType.name,
-          },
-        },
-        directives: [],
-        selectionSet: {
-          kind: Kind.SELECTION_SET,
-          selections: fieldNodes,
-        },
-      };
-      inlineFragmentSelections.push(fieldInlineFragment);
+      inlineFragmentSelections.push(this._createInlineFragmentForFieldNodes(this._parentSchemaType, fieldNodes));
     }
 
     const selectionNodesByTypeName = new Map<string, SelectionNode[]>();
     this._collectInlineFragments(this._parentSchemaType, inlineFragmentSelections, selectionNodesByTypeName);
 
-    const possibleTypes = this._getPossibleTypes();
+    const possibleTypes = this._getPossibleTypes(this._parentSchemaType);
 
-    let fieldSelectionStringParts = possibleTypes
-      .map(type => {
-        const typeName = type.name;
-        const selectionNodes = selectionNodesByTypeName.get(typeName) || [];
+    const fieldSelections = possibleTypes.map(type => {
+      const typeName = type.name;
+      const schemaType = this._schema.getType(typeName);
+      if (!isObjectType(schemaType)) {
+        throw new TypeError('Invalid state.');
+      }
+      const selectionNodes = selectionNodesByTypeName.get(typeName) || [];
+      return this.buildSelectionSetString(schemaType, selectionNodes);
+    });
 
-        const primitiveFields = new Map<string, FieldNode>();
-        const primitiveAliasFields = new Map<string, FieldNode>();
-        const linkFieldSelectionSets = new Map<
-          string,
-          {
-            selectedFieldType: GraphQLOutputType;
-            field: FieldNode;
-          }
-        >();
-        let requireTypename = false;
+    let fieldSelectionString = fieldSelections.join(' | ');
 
-        for (const selectionNode of selectionNodes) {
-          if (selectionNode.kind === 'Field') {
-            if (!selectionNode.selectionSet) {
-              if (selectionNode.alias) {
-                primitiveAliasFields.set(selectionNode.alias.value, selectionNode);
-              } else if (selectionNode.name.value === '__typename') {
-                requireTypename = true;
-              } else {
-                primitiveFields.set(selectionNode.name.value, selectionNode);
-              }
-            } else {
-              let selectedField: GraphQLField<any, any, any> = null;
-
-              if (isObjectType(this._parentSchemaType)) {
-                const fields = this._parentSchemaType.getFields();
-                selectedField = fields[selectionNode.name.value];
-              } else if (isInterfaceType(this._parentSchemaType)) {
-                const fields = this._parentSchemaType.getFields();
-                selectedField = fields[selectionNode.name.value];
-                if (!selectedField) {
-                  const possibleTypes = this._schema.getPossibleTypes(this._parentSchemaType);
-                  for (const possibleType of possibleTypes) {
-                    selectedField = possibleType.getFields()[selectionNode.name.value];
-                    if (selectedField) {
-                      break;
-                    }
-                  }
-                }
-              } else if (isUnionType(this._parentSchemaType)) {
-                const types = this._parentSchemaType.getTypes();
-                for (const type of types) {
-                  const fields = type.getFields();
-                  selectedField = fields[selectionNode.name.value];
-                  if (selectedField) {
-                    break;
-                  }
-                }
-              }
-
-              if (isMetadataFieldName(selectionNode.name.value)) {
-                selectedField = metadataFieldMap[selectionNode.name.value];
-              }
-
-              if (!selectedField) {
-                throw new TypeError(`Could not find field type. ${this._parentSchemaType}.${selectionNode.name.value}`);
-              }
-
-              const fieldName = getFieldNodeNameValue(selectionNode);
-              let linkFieldNode = linkFieldSelectionSets.get(fieldName);
-              if (!linkFieldNode) {
-                linkFieldNode = {
-                  selectedFieldType: selectedField.type,
-                  field: selectionNode,
-                };
-                linkFieldSelectionSets.set(fieldName, linkFieldNode);
-              } else {
-                mergeSelectionSets(linkFieldNode.field.selectionSet, selectionNode.selectionSet);
-              }
-            }
-          }
-        }
-
-        const linkFields: LinkField[] = [];
-        for (const { field, selectedFieldType } of linkFieldSelectionSets.values()) {
-          const realSelectedFieldType = getBaseType(selectedFieldType as any);
-          const selectionSet = this.createNext(realSelectedFieldType, field.selectionSet);
-
-          linkFields.push({
-            alias: field.alias ? field.alias.value : undefined,
-            name: field.name.value,
-            type: realSelectedFieldType.name,
-            selectionSet: this.wrapTypeWithModifiers(selectionSet.string.split(`\n`).join(`\n  `), selectedFieldType as any),
-          });
-        }
-
-        const parentName =
-          (this._namespacedImportName ? `${this._namespacedImportName}.` : '') +
-          this._convertName(typeName, {
-            useTypesPrefix: true,
-          });
-        let typeInfoString: null | string = null;
-        if (this._nonOptionalTypename || this._addTypename || requireTypename) {
-          const optionalTypename = !requireTypename && !this._nonOptionalTypename;
-          typeInfoString = `{ ${this.formatNamedField('__typename')}${optionalTypename ? '?' : ''}: '${typeName}' }`;
-        }
-        const primitiveFieldsString = this.buildPrimitiveFields(parentName, Array.from(primitiveFields.values()).map(field => field.name.value));
-        const primitiveAliasFieldsString = this.buildAliasedPrimitiveFields(parentName, Array.from(primitiveAliasFields.values()).map(field => ({ alias: field.alias.value, fieldName: field.name.value })));
-        const linkFieldsString = this.buildLinkFields(linkFields);
-
-        return [typeInfoString, primitiveFieldsString, primitiveAliasFieldsString, linkFieldsString].filter(Boolean);
-      })
-      .filter(fieldSelectionStringParts => fieldSelectionStringParts.length > 0);
-
-    let fieldSelectionString = null;
-    if (fieldSelectionStringParts.length) {
-      fieldSelectionString = fieldSelectionStringParts.map(fieldSelectionStringParts => '(\n  ' + fieldSelectionStringParts.join('\n  & ') + '\n)').join(' | ');
+    // wrap in case we have some fragment spreads
+    if (fieldSelections.length > 1 && fragmentSpreadNodes.length) {
+      fieldSelectionString = `(${fieldSelectionString})`;
     }
 
-    let fragmentSelectionString: string | null = null;
-    if (fragmentSpreadNodes.length) {
-      const fragmentSpreadTypeNames = fragmentSpreadNodes.map(node => this._convertName(node.name.value, { useTypesPrefix: true, suffix: 'Fragment' }));
-      fragmentSelectionString = fragmentSpreadTypeNames.join(`\n  & `);
-    }
+    const fragmentSelectionString: string | null = this.buildFragmentSpreadString(fragmentSpreadNodes);
     if (!fieldSelectionString && !fragmentSelectionString) {
       throw new TypeError('Invalid State.');
     }
@@ -469,47 +294,155 @@ export class SelectionSetToObject {
       return fragmentSelectionString;
     }
 
-    return (
-      `(\n` +
-      fieldSelectionString
-        .split(`\n`)
-        .map(str => `    ${str}`)
-        .join(`\n`) +
-      `\n  )\n  & ` +
-      fragmentSelectionString
-        .split(`\n`)
-        .map(str => `${str}`)
-        .join(`\n`) +
-      '\n'
-    );
-
-    // else {
-    //   for (const fieldNode of fieldNodes) {
-    //     this._collectField(fieldNode);
-    //   }
-    // }
-
-    // if (this._preResolveTypes) {
-    //   return this.buildFieldsWithoutPick();
-    // } else {
-    //   return this.buildFieldsWithPick();
-    // }
+    return fieldSelectionString + `\n  & ` + fragmentSelectionString + '\n';
   }
 
-  protected buildFieldsWithoutPick(): string {
-    const typeName = this.buildTypeNameField();
+  protected buildFragmentSpreadString(fragmentSpreadNodes: FragmentSpreadNode[]) {
+    if (!fragmentSpreadNodes.length) {
+      return null;
+    }
+
+
+    return fragmentSpreadNodes.map(node => {
+      const fragmentSuffix = this._dedupeOperationSuffix && node.name.value.toLowerCase().endsWith('fragment') ? '' : 'Fragment';
+      return this._convertName(node.name.value, { useTypesPrefix: true, suffix: fragmentSuffix });
+    }).join(`\n  & `);
+  }
+
+  protected buildSelectionSetString(parentSchemaType: GraphQLObjectType, selectionNodes: SelectionNode[]) {
+    const primitiveFields = new Map<string, FieldNode>();
+    const primitiveAliasFields = new Map<string, FieldNode>();
+    const linkFieldSelectionSets = new Map<
+      string,
+      {
+        selectedFieldType: GraphQLOutputType;
+        field: FieldNode;
+      }
+    >();
+    let requireTypename = false;
+
+    for (const selectionNode of selectionNodes) {
+      if (selectionNode.kind === 'Field') {
+        if (!selectionNode.selectionSet) {
+          if (selectionNode.alias) {
+            primitiveAliasFields.set(selectionNode.alias.value, selectionNode);
+          } else if (selectionNode.name.value === '__typename') {
+            requireTypename = true;
+          } else {
+            primitiveFields.set(selectionNode.name.value, selectionNode);
+          }
+        } else {
+          let selectedField: GraphQLField<any, any, any> = null;
+
+          if (isObjectType(this._parentSchemaType)) {
+            const fields = this._parentSchemaType.getFields();
+            selectedField = fields[selectionNode.name.value];
+          } else if (isInterfaceType(this._parentSchemaType)) {
+            const fields = this._parentSchemaType.getFields();
+            selectedField = fields[selectionNode.name.value];
+            if (!selectedField) {
+              const possibleTypes = this._getPossibleTypes(this._parentSchemaType);
+              for (const possibleType of possibleTypes) {
+                selectedField = possibleType.getFields()[selectionNode.name.value];
+                if (selectedField) {
+                  break;
+                }
+              }
+            }
+          } else if (isUnionType(this._parentSchemaType)) {
+            const types = this._parentSchemaType.getTypes();
+            for (const type of types) {
+              const fields = type.getFields();
+              selectedField = fields[selectionNode.name.value];
+              if (selectedField) {
+                break;
+              }
+            }
+          }
+
+          if (isMetadataFieldName(selectionNode.name.value)) {
+            selectedField = metadataFieldMap[selectionNode.name.value];
+          }
+
+          if (!selectedField) {
+            throw new TypeError(`Could not find field type. ${this._parentSchemaType}.${selectionNode.name.value}`);
+          }
+
+          const fieldName = getFieldNodeNameValue(selectionNode);
+          let linkFieldNode = linkFieldSelectionSets.get(fieldName);
+          if (!linkFieldNode) {
+            linkFieldNode = {
+              selectedFieldType: selectedField.type,
+              field: selectionNode,
+            };
+            linkFieldSelectionSets.set(fieldName, linkFieldNode);
+          } else {
+            mergeSelectionSets(linkFieldNode.field.selectionSet, selectionNode.selectionSet);
+          }
+        }
+      }
+    }
+
+    const linkFields: LinkField[] = [];
+    for (const { field, selectedFieldType } of linkFieldSelectionSets.values()) {
+      const realSelectedFieldType = getBaseType(selectedFieldType as any);
+      const selectionSet = this.createNext(realSelectedFieldType, field.selectionSet);
+
+      linkFields.push({
+        alias: field.alias ? field.alias.value : undefined,
+        name: field.name.value,
+        type: realSelectedFieldType.name,
+        selectionSet: this.wrapTypeWithModifiers(selectionSet.string.split(`\n`).join(`\n  `), selectedFieldType as any),
+      });
+    }
+
+    const parentName =
+      (this._namespacedImportName ? `${this._namespacedImportName}.` : '') +
+      this._convertName(parentSchemaType.name, {
+        useTypesPrefix: true,
+      });
+
+    const typeInfoField = this.buildTypeNameField(parentSchemaType, this._nonOptionalTypename, this._addTypename, requireTypename);
+
+    if (this._preResolveTypes) {
+      const primitiveFieldsTypes = this.buildPrimitiveFieldsWithoutPick(parentSchemaType, Array.from(primitiveFields.values()).map(field => field.name.value));
+      const primitiveAliasTypes = this.buildAliasedPrimitiveFieldsWithoutPick(parentSchemaType, Array.from(primitiveAliasFields.values()).map(field => ({ alias: field.alias.value, fieldName: field.name.value })));
+      const linkFieldsTypes = this.buildLinkFieldsWithoutPick(linkFields);
+
+      return `{ ${[typeInfoField, ...primitiveFieldsTypes, ...primitiveAliasTypes, ...linkFieldsTypes]
+        .filter(a => a)
+        .map(b => `${b.name}: ${b.type}`)
+        .join(', ')} }`;
+    }
+
+    let typeInfoString: null | string = null;
+    if (typeInfoField) {
+      typeInfoString = `{ ${typeInfoField.name}: ${typeInfoField.type} }`;
+    }
+
+    const primitiveFieldsString = this.buildPrimitiveFields(parentName, Array.from(primitiveFields.values()).map(field => field.name.value));
+    const primitiveAliasFieldsString = this.buildAliasedPrimitiveFields(parentName, Array.from(primitiveAliasFields.values()).map(field => ({ alias: field.alias.value, fieldName: field.name.value })));
+    const linkFieldsString = this.buildLinkFields(linkFields);
+
+    const result = [typeInfoString, primitiveFieldsString, primitiveAliasFieldsString, linkFieldsString].filter(Boolean);
+    if (result.length === 0) {
+      return null;
+    } else if (result.length === 1) {
+      return result[0];
+    } else {
+      return `(\n  ` + result.join(`\n  & `) + `\n)`;
+    }
+  }
+
+  protected buildFieldsWithoutPick(parentType: GraphQLObjectType): string {
+    const typeName = this.buildTypeNameField(parentType);
     const baseFields = this.buildPrimitiveFieldsWithoutPick(this._parentSchemaType as any, this._primitiveFields);
     const linksFields = this.buildLinkFieldsWithoutPick(this._linksFields);
     const aliasBaseFields = this.buildAliasedPrimitiveFieldsWithoutPick(this._parentSchemaType as any, this._primitiveAliasedFields);
-    const fragments = this.buildFragments(this._fragments);
     let mergedFields = `{ ${[typeName, ...baseFields, ...aliasBaseFields, ...linksFields]
       .filter(a => a)
       .map(b => `${b.name}: ${b.type}`)
       .join(', ')} }`;
-
-    if (fragments && fragments !== '') {
-      mergedFields = this.mergeAllFields([mergedFields, fragments]);
-    }
 
     return mergedFields;
   }
@@ -568,66 +501,15 @@ export class SelectionSetToObject {
     });
   }
 
-  protected buildFieldsWithPick(): string {
-    const parentName =
-      (this._namespacedImportName ? `${this._namespacedImportName}.` : '') +
-      this._convertName(this._parentSchemaType.name, {
-        useTypesPrefix: true,
-      });
-    const typeName = this.buildTypeNameField();
-    const baseFields = this.buildPrimitiveFields(parentName, this._primitiveFields);
-    const aliasBaseFields = this.buildAliasedPrimitiveFields(parentName, this._primitiveAliasedFields);
-    const linksFields = this.buildLinkFields(this._linksFields);
-    const fragments = this.buildFragments(this._fragments);
-    const fieldsSet = [typeName ? `{ ${typeName.name}: ${typeName.type} }` : '', baseFields, aliasBaseFields, linksFields, fragments].filter(f => f && f !== '');
-
-    return this.mergeAllFields(fieldsSet);
-  }
-
-  protected mergeAllFields(fieldsSet: Array<string | null>): string {
-    return quoteIfNeeded(fieldsSet, ' & ');
-  }
-
-  protected getImplementingTypes(node: GraphQLInterfaceType): string[] {
-    const allTypesMap = this._schema.getTypeMap();
-    const implementingTypes: string[] = [];
-
-    for (const graphqlType of Object.values(allTypesMap)) {
-      if (graphqlType instanceof GraphQLObjectType) {
-        const allInterfaces = graphqlType.getInterfaces();
-        if (allInterfaces.find(int => int.name === ((node.name as any) as string))) {
-          implementingTypes.push(graphqlType.name);
-        }
-      }
-    }
-
-    return implementingTypes;
-  }
-
-  protected buildTypeNameField(): { name: string; type: string } {
-    if (this._nonOptionalTypename || this._addTypename || this._queriedForTypename) {
-      const possibleTypes = [];
-
-      if (isUnionType(this._parentSchemaType)) {
-        return null;
-      } else if (isInterfaceType(this._parentSchemaType)) {
-        possibleTypes.push(...this.getImplementingTypes(this._parentSchemaType));
-      } else {
-        possibleTypes.push(this._parentSchemaType.name);
-      }
-
-      if (possibleTypes.length === 0) {
-        return null;
-      }
-
-      const optionalTypename = !this._queriedForTypename && !this._nonOptionalTypename;
+  protected buildTypeNameField(type: GraphQLObjectType, nonOptionalTypename: boolean = this._nonOptionalTypename, addTypename: boolean = this._addTypename, queriedForTypename: boolean = this._queriedForTypename): { name: string; type: string } {
+    if (nonOptionalTypename || addTypename || queriedForTypename) {
+      const optionalTypename = !queriedForTypename && !nonOptionalTypename;
 
       return {
         name: `${this.formatNamedField('__typename')}${optionalTypename ? '?' : ''}`,
-        type: `${possibleTypes.map(t => `'${t}'`).join(' | ')}`,
+        type: `'${type.name}'`,
       };
     }
-
     return null;
   }
 
@@ -657,75 +539,5 @@ export class SelectionSetToObject {
     }
 
     return `{ ${fields.map(field => `${this.formatNamedField(field.alias || field.name)}: ${field.selectionSet}`).join(', ')} }`;
-  }
-
-  protected buildFragments(fragments: FragmentsMap): string | null {
-    if (isUnionType(this._parentSchemaType) || isInterfaceType(this._parentSchemaType)) {
-      return this._handleFragmentsForUnionAndInterface(fragments);
-    } else if (isObjectType(this._parentSchemaType)) {
-      return this._handleFragmentsForObjectType(fragments);
-    }
-
-    return null;
-  }
-
-  protected _handleFragmentsForObjectType(fragments: FragmentsMap): string | null {
-    const fragmentsValue = Object.keys(fragments).reduce((prev, fragmentName) => {
-      const fragmentArr = fragments[fragmentName];
-
-      return [...prev, ...fragmentArr];
-    }, []);
-
-    return quoteIfNeeded(fragmentsValue, ' & ');
-  }
-
-  protected _handleFragmentsForUnionAndInterface(fragments: FragmentsMap): string | null {
-    const interfaces: { [onType: string]: { fragments: string[]; implementingFragments: string[] } } = {};
-    const types: { [onType: string]: { fragments: string[]; implementingFragments: string[] } } = {};
-    const onInterfaces = Object.keys(fragments).filter(typeName => isInterfaceType(this._schema.getType(typeName)));
-    const onNonInterfaces = Object.keys(fragments).filter(typeName => !isInterfaceType(this._schema.getType(typeName)));
-
-    for (const typeName of onInterfaces) {
-      const interfaceFragments = fragments[typeName];
-
-      interfaces[typeName] = {
-        fragments: interfaceFragments,
-        implementingFragments: [],
-      };
-    }
-
-    for (const typeName of onNonInterfaces) {
-      const schemaType = this._schema.getType(typeName) as GraphQLObjectType;
-
-      if (!schemaType) {
-        throw new Error(`Inline fragment refernces a GraphQL type "${typeName}" that does not exists in your schema!`);
-      }
-
-      const typeFragments = fragments[typeName];
-      const interfacesFragments = schemaType.getInterfaces === undefined ? [] : schemaType.getInterfaces().filter(gqlInterface => !!interfaces[gqlInterface.name]);
-
-      if (interfacesFragments.length > 0) {
-        for (const relevantInterface of interfacesFragments) {
-          interfaces[relevantInterface.name].implementingFragments.push(...typeFragments);
-        }
-      } else {
-        types[typeName] = {
-          fragments: typeFragments,
-          implementingFragments: [],
-        };
-      }
-    }
-
-    const mergedResult = { ...interfaces, ...types };
-
-    return quoteIfNeeded(
-      Object.keys(mergedResult).map(typeName => {
-        const baseFragments = quoteIfNeeded(mergedResult[typeName].fragments, ' & ');
-        const implementingFragments = quoteIfNeeded(mergedResult[typeName].implementingFragments, ' | ');
-
-        return quoteIfNeeded([baseFragments, implementingFragments].filter(a => a), ' & ');
-      }),
-      ' | '
-    );
   }
 }

--- a/packages/plugins/typescript/compatibility/tests/compatibility.spec.ts
+++ b/packages/plugins/typescript/compatibility/tests/compatibility.spec.ts
@@ -516,7 +516,7 @@ describe('Compatibility Plugin', () => {
 
   it('Should work with interfaces and inline fragments', async () => {
     const testSchema = buildSchema(/* GraphQL */ `
-      type Node {
+      interface Node {
         id: ID!
       }
 

--- a/packages/plugins/typescript/operations/src/ts-selection-set-to-object.ts
+++ b/packages/plugins/typescript/operations/src/ts-selection-set-to-object.ts
@@ -24,7 +24,7 @@ export class TypeScriptSelectionSetToObject extends SelectionSetToObject {
 
   private clearOptional(str: string): string {
     const prefix = this._config.namespacedImportName ? `${this._config.namespacedImportName}\.` : '';
-    const rgx = new RegExp(`^${prefix}Maybe<(.*?)>$`, 'i');
+    const rgx = new RegExp(`^${prefix}Maybe<(.*?)>$`, 'is');
 
     if (str.startsWith(`${this._config.namespacedImportName ? `${this._config.namespacedImportName}.` : ''}Maybe`)) {
       return str.replace(rgx, '$1');

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -95,7 +95,7 @@ describe('TypeScript Operations Plugin', () => {
   };
 
   describe('Config', () => {
-    it('Should handle "namespacedImportName" and add it when specified', async () => {
+    it('Should not generate "export" when noExport is set to true', async () => {
       const ast = parse(/* GraphQL */ `
         query notifications {
           notifications {
@@ -149,15 +149,21 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<(
-          { __typename?: 'TextNotification' }
-          & Pick<Types.TextNotification, 'text' | 'id'>
-          & { textAlias: Types.TextNotification['text'] }
-        ) | (
-          { __typename?: 'ImageNotification' }
-          & Pick<Types.ImageNotification, 'imageUrl' | 'id'>
-          & { metadata: ({ __typename?: 'ImageMetadata' } & { created: Types.ImageMetadata['createdBy'] }) }
-        )> });
+        export type NotificationsQuery = (
+          { __typename?: 'Query' }
+          & { notifications: Array<(
+            { __typename?: 'TextNotification' }
+            & Pick<Types.TextNotification, 'text' | 'id'>
+            & { textAlias: Types.TextNotification['text'] }
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & Pick<Types.ImageNotification, 'imageUrl' | 'id'>
+            & { metadata: (
+              { __typename?: 'ImageMetadata' }
+              & { created: Types.ImageMetadata['createdBy'] }
+            ) }
+          )> }
+        );
       `);
       await validate(result, config);
     });
@@ -185,14 +191,20 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type notificationsquery = ({ readonly __typename?: 'Query' } & { readonly notifications: ReadonlyArray<(
-          { readonly __typename?: 'TextNotification' }
-          & Pick<textnotification, 'text' | 'id'>
-        ) | (
-          { readonly __typename?: 'ImageNotification' }
-          & Pick<imagenotification, 'imageUrl' | 'id'>
-          & { readonly metadata: ({ readonly __typename?: 'ImageMetadata' } & Pick<imagemetadata, 'createdBy'>) }
-        )> });
+        export type notificationsquery = (
+          { readonly __typename?: 'Query' }
+          & { readonly notifications: ReadonlyArray<(
+            { readonly __typename?: 'TextNotification' }
+            & Pick<textnotification, 'text' | 'id'>
+          ) | (
+            { readonly __typename?: 'ImageNotification' }
+            & Pick<imagenotification, 'imageUrl' | 'id'>
+            & { readonly metadata: (
+              { readonly __typename?: 'ImageMetadata' }
+              & Pick<imagemetadata, 'createdBy'>
+            ) }
+          )> }
+        );
       `);
       await validate(result, config);
     });
@@ -251,14 +263,20 @@ describe('TypeScript Operations Plugin', () => {
 
       expect(result).toBeSimilarStringTo(`export type NotificationsQueryVariables = {};`);
       expect(result).toBeSimilarStringTo(`
-        export type NotificationsQueryResult = ({ __typename?: 'Query' } & { notifications: Array<(
-          { __typename?: 'TextNotification' }
-          & Pick<TextNotification, 'text' | 'id'>
-        ) | (
-          { __typename?: 'ImageNotification' }
-          & Pick<ImageNotification, 'imageUrl' | 'id'>
-          & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<ImageMetadata, 'createdBy'>) }
-        )> });
+        export type NotificationsQueryResult = (
+          { __typename?: 'Query' }
+          & { notifications: Array<(
+            { __typename?: 'TextNotification' }
+            & Pick<TextNotification, 'text' | 'id'>
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & Pick<ImageNotification, 'imageUrl' | 'id'>
+            & { metadata: (
+              { __typename?: 'ImageMetadata' }
+              & Pick<ImageMetadata, 'createdBy'>
+            ) }
+          )> }
+        );
       `);
 
       await validate(result, config);
@@ -289,14 +307,20 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type notificationsquery = ({ __typename?: 'Query' } & { notifications: Array<(
-          { __typename?: 'TextNotification' }
-          & Pick<textnotification, 'text' | 'id'>
-        ) | (
-          { __typename?: 'ImageNotification' }
-          & Pick<imagenotification, 'imageUrl' | 'id'>
-          & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<imagemetadata, 'createdBy'>) }
-        )> });
+        export type notificationsquery = (
+          { __typename?: 'Query' }
+          & { notifications: Array<(
+            { __typename?: 'TextNotification' }
+            & Pick<textnotification, 'text' | 'id'>
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & Pick<imagenotification, 'imageUrl' | 'id'>
+            & { metadata: (
+              { __typename?: 'ImageMetadata' }
+              & Pick<imagemetadata, 'createdBy'>
+            ) }
+          )> }
+        );
       `);
       await validate(result, config);
     });
@@ -326,17 +350,22 @@ describe('TypeScript Operations Plugin', () => {
 
       expect(result).toBeSimilarStringTo(`export type inotificationsqueryvariables = {};`);
       expect(result).toBeSimilarStringTo(`
-        export type inotificationsquery = ({ __typename?: 'Query' } & { notifications: Array<(
-          { __typename?: 'TextNotification' }
-          & Pick<itextnotification, 'text' | 'id'>
-        ) | (
-          { __typename?: 'ImageNotification' }
-          & Pick<iimagenotification, 'imageUrl' | 'id'>
-          & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<iimagemetadata, 'createdBy'>) }
-        )> });
-        
+        export type inotificationsquery = (
+          { __typename?: 'Query' }
+          & { notifications: Array<(
+            { __typename?: 'TextNotification' }
+            & Pick<itextnotification, 'text' | 'id'>
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & Pick<iimagenotification, 'imageUrl' | 'id'>
+            & { metadata: (
+                { __typename?: 'ImageMetadata' }
+                & Pick<iimagemetadata, 'createdBy'>
+              ) }
+          )> }
+        );
       `);
-      validate(result, config);
+      await validate(result, config);
     });
 
     it('Test for dedupeOperationSuffix', async () => {
@@ -404,7 +433,7 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).not.toContain(`__typename`);
-      validate(result, config);
+      await validate(result, config);
     });
 
     it('Should add __typename when dealing with fragments', async () => {
@@ -441,8 +470,16 @@ describe('TypeScript Operations Plugin', () => {
       `);
       const config = {};
       const result = await plugin(testSchema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
-      expect(result).toContain(`export type NodeFragment = ({ __typename: 'A' | 'B' } & Pick<Node, 'id'>);`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type NodeFragment = (
+          { __typename: 'A' }
+          & Pick<A, 'id'>
+        ) | (
+          { __typename: 'B' }
+          & Pick<B, 'id'>
+        );
+      `);
+      await validate(result, config, testSchema);
     });
 
     it('Should add __typename as non-optional when explicitly specified', async () => {
@@ -454,8 +491,13 @@ describe('TypeScript Operations Plugin', () => {
       `);
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = ({ __typename: 'Query' } & Pick<Query, 'dummy'>);`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_Query = (
+          { __typename: 'Query' }
+          & Pick<Query, 'dummy'>
+        );
+      `);
+      await validate(result, config);
     });
     it('Should add __typename as non-optional when forced', async () => {
       const ast = parse(/* GraphQL */ `
@@ -465,8 +507,13 @@ describe('TypeScript Operations Plugin', () => {
       `);
       const config = { nonOptionalTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = ({ __typename: 'Query' } & Pick<Query, 'dummy'>);`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_Query = (
+          { __typename: 'Query' }
+          & Pick<Query, 'dummy'>
+        );
+      `);
+      await validate(result, config);
     });
 
     it('Should add __typename as optional when its not specified', async () => {
@@ -477,8 +524,13 @@ describe('TypeScript Operations Plugin', () => {
       `);
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = ({ __typename?: 'Query' } & Pick<Query, 'dummy'>);`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_Query = (
+          { __typename?: 'Query' }
+          & Pick<Query, 'dummy'>
+        );
+      `);
+      await validate(result, config);
     });
 
     it('Should add __typename as non-optional when its explictly specified, even if skipTypename is true', async () => {
@@ -491,8 +543,13 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = ({ __typename: 'Query' } & Pick<Query, 'dummy'>);`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_Query = (
+          { __typename: 'Query' }
+          & Pick<Query, 'dummy'>
+        );
+      `);
+      await validate(result, config);
     });
 
     it('Should add __typename correctly when unions are in use', async () => {
@@ -512,15 +569,18 @@ describe('TypeScript Operations Plugin', () => {
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
-        export type UnionTestQuery = ({ __typename?: 'Query' } & { unionTest: Maybe<(
-          { __typename?: 'User' }
-          & Pick<User, 'id'>
-        ) | (
-          { __typename?: 'Profile' }
-          & Pick<Profile, 'age'>
-        )> });
+        export type UnionTestQuery = (
+          { __typename?: 'Query' } 
+          & { unionTest: Maybe<(
+            { __typename?: 'User' }
+            & Pick<User, 'id'>
+          ) | (
+            { __typename?: 'Profile' }
+            & Pick<Profile, 'age'>
+          )> }
+        );
       `);
-      validate(result, config);
+      await validate(result, config);
     });
 
     it('Should add __typename correctly when interfaces are in use', async () => {
@@ -545,16 +605,22 @@ describe('TypeScript Operations Plugin', () => {
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
-        export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<(
-          { __typename?: 'TextNotification' }
-          & Pick<TextNotification, 'text' | 'id'>
-        ) | (
-          { __typename?: 'ImageNotification' }
-          & Pick<ImageNotification, 'imageUrl' | 'id'>
-          & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<ImageMetadata, 'createdBy'>) }
-        )> });
+        export type NotificationsQuery = (
+          { __typename?: 'Query' }
+          & { notifications: Array<(
+            { __typename?: 'TextNotification' }
+            & Pick<TextNotification, 'text' | 'id'>
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & Pick<ImageNotification, 'imageUrl' | 'id'>
+            & { metadata: (
+                { __typename?: 'ImageMetadata' }
+                & Pick<ImageMetadata, 'createdBy'>
+              ) }
+          )> }
+        );
       `);
-      validate(result, config);
+      await validate(result, config);
     });
   });
 
@@ -567,9 +633,15 @@ describe('TypeScript Operations Plugin', () => {
       `);
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = Pick<Query, 'dummy'>;`);
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_QueryVariables = {};`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_Query = (
+          Pick<Query, 'dummy'>
+        );
+      `);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_QueryVariables = {};
+      `);
+      await validate(result, config);
     });
 
     it('Should handle unnamed documents correctly with multiple documents', async () => {
@@ -585,11 +657,23 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = Pick<Query, 'dummy'>;`);
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_QueryVariables = {};`);
-      expect(result).toBeSimilarStringTo(`export type Unnamed_2_Query = Pick<Query, 'dummy'>;`);
-      expect(result).toBeSimilarStringTo(`export type Unnamed_2_QueryVariables = {};`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_Query = (
+          Pick<Query, 'dummy'>
+        );
+      `);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_QueryVariables = {};
+      `);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_2_Query = (
+          Pick<Query, 'dummy'>
+        );
+      `);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_2_QueryVariables = {};
+      `);
+      await validate(result, config);
     });
   });
 
@@ -638,8 +722,12 @@ describe('TypeScript Operations Plugin', () => {
       `);
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`export type MeQuery = { me: Maybe<UserFieldsFragment> };`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type MeQuery = (
+          { me: Maybe<UserFieldsFragment> }
+        );
+      `);
+      await validate(result, config);
     });
 
     it('Should support fragment spread correctly with simple type with other fields', async () => {
@@ -661,8 +749,18 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type MeQuery = { me: Maybe<(Pick<User, 'username'> & UserFieldsFragment)> };`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type MeQuery = (
+          { me: Maybe<(
+              (
+                Pick<User, 'username'>
+              )
+            )
+            & UserFieldsFragment
+          > }
+        );
+      `);
+      await validate(result, config);
     });
 
     it('Should support fragment spread correctly with multiple fragment spread', async () => {
@@ -688,10 +786,36 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: false };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type MeQuery = ({ __typename?: 'Query' } & { me: Maybe<({ __typename?: 'User' } & Pick<User, 'username'> & (UserFieldsFragment & UserProfileFragment))> });`);
-      expect(result).toBeSimilarStringTo(`export type UserProfileFragment = ({ __typename?: 'User' } & { profile: Maybe<({ __typename?: 'Profile' } & Pick<Profile, 'age'>)> });`);
-      expect(result).toBeSimilarStringTo(`export type UserFieldsFragment = ({ __typename?: 'User' } & Pick<User, 'id'>);`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type MeQuery = (
+          { __typename?: 'Query' }
+          & { me: Maybe<(
+              (
+                { __typename?: 'User' }
+                & Pick<User, 'username'>
+              )
+            )
+            & UserFieldsFragment
+            & UserProfileFragment
+          > }
+        );
+      `);
+      expect(result).toBeSimilarStringTo(`
+        export type UserProfileFragment = (
+          { __typename?: 'User' }
+          & { profile: Maybe<(
+            { __typename?: 'Profile' }
+            & Pick<Profile, 'age'>
+          )> }
+        );
+      `);
+      expect(result).toBeSimilarStringTo(`
+        export type UserFieldsFragment = (
+          { __typename?: 'User' }
+          & Pick<User, 'id'>
+        );
+      `);
+      await validate(result, config);
     });
 
     it('Should generate the correct intersection for fragments when using with interfaces with different type', async () => {
@@ -737,12 +861,31 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-      export type Unnamed_1_Query = ({ __typename?: 'Query' } & { b: Maybe<({ __typename?: 'A' | 'B' } & (AFragment | BFragment))> });
+        export type Unnamed_1_Query = (
+          { __typename?: 'Query' }
+          & { b: Maybe<(
+              (
+                { __typename?: 'A' }
+              ) | (
+                { __typename?: 'B' }
+              )
+            )
+            & AFragment
+            & BFragment
+          > }
+        );
 
-      export type AFragment = ({ __typename?: 'A' } & Pick<A, 'id' | 'x'>);
-  
-      export type BFragment = ({ __typename?: 'B' } & Pick<B, 'id' | 'y'>);`);
-      validate(result, config);
+        export type AFragment = (
+          { __typename?: 'A' }
+          & Pick<A, 'id' | 'x'>
+        );
+
+        export type BFragment = (
+          { __typename?: 'B' }
+          & Pick<B, 'id' | 'y'>
+        );
+      `);
+      await validate(result, config, schema);
     });
 
     it('Should generate the correct intersection for fragments when type implements 2 interfaces', async () => {
@@ -789,9 +932,20 @@ describe('TypeScript Operations Plugin', () => {
       `);
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
-
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = ({ __typename?: 'Query' } & { myType: ({ __typename?: 'MyType' } & (AFragment & BFragment & CFragment)) })`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type Unnamed_1_Query = (
+          { __typename?: 'Query' }
+          & { myType: (
+              (
+                { __typename?: 'MyType' }
+              )
+            )
+            & AFragment
+            & BFragment
+            & CFragment
+          }
+        )`);
+      await validate(result, config);
     });
 
     it('Should generate the correct intersection for fragments when using with interfaces with same type', async () => {
@@ -835,11 +989,30 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-      export type Unnamed_1_Query = ({ __typename?: 'Query' } & { b: Maybe<({ __typename?: 'A' | 'B' } & (AFragment & BFragment))> });
-    
-      export type AFragment = ({ __typename?: 'A' } & Pick<A, 'id'>);
-      
-      export type BFragment = ({ __typename?: 'A' } & Pick<A, 'x'>);`);
+        export type Unnamed_1_Query = (
+          { __typename?: 'Query' }
+          & { b: Maybe<(
+              (
+                { __typename?: 'A' }
+              ) | (
+                { __typename?: 'B' }
+              )
+            )
+            & AFragment
+            & BFragment
+          > }
+        );
+  
+        export type AFragment = (
+          { __typename?: 'A' }
+          & Pick<A, 'id'>
+        );
+  
+        export type BFragment = (
+          { __typename?: 'A' }
+          & Pick<A, 'x'>
+        );
+      `);
       compileTs(mergeOutputs([result]), config);
     });
 
@@ -866,16 +1039,22 @@ describe('TypeScript Operations Plugin', () => {
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
-        export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<(
-          { __typename?: 'TextNotification' }
-          & Pick<TextNotification, 'text' | 'id'>
-        ) | (
-          { __typename?: 'ImageNotification' }
-          & Pick<ImageNotification, 'imageUrl' | 'id'>
-          & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<ImageMetadata, 'createdBy'>) }
-        )> });
+        export type NotificationsQuery = (
+          { __typename?: 'Query' }
+          & { notifications: Array<(
+            { __typename?: 'TextNotification' }
+            & Pick<TextNotification, 'text' | 'id'>
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & Pick<ImageNotification, 'imageUrl' | 'id'>
+            & { metadata: (
+                { __typename?: 'ImageMetadata' }
+                & Pick<ImageMetadata, 'createdBy'>
+              ) }
+          )> }
+        );
       `);
-      validate(result, config);
+      await validate(result, config);
     });
 
     it('Should support union correctly when used with inline fragments', async () => {
@@ -896,15 +1075,18 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type UnionTestQuery = ({ __typename?: 'Query' } & { unionTest: Maybe<(
-          { __typename?: 'User' }
-          & Pick<User, 'id'>
-        ) | (
-          { __typename?: 'Profile' }
-          & Pick<Profile, 'age'>
-        )> });
+        export type UnionTestQuery = (
+          { __typename?: 'Query' }
+            & { unionTest: Maybe<(
+            { __typename?: 'User' }
+            & Pick<User, 'id'>
+          ) | (
+            { __typename?: 'Profile' }
+            & Pick<Profile, 'age'>
+          )> }
+        );
       `);
-      validate(result, config);
+      await validate(result, config);
     });
 
     it('Should support union correctly when used with inline fragments on types implementing common interface', async () => {
@@ -929,15 +1111,18 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type UnionTestQuery = ({ __typename?: 'Query' } & { mixedNotifications: Array<(
-          { __typename?: 'TextNotification' }
-          & Pick<TextNotification, 'id' | 'text'>
-        ) | (
-          { __typename?: 'ImageNotification' }
-          & Pick<ImageNotification, 'id' | 'imageUrl'>
-        )> });
+        export type UnionTestQuery = (
+          { __typename?: 'Query' }
+          & { mixedNotifications: Array<(
+            { __typename?: 'TextNotification' }
+            & Pick<TextNotification, 'id' | 'text'>
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & Pick<ImageNotification, 'id' | 'imageUrl'>
+          )> }
+        );
       `);
-      validate(result, config);
+      await validate(result, config);
     });
 
     it('Should support union correctly when used with inline fragments on types implementing common interface and also other types', async () => {
@@ -966,18 +1151,21 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type UnionTestQuery = ({ __typename?: 'Query' } & { search: Array<(
-          { __typename?: 'User' }
-          & Pick<User, 'id'>
-        ) | (
-          { __typename?: 'TextNotification' }
-          & Pick<TextNotification, 'id' | 'text'>
-        ) | (
-          { __typename?: 'ImageNotification' }
-          & Pick<ImageNotification, 'id' | 'imageUrl'>
-        )> });
+        export type UnionTestQuery = (
+          { __typename?: 'Query' }
+          & { search: Array<(
+            { __typename?: 'TextNotification' }
+            & Pick<TextNotification, 'id' | 'text'>
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & Pick<ImageNotification, 'id' | 'imageUrl'>
+          ) | (
+            { __typename?: 'User' }
+            & Pick<User, 'id'>
+          )> }
+        );
       `);
-      validate(result, config);
+      await validate(result, config);
     });
 
     it('Should support inline fragments', async () => {
@@ -997,13 +1185,17 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = { me: Maybe<(
-          Pick<User, 'username' | 'id'>
-          & { profile: Maybe<Pick<Profile, 'age'>> }
-        )> };
+        export type CurrentUserQuery = (
+          { me: Maybe<(
+            Pick<User, 'username' | 'id'>
+            & { profile: Maybe<(
+              Pick<Profile, 'age'>
+            )> }
+          )> }
+        );
       `);
 
-      validate(result, config);
+      await validate(result, config);
     });
 
     it('Should build a basic selection set based on basic query on GitHub schema', async () => {
@@ -1033,8 +1225,19 @@ describe('TypeScript Operations Plugin', () => {
           repoFullName: Scalars['String']
         };`
       );
-      expect(result).toBeSimilarStringTo(`export type MeQuery = { currentUser: Maybe<Pick<User, 'login' | 'html_url'>>, entry: Maybe<(Pick<Entry, 'id' | 'createdAt'> & { postedBy: Pick<User, 'login' | 'html_url'> })> };`);
-      validate(result, config, gitHuntSchema);
+      expect(result).toBeSimilarStringTo(`
+        export type MeQuery = (
+          { currentUser: Maybe<(
+            Pick<User, 'login' | 'html_url'>
+          )>, entry: Maybe<(
+            Pick<Entry, 'id' | 'createdAt'>
+            & { postedBy: (
+              Pick<User, 'login' | 'html_url'> 
+            ) }
+          )> }
+        );
+      `);
+      await validate(result, config, gitHuntSchema);
     });
 
     it('Should build a basic selection set based on basic query on GitHub schema with preResolveTypes=true', async () => {
@@ -1060,9 +1263,9 @@ describe('TypeScript Operations Plugin', () => {
       });
 
       expect(result).toBeSimilarStringTo(
-        `export type MeQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, postedBy: { __typename?: 'User', login: string, html_url: string } }> };`
+        `export type MeQuery = ({ __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, postedBy: { __typename?: 'User', login: string, html_url: string } }> };`
       );
-      validate(result, config, gitHuntSchema);
+      await validate(result, config, gitHuntSchema);
     });
 
     it('Should produce valid output with preResolveTypes=true and enums', async () => {
@@ -1117,8 +1320,12 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type DummyQuery = Pick<Query, 'dummy'>;`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type DummyQuery = (
+          Pick<Query, 'dummy'>
+        );
+      `);
+      await validate(result, config);
     });
 
     it('Should build a basic selection set based on basic query with field aliasing for basic scalar', async () => {
@@ -1133,8 +1340,15 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type DummyQuery = ({ customName: Query['dummy'] } & { customName2: Maybe<Pick<Profile, 'age'>> });`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type DummyQuery = (
+          { customName: Query['dummy'] }
+          & { customName2: Maybe<(
+            Pick<Profile, 'age'>
+          )> }
+        );
+      `);
+      await validate(result, config);
     });
 
     it('Should build a basic selection set based on a query with inner fields', async () => {
@@ -1153,8 +1367,17 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type CurrentUserQuery = { me: Maybe<(Pick<User, 'id' | 'username' | 'role'> & { profile: Maybe<Pick<Profile, 'age'>> })> };`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type CurrentUserQuery = (
+          { me: Maybe<(
+            Pick<User, 'id' | 'username' | 'role'>
+            & { profile: Maybe<(
+              Pick<Profile, 'age'>
+            )> }
+          )> }
+        );
+      `);
+      await validate(result, config);
     });
   });
 
@@ -1172,8 +1395,15 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type UserFieldsFragment = (Pick<User, 'id' | 'username'> & { profile: Maybe<Pick<Profile, 'age'>> });`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type UserFieldsFragment = (
+          Pick<User, 'id' | 'username'>
+          & { profile: Maybe<(
+            Pick<Profile, 'age'>
+          )> }
+        );
+      `);
+      await validate(result, config);
     });
   });
 
@@ -1193,8 +1423,16 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type LoginMutation = { login: Maybe<(Pick<User, 'id' | 'username'> & { profile: Maybe<Pick<Profile, 'age'>> })> };`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type LoginMutation = (
+          { login: Maybe<(
+            Pick<User, 'id' | 'username'>
+            & { profile: Maybe<(
+              Pick<Profile, 'age'>
+            )> }
+          )> }
+        );`);
+      await validate(result, config);
     });
 
     it('Should detect Query correctly', async () => {
@@ -1206,8 +1444,12 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type TestQuery = Pick<Query, 'dummy'>;`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type TestQuery = (
+          Pick<Query, 'dummy'>
+        );
+      `);
+      await validate(result, config);
     });
 
     it('Should detect Subscription correctly', async () => {
@@ -1221,8 +1463,14 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type TestSubscription = { userCreated: Maybe<Pick<User, 'id'>> };`);
-      validate(result, config);
+      expect(result).toBeSimilarStringTo(`
+        export type TestSubscription = (
+          { userCreated: Maybe<(
+            Pick<User, 'id'>
+          )> }
+        );
+      `);
+      await validate(result, config);
     });
 
     it('Should handle operation variables correctly', async () => {
@@ -1246,7 +1494,7 @@ describe('TypeScript Operations Plugin', () => {
           innerRequired: Array<Scalars['String']>
         };`
       );
-      validate(result, config);
+      await validate(result, config);
     });
 
     it('Should handle operation variables correctly when they use custom scalars', async () => {
@@ -1263,7 +1511,7 @@ describe('TypeScript Operations Plugin', () => {
           test?: Maybe<Scalars['DateTime']>
         };`
       );
-      validate(result, config);
+      await validate(result, config);
     });
 
     it('Should create empty variables when there are no operation variables', async () => {
@@ -1276,7 +1524,7 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`export type TestQueryQueryVariables = {};`);
-      validate(result, config);
+      await validate(result, config);
     });
 
     it('avoid duplicates - each type name should be unique', async () => {
@@ -1318,13 +1566,16 @@ describe('TypeScript Operations Plugin', () => {
       );
 
       expect(content).toBeSimilarStringTo(`
-        export type SubmitMessageMutation = ({ __typename?: 'Mutation' } & { mutation: (
-          { __typename?: 'DeleteMutation' }
-          & Pick<DeleteMutation, 'deleted'>
-        ) | (
-          { __typename?: 'UpdateMutation' }
-        & Pick<UpdateMutation, 'updated'>
-        ) });
+        export type SubmitMessageMutation = (
+          { __typename?: 'Mutation' }
+          & { mutation: (
+            { __typename?: 'DeleteMutation' }
+            & Pick<DeleteMutation, 'deleted'>
+          ) | (
+            { __typename?: 'UpdateMutation' }
+          & Pick<UpdateMutation, 'updated'>
+          ) }
+        );
       `);
     });
 
@@ -1357,9 +1608,12 @@ describe('TypeScript Operations Plugin', () => {
       );
 
       expect(content).toBeSimilarStringTo(`
-        export type PostQuery = ({ __typename?: 'Query' } & { post: (
-          { __typename: 'Post' }
-        ) });
+        export type PostQuery = (
+          { __typename?: 'Query' }
+          & { post: (
+            { __typename: 'Post' }
+          ) }
+        );
       `);
     });
 
@@ -1393,9 +1647,20 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
 
-      expect(content).toBeSimilarStringTo(
-        `export type InfoQuery = ({ __typename?: 'Query' } & { __schema: ({ __typename?: '__Schema' } & { queryType: ({ __typename?: '__Type' } & { fields: Maybe<Array<({ __typename?: '__Field' } & Pick<__Field, 'name'>)>> }) }) });`
-      );
+      expect(content).toBeSimilarStringTo(`
+        export type InfoQuery = (
+          { __typename?: 'Query' }
+          & { __schema: (
+            { __typename?: '__Schema' }
+            & { queryType: (
+              { __typename?: '__Type' }
+              & { fields: Maybe<Array<(
+                { __typename?: '__Field' }
+                & Pick<__Field, 'name'>
+              )>> }
+            ) }
+          ) }
+        );`);
     });
 
     it('should handle introspection types (__type)', async () => {
@@ -1431,9 +1696,23 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
 
-      expect(content).toBeSimilarStringTo(
-        `export type InfoQuery = ({ __typename?: 'Query' } & { __type: Maybe<({ __typename?: '__Type' } & Pick<__Type, 'name'> & { fields: Maybe<Array<({ __typename?: '__Field' } & Pick<__Field, 'name'> & { type: ({ __typename?: '__Type' } & Pick<__Type, 'name' | 'kind'>) })>> })> });`
-      );
+      expect(content).toBeSimilarStringTo(`
+        export type InfoQuery = (
+          { __typename?: 'Query' }
+          & { __type: Maybe<(
+            { __typename?: '__Type' }
+            & Pick<__Type, 'name'>
+            & { fields: Maybe<Array<(
+              { __typename?: '__Field' }
+              & Pick<__Field, 'name'>
+              & { type: (
+                { __typename?: '__Type' }
+                & Pick<__Type, 'name' | 'kind'>
+              ) }
+            )>> }
+          )> }
+        );
+      `);
     });
 
     it('should handle introspection types (like __TypeKind)', async () => {
@@ -1539,10 +1818,20 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
 
-      expect(content).toBeSimilarStringTo(`export type PREFIX_UsersQueryVariables = {
-        filter: PREFIX_Filter
-      };`);
-      expect(content).toBeSimilarStringTo(`export type PREFIX_UsersQuery = ({ __typename?: 'Query' } & { users: Maybe<Array<Maybe<({ __typename?: 'User' } & Pick<PREFIX_User, 'access'>)>>> });`);
+      expect(content).toBeSimilarStringTo(`
+        export type PREFIX_UsersQueryVariables = {
+          filter: PREFIX_Filter
+        };
+      `);
+      expect(content).toBeSimilarStringTo(`
+        export type PREFIX_UsersQuery = (
+          { __typename?: 'Query' }
+          & { users: Maybe<Array<Maybe<(
+            { __typename?: 'User' }
+            & Pick<PREFIX_User, 'access'>
+          )>>> }
+        );
+      `);
     });
 
     it('Should make arguments optional when there is a default value', async () => {
@@ -1636,24 +1925,27 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
       expect(content).toBeSimilarStringTo(`
-        export type FieldQuery = ({ __typename?: 'Query' } & { field: (
-          { __typename?: 'Error1' }
-          & Pick<Error1, 'message'>
-        ) | (
-          { __typename?: 'Error2' }
-          & Pick<Error2, 'message'>
-        ) | (
-          { __typename?: 'ComplexError' }
-          & Pick<ComplexError, 'message' | 'additionalInfo'>
-        ) | (
-          { __typename?: 'FieldResultSuccess' }
-          & Pick<FieldResultSuccess, 'someValue'>
-        ) });
+        export type FieldQuery = (
+          { __typename?: 'Query' }
+          & { field: (
+            { __typename?: 'Error1' }
+            & Pick<Error1, 'message'>
+          ) | (
+            { __typename?: 'Error2' }
+            & Pick<Error2, 'message'>
+          ) | (
+            { __typename?: 'ComplexError' }
+            & Pick<ComplexError, 'message' | 'additionalInfo'>
+          ) | (
+            { __typename?: 'FieldResultSuccess' }
+            & Pick<FieldResultSuccess, 'someValue'>
+          ) }
+        );
       `);
     });
     it('interface with same field names', async () => {
       const testSchema = buildSchema(/* GraphQL */ `
-        type Node {
+        interface Node {
           id: ID!
         }
 
@@ -1696,13 +1988,16 @@ describe('TypeScript Operations Plugin', () => {
       );
 
       expect(content).toBeSimilarStringTo(`
-        export type SomethingQuery = ({ __typename?: 'Query' } & { node: Maybe<(
-          { __typename?: 'A' }
-          & Pick<A, 'a'>
-        ) | (
-          { __typename?: 'B' }
-          & Pick<B, 'a'>
-        )> });
+        export type SomethingQuery = (
+          { __typename?: 'Query' }
+          & { node: Maybe<(
+            { __typename?: 'A' }
+            & Pick<A, 'a'>
+          ) | (
+            { __typename?: 'B' }
+            & Pick<B, 'a'>
+          )> }
+        );
       `);
     });
     it('union returning single interface types', async () => {
@@ -1763,17 +2058,23 @@ describe('TypeScript Operations Plugin', () => {
       );
 
       expect(content).toBeSimilarStringTo(`
-        export type UserQuery = ({ __typename?: 'Query' } & { user: Maybe<(
-          { __typename?: 'User' }
-          & Pick<User, 'id' | 'login'>
-        ) | (
-          { __typename?: 'Error2' }
-          & Pick<Error2, 'message'>
-        ) | (
-          { __typename?: 'Error3' }
-          & Pick<Error3, 'message'>
-          & { info: Maybe<({ __typename?: 'AdditionalInfo' } & Pick<AdditionalInfo, 'message'>)> }
-        )> });
+        export type UserQuery = (
+          { __typename?: 'Query' }
+          & { user: Maybe<(
+            { __typename?: 'User' }
+            & Pick<User, 'id' | 'login'>
+          ) | (
+            { __typename?: 'Error2' }
+            & Pick<Error2, 'message'>
+          ) | (
+            { __typename?: 'Error3' }
+            & Pick<Error3, 'message'>
+            & { info: Maybe<(
+              { __typename?: 'AdditionalInfo' }
+              & Pick<AdditionalInfo, 'message'>
+            )> }
+          )> }
+        );
       `);
     });
     it('duplicated fragment on type includes combined types only once', async () => {
@@ -1849,18 +2150,168 @@ describe('TypeScript Operations Plugin', () => {
       );
 
       expect(content).toBeSimilarStringTo(`
-        export type UserQuery = ({ __typename?: 'Query' } & { user: Maybe<(
+        export type UserQuery = (
+          { __typename?: 'Query' } 
+          & { user: Maybe<(
+            { __typename?: 'User' }
+            & Pick<User, 'id' | 'login'>
+          ) | (
+            { __typename?: 'Error2' }
+            & Pick<Error2, 'message'>
+          ) | (
+            { __typename?: 'Error3' }
+            & Pick<Error3, 'message'>
+            & { info: Maybe<(
+                { __typename?: 'AdditionalInfo' }
+                & Pick<AdditionalInfo, 'message' | 'message2'>
+              )> }
+          )> }
+        );
+      `);
+    });
+
+    it('Should handle union selection sets with both FragmentSpreads and InlineFragments', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        interface Error {
+          message: String!
+        }
+        type Error1 implements Error {
+          message: String!
+        }
+        type Error2 implements Error {
+          message: String!
+        }
+        type Error3 implements Error {
+          message: String!
+          info: AdditionalInfo
+        }
+        type AdditionalInfo {
+          message: String!
+          message2: String!
+        }
+        type User {
+          id: ID!
+          login: String!
+        }
+
+        union UserResult = User | Error2 | Error3
+        type Query {
+          user: UserResult!
+        }
+      `);
+
+      const fragment1 = parse(/* GraphQL */ `
+        fragment UserResultFragment on UserResult {
+          ... on User {
+            id
+          }
+          ... on Error2 {
+            message
+          }
+        }
+      `);
+
+      const fragment2 = parse(/* GraphQL */ `
+        fragment UserResult1Fragment on UserResult {
+          ... on User {
+            id
+          }
+          ... on Error3 {
+            info {
+              message2
+            }
+          }
+        }
+      `);
+
+      const fragment3 = parse(/* GraphQL */ `
+        fragment AdditionalInfoFragment on AdditionalInfo {
+          message
+        }
+      `);
+
+      const query = parse(/* GraphQL */ `
+        query UserQuery {
+          user {
+            ...UserResultFragment
+            ...UserResult1Fragment
+            ... on User {
+              login
+            }
+            ... on Error3 {
+              message
+              info {
+                ...AdditionalInfoFragment
+              }
+            }
+          }
+        }
+      `);
+
+      const content = await plugin(
+        testSchema,
+        [{ filePath: '', content: query }, { filePath: '', content: fragment1 }, { filePath: '', content: fragment2 }, { filePath: '', content: fragment3 }],
+        {},
+        {
+          outputFile: 'graphql.ts',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`
+        export type UserQueryQuery = (
+          { __typename?: 'Query' }
+          & { user: (
+              (
+                { __typename?: 'User' }
+                & Pick<User, 'login'>
+              ) | (
+                { __typename?: 'Error2' }
+              ) | (
+                { __typename?: 'Error3' }
+                & Pick<Error3, 'message'>
+                & { info: Maybe<(
+                    (
+                      { __typename?: 'AdditionalInfo' }
+                    )
+                  )
+                  & AdditionalInfoFragmentFragment
+                > }
+              )
+            )
+            & UserResultFragmentFragment
+            & UserResult1FragmentFragment
+          }
+        );
+
+        export type UserResultFragmentFragment = (
           { __typename?: 'User' }
-          & Pick<User, 'id' | 'login'>
+          & Pick<User, 'id'>
         ) | (
           { __typename?: 'Error2' }
           & Pick<Error2, 'message'>
         ) | (
           { __typename?: 'Error3' }
-          & Pick<Error3, 'message'>
-          & { info: Maybe<({ __typename?: 'AdditionalInfo' } & Pick<AdditionalInfo, 'message' | 'message2'>)> }
-        )> });
+        );
+    
+        export type UserResult1FragmentFragment = (
+          { __typename?: 'User' }
+          & Pick<User, 'id'>
+        ) | (
+          { __typename?: 'Error2' }
+        ) | (
+          { __typename?: 'Error3' }
+          & { info: Maybe<(
+            { __typename?: 'AdditionalInfo' }
+            & Pick<AdditionalInfo, 'message2'>
+          )> }
+        );
+    
+        export type AdditionalInfoFragmentFragment = (
+          { __typename?: 'AdditionalInfo' }
+          & Pick<AdditionalInfo, 'message'>
+        );
       `);
+      await validate(content, {}, testSchema);
     });
   });
 
@@ -1909,7 +2360,18 @@ describe('TypeScript Operations Plugin', () => {
       );
 
       expect(content).toBeSimilarStringTo(`
-        export type TestQueryQuery = ({ __typename?: 'Query' } & { fooBar: Array<FooBarFragmentFragment> });
+        export type TestQueryQuery = (
+          { __typename?: 'Query' }
+          & { fooBar: Array<(
+              (
+                { __typename?: 'Foo' }
+              ) | (
+                { __typename?: 'Bar' }
+              )
+            )
+            & FooBarFragmentFragment
+          > }
+        );
 
         export type FooBarFragmentFragment = (
           { __typename?: 'Foo' }

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -4,7 +4,6 @@ import { readFileSync } from 'fs';
 import { plugin } from '../src/index';
 import { plugin as tsPlugin } from '../../typescript/src';
 import { mergeOutputs, Types } from '@graphql-codegen/plugin-helpers';
-import * as prettier from 'prettier';
 
 describe('TypeScript Operations Plugin', () => {
   const gitHuntSchema = buildClientSchema(JSON.parse(readFileSync('../../../../dev-test/githunt/schema.json', 'utf-8')));
@@ -1635,23 +1634,20 @@ describe('TypeScript Operations Plugin', () => {
           outputFile: 'graphql.ts',
         }
       );
-      const formattedContent = prettier.format(content.toString(), { filepath: 'graphql.ts' });
-      expect(formattedContent).toBeSimilarStringTo(`
-        export type FieldQueryVariables = {};
-
-        export type FieldQuery = { __typename?: "Query" } & {
-          field:
-            | ({ __typename?: "Error1" } & Pick<Error1, "message">)
-            | ({ __typename?: "Error2" } & Pick<Error2, "message">)
-            | ({ __typename?: "ComplexError" } & Pick<
-                ComplexError,
-                "message" | "additionalInfo"
-              >)
-            | ({ __typename?: "FieldResultSuccess" } & Pick<
-                FieldResultSuccess,
-                "someValue"
-              >);
-        };
+      expect(content).toBeSimilarStringTo(`
+        export type FieldQuery = ({ __typename?: 'Query' } & { field: (
+          { __typename?: 'Error1' }
+          & Pick<Error1, 'message'>
+        ) | (
+          { __typename?: 'Error2' }
+          & Pick<Error2, 'message'>
+        ) | (
+          { __typename?: 'ComplexError' }
+          & Pick<ComplexError, 'message' | 'additionalInfo'>
+        ) | (
+          { __typename?: 'FieldResultSuccess' }
+          & Pick<FieldResultSuccess, 'someValue'>
+        ) });
       `);
     });
   });

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -996,8 +996,7 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
         export type CurrentUserQuery = { me: Maybe<(
-          { __typename?: 'User' }
-          & Pick<User, 'username' | 'id'>
+          Pick<User, 'username' | 'id'>
           & { profile: Maybe<Pick<Profile, 'age'>> }
         )> };
       `);
@@ -1814,6 +1813,14 @@ describe('TypeScript Operations Plugin', () => {
             }
             ... on Error {
               message
+              ... on Error3 {
+                info {
+                  message
+                  message2
+                }
+              }
+            }
+            ... on Error {
               ... on Error3 {
                 info {
                   message

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -634,9 +634,7 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
-        export type Unnamed_1_Query = (
-          Pick<Query, 'dummy'>
-        );
+        export type Unnamed_1_Query = Pick<Query, 'dummy'>;
       `);
       expect(result).toBeSimilarStringTo(`
         export type Unnamed_1_QueryVariables = {};
@@ -658,17 +656,13 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type Unnamed_1_Query = (
-          Pick<Query, 'dummy'>
-        );
+        export type Unnamed_1_Query = Pick<Query, 'dummy'>;
       `);
       expect(result).toBeSimilarStringTo(`
         export type Unnamed_1_QueryVariables = {};
       `);
       expect(result).toBeSimilarStringTo(`
-        export type Unnamed_2_Query = (
-          Pick<Query, 'dummy'>
-        );
+        export type Unnamed_2_Query = Pick<Query, 'dummy'>;
       `);
       expect(result).toBeSimilarStringTo(`
         export type Unnamed_2_QueryVariables = {};
@@ -723,9 +717,7 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
-        export type MeQuery = (
-          { me: Maybe<UserFieldsFragment> }
-        );
+        export type MeQuery = { me: Maybe<UserFieldsFragment> };
       `);
       await validate(result, config);
     });
@@ -750,15 +742,9 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type MeQuery = (
-          { me: Maybe<(
-              (
-                Pick<User, 'username'>
-              )
-            )
+        export type MeQuery = { me: Maybe<Pick<User, 'username'>
             & UserFieldsFragment
-          > }
-        );
+        > };
       `);
       await validate(result, config);
     });
@@ -790,11 +776,9 @@ describe('TypeScript Operations Plugin', () => {
         export type MeQuery = (
           { __typename?: 'Query' }
           & { me: Maybe<(
-              (
-                { __typename?: 'User' }
-                & Pick<User, 'username'>
-              )
-            )
+            { __typename?: 'User' }
+            & Pick<User, 'username'>
+          )
             & UserFieldsFragment
             & UserProfileFragment
           > }
@@ -863,13 +847,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
         export type Unnamed_1_Query = (
           { __typename?: 'Query' }
-          & { b: Maybe<(
-              (
-                { __typename?: 'A' }
-              ) | (
-                { __typename?: 'B' }
-              )
-            )
+          & { b: Maybe<({ __typename?: 'A' } | { __typename?: 'B' })
             & AFragment
             & BFragment
           > }
@@ -935,16 +913,13 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
         export type Unnamed_1_Query = (
           { __typename?: 'Query' }
-          & { myType: (
-              (
-                { __typename?: 'MyType' }
-              )
-            )
+          & { myType: { __typename?: 'MyType' }
             & AFragment
             & BFragment
             & CFragment
           }
-        )`);
+        );
+      `);
       await validate(result, config);
     });
 
@@ -991,13 +966,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
         export type Unnamed_1_Query = (
           { __typename?: 'Query' }
-          & { b: Maybe<(
-              (
-                { __typename?: 'A' }
-              ) | (
-                { __typename?: 'B' }
-              )
-            )
+          & { b: Maybe<({ __typename?: 'A' } | { __typename?: 'B' })
             & AFragment
             & BFragment
           > }
@@ -1185,14 +1154,10 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = (
-          { me: Maybe<(
+        export type CurrentUserQuery = { me: Maybe<(
             Pick<User, 'username' | 'id'>
-            & { profile: Maybe<(
-              Pick<Profile, 'age'>
-            )> }
-          )> }
-        );
+            & { profile: Maybe<Pick<Profile, 'age'>> }
+        )> };
       `);
 
       await validate(result, config);
@@ -1226,16 +1191,10 @@ describe('TypeScript Operations Plugin', () => {
         };`
       );
       expect(result).toBeSimilarStringTo(`
-        export type MeQuery = (
-          { currentUser: Maybe<(
-            Pick<User, 'login' | 'html_url'>
-          )>, entry: Maybe<(
-            Pick<Entry, 'id' | 'createdAt'>
-            & { postedBy: (
-              Pick<User, 'login' | 'html_url'> 
-            ) }
-          )> }
-        );
+        export type MeQuery = { currentUser: Maybe<Pick<User, 'login' | 'html_url'>>, entry: Maybe<(
+          Pick<Entry, 'id' | 'createdAt'>
+          & { postedBy: Pick<User, 'login' | 'html_url'> }
+        )> };
       `);
       await validate(result, config, gitHuntSchema);
     });
@@ -1262,9 +1221,9 @@ describe('TypeScript Operations Plugin', () => {
         outputFile: '',
       });
 
-      expect(result).toBeSimilarStringTo(
-        `export type MeQuery = ({ __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, postedBy: { __typename?: 'User', login: string, html_url: string } }> };`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type MeQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, postedBy: { __typename?: 'User', login: string, html_url: string } }> };
+      `);
       await validate(result, config, gitHuntSchema);
     });
 
@@ -1321,9 +1280,7 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type DummyQuery = (
-          Pick<Query, 'dummy'>
-        );
+        export type DummyQuery = Pick<Query, 'dummy'>;
       `);
       await validate(result, config);
     });
@@ -1343,9 +1300,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
         export type DummyQuery = (
           { customName: Query['dummy'] }
-          & { customName2: Maybe<(
-            Pick<Profile, 'age'>
-          )> }
+          & { customName2: Maybe<Pick<Profile, 'age'>> }
         );
       `);
       await validate(result, config);
@@ -1368,14 +1323,10 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = (
-          { me: Maybe<(
-            Pick<User, 'id' | 'username' | 'role'>
-            & { profile: Maybe<(
-              Pick<Profile, 'age'>
-            )> }
-          )> }
-        );
+        export type CurrentUserQuery = { me: Maybe<(
+          Pick<User, 'id' | 'username' | 'role'>
+          & { profile: Maybe<Pick<Profile, 'age'>> }
+        )> };
       `);
       await validate(result, config);
     });
@@ -1398,9 +1349,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
         export type UserFieldsFragment = (
           Pick<User, 'id' | 'username'>
-          & { profile: Maybe<(
-            Pick<Profile, 'age'>
-          )> }
+          & { profile: Maybe<Pick<Profile, 'age'>> }
         );
       `);
       await validate(result, config);
@@ -1424,14 +1373,11 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type LoginMutation = (
-          { login: Maybe<(
-            Pick<User, 'id' | 'username'>
-            & { profile: Maybe<(
-              Pick<Profile, 'age'>
-            )> }
-          )> }
-        );`);
+        export type LoginMutation = { login: Maybe<(
+          Pick<User, 'id' | 'username'>
+          & { profile: Maybe<Pick<Profile, 'age'>> }
+        )> };
+      `);
       await validate(result, config);
     });
 
@@ -1445,9 +1391,7 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type TestQuery = (
-          Pick<Query, 'dummy'>
-        );
+        export type TestQuery = Pick<Query, 'dummy'>;
       `);
       await validate(result, config);
     });
@@ -1464,11 +1408,7 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type TestSubscription = (
-          { userCreated: Maybe<(
-            Pick<User, 'id'>
-          )> }
-        );
+        export type TestSubscription = { userCreated: Maybe<Pick<User, 'id'>> };
       `);
       await validate(result, config);
     });
@@ -1610,9 +1550,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(content).toBeSimilarStringTo(`
         export type PostQuery = (
           { __typename?: 'Query' }
-          & { post: (
-            { __typename: 'Post' }
-          ) }
+          & { post:  { __typename: 'Post' } }
         );
       `);
     });
@@ -2260,27 +2198,19 @@ describe('TypeScript Operations Plugin', () => {
       expect(content).toBeSimilarStringTo(`
         export type UserQueryQuery = (
           { __typename?: 'Query' }
-          & { user: (
-              (
-                { __typename?: 'User' }
-                & Pick<User, 'login'>
-              ) | (
-                { __typename?: 'Error2' }
-              ) | (
-                { __typename?: 'Error3' }
-                & Pick<Error3, 'message'>
-                & { info: Maybe<(
-                    (
-                      { __typename?: 'AdditionalInfo' }
-                    )
-                  )
-                  & AdditionalInfoFragmentFragment
-                > }
-              )
-            )
+          & { user: ((
+            { __typename?: 'User' }
+            & Pick<User, 'login'>
+          ) | { __typename?: 'Error2' } | (
+            { __typename?: 'Error3' }
+            & Pick<Error3, 'message'>
+            & { info: Maybe<{ __typename?: 'AdditionalInfo' }
+              & AdditionalInfoFragmentFragment
+            > }
+          ))
             & UserResultFragmentFragment
             & UserResult1FragmentFragment
-          }
+           }
         );
 
         export type UserResultFragmentFragment = (
@@ -2289,23 +2219,19 @@ describe('TypeScript Operations Plugin', () => {
         ) | (
           { __typename?: 'Error2' }
           & Pick<Error2, 'message'>
-        ) | (
-          { __typename?: 'Error3' }
-        );
-    
+        ) | { __typename?: 'Error3' };
+
         export type UserResult1FragmentFragment = (
           { __typename?: 'User' }
           & Pick<User, 'id'>
-        ) | (
-          { __typename?: 'Error2' }
-        ) | (
+        ) | { __typename?: 'Error2' } | (
           { __typename?: 'Error3' }
           & { info: Maybe<(
             { __typename?: 'AdditionalInfo' }
             & Pick<AdditionalInfo, 'message2'>
           )> }
         );
-    
+
         export type AdditionalInfoFragmentFragment = (
           { __typename?: 'AdditionalInfo' }
           & Pick<AdditionalInfo, 'message'>
@@ -2362,13 +2288,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(content).toBeSimilarStringTo(`
         export type TestQueryQuery = (
           { __typename?: 'Query' }
-          & { fooBar: Array<(
-              (
-                { __typename?: 'Foo' }
-              ) | (
-                { __typename?: 'Bar' }
-              )
-            )
+          & { fooBar: Array<({ __typename?: 'Foo' } | { __typename?: 'Bar' })
             & FooBarFragmentFragment
           > }
         );

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -129,6 +129,7 @@ describe('TypeScript Operations Plugin', () => {
 
             ... on TextNotification {
               text
+              textAlias: text
             }
 
             ... on TextNotification {
@@ -151,9 +152,10 @@ describe('TypeScript Operations Plugin', () => {
         export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<(
           { __typename?: 'TextNotification' }
           & Pick<Types.TextNotification, 'text' | 'id'>
+          & { textAlias: Types.TextNotification['text'] }
         ) | (
           { __typename?: 'ImageNotification' }
-          & Pick<Types.ImageNotification, 'imageUrl' | 'id'>  
+          & Pick<Types.ImageNotification, 'imageUrl' | 'id'>
           & { metadata: ({ __typename?: 'ImageMetadata' } & { created: Types.ImageMetadata['createdBy'] }) }
         )> });
       `);

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -417,8 +417,23 @@ describe('TypeScript Operations Plugin', () => {
       expect(await plugin(schema, [{ filePath: 'test-file.ts', content: ast2 }], { dedupeOperationSuffix: false }, { outputFile: '' })).toContain('export type MyFragment =');
 
       const withUsage = await plugin(schema, [{ filePath: 'test-file.ts', content: ast3 }], { dedupeOperationSuffix: true }, { outputFile: '' });
-      expect(withUsage).toContain(`export type MyFragment = `);
-      expect(withUsage).toContain(`({ __typename?: 'Query' } & MyFragment)`);
+      expect(withUsage).toBeSimilarStringTo(`
+        export type MyFragment = (
+          { __typename?: 'Query' }
+          & { notifications: Array<(
+            { __typename?: 'TextNotification' }
+            & Pick<TextNotification, 'id'>
+          ) | (
+            { __typename?: 'ImageNotification' }
+            & Pick<ImageNotification, 'id'>
+          )> }
+        );
+      `);
+      expect(withUsage).toBeSimilarStringTo(`
+        export type NotificationsQuery = { __typename?: 'Query' }
+          & MyFragment
+        ;
+      `);
     });
   });
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -96,7 +96,7 @@ describe('TypeScript Operations Plugin', () => {
   };
 
   describe('Config', () => {
-    it('Should not generate "export" when noExport is set to true', async () => {
+    it('Should handle "namespacedImportName" and add it when specified', async () => {
       const ast = parse(/* GraphQL */ `
         query notifications {
           notifications {
@@ -132,6 +132,10 @@ describe('TypeScript Operations Plugin', () => {
               text
             }
 
+            ... on TextNotification {
+              text
+            }
+
             ... on ImageNotification {
               imageUrl
               metadata {
@@ -144,9 +148,16 @@ describe('TypeScript Operations Plugin', () => {
       const config = { namespacedImportName: 'Types' };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(
-        `export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<({ __typename?: 'TextNotification' | 'ImageNotification' } & Pick<Types.Notifiction, 'id'> & (({ __typename?: 'TextNotification' } & Pick<Types.TextNotification, 'text'>) | ({ __typename?: 'ImageNotification' } & Pick<Types.ImageNotification, 'imageUrl'> & { metadata: ({ __typename?: 'ImageMetadata' } & { created: Types.ImageMetadata['createdBy'] }) })))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<(
+          { __typename?: 'TextNotification' }
+          & Pick<Types.TextNotification, 'text' | 'id'>
+        ) | (
+          { __typename?: 'ImageNotification' }
+          & Pick<Types.ImageNotification, 'imageUrl' | 'id'>  
+          & { metadata: ({ __typename?: 'ImageMetadata' } & { created: Types.ImageMetadata['createdBy'] }) }
+        )> });
+      `);
       await validate(result, config);
     });
 
@@ -172,9 +183,16 @@ describe('TypeScript Operations Plugin', () => {
       const config = { namingConvention: 'change-case#lowerCase', immutableTypes: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(
-        `export type notificationsquery = ({ readonly __typename?: 'Query' } & { readonly notifications: ReadonlyArray<({ readonly __typename?: 'TextNotification' | 'ImageNotification' } & Pick<notifiction, 'id'> & (({ readonly __typename?: 'TextNotification' } & Pick<textnotification, 'text'>) | ({ readonly __typename?: 'ImageNotification' } & Pick<imagenotification, 'imageUrl'> & { readonly metadata: ({ readonly __typename?: 'ImageMetadata' } & Pick<imagemetadata, 'createdBy'>) })))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type notificationsquery = ({ readonly __typename?: 'Query' } & { readonly notifications: ReadonlyArray<(
+          { readonly __typename?: 'TextNotification' }
+          & Pick<textnotification, 'text' | 'id'>
+        ) | (
+          { readonly __typename?: 'ImageNotification' }
+          & Pick<imagenotification, 'imageUrl' | 'id'>
+          & { readonly metadata: ({ readonly __typename?: 'ImageMetadata' } & Pick<imagemetadata, 'createdBy'>) }
+        )> });
+      `);
       await validate(result, config);
     });
   });
@@ -231,9 +249,16 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`export type NotificationsQueryVariables = {};`);
-      expect(result).toBeSimilarStringTo(
-        `export type NotificationsQueryResult = ({ __typename?: 'Query' } & { notifications: Array<({ __typename?: 'TextNotification' | 'ImageNotification' } & Pick<Notifiction, 'id'> & (({ __typename?: 'TextNotification' } & Pick<TextNotification, 'text'>) | ({ __typename?: 'ImageNotification' } & Pick<ImageNotification, 'imageUrl'> & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<ImageMetadata, 'createdBy'>) })))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type NotificationsQueryResult = ({ __typename?: 'Query' } & { notifications: Array<(
+          { __typename?: 'TextNotification' }
+          & Pick<TextNotification, 'text' | 'id'>
+        ) | (
+          { __typename?: 'ImageNotification' }
+          & Pick<ImageNotification, 'imageUrl' | 'id'>
+          & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<ImageMetadata, 'createdBy'>) }
+        )> });
+      `);
 
       await validate(result, config);
     });
@@ -262,9 +287,16 @@ describe('TypeScript Operations Plugin', () => {
       const config = { namingConvention: 'change-case#lowerCase' };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(
-        `export type notificationsquery = ({ __typename?: 'Query' } & { notifications: Array<({ __typename?: 'TextNotification' | 'ImageNotification' } & Pick<notifiction, 'id'> & (({ __typename?: 'TextNotification' } & Pick<textnotification, 'text'>) | ({ __typename?: 'ImageNotification' } & Pick<imagenotification, 'imageUrl'> & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<imagemetadata, 'createdBy'>) })))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type notificationsquery = ({ __typename?: 'Query' } & { notifications: Array<(
+          { __typename?: 'TextNotification' }
+          & Pick<textnotification, 'text' | 'id'>
+        ) | (
+          { __typename?: 'ImageNotification' }
+          & Pick<imagenotification, 'imageUrl' | 'id'>
+          & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<imagemetadata, 'createdBy'>) }
+        )> });
+      `);
       await validate(result, config);
     });
 
@@ -292,9 +324,17 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`export type inotificationsqueryvariables = {};`);
-      expect(result).toBeSimilarStringTo(
-        `export type inotificationsquery = ({ __typename?: 'Query' } & { notifications: Array<({ __typename?: 'TextNotification' | 'ImageNotification' } & Pick<inotifiction, 'id'> & (({ __typename?: 'TextNotification' } & Pick<itextnotification, 'text'>) | ({ __typename?: 'ImageNotification' } & Pick<iimagenotification, 'imageUrl'> & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<iimagemetadata, 'createdBy'>) })))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type inotificationsquery = ({ __typename?: 'Query' } & { notifications: Array<(
+          { __typename?: 'TextNotification' }
+          & Pick<itextnotification, 'text' | 'id'>
+        ) | (
+          { __typename?: 'ImageNotification' }
+          & Pick<iimagenotification, 'imageUrl' | 'id'>
+          & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<iimagemetadata, 'createdBy'>) }
+        )> });
+        
+      `);
       validate(result, config);
     });
 
@@ -470,7 +510,15 @@ describe('TypeScript Operations Plugin', () => {
       `);
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`export type UnionTestQuery = ({ __typename?: 'Query' } & { unionTest: Maybe<(({ __typename?: 'User' } & Pick<User, 'id'>) | ({ __typename?: 'Profile' } & Pick<Profile, 'age'>))> });`);
+      expect(result).toBeSimilarStringTo(`
+        export type UnionTestQuery = ({ __typename?: 'Query' } & { unionTest: Maybe<(
+          { __typename?: 'User' }
+          & Pick<User, 'id'>
+        ) | (
+          { __typename?: 'Profile' }
+          & Pick<Profile, 'age'>
+        )> });
+      `);
       validate(result, config);
     });
 
@@ -495,9 +543,16 @@ describe('TypeScript Operations Plugin', () => {
       `);
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(
-        `export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<({ __typename?: 'TextNotification' | 'ImageNotification' } & Pick<Notifiction, 'id'> & (({ __typename?: 'TextNotification' } & Pick<TextNotification, 'text'>) | ({ __typename?: 'ImageNotification' } & Pick<ImageNotification, 'imageUrl'> & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<ImageMetadata, 'createdBy'>) })))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<(
+          { __typename?: 'TextNotification' }
+          & Pick<TextNotification, 'text' | 'id'>
+        ) | (
+          { __typename?: 'ImageNotification' }
+          & Pick<ImageNotification, 'imageUrl' | 'id'>
+          & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<ImageMetadata, 'createdBy'>) }
+        )> });
+      `);
       validate(result, config);
     });
   });
@@ -809,9 +864,16 @@ describe('TypeScript Operations Plugin', () => {
 
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(
-        `export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<({ __typename?: 'TextNotification' | 'ImageNotification' } & Pick<Notifiction, 'id'> & (({ __typename?: 'TextNotification' } & Pick<TextNotification, 'text'>) | ({ __typename?: 'ImageNotification' } & Pick<ImageNotification, 'imageUrl'> & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<ImageMetadata, 'createdBy'>) })))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type NotificationsQuery = ({ __typename?: 'Query' } & { notifications: Array<(
+          { __typename?: 'TextNotification' }
+          & Pick<TextNotification, 'text' | 'id'>
+        ) | (
+          { __typename?: 'ImageNotification' }
+          & Pick<ImageNotification, 'imageUrl' | 'id'>
+          & { metadata: ({ __typename?: 'ImageMetadata' } & Pick<ImageMetadata, 'createdBy'>) }
+        )> });
+      `);
       validate(result, config);
     });
 
@@ -832,7 +894,15 @@ describe('TypeScript Operations Plugin', () => {
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(`export type UnionTestQuery = ({ __typename?: 'Query' } & { unionTest: Maybe<(({ __typename?: 'User' } & Pick<User, 'id'>) | ({ __typename?: 'Profile' } & Pick<Profile, 'age'>))> });`);
+      expect(result).toBeSimilarStringTo(`
+        export type UnionTestQuery = ({ __typename?: 'Query' } & { unionTest: Maybe<(
+          { __typename?: 'User' }
+          & Pick<User, 'id'>
+        ) | (
+          { __typename?: 'Profile' }
+          & Pick<Profile, 'age'>
+        )> });
+      `);
       validate(result, config);
     });
 
@@ -857,9 +927,15 @@ describe('TypeScript Operations Plugin', () => {
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(
-        `export type UnionTestQuery = ({ __typename?: 'Query' } & { mixedNotifications: Array<(({ __typename?: 'TextNotification' | 'ImageNotification' } & Pick<Notifiction, 'id'>) & (({ __typename?: 'TextNotification' } & Pick<TextNotification, 'text'>) | ({ __typename?: 'ImageNotification' } & Pick<ImageNotification, 'imageUrl'>)))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type UnionTestQuery = ({ __typename?: 'Query' } & { mixedNotifications: Array<(
+          { __typename?: 'TextNotification' }
+          & Pick<TextNotification, 'id' | 'text'>
+        ) | (
+          { __typename?: 'ImageNotification' }
+          & Pick<ImageNotification, 'id' | 'imageUrl'>
+        )> });
+      `);
       validate(result, config);
     });
 
@@ -888,9 +964,18 @@ describe('TypeScript Operations Plugin', () => {
       const config = {};
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
 
-      expect(result).toBeSimilarStringTo(
-        `export type UnionTestQuery = ({ __typename?: 'Query' } & { search: Array<((({ __typename?: 'TextNotification' | 'ImageNotification' } & Pick<Notifiction, 'id'>) & (({ __typename?: 'TextNotification' } & Pick<TextNotification, 'text'>) | ({ __typename?: 'ImageNotification' } & Pick<ImageNotification, 'imageUrl'>))) | ({ __typename?: 'User' } & Pick<User, 'id'>))> });`
-      );
+      expect(result).toBeSimilarStringTo(`
+        export type UnionTestQuery = ({ __typename?: 'Query' } & { search: Array<(
+          { __typename?: 'User' }
+          & Pick<User, 'id'>
+        ) | (
+          { __typename?: 'TextNotification' }
+          & Pick<TextNotification, 'id' | 'text'>
+        ) | (
+          { __typename?: 'ImageNotification' }
+          & Pick<ImageNotification, 'id' | 'imageUrl'>
+        )> });
+      `);
       validate(result, config);
     });
 
@@ -910,7 +995,14 @@ describe('TypeScript Operations Plugin', () => {
       `);
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`export type CurrentUserQuery = { me: Maybe<(Pick<User, 'id'> & (Pick<User, 'username'> & { profile: Maybe<Pick<Profile, 'age'>> }))> };`);
+      expect(result).toBeSimilarStringTo(`
+        export type CurrentUserQuery = { me: Maybe<(
+          { __typename?: 'User' }
+          & Pick<User, 'username' | 'id'>
+          & { profile: Pick<Profile, 'age'> }
+        )> };
+      `);
+
       validate(result, config);
     });
 
@@ -1225,9 +1317,15 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
 
-      expect(content).toBeSimilarStringTo(
-        `export type SubmitMessageMutation = ({ __typename?: 'Mutation' } & { mutation: (({ __typename?: 'DeleteMutation' } & Pick<DeleteMutation, 'deleted'>) | ({ __typename?: 'UpdateMutation' } & Pick<UpdateMutation, 'updated'>)) });`
-      );
+      expect(content).toBeSimilarStringTo(`
+        export type SubmitMessageMutation = ({ __typename?: 'Mutation' } & { mutation: (
+          { __typename?: 'DeleteMutation' }
+          & Pick<DeleteMutation, 'deleted'>
+        ) | (
+          { __typename?: 'UpdateMutation' }
+        & Pick<UpdateMutation, 'updated'>
+        ) });
+      `);
     });
 
     it('should use __typename in fragments when requested', async () => {
@@ -1258,7 +1356,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       );
 
-      expect(content).toBeSimilarStringTo(`export type PostQuery = ({ __typename?: 'Query' } & { post: ({ __typename?: 'Post' } & { __typename: 'Post' }) });`);
+      expect(content).toBeSimilarStringTo(`
+        export type PostQuery = ({ __typename?: 'Query' } & { post: (
+          { __typename: 'Post' }
+        ) });
+      `);
     });
 
     it('should handle introspection types (__schema)', async () => {
@@ -1477,7 +1579,7 @@ describe('TypeScript Operations Plugin', () => {
     });
   });
 
-  describe.only('Union & Interfaces', () => {
+  describe('Union & Interfaces', () => {
     it('should generate correct types', async () => {
       const schema = buildSchema(/* GraphQL */ `
         interface Error {
@@ -1533,22 +1635,22 @@ describe('TypeScript Operations Plugin', () => {
           outputFile: 'graphql.ts',
         }
       );
-
-      expect(prettier.format(content.toString(), { filepath: 'graphql.ts' })).toBeSimilarStringTo(`
+      const formattedContent = prettier.format(content.toString(), { filepath: 'graphql.ts' });
+      expect(formattedContent).toBeSimilarStringTo(`
         export type FieldQueryVariables = {};
 
         export type FieldQuery = { __typename?: "Query" } & {
           field:
-            | ({ __typename?: "Error1" | "Error2" } & Pick<Error, "message">)
+            | ({ __typename?: "Error1" } & Pick<Error1, "message">)
+            | ({ __typename?: "Error2" } & Pick<Error2, "message">)
             | ({ __typename?: "ComplexError" } & Pick<
                 ComplexError,
-                "message",
-                "additionalInfo"
+                "message" | "additionalInfo"
               >)
             | ({ __typename?: "FieldResultSuccess" } & Pick<
                 FieldResultSuccess,
                 "someValue"
-              >)
+              >);
         };
       `);
     });
@@ -1556,20 +1658,21 @@ describe('TypeScript Operations Plugin', () => {
 
   describe('Issues', () => {
     it('#1624 - Should work with fragment on union type', async () => {
-      const testSchema = buildSchema(`
-      type Query {
-        fooBar: [FooBar!]!
-      }
-      
-      union FooBar = Foo | Bar
-      
-      type Foo {
-        id: ID!
-      }
-      
-      type Bar {
-        id: ID!
-      }`);
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          fooBar: [FooBar!]!
+        }
+
+        union FooBar = Foo | Bar
+
+        type Foo {
+          id: ID!
+        }
+
+        type Bar {
+          id: ID!
+        }
+      `);
 
       const query = parse(/* GraphQL */ `
         query TestQuery {
@@ -1598,9 +1701,15 @@ describe('TypeScript Operations Plugin', () => {
       );
 
       expect(content).toBeSimilarStringTo(`
-      export type TestQueryQueryVariables = {};
-      export type TestQueryQuery = ({ __typename?: 'Query' } & { fooBar: Array<FooBarFragmentFragment> });
-      export type FooBarFragmentFragment = (({ __typename?: 'Foo' } & Pick<Foo, 'id'>) | ({ __typename?: 'Bar' } & Pick<Bar, 'id'>));
+        export type TestQueryQuery = ({ __typename?: 'Query' } & { fooBar: Array<FooBarFragmentFragment> });
+
+        export type FooBarFragmentFragment = (
+          { __typename?: 'Foo' }
+          & Pick<Foo, 'id'>
+        ) | (
+          { __typename?: 'Bar' }
+          & Pick<Bar, 'id'>
+        );
       `);
     });
   });


### PR DESCRIPTION
- Changes the tests for union/interfaces according to #2240 and #2200
- Fixes code generation

**TODO:**

- [x] fix `preResolveTypes` option
- [x] clean up code (kind of^^)
