### PR TITLE
fix(visitor-plugin-common): __typename field selection on union

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -267,6 +267,15 @@ export class SelectionSetToObject {
 
     const possibleTypes = this._getPossibleTypes(this._parentSchemaType);
 
+    if (possibleTypes.length > 0) {
+      const sharedFieldNodes = fieldNodes.filter(node => node.name.value === '__typename');
+      if (sharedFieldNodes.length) {
+        selectionNodesByTypeName.forEach(nodes => {
+          nodes.push(...sharedFieldNodes);
+        });
+      }
+    }
+
     const fieldSelections = possibleTypes.map(type => {
       const typeName = type.name;
       const schemaType = this._schema.getType(typeName);


### PR DESCRIPTION
Follow up to #2248

```graphql
query field {
  field {
    ... on Error {
      __typename
      message
    }
    ... on ComplexError {
      additionalInfo
    }
    ... on FieldResultSuccess {
      someValue
    }
  }
}
```

should generate

```ts
export type FieldQuery = (
  { __typename?: 'Query' }
  & { field: (
    { __typename: 'Error1' }
    & Pick<Error1, 'message'>
  ) | (
    { __typename: 'Error2' }
    & Pick<Error2, 'message'>
  ) | (
    { __typename: 'ComplexError' }
    & Pick<ComplexError, 'message' | 'additionalInfo'>
  ) | (
    { __typename?: 'FieldResultSuccess' }
    & Pick<FieldResultSuccess, 'someValue'>
  ) }
);
```
