### PR TITLE
[typescript-react-apollo] Add support for importing document node from external file for hooks and HOCs

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -68,6 +68,10 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     return OMIT_TYPE;
   }
 
+  private getDocumentNodeVariable(node: OperationDefinitionNode, documentVariableName: string): string {
+    return this.config.documentMode === DocumentMode.external ? `Operations.${node.name.value}` : documentVariableName;
+  }
+
   public getImports(): string[] {
     const baseImports = super.getImports();
     const hasOperations = this._collectedOperations.length > 0;
@@ -147,7 +151,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
 
     const component = `
     export const ${componentName} = (props: ${componentPropsName}) => (
-      <ApolloReactComponents.${operationType}<${operationResultType}, ${operationVariablesTypes}> ${node.operation}={${this.config.documentMode === DocumentMode.external ? `Operations.${node.name.value}` : documentVariableName}} {...props} />
+      <ApolloReactComponents.${operationType}<${operationResultType}, ${operationVariablesTypes}> ${node.operation}={${this.getDocumentNodeVariable(node, documentVariableName)}} {...props} />
     );
     `;
     return [componentProps, component].join('\n');
@@ -164,7 +168,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
 
     let hookFn = `
     export function use${operationName}(baseOptions?: ApolloReactHooks.${operationType}HookOptions<${operationResultType}, ${operationVariablesTypes}>) {
-      return ApolloReactHooks.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, baseOptions);
+      return ApolloReactHooks.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${this.getDocumentNodeVariable(node, documentVariableName)}, baseOptions);
     };`;
 
     if (operationType === 'Query') {
@@ -174,7 +178,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
       });
       hookFn += `
       export function use${lazyOperationName}(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<${operationResultType}, ${operationVariablesTypes}>) {
-        return ApolloReactHooks.useLazyQuery<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, baseOptions);
+        return ApolloReactHooks.useLazyQuery<${operationResultType}, ${operationVariablesTypes}>(${this.getDocumentNodeVariable(node, documentVariableName)}, baseOptions);
       };
       `;
     }

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -115,7 +115,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
   ${operationResultType},
   ${operationVariablesTypes},
   ${propsTypeName}<TChildProps>>) {
-    return ApolloReactHoc.with${titleCase(node.operation)}<TProps, ${operationResultType}, ${operationVariablesTypes}, ${propsTypeName}<TChildProps>>(${documentVariableName}, {
+    return ApolloReactHoc.with${titleCase(node.operation)}<TProps, ${operationResultType}, ${operationVariablesTypes}, ${propsTypeName}<TChildProps>>(${this.getDocumentNodeVariable(node, documentVariableName)}, {
       alias: 'with${operationName}',
       ...operationOptions
     });

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1211,10 +1211,13 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('should import Operations from one external file and use it in Queries', async () => {
+    it('should import Operations from one external file and use it in Query component', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: true,
+        withHooks: false,
+        withHOC: false,
       };
 
       const docs = [{ filePath: '', content: basicDoc }];
@@ -1235,7 +1238,9 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: false,
         withHooks: true,
+        withHOC: false,
       };
 
       const docs = [{ filePath: '', content: basicDoc }];
@@ -1289,10 +1294,13 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('should import Operations from one external file and use it in Mutations', async () => {
+    it('should import Operations from one external file and use it in Mutation component', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: true,
+        withHooks: false,
+        withHOC: false,
       };
 
       const docs = [{ filePath: '', content: mutationDoc }];
@@ -1313,7 +1321,9 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: false,
         withHooks: true,
+        withHOC: false,
       };
 
       const docs = [{ filePath: '', content: mutationDoc }];
@@ -1362,10 +1372,13 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('should import Operations from one external file and use it in Subscriptions', async () => {
+    it('should import Operations from one external file and use it in Subscription component', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: true,
+        withHooks: false,
+        withHOC: false,
       };
 
       const docs = [{ filePath: '', content: subscriptionDoc }];
@@ -1386,7 +1399,9 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: false,
         withHooks: true,
+        withHOC: false,
       };
 
       const docs = [{ filePath: '', content: subscriptionDoc }];
@@ -1439,6 +1454,9 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: true,
+        withHooks: false,
+        withHOC: false,
       };
 
       const docs = [{ filePath: '', content: multipleOperationDoc }];
@@ -1468,7 +1486,9 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: false,
         withHooks: true,
+        withHOC: false,
       };
 
       const docs = [{ filePath: '', content: multipleOperationDoc }];
@@ -1557,10 +1577,13 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('should import Operations from near operation file for Queries', async () => {
+    it('should import Operations from near operation file for Query component', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: true,
+        withHooks: false,
+        withHOC: false,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: basicDoc }];
@@ -1581,7 +1604,9 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: false,
         withHooks: true,
+        withHOC: false,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: basicDoc }];
@@ -1635,10 +1660,13 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('should import Operations from near operation file for Mutations', async () => {
+    it('should import Operations from near operation file for Mutation component', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: true,
+        withHooks: false,
+        withHOC: false,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: mutationDoc }];
@@ -1659,7 +1687,9 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: false,
         withHooks: true,
+        withHOC: false,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: mutationDoc }];
@@ -1707,10 +1737,13 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('should import Operations from near operation file for Subscriptions', async () => {
+    it('should import Operations from near operation file for Subscription component', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: true,
+        withHooks: false,
+        withHOC: false,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: subscriptionDoc }];
@@ -1731,7 +1764,9 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: false,
         withHooks: true,
+        withHOC: false,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: subscriptionDoc }];
@@ -1782,6 +1817,9 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: true,
+        withHooks: false,
+        withHOC: false,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: multipleOperationDoc }];
@@ -1811,7 +1849,9 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: false,
         withHooks: true,
+        withHOC: false,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: multipleOperationDoc }];

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1258,6 +1258,37 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should import Operations from one external file and use it in withQuery', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: false,
+        withHooks: false,
+        withHOC: true,
+      };
+
+      const docs = [{ filePath: '', content: basicDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestQuery,
+        TestQueryVariables,
+        TestProps<TChildProps>>) {
+          return ApolloReactHoc.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps>>(Operations.test, {
+            alias: 'withTest',
+            ...operationOptions
+          });
+      };
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should import Operations from one external file and use it in Mutations', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
@@ -1300,6 +1331,37 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should import Operations from one external file and use it in withMutation', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: false,
+        withHooks: false,
+        withHOC: true,
+      };
+
+      const docs = [{ filePath: '', content: mutationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestMutation,
+        TestMutationVariables,
+        TestProps<TChildProps>>) {
+          return ApolloReactHoc.withMutation<TProps, TestMutation, TestMutationVariables, TestProps<TChildProps>>(Operations.test, {
+            alias: 'withTest',
+            ...operationOptions
+          });
+      };
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should import Operations from one external file and use it in Subscriptions', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
@@ -1337,6 +1399,37 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       expect(content.content).toBeSimilarStringTo(`
       export function useTestSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<TestSubscription, TestSubscriptionVariables>) {
         return ApolloReactHooks.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, baseOptions);
+      };
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from one external file and use it in withSubscription', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: false,
+        withHooks: false,
+        withHOC: true,
+      };
+
+      const docs = [{ filePath: '', content: subscriptionDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestSubscription,
+        TestSubscriptionVariables,
+        TestProps<TChildProps>>) {
+          return ApolloReactHoc.withSubscription<TProps, TestSubscription, TestSubscriptionVariables, TestProps<TChildProps>>(Operations.test, {
+            alias: 'withTest',
+            ...operationOptions
+          });
       };
       `);
       await validateTypeScript(content, schema, docs, {});
@@ -1409,6 +1502,61 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should import Operations from one external file and use it in multiple HOCs', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withComponent: false,
+        withHooks: false,
+        withHOC: true,
+      };
+
+      const docs = [{ filePath: '', content: multipleOperationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTestOne<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestOneQuery,
+        TestOneQueryVariables,
+        TestOneProps<TChildProps>>) {
+          return ApolloReactHoc.withQuery<TProps, TestOneQuery, TestOneQueryVariables, TestOneProps<TChildProps>>(Operations.testOne, {
+            alias: 'withTestOne',
+            ...operationOptions
+          });
+      };
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTestTwo<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestTwoMutation,
+        TestTwoMutationVariables,
+        TestTwoProps<TChildProps>>) {
+          return ApolloReactHoc.withMutation<TProps, TestTwoMutation, TestTwoMutationVariables, TestTwoProps<TChildProps>>(Operations.testTwo, {
+            alias: 'withTestTwo',
+            ...operationOptions
+          });
+      };
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTestThree<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestThreeSubscription,
+        TestThreeSubscriptionVariables,
+        TestThreeProps<TChildProps>>) {
+          return ApolloReactHoc.withSubscription<TProps, TestThreeSubscription, TestThreeSubscriptionVariables, TestThreeProps<TChildProps>>(Operations.testThree, {
+            alias: 'withTestThree',
+            ...operationOptions
+          });
+      };
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should import Operations from near operation file for Queries', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
@@ -1456,6 +1604,37 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should import Operations from near operation file for withQuery', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: false,
+        withHooks: false,
+        withHOC: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: basicDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestQuery,
+        TestQueryVariables,
+        TestProps<TChildProps>>) {
+          return ApolloReactHoc.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps>>(Operations.test, {
+            alias: 'withTest',
+            ...operationOptions
+          });
+      };
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should import Operations from near operation file for Mutations', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
@@ -1497,6 +1676,37 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should import Operations from near operation file for withMutation', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: false,
+        withHooks: false,
+        withHOC: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: mutationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestMutation,
+        TestMutationVariables,
+        TestProps<TChildProps>>) {
+          return ApolloReactHoc.withMutation<TProps, TestMutation, TestMutationVariables, TestProps<TChildProps>>(Operations.test, {
+            alias: 'withTest',
+            ...operationOptions
+          });
+      };
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should import Operations from near operation file for Subscriptions', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
@@ -1534,6 +1744,36 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       expect(content.content).toBeSimilarStringTo(`
       export function useTestSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<TestSubscription, TestSubscriptionVariables>) {
         return ApolloReactHooks.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, baseOptions);
+      };`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from near operation file for withSubscription', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: false,
+        withHooks: false,
+        withHOC: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: subscriptionDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestSubscription,
+        TestSubscriptionVariables,
+        TestProps<TChildProps>>) {
+          return ApolloReactHoc.withSubscription<TProps, TestSubscription, TestSubscriptionVariables, TestProps<TChildProps>>(Operations.test, {
+            alias: 'withTest',
+            ...operationOptions
+          });
       };`);
       await validateTypeScript(content, schema, docs, {});
     });
@@ -1600,6 +1840,62 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       export function useTestThreeSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
         return ApolloReactHooks.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, baseOptions);
       };`);
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from near operation file and use it in multiple HOCs', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: false,
+        withHooks: false,
+        withHOC: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: multipleOperationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTestOne<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestOneQuery,
+        TestOneQueryVariables,
+        TestOneProps<TChildProps>>) {
+          return ApolloReactHoc.withQuery<TProps, TestOneQuery, TestOneQueryVariables, TestOneProps<TChildProps>>(Operations.testOne, {
+            alias: 'withTestOne',
+            ...operationOptions
+          });
+      };
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTestTwo<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestTwoMutation,
+        TestTwoMutationVariables,
+        TestTwoProps<TChildProps>>) {
+          return ApolloReactHoc.withMutation<TProps, TestTwoMutation, TestTwoMutationVariables, TestTwoProps<TChildProps>>(Operations.testTwo, {
+            alias: 'withTestTwo',
+            ...operationOptions
+          });
+      };
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function withTestThree<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+        TProps,
+        TestThreeSubscription,
+        TestThreeSubscriptionVariables,
+        TestThreeProps<TChildProps>>) {
+          return ApolloReactHoc.withSubscription<TProps, TestThreeSubscription, TestThreeSubscriptionVariables, TestThreeProps<TChildProps>>(Operations.testThree, {
+            alias: 'withTestThree',
+            ...operationOptions
+          });
+      };
+      `);
 
       await validateTypeScript(content, schema, docs, {});
     });

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1231,6 +1231,33 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should import Operations from one external file and use it in useQuery and useLazyQuery', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withHooks: true,
+      };
+
+      const docs = [{ filePath: '', content: basicDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<TestQuery, TestQueryVariables>) {
+        return ApolloReactHooks.useQuery<TestQuery, TestQueryVariables>(Operations.test, baseOptions);
+      };
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<TestQuery, TestQueryVariables>) {
+        return ApolloReactHooks.useLazyQuery<TestQuery, TestQueryVariables>(Operations.test, baseOptions);
+      };
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should import Operations from one external file and use it in Mutations', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
@@ -1251,6 +1278,28 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should import Operations from one external file and use it in useMutation', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withHooks: true,
+      };
+
+      const docs = [{ filePath: '', content: mutationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<TestMutation, TestMutationVariables>) {
+        return ApolloReactHooks.useMutation<TestMutation, TestMutationVariables>(Operations.test, baseOptions);
+      };
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should import Operations from one external file and use it in Subscriptions', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
@@ -1268,6 +1317,28 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         export const TestComponent = (props: TestComponentProps) => (
           <ApolloReactComponents.Subscription<TestSubscription, TestSubscriptionVariables> subscription={Operations.test} {...props} />
         );`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from one external file and use it in useSubscription', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withHooks: true,
+      };
+
+      const docs = [{ filePath: '', content: subscriptionDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<TestSubscription, TestSubscriptionVariables>) {
+        return ApolloReactHooks.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, baseOptions);
+      };
+      `);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -1300,6 +1371,44 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should import Operations from one external file and use it in multiple hooks', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        withHooks: true,
+      };
+
+      const docs = [{ filePath: '', content: multipleOperationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestOneQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<TestOneQuery, TestOneQueryVariables>) {
+        return ApolloReactHooks.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, baseOptions);
+      };
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestOneLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<TestOneQuery, TestOneQueryVariables>) {
+        return ApolloReactHooks.useLazyQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, baseOptions);
+      };
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestTwoMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<TestTwoMutation, TestTwoMutationVariables>) {
+        return ApolloReactHooks.useMutation<TestTwoMutation, TestTwoMutationVariables>(Operations.testTwo, baseOptions);
+      };
+      `);
+
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestThreeSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
+        return ApolloReactHooks.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, baseOptions);
+      };`);
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should import Operations from near operation file for Queries', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
@@ -1317,6 +1426,33 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         export const TestComponent = (props: TestComponentProps) => (
           <ApolloReactComponents.Query<TestQuery, TestQueryVariables> query={Operations.test} {...props} />
         );`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from near operation file for useQuery and useLazyQuery', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+        withHooks: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: basicDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<TestQuery, TestQueryVariables>) {
+        return ApolloReactHooks.useQuery<TestQuery, TestQueryVariables>(Operations.test, baseOptions);
+      };
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<TestQuery, TestQueryVariables>) {
+        return ApolloReactHooks.useLazyQuery<TestQuery, TestQueryVariables>(Operations.test, baseOptions);
+      };
+      `);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -1340,6 +1476,27 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should import Operations from near operation file for useMutation', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+        withHooks: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: mutationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<TestMutation, TestMutationVariables>) {
+        return ApolloReactHooks.useMutation<TestMutation, TestMutationVariables>(Operations.test, baseOptions);
+      };`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should import Operations from near operation file for Subscriptions', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
@@ -1357,6 +1514,27 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       export const TestComponent = (props: TestComponentProps) => (
         <ApolloReactComponents.Subscription<TestSubscription, TestSubscriptionVariables> subscription={Operations.test} {...props} />
       );`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from near operation file for useSubscription', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+        withHooks: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: subscriptionDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<TestSubscription, TestSubscriptionVariables>) {
+        return ApolloReactHooks.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, baseOptions);
+      };`);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -1385,6 +1563,43 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         export const TestThreeComponent = (props: TestThreeComponentProps) => (
           <ApolloReactComponents.Subscription<TestThreeSubscription, TestThreeSubscriptionVariables> subscription={Operations.testThree} {...props} />
         );`);
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from near operation file and use it in multiple hooks', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+        withHooks: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: multipleOperationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestOneQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<TestOneQuery, TestOneQueryVariables>) {
+        return ApolloReactHooks.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, baseOptions);
+      };
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestOneLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<TestOneQuery, TestOneQueryVariables>) {
+        return ApolloReactHooks.useLazyQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, baseOptions);
+      };
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestTwoMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<TestTwoMutation, TestTwoMutationVariables>) {
+        return ApolloReactHooks.useMutation<TestTwoMutation, TestTwoMutationVariables>(Operations.testTwo, baseOptions);
+      };
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestThreeSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
+        return ApolloReactHooks.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, baseOptions);
+      };`);
 
       await validateTypeScript(content, schema, docs, {});
     });


### PR DESCRIPTION
This PR adds support for importing document node from an external file for hooks i.e. `useQuery`, `useLazyQuery`, `useMutation`, `useSubscription`. 

The current implementation only works with `withComponent` config. As the result, hook document nodes are not used correctly. This can be seen here: https://codesandbox.io/s/gcg-15-experiments-c8l15 (Look for `src/GetProject.operation.generated.tsx`)