### PR TITLE
allow duplicate operations when near-operation-file is used

### DIFF
--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -1,5 +1,5 @@
 import { Types, isComplexPluginOutput } from '@graphql-codegen/plugin-helpers';
-import { DocumentNode, visit, buildASTSchema } from 'graphql';
+import { visit, buildASTSchema } from 'graphql';
 import { mergeSchemas } from './merge-schemas';
 import { executePlugin } from './execute-plugin';
 import { DetailedError } from './errors';
@@ -9,8 +9,8 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
 
   const documents = options.documents || [];
 
-  if (documents.length > 0) {
-    validateDocuments(options.schema, documents);
+  if (documents.length > 0 && !options.skipDuplicateDocumentsValidation) {
+    validateDocuments(documents);
   }
 
   const pluginPackages = Object.keys(options.pluginMap).map(key => options.pluginMap[key]);
@@ -105,7 +105,7 @@ export function sortPrependValues(values: string[]): string[] {
   });
 }
 
-function validateDocuments(schema: DocumentNode, files: Types.DocumentFile[]) {
+function validateDocuments(files: Types.DocumentFile[]) {
   // duplicated names
   const operationMap: {
     [name: string]: string[];

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -179,6 +179,7 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
           schema: options.schema,
           schemaAst: options.schemaAst,
           documents: [documentFile],
+          skipDuplicateDocumentsValidation: true,
         };
       })
       .filter(f => f);

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -95,6 +95,22 @@ describe('near-operation-file preset', () => {
     ]);
   });
 
+  it('Should skip the duplicate documents validation', async () => {
+    const result = await preset.buildGeneratesSection({
+      baseOutputDir: './src/',
+      config: {},
+      presetConfig: {
+        baseTypesPath: 'types.ts',
+      },
+      schema: schemaDocumentNode,
+      documents: testDocuments,
+      plugins: [],
+      pluginMap: {},
+    });
+
+    expect(result[0].skipDuplicateDocumentsValidation).toBeTruthy();
+  });
+
   it('Should allow to customize output extension', async () => {
     const result = await preset.buildGeneratesSection({
       baseOutputDir: './src/',

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -12,6 +12,7 @@ export namespace Types {
     pluginMap: {
       [name: string]: CodegenPlugin;
     };
+    skipDuplicateDocumentsValidation?: boolean;
   }
 
   export type FileOutput = {


### PR DESCRIPTION
related: https://github.com/dotansimha/graphql-code-generator/issues/2143