### PR TITLE
Minor type changes for visitor-plugin-common

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -170,8 +170,8 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
     return comment + indent(`${node.name}: ${typeString},`);
   }
 
-  UnionTypeDefinition(node: UnionTypeDefinitionNode, key: string | number, parent: any): string {
-    const originalNode = parent[key] as UnionTypeDefinitionNode;
+  UnionTypeDefinition(node: UnionTypeDefinitionNode, key: string | number | undefined, parent: any): string {
+    const originalNode = parent[key!] as UnionTypeDefinitionNode;
     const possibleTypes = originalNode.types.map(t => (this.scalars[t.name.value] ? this._getScalar(t.name.value) : this.convertName(t))).join(' | ');
 
     return new DeclarationBlock(this._declarationBlockConfig)
@@ -182,8 +182,8 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
       .withContent(possibleTypes).string;
   }
 
-  ObjectTypeDefinition(node: ObjectTypeDefinitionNode, key: number | string, parent: any): string {
-    const originalNode = parent[key] as ObjectTypeDefinitionNode;
+  ObjectTypeDefinition(node: ObjectTypeDefinitionNode, key: number | string | undefined, parent: any): string {
+    const originalNode = parent[key!] as ObjectTypeDefinitionNode;
     const optionalTypename = this.config.nonOptionalTypename ? '__typename' : '__typename?';
     const allFields = [...(this.config.addTypename ? [indent(`${optionalTypename}: '${node.name}',`)] : []), ...node.fields];
     const { type } = this._parsedConfig.declarationKind;
@@ -217,8 +217,8 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
     return [typeDefinition, argumentsBlock].filter(f => f).join('\n\n');
   }
 
-  InterfaceTypeDefinition(node: InterfaceTypeDefinitionNode, key: number | string, parent: any): string {
-    const argumentsBlock = this.buildArgumentsBlock(parent[key] as InterfaceTypeDefinitionNode);
+  InterfaceTypeDefinition(node: InterfaceTypeDefinitionNode, key: number | string | undefined, parent: any): string {
+    const argumentsBlock = this.buildArgumentsBlock(parent[key!] as InterfaceTypeDefinitionNode);
 
     let declarationBlock = new DeclarationBlock(this._declarationBlockConfig)
       .export()


### PR DESCRIPTION
Currently, when calling `visit` with a visitor extending the `BaseTypesVisitor` in the `@graphql-codegen/visitor-plugin-common` package, the compiler throws a wobbly because the types do not match. Example:
```ts
import { visit } from 'graphql'
const visitorResult = visit(astNode, { leave: visitor })
```

If it matters, the full error at `{ leave: visitor }` is this:
```
Argument of type '{ leave: Visitor<PluginConfig, ParsedConfig>; }' is not assignable to parameter of type 'Visitor<ASTKindToNode, ASTNode>'.
  Type '{ leave: Visitor<PluginConfig, ParsedConfig>; }' is not assignable to type 'EnterLeave<VisitFn<ASTNode, ASTNode> | { Name?: VisitFn<ASTNode, NameNode> | undefined; Document?: VisitFn<ASTNode, DocumentNode> | undefined; OperationDefinition?: VisitFn<ASTNode, OperationDefinitionNode> | undefined; ... 39 more ...; InputObjectTypeExtension?: VisitFn<...> | undefined; }>'.
    Types of property 'leave' are incompatible.
      Type 'Visitor<PluginConfig, ParsedConfig>' is not assignable to type 'VisitFn<ASTNode, ASTNode> | { Name?: VisitFn<ASTNode, NameNode> | undefined; Document?: VisitFn<ASTNode, DocumentNode> | undefined; OperationDefinition?: VisitFn<ASTNode, OperationDefinitionNode> | undefined; ... 39 more ...; InputObjectTypeExtension?: VisitFn<...> | undefined; } | undefined'.
        Type 'Visitor<PluginConfig, ParsedConfig>' is not assignable to type '{ Name?: VisitFn<ASTNode, NameNode> | undefined; Document?: VisitFn<ASTNode, DocumentNode> | undefined; OperationDefinition?: VisitFn<ASTNode, OperationDefinitionNode> | undefined; ... 39 more ...; InputObjectTypeExtension?: VisitFn<...> | undefined; }'.
          Types of property 'UnionTypeDefinition' are incompatible.
            Type '(node: UnionTypeDefinitionNode, key: string | number, parent: any) => string' is not assignable to type 'VisitFn<ASTNode, UnionTypeDefinitionNode>'.
              Types of parameters 'key' and 'key' are incompatible.
                Type 'string | number | undefined' is not assignable to type 'string | number'.
                  Type 'undefined' is not assignable to type 'string | number'.
```

And now it works, voila! Apologies for the slightly hacky nature of the fix.