### PR TITLE
Watcher fixes

### DIFF
--- a/dev-test/githunt/comment-added.subscription.graphql
+++ b/dev-test/githunt/comment-added.subscription.graphql
@@ -9,3 +9,4 @@ subscription onCommentAdded($repoFullName: String!){
     content
   }
 }
+

--- a/dev-test/githunt/comment-added.subscription.stencil-component.tsx
+++ b/dev-test/githunt/comment-added.subscription.stencil-component.tsx
@@ -11,7 +11,17 @@ import { Component, Prop, h } from '@stencil/core';
 };
 
 
-export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Types.Maybe<({ __typename?: 'Comment' } & Pick<Types.Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'>) })> });
+export type OnCommentAddedSubscription = (
+  { __typename?: 'Subscription' }
+  & { commentAdded: Types.Maybe<(
+    { __typename?: 'Comment' }
+    & Pick<Types.Comment, 'id' | 'createdAt' | 'content'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<Types.User, 'login' | 'html_url'>
+    ) }
+  )> }
+);
  
     }
           

--- a/dev-test/githunt/comment.query.stencil-component.tsx
+++ b/dev-test/githunt/comment.query.stencil-component.tsx
@@ -14,7 +14,25 @@ import { Component, Prop, h } from '@stencil/core';
 };
 
 
-export type CommentQuery = ({ __typename?: 'Query' } & { currentUser: Types.Maybe<({ __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'>)>, entry: Types.Maybe<({ __typename?: 'Entry' } & Pick<Types.Entry, 'id' | 'createdAt' | 'commentCount'> & { postedBy: ({ __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'>), comments: Array<Types.Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository' } & Pick<Types.Repository, 'full_name' | 'html_url'> & ({ __typename?: 'Repository' } & Pick<Types.Repository, 'description' | 'open_issues_count' | 'stargazers_count'>)) })> });
+export type CommentQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Types.Maybe<(
+    { __typename?: 'User' }
+    & Pick<Types.User, 'login' | 'html_url'>
+  )>, entry: Types.Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Types.Entry, 'id' | 'createdAt' | 'commentCount'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<Types.User, 'login' | 'html_url'>
+    ), comments: Array<Types.Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: (
+      { __typename?: 'Repository' }
+      & Pick<Types.Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>
+    ) }
+  )> }
+);
  
     }
           

--- a/dev-test/githunt/comments-page-comment.fragment.stencil-component.tsx
+++ b/dev-test/githunt/comments-page-comment.fragment.stencil-component.tsx
@@ -4,7 +4,14 @@ import * as Types from './types.d';
 import gql from 'graphql-tag';
 
     declare global { 
-      export type CommentsPageCommentFragment = ({ __typename?: 'Comment' } & Pick<Types.Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'>) });
+      export type CommentsPageCommentFragment = (
+  { __typename?: 'Comment' }
+  & Pick<Types.Comment, 'id' | 'createdAt' | 'content'>
+  & { postedBy: (
+    { __typename?: 'User' }
+    & Pick<Types.User, 'login' | 'html_url'>
+  ) }
+);
  
     }
           

--- a/dev-test/githunt/current-user.query.stencil-component.tsx
+++ b/dev-test/githunt/current-user.query.stencil-component.tsx
@@ -9,7 +9,13 @@ import { Component, Prop, h } from '@stencil/core';
       export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQuery = ({ __typename?: 'Query' } & { currentUser: Types.Maybe<({ __typename?: 'User' } & Pick<Types.User, 'login' | 'avatar_url'>)> });
+export type CurrentUserForProfileQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Types.Maybe<(
+    { __typename?: 'User' }
+    & Pick<Types.User, 'login' | 'avatar_url'>
+  )> }
+);
  
     }
           

--- a/dev-test/githunt/feed-entry.fragment.stencil-component.tsx
+++ b/dev-test/githunt/feed-entry.fragment.stencil-component.tsx
@@ -6,7 +6,21 @@ import { VoteButtonsFragmentDoc } from './vote-buttons.fragment.stencil-componen
 import { RepoInfoFragmentDoc } from './repo-info.fragment.stencil-component';
 
     declare global { 
-      export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Types.Entry, 'id' | 'commentCount'> & { repository: ({ __typename?: 'Repository' } & Pick<Types.Repository, 'full_name' | 'html_url'> & { owner: Types.Maybe<({ __typename?: 'User' } & Pick<Types.User, 'avatar_url'>)> }) } & (VoteButtonsFragment & RepoInfoFragment));
+      export type FeedEntryFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Types.Entry, 'id' | 'commentCount'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Types.Repository, 'full_name' | 'html_url'>
+    & { owner: Types.Maybe<(
+      { __typename?: 'User' }
+      & Pick<Types.User, 'avatar_url'>
+    )> }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
  
     }
           

--- a/dev-test/githunt/feed.query.stencil-component.tsx
+++ b/dev-test/githunt/feed.query.stencil-component.tsx
@@ -14,7 +14,15 @@ import { Component, Prop, h } from '@stencil/core';
 };
 
 
-export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Types.Maybe<({ __typename?: 'User' } & Pick<Types.User, 'login'>)>, feed: Types.Maybe<Array<Types.Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Types.Maybe<(
+    { __typename?: 'User' }
+    & Pick<Types.User, 'login'>
+  )>, feed: Types.Maybe<Array<Types.Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> }
+);
  
     }
           

--- a/dev-test/githunt/flow.flow.js
+++ b/dev-test/githunt/flow.flow.js
@@ -183,7 +183,17 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 
-export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: ?({ __typename?: 'Comment' } & $Pick<Comment, { id: *, createdAt: *, content: * }> & { postedBy: ({ __typename?: 'User' } & $Pick<User, { login: *, html_url: * }>) }) });
+export type OnCommentAddedSubscription = (
+  { __typename?: 'Subscription' }
+  & { commentAdded: ?(
+    { __typename?: 'Comment' }
+    & $Pick<Comment, { id: *, createdAt: *, content: * }>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & $Pick<User, { login: *, html_url: * }>
+    ) }
+  ) }
+);
 
 export type CommentQueryVariables = {
   repoFullName: $ElementType<Scalars, 'String'>,
@@ -192,16 +202,61 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = ({ __typename?: 'Query' } & { currentUser: ?({ __typename?: 'User' } & $Pick<User, { login: *, html_url: * }>), entry: ?({ __typename?: 'Entry' } & $Pick<Entry, { id: *, createdAt: *, commentCount: * }> & { postedBy: ({ __typename?: 'User' } & $Pick<User, { login: *, html_url: * }>), comments: Array<?({ __typename?: 'Comment' } & CommentsPageCommentFragment)>, repository: ({ __typename?: 'Repository' } & $Pick<Repository, { full_name: *, html_url: * }> & ({ __typename?: 'Repository' } & $Pick<Repository, { description: *, open_issues_count: *, stargazers_count: * }>)) }) });
+export type CommentQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: ?(
+    { __typename?: 'User' }
+    & $Pick<User, { login: *, html_url: * }>
+  ), entry: ?(
+    { __typename?: 'Entry' }
+    & $Pick<Entry, { id: *, createdAt: *, commentCount: * }>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & $Pick<User, { login: *, html_url: * }>
+    ), comments: Array<?{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >, repository: (
+      { __typename?: 'Repository' }
+      & $Pick<Repository, { description: *, open_issues_count: *, stargazers_count: *, full_name: *, html_url: * }>
+    ) }
+  ) }
+);
 
-export type CommentsPageCommentFragment = ({ __typename?: 'Comment' } & $Pick<Comment, { id: *, createdAt: *, content: * }> & { postedBy: ({ __typename?: 'User' } & $Pick<User, { login: *, html_url: * }>) });
+export type CommentsPageCommentFragment = (
+  { __typename?: 'Comment' }
+  & $Pick<Comment, { id: *, createdAt: *, content: * }>
+  & { postedBy: (
+    { __typename?: 'User' }
+    & $Pick<User, { login: *, html_url: * }>
+  ) }
+);
 
 export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQuery = ({ __typename?: 'Query' } & { currentUser: ?({ __typename?: 'User' } & $Pick<User, { login: *, avatar_url: * }>) });
+export type CurrentUserForProfileQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: ?(
+    { __typename?: 'User' }
+    & $Pick<User, { login: *, avatar_url: * }>
+  ) }
+);
 
-export type FeedEntryFragment = ({ __typename?: 'Entry' } & $Pick<Entry, { id: *, commentCount: * }> & { repository: ({ __typename?: 'Repository' } & $Pick<Repository, { full_name: *, html_url: * }> & { owner: ?({ __typename?: 'User' } & $Pick<User, { avatar_url: * }>) }) } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = (
+  { __typename?: 'Entry' }
+  & $Pick<Entry, { id: *, commentCount: * }>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & $Pick<Repository, { full_name: *, html_url: * }>
+    & { owner: ?(
+      { __typename?: 'User' }
+      & $Pick<User, { avatar_url: * }>
+    ) }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -210,16 +265,40 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: ?({ __typename?: 'User' } & $Pick<User, { login: * }>), feed: ?Array<?({ __typename?: 'Entry' } & FeedEntryFragment)> });
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: ?(
+    { __typename?: 'User' }
+    & $Pick<User, { login: * }>
+  ), feed: ?Array<?{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  > }
+);
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: $ElementType<Scalars, 'String'>
 };
 
 
-export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRepository: ?({ __typename?: 'Entry' } & $Pick<Entry, { createdAt: * }>) });
+export type SubmitRepositoryMutation = (
+  { __typename?: 'Mutation' }
+  & { submitRepository: ?(
+    { __typename?: 'Entry' }
+    & $Pick<Entry, { createdAt: * }>
+  ) }
+);
 
-export type RepoInfoFragment = ({ __typename?: 'Entry' } & $Pick<Entry, { createdAt: * }> & { repository: ({ __typename?: 'Repository' } & $Pick<Repository, { description: *, stargazers_count: *, open_issues_count: * }>), postedBy: ({ __typename?: 'User' } & $Pick<User, { html_url: *, login: * }>) });
+export type RepoInfoFragment = (
+  { __typename?: 'Entry' }
+  & $Pick<Entry, { createdAt: * }>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & $Pick<Repository, { description: *, stargazers_count: *, open_issues_count: * }>
+  ), postedBy: (
+    { __typename?: 'User' }
+    & $Pick<User, { html_url: *, login: * }>
+  ) }
+);
 
 export type SubmitCommentMutationVariables = {
   repoFullName: $ElementType<Scalars, 'String'>,
@@ -227,9 +306,21 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComment: ?({ __typename?: 'Comment' } & CommentsPageCommentFragment) });
+export type SubmitCommentMutation = (
+  { __typename?: 'Mutation' }
+  & { submitComment: ?{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+   }
+);
 
-export type VoteButtonsFragment = ({ __typename?: 'Entry' } & $Pick<Entry, { score: * }> & { vote: ({ __typename?: 'Vote' } & $Pick<Vote, { vote_value: * }>) });
+export type VoteButtonsFragment = (
+  { __typename?: 'Entry' }
+  & $Pick<Entry, { score: * }>
+  & { vote: (
+    { __typename?: 'Vote' }
+    & $Pick<Vote, { vote_value: * }>
+  ) }
+);
 
 export type VoteMutationVariables = {
   repoFullName: $ElementType<Scalars, 'String'>,
@@ -237,4 +328,14 @@ export type VoteMutationVariables = {
 };
 
 
-export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: ?({ __typename?: 'Entry' } & $Pick<Entry, { score: *, id: * }> & { vote: ({ __typename?: 'Vote' } & $Pick<Vote, { vote_value: * }>) }) });
+export type VoteMutation = (
+  { __typename?: 'Mutation' }
+  & { vote: ?(
+    { __typename?: 'Entry' }
+    & $Pick<Entry, { score: *, id: * }>
+    & { vote: (
+      { __typename?: 'Vote' }
+      & $Pick<Vote, { vote_value: * }>
+    ) }
+  ) }
+);

--- a/dev-test/githunt/new-entry.mutation.stencil-component.tsx
+++ b/dev-test/githunt/new-entry.mutation.stencil-component.tsx
@@ -11,7 +11,13 @@ import { Component, Prop, h } from '@stencil/core';
 };
 
 
-export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRepository: Types.Maybe<({ __typename?: 'Entry' } & Pick<Types.Entry, 'createdAt'>)> });
+export type SubmitRepositoryMutation = (
+  { __typename?: 'Mutation' }
+  & { submitRepository: Types.Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Types.Entry, 'createdAt'>
+  )> }
+);
  
     }
           

--- a/dev-test/githunt/repo-info.fragment.stencil-component.tsx
+++ b/dev-test/githunt/repo-info.fragment.stencil-component.tsx
@@ -4,7 +4,17 @@ import * as Types from './types.d';
 import gql from 'graphql-tag';
 
     declare global { 
-      export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Types.Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Types.Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<Types.User, 'html_url' | 'login'>) });
+      export type RepoInfoFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Types.Entry, 'createdAt'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Types.Repository, 'description' | 'stargazers_count' | 'open_issues_count'>
+  ), postedBy: (
+    { __typename?: 'User' }
+    & Pick<Types.User, 'html_url' | 'login'>
+  ) }
+);
  
     }
           

--- a/dev-test/githunt/submit-comment.mutation.stencil-component.tsx
+++ b/dev-test/githunt/submit-comment.mutation.stencil-component.tsx
@@ -13,7 +13,12 @@ import { Component, Prop, h } from '@stencil/core';
 };
 
 
-export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComment: Types.Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> });
+export type SubmitCommentMutation = (
+  { __typename?: 'Mutation' }
+  & { submitComment: Types.Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > }
+);
  
     }
           

--- a/dev-test/githunt/types.avoidOptionals.ts
+++ b/dev-test/githunt/types.avoidOptionals.ts
@@ -173,7 +173,17 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 
-export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
+export type OnCommentAddedSubscription = (
+  { __typename?: 'Subscription' }
+  & { commentAdded: Maybe<(
+    { __typename?: 'Comment' }
+    & Pick<Comment, 'id' | 'createdAt' | 'content'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ) }
+  )> }
+);
 
 export type CommentQueryVariables = {
   repoFullName: Scalars['String'],
@@ -182,16 +192,61 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>)>, entry: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>), comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count'>)) })> });
+export type CommentQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  )>, entry: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id' | 'createdAt' | 'commentCount'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ), comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: (
+      { __typename?: 'Repository' }
+      & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>
+    ) }
+  )> }
+);
 
-export type CommentsPageCommentFragment = ({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) });
+export type CommentsPageCommentFragment = (
+  { __typename?: 'Comment' }
+  & Pick<Comment, 'id' | 'createdAt' | 'content'>
+  & { postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  ) }
+);
 
 export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>)> });
+export type CurrentUserForProfileQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'avatar_url'>
+  )> }
+);
 
-export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & { owner: Maybe<({ __typename?: 'User' } & Pick<User, 'avatar_url'>)> }) } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'id' | 'commentCount'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'full_name' | 'html_url'>
+    & { owner: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'avatar_url'>
+    )> }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -200,16 +255,40 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login'>
+  )>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> }
+);
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
 };
 
 
-export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRepository: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>)> });
+export type SubmitRepositoryMutation = (
+  { __typename?: 'Mutation' }
+  & { submitRepository: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'createdAt'>
+  )> }
+);
 
-export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
+export type RepoInfoFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'createdAt'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>
+  ), postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'html_url' | 'login'>
+  ) }
+);
 
 export type SubmitCommentMutationVariables = {
   repoFullName: Scalars['String'],
@@ -217,9 +296,21 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> });
+export type SubmitCommentMutation = (
+  { __typename?: 'Mutation' }
+  & { submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > }
+);
 
-export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
+export type VoteButtonsFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'score'>
+  & { vote: (
+    { __typename?: 'Vote' }
+    & Pick<Vote, 'vote_value'>
+  ) }
+);
 
 export type VoteMutationVariables = {
   repoFullName: Scalars['String'],
@@ -227,4 +318,14 @@ export type VoteMutationVariables = {
 };
 
 
-export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
+export type VoteMutation = (
+  { __typename?: 'Mutation' }
+  & { vote: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'score' | 'id'>
+    & { vote: (
+      { __typename?: 'Vote' }
+      & Pick<Vote, 'vote_value'>
+    ) }
+  )> }
+);

--- a/dev-test/githunt/types.d.ts
+++ b/dev-test/githunt/types.d.ts
@@ -171,7 +171,17 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 
-export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
+export type OnCommentAddedSubscription = (
+  { __typename?: 'Subscription' }
+  & { commentAdded: Maybe<(
+    { __typename?: 'Comment' }
+    & Pick<Comment, 'id' | 'createdAt' | 'content'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ) }
+  )> }
+);
 
 export type CommentQueryVariables = {
   repoFullName: Scalars['String'],
@@ -180,16 +190,61 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>)>, entry: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>), comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count'>)) })> });
+export type CommentQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  )>, entry: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id' | 'createdAt' | 'commentCount'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ), comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: (
+      { __typename?: 'Repository' }
+      & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>
+    ) }
+  )> }
+);
 
-export type CommentsPageCommentFragment = ({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) });
+export type CommentsPageCommentFragment = (
+  { __typename?: 'Comment' }
+  & Pick<Comment, 'id' | 'createdAt' | 'content'>
+  & { postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  ) }
+);
 
 export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>)> });
+export type CurrentUserForProfileQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'avatar_url'>
+  )> }
+);
 
-export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & { owner: Maybe<({ __typename?: 'User' } & Pick<User, 'avatar_url'>)> }) } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'id' | 'commentCount'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'full_name' | 'html_url'>
+    & { owner: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'avatar_url'>
+    )> }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -198,16 +253,40 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login'>
+  )>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> }
+);
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
 };
 
 
-export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRepository: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>)> });
+export type SubmitRepositoryMutation = (
+  { __typename?: 'Mutation' }
+  & { submitRepository: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'createdAt'>
+  )> }
+);
 
-export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
+export type RepoInfoFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'createdAt'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>
+  ), postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'html_url' | 'login'>
+  ) }
+);
 
 export type SubmitCommentMutationVariables = {
   repoFullName: Scalars['String'],
@@ -215,9 +294,21 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> });
+export type SubmitCommentMutation = (
+  { __typename?: 'Mutation' }
+  & { submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > }
+);
 
-export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
+export type VoteButtonsFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'score'>
+  & { vote: (
+    { __typename?: 'Vote' }
+    & Pick<Vote, 'vote_value'>
+  ) }
+);
 
 export type VoteMutationVariables = {
   repoFullName: Scalars['String'],
@@ -225,4 +316,14 @@ export type VoteMutationVariables = {
 };
 
 
-export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
+export type VoteMutation = (
+  { __typename?: 'Mutation' }
+  & { vote: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'score' | 'id'>
+    & { vote: (
+      { __typename?: 'Vote' }
+      & Pick<Vote, 'vote_value'>
+    ) }
+  )> }
+);

--- a/dev-test/githunt/types.enumsAsTypes.ts
+++ b/dev-test/githunt/types.enumsAsTypes.ts
@@ -171,7 +171,17 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 
-export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
+export type OnCommentAddedSubscription = (
+  { __typename?: 'Subscription' }
+  & { commentAdded: Maybe<(
+    { __typename?: 'Comment' }
+    & Pick<Comment, 'id' | 'createdAt' | 'content'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ) }
+  )> }
+);
 
 export type CommentQueryVariables = {
   repoFullName: Scalars['String'],
@@ -180,16 +190,61 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>)>, entry: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>), comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count'>)) })> });
+export type CommentQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  )>, entry: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id' | 'createdAt' | 'commentCount'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ), comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: (
+      { __typename?: 'Repository' }
+      & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>
+    ) }
+  )> }
+);
 
-export type CommentsPageCommentFragment = ({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) });
+export type CommentsPageCommentFragment = (
+  { __typename?: 'Comment' }
+  & Pick<Comment, 'id' | 'createdAt' | 'content'>
+  & { postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  ) }
+);
 
 export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>)> });
+export type CurrentUserForProfileQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'avatar_url'>
+  )> }
+);
 
-export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & { owner: Maybe<({ __typename?: 'User' } & Pick<User, 'avatar_url'>)> }) } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'id' | 'commentCount'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'full_name' | 'html_url'>
+    & { owner: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'avatar_url'>
+    )> }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -198,16 +253,40 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login'>
+  )>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> }
+);
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
 };
 
 
-export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRepository: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>)> });
+export type SubmitRepositoryMutation = (
+  { __typename?: 'Mutation' }
+  & { submitRepository: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'createdAt'>
+  )> }
+);
 
-export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
+export type RepoInfoFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'createdAt'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>
+  ), postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'html_url' | 'login'>
+  ) }
+);
 
 export type SubmitCommentMutationVariables = {
   repoFullName: Scalars['String'],
@@ -215,9 +294,21 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> });
+export type SubmitCommentMutation = (
+  { __typename?: 'Mutation' }
+  & { submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > }
+);
 
-export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
+export type VoteButtonsFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'score'>
+  & { vote: (
+    { __typename?: 'Vote' }
+    & Pick<Vote, 'vote_value'>
+  ) }
+);
 
 export type VoteMutationVariables = {
   repoFullName: Scalars['String'],
@@ -225,4 +316,14 @@ export type VoteMutationVariables = {
 };
 
 
-export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
+export type VoteMutation = (
+  { __typename?: 'Mutation' }
+  & { vote: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'score' | 'id'>
+    & { vote: (
+      { __typename?: 'Vote' }
+      & Pick<Vote, 'vote_value'>
+    ) }
+  )> }
+);

--- a/dev-test/githunt/types.immutableTypes.ts
+++ b/dev-test/githunt/types.immutableTypes.ts
@@ -173,7 +173,17 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 
-export type OnCommentAddedSubscription = ({ readonly __typename?: 'Subscription' } & { readonly commentAdded: Maybe<({ readonly __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { readonly postedBy: ({ readonly __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
+export type OnCommentAddedSubscription = (
+  { readonly __typename?: 'Subscription' }
+  & { readonly commentAdded: Maybe<(
+    { readonly __typename?: 'Comment' }
+    & Pick<Comment, 'id' | 'createdAt' | 'content'>
+    & { readonly postedBy: (
+      { readonly __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ) }
+  )> }
+);
 
 export type CommentQueryVariables = {
   repoFullName: Scalars['String'],
@@ -182,16 +192,61 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = ({ readonly __typename?: 'Query' } & { readonly currentUser: Maybe<({ readonly __typename?: 'User' } & Pick<User, 'login' | 'html_url'>)>, readonly entry: Maybe<({ readonly __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & { readonly postedBy: ({ readonly __typename?: 'User' } & Pick<User, 'login' | 'html_url'>), readonly comments: ReadonlyArray<Maybe<({ readonly __typename?: 'Comment' } & CommentsPageCommentFragment)>>, readonly repository: ({ readonly __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & ({ readonly __typename?: 'Repository' } & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count'>)) })> });
+export type CommentQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly currentUser: Maybe<(
+    { readonly __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  )>, readonly entry: Maybe<(
+    { readonly __typename?: 'Entry' }
+    & Pick<Entry, 'id' | 'createdAt' | 'commentCount'>
+    & { readonly postedBy: (
+      { readonly __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ), readonly comments: ReadonlyArray<Maybe<{ readonly __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, readonly repository: (
+      { readonly __typename?: 'Repository' }
+      & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>
+    ) }
+  )> }
+);
 
-export type CommentsPageCommentFragment = ({ readonly __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { readonly postedBy: ({ readonly __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) });
+export type CommentsPageCommentFragment = (
+  { readonly __typename?: 'Comment' }
+  & Pick<Comment, 'id' | 'createdAt' | 'content'>
+  & { readonly postedBy: (
+    { readonly __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  ) }
+);
 
 export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQuery = ({ readonly __typename?: 'Query' } & { readonly currentUser: Maybe<({ readonly __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>)> });
+export type CurrentUserForProfileQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly currentUser: Maybe<(
+    { readonly __typename?: 'User' }
+    & Pick<User, 'login' | 'avatar_url'>
+  )> }
+);
 
-export type FeedEntryFragment = ({ readonly __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & { readonly repository: ({ readonly __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & { readonly owner: Maybe<({ readonly __typename?: 'User' } & Pick<User, 'avatar_url'>)> }) } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = (
+  { readonly __typename?: 'Entry' }
+  & Pick<Entry, 'id' | 'commentCount'>
+  & { readonly repository: (
+    { readonly __typename?: 'Repository' }
+    & Pick<Repository, 'full_name' | 'html_url'>
+    & { readonly owner: Maybe<(
+      { readonly __typename?: 'User' }
+      & Pick<User, 'avatar_url'>
+    )> }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -200,16 +255,40 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = ({ readonly __typename?: 'Query' } & { readonly currentUser: Maybe<({ readonly __typename?: 'User' } & Pick<User, 'login'>)>, readonly feed: Maybe<ReadonlyArray<Maybe<({ readonly __typename?: 'Entry' } & FeedEntryFragment)>>> });
+export type FeedQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly currentUser: Maybe<(
+    { readonly __typename?: 'User' }
+    & Pick<User, 'login'>
+  )>, readonly feed: Maybe<ReadonlyArray<Maybe<{ readonly __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> }
+);
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
 };
 
 
-export type SubmitRepositoryMutation = ({ readonly __typename?: 'Mutation' } & { readonly submitRepository: Maybe<({ readonly __typename?: 'Entry' } & Pick<Entry, 'createdAt'>)> });
+export type SubmitRepositoryMutation = (
+  { readonly __typename?: 'Mutation' }
+  & { readonly submitRepository: Maybe<(
+    { readonly __typename?: 'Entry' }
+    & Pick<Entry, 'createdAt'>
+  )> }
+);
 
-export type RepoInfoFragment = ({ readonly __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { readonly repository: ({ readonly __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), readonly postedBy: ({ readonly __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
+export type RepoInfoFragment = (
+  { readonly __typename?: 'Entry' }
+  & Pick<Entry, 'createdAt'>
+  & { readonly repository: (
+    { readonly __typename?: 'Repository' }
+    & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>
+  ), readonly postedBy: (
+    { readonly __typename?: 'User' }
+    & Pick<User, 'html_url' | 'login'>
+  ) }
+);
 
 export type SubmitCommentMutationVariables = {
   repoFullName: Scalars['String'],
@@ -217,9 +296,21 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = ({ readonly __typename?: 'Mutation' } & { readonly submitComment: Maybe<({ readonly __typename?: 'Comment' } & CommentsPageCommentFragment)> });
+export type SubmitCommentMutation = (
+  { readonly __typename?: 'Mutation' }
+  & { readonly submitComment: Maybe<{ readonly __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > }
+);
 
-export type VoteButtonsFragment = ({ readonly __typename?: 'Entry' } & Pick<Entry, 'score'> & { readonly vote: ({ readonly __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
+export type VoteButtonsFragment = (
+  { readonly __typename?: 'Entry' }
+  & Pick<Entry, 'score'>
+  & { readonly vote: (
+    { readonly __typename?: 'Vote' }
+    & Pick<Vote, 'vote_value'>
+  ) }
+);
 
 export type VoteMutationVariables = {
   repoFullName: Scalars['String'],
@@ -227,4 +318,14 @@ export type VoteMutationVariables = {
 };
 
 
-export type VoteMutation = ({ readonly __typename?: 'Mutation' } & { readonly vote: Maybe<({ readonly __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { readonly vote: ({ readonly __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
+export type VoteMutation = (
+  { readonly __typename?: 'Mutation' }
+  & { readonly vote: Maybe<(
+    { readonly __typename?: 'Entry' }
+    & Pick<Entry, 'score' | 'id'>
+    & { readonly vote: (
+      { readonly __typename?: 'Vote' }
+      & Pick<Vote, 'vote_value'>
+    ) }
+  )> }
+);

--- a/dev-test/githunt/types.preResolveTypes.compatibility.ts
+++ b/dev-test/githunt/types.preResolveTypes.compatibility.ts
@@ -182,7 +182,9 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, commentCount: number, postedBy: { __typename?: 'User', login: string, html_url: string }, comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository', full_name: string, html_url: string } & { __typename?: 'Repository', description: Maybe<string>, open_issues_count: Maybe<number>, stargazers_count: number }) }> };
+export type CommentQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, commentCount: number, postedBy: { __typename?: 'User', login: string, html_url: string }, comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: { __typename?: 'Repository', description: Maybe<string>, open_issues_count: Maybe<number>, stargazers_count: number, full_name: string, html_url: string } }> };
 
 export type CommentsPageCommentFragment = { __typename?: 'Comment', id: number, createdAt: number, content: string, postedBy: { __typename?: 'User', login: string, html_url: string } };
 
@@ -191,7 +193,10 @@ export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, avatar_url: string }> };
 
-export type FeedEntryFragment = ({ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', full_name: string, html_url: string, owner: Maybe<{ __typename?: 'User', avatar_url: string }> } } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = { __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', full_name: string, html_url: string, owner: Maybe<{ __typename?: 'User', avatar_url: string }> } }
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -200,7 +205,9 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string }>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> };
+export type FeedQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string }>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> };
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
@@ -217,7 +224,9 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = { __typename?: 'Mutation', submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> };
+export type SubmitCommentMutation = { __typename?: 'Mutation', submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > };
 
 export type VoteButtonsFragment = { __typename?: 'Entry', score: number, vote: { __typename?: 'Vote', vote_value: number } };
 

--- a/dev-test/githunt/types.preResolveTypes.ts
+++ b/dev-test/githunt/types.preResolveTypes.ts
@@ -182,7 +182,9 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, commentCount: number, postedBy: { __typename?: 'User', login: string, html_url: string }, comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository', full_name: string, html_url: string } & { __typename?: 'Repository', description: Maybe<string>, open_issues_count: Maybe<number>, stargazers_count: number }) }> };
+export type CommentQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, commentCount: number, postedBy: { __typename?: 'User', login: string, html_url: string }, comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: { __typename?: 'Repository', description: Maybe<string>, open_issues_count: Maybe<number>, stargazers_count: number, full_name: string, html_url: string } }> };
 
 export type CommentsPageCommentFragment = { __typename?: 'Comment', id: number, createdAt: number, content: string, postedBy: { __typename?: 'User', login: string, html_url: string } };
 
@@ -191,7 +193,10 @@ export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, avatar_url: string }> };
 
-export type FeedEntryFragment = ({ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', full_name: string, html_url: string, owner: Maybe<{ __typename?: 'User', avatar_url: string }> } } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = { __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', full_name: string, html_url: string, owner: Maybe<{ __typename?: 'User', avatar_url: string }> } }
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -200,7 +205,9 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string }>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> };
+export type FeedQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string }>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> };
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
@@ -217,7 +224,9 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = { __typename?: 'Mutation', submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> };
+export type SubmitCommentMutation = { __typename?: 'Mutation', submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > };
 
 export type VoteButtonsFragment = { __typename?: 'Entry', score: number, vote: { __typename?: 'Vote', vote_value: number } };
 

--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -180,7 +180,17 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 
-export type OnCommentAddedSubscriptionMyOperation = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
+export type OnCommentAddedSubscriptionMyOperation = (
+  { __typename?: 'Subscription' }
+  & { commentAdded: Maybe<(
+    { __typename?: 'Comment' }
+    & Pick<Comment, 'id' | 'createdAt' | 'content'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ) }
+  )> }
+);
 
 export type CommentQueryVariables = {
   repoFullName: Scalars['String'],
@@ -189,16 +199,61 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQueryMyOperation = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>)>, entry: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>), comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count'>)) })> });
+export type CommentQueryMyOperation = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  )>, entry: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id' | 'createdAt' | 'commentCount'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ), comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: (
+      { __typename?: 'Repository' }
+      & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>
+    ) }
+  )> }
+);
 
-export type CommentsPageCommentFragment = ({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) });
+export type CommentsPageCommentFragment = (
+  { __typename?: 'Comment' }
+  & Pick<Comment, 'id' | 'createdAt' | 'content'>
+  & { postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  ) }
+);
 
 export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQueryMyOperation = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>)> });
+export type CurrentUserForProfileQueryMyOperation = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'avatar_url'>
+  )> }
+);
 
-export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & { owner: Maybe<({ __typename?: 'User' } & Pick<User, 'avatar_url'>)> }) } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'id' | 'commentCount'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'full_name' | 'html_url'>
+    & { owner: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'avatar_url'>
+    )> }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -207,16 +262,40 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQueryMyOperation = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
+export type FeedQueryMyOperation = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login'>
+  )>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> }
+);
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
 };
 
 
-export type SubmitRepositoryMutationMyOperation = ({ __typename?: 'Mutation' } & { submitRepository: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>)> });
+export type SubmitRepositoryMutationMyOperation = (
+  { __typename?: 'Mutation' }
+  & { submitRepository: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'createdAt'>
+  )> }
+);
 
-export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
+export type RepoInfoFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'createdAt'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>
+  ), postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'html_url' | 'login'>
+  ) }
+);
 
 export type SubmitCommentMutationVariables = {
   repoFullName: Scalars['String'],
@@ -224,9 +303,21 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutationMyOperation = ({ __typename?: 'Mutation' } & { submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> });
+export type SubmitCommentMutationMyOperation = (
+  { __typename?: 'Mutation' }
+  & { submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > }
+);
 
-export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
+export type VoteButtonsFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'score'>
+  & { vote: (
+    { __typename?: 'Vote' }
+    & Pick<Vote, 'vote_value'>
+  ) }
+);
 
 export type VoteMutationVariables = {
   repoFullName: Scalars['String'],
@@ -234,7 +325,17 @@ export type VoteMutationVariables = {
 };
 
 
-export type VoteMutationMyOperation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
+export type VoteMutationMyOperation = (
+  { __typename?: 'Mutation' }
+  & { vote: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'score' | 'id'>
+    & { vote: (
+      { __typename?: 'Vote' }
+      & Pick<Vote, 'vote_value'>
+    ) }
+  )> }
+);
 export const CommentsPageCommentFragmentDoc = gql`
     fragment CommentsPageComment on Comment {
   id

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -181,7 +181,17 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 
-export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
+export type OnCommentAddedSubscription = (
+  { __typename?: 'Subscription' }
+  & { commentAdded: Maybe<(
+    { __typename?: 'Comment' }
+    & Pick<Comment, 'id' | 'createdAt' | 'content'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ) }
+  )> }
+);
 
 export type CommentQueryVariables = {
   repoFullName: Scalars['String'],
@@ -190,16 +200,61 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>)>, entry: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>), comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count'>)) })> });
+export type CommentQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  )>, entry: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id' | 'createdAt' | 'commentCount'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ), comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: (
+      { __typename?: 'Repository' }
+      & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>
+    ) }
+  )> }
+);
 
-export type CommentsPageCommentFragment = ({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) });
+export type CommentsPageCommentFragment = (
+  { __typename?: 'Comment' }
+  & Pick<Comment, 'id' | 'createdAt' | 'content'>
+  & { postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  ) }
+);
 
 export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>)> });
+export type CurrentUserForProfileQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'avatar_url'>
+  )> }
+);
 
-export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & { owner: Maybe<({ __typename?: 'User' } & Pick<User, 'avatar_url'>)> }) } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'id' | 'commentCount'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'full_name' | 'html_url'>
+    & { owner: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'avatar_url'>
+    )> }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -208,16 +263,40 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login'>
+  )>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> }
+);
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
 };
 
 
-export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRepository: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>)> });
+export type SubmitRepositoryMutation = (
+  { __typename?: 'Mutation' }
+  & { submitRepository: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'createdAt'>
+  )> }
+);
 
-export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
+export type RepoInfoFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'createdAt'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>
+  ), postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'html_url' | 'login'>
+  ) }
+);
 
 export type SubmitCommentMutationVariables = {
   repoFullName: Scalars['String'],
@@ -225,9 +304,21 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> });
+export type SubmitCommentMutation = (
+  { __typename?: 'Mutation' }
+  & { submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > }
+);
 
-export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
+export type VoteButtonsFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'score'>
+  & { vote: (
+    { __typename?: 'Vote' }
+    & Pick<Vote, 'vote_value'>
+  ) }
+);
 
 export type VoteMutationVariables = {
   repoFullName: Scalars['String'],
@@ -235,7 +326,17 @@ export type VoteMutationVariables = {
 };
 
 
-export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
+export type VoteMutation = (
+  { __typename?: 'Mutation' }
+  & { vote: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'score' | 'id'>
+    & { vote: (
+      { __typename?: 'Vote' }
+      & Pick<Vote, 'vote_value'>
+    ) }
+  )> }
+);
 export const CommentsPageCommentFragmentDoc = gql`
     fragment CommentsPageComment on Comment {
   id
@@ -371,6 +472,10 @@ export function withComment<TProps, TChildProps = {}>(operationOptions?: ApolloR
     export function useCommentQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<CommentQuery, CommentQueryVariables>) {
       return ApolloReactHooks.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, baseOptions);
     };
+      export function useCommentLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<CommentQuery, CommentQueryVariables>) {
+        return ApolloReactHooks.useLazyQuery<CommentQuery, CommentQueryVariables>(CommentDocument, baseOptions);
+      };
+      
 export type CommentQueryHookResult = ReturnType<typeof useCommentQuery>;
 export type CommentQueryResult = ApolloReactCommon.QueryResult<CommentQuery, CommentQueryVariables>;
 export const CurrentUserForProfileDocument = gql`
@@ -402,6 +507,10 @@ export function withCurrentUserForProfile<TProps, TChildProps = {}>(operationOpt
     export function useCurrentUserForProfileQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>) {
       return ApolloReactHooks.useQuery<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>(CurrentUserForProfileDocument, baseOptions);
     };
+      export function useCurrentUserForProfileLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>) {
+        return ApolloReactHooks.useLazyQuery<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>(CurrentUserForProfileDocument, baseOptions);
+      };
+      
 export type CurrentUserForProfileQueryHookResult = ReturnType<typeof useCurrentUserForProfileQuery>;
 export type CurrentUserForProfileQueryResult = ApolloReactCommon.QueryResult<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
 export const FeedDocument = gql`
@@ -435,6 +544,10 @@ export function withFeed<TProps, TChildProps = {}>(operationOptions?: ApolloReac
     export function useFeedQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<FeedQuery, FeedQueryVariables>) {
       return ApolloReactHooks.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, baseOptions);
     };
+      export function useFeedLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<FeedQuery, FeedQueryVariables>) {
+        return ApolloReactHooks.useLazyQuery<FeedQuery, FeedQueryVariables>(FeedDocument, baseOptions);
+      };
+      
 export type FeedQueryHookResult = ReturnType<typeof useFeedQuery>;
 export type FeedQueryResult = ApolloReactCommon.QueryResult<FeedQuery, FeedQueryVariables>;
 export const SubmitRepositoryDocument = gql`

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -189,7 +189,9 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, commentCount: number, postedBy: { __typename?: 'User', login: string, html_url: string }, comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository', full_name: string, html_url: string } & { __typename?: 'Repository', description: Maybe<string>, open_issues_count: Maybe<number>, stargazers_count: number }) }> };
+export type CommentQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, commentCount: number, postedBy: { __typename?: 'User', login: string, html_url: string }, comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: { __typename?: 'Repository', description: Maybe<string>, open_issues_count: Maybe<number>, stargazers_count: number, full_name: string, html_url: string } }> };
 
 export type CommentsPageCommentFragment = { __typename?: 'Comment', id: number, createdAt: number, content: string, postedBy: { __typename?: 'User', login: string, html_url: string } };
 
@@ -198,7 +200,10 @@ export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, avatar_url: string }> };
 
-export type FeedEntryFragment = ({ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', full_name: string, html_url: string, owner: Maybe<{ __typename?: 'User', avatar_url: string }> } } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = { __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', full_name: string, html_url: string, owner: Maybe<{ __typename?: 'User', avatar_url: string }> } }
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -207,7 +212,9 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string }>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> };
+export type FeedQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string }>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> };
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
@@ -224,7 +231,9 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = { __typename?: 'Mutation', submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> };
+export type SubmitCommentMutation = { __typename?: 'Mutation', submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > };
 
 export type VoteButtonsFragment = { __typename?: 'Entry', score: number, vote: { __typename?: 'Vote', vote_value: number } };
 

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -180,7 +180,17 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 
-export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
+export type OnCommentAddedSubscription = (
+  { __typename?: 'Subscription' }
+  & { commentAdded: Maybe<(
+    { __typename?: 'Comment' }
+    & Pick<Comment, 'id' | 'createdAt' | 'content'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ) }
+  )> }
+);
 
 export type CommentQueryVariables = {
   repoFullName: Scalars['String'],
@@ -189,16 +199,61 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>)>, entry: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>), comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count'>)) })> });
+export type CommentQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  )>, entry: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id' | 'createdAt' | 'commentCount'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ), comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: (
+      { __typename?: 'Repository' }
+      & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>
+    ) }
+  )> }
+);
 
-export type CommentsPageCommentFragment = ({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) });
+export type CommentsPageCommentFragment = (
+  { __typename?: 'Comment' }
+  & Pick<Comment, 'id' | 'createdAt' | 'content'>
+  & { postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  ) }
+);
 
 export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>)> });
+export type CurrentUserForProfileQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'avatar_url'>
+  )> }
+);
 
-export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & { owner: Maybe<({ __typename?: 'User' } & Pick<User, 'avatar_url'>)> }) } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'id' | 'commentCount'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'full_name' | 'html_url'>
+    & { owner: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'avatar_url'>
+    )> }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -207,16 +262,40 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login'>
+  )>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> }
+);
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
 };
 
 
-export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRepository: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>)> });
+export type SubmitRepositoryMutation = (
+  { __typename?: 'Mutation' }
+  & { submitRepository: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'createdAt'>
+  )> }
+);
 
-export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
+export type RepoInfoFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'createdAt'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>
+  ), postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'html_url' | 'login'>
+  ) }
+);
 
 export type SubmitCommentMutationVariables = {
   repoFullName: Scalars['String'],
@@ -224,9 +303,21 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> });
+export type SubmitCommentMutation = (
+  { __typename?: 'Mutation' }
+  & { submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > }
+);
 
-export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
+export type VoteButtonsFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'score'>
+  & { vote: (
+    { __typename?: 'Vote' }
+    & Pick<Vote, 'vote_value'>
+  ) }
+);
 
 export type VoteMutationVariables = {
   repoFullName: Scalars['String'],
@@ -234,7 +325,17 @@ export type VoteMutationVariables = {
 };
 
 
-export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
+export type VoteMutation = (
+  { __typename?: 'Mutation' }
+  & { vote: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'score' | 'id'>
+    & { vote: (
+      { __typename?: 'Vote' }
+      & Pick<Vote, 'vote_value'>
+    ) }
+  )> }
+);
 export const CommentsPageCommentFragmentDoc = gql`
     fragment CommentsPageComment on Comment {
   id

--- a/dev-test/githunt/types.stencilApollo.tsx
+++ b/dev-test/githunt/types.stencilApollo.tsx
@@ -177,7 +177,17 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 
-export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
+export type OnCommentAddedSubscription = (
+  { __typename?: 'Subscription' }
+  & { commentAdded: Maybe<(
+    { __typename?: 'Comment' }
+    & Pick<Comment, 'id' | 'createdAt' | 'content'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ) }
+  )> }
+);
 
 export type CommentQueryVariables = {
   repoFullName: Scalars['String'],
@@ -186,16 +196,61 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>)>, entry: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>), comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count'>)) })> });
+export type CommentQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  )>, entry: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id' | 'createdAt' | 'commentCount'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ), comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: (
+      { __typename?: 'Repository' }
+      & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>
+    ) }
+  )> }
+);
 
-export type CommentsPageCommentFragment = ({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) });
+export type CommentsPageCommentFragment = (
+  { __typename?: 'Comment' }
+  & Pick<Comment, 'id' | 'createdAt' | 'content'>
+  & { postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  ) }
+);
 
 export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>)> });
+export type CurrentUserForProfileQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'avatar_url'>
+  )> }
+);
 
-export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & { owner: Maybe<({ __typename?: 'User' } & Pick<User, 'avatar_url'>)> }) } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'id' | 'commentCount'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'full_name' | 'html_url'>
+    & { owner: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'avatar_url'>
+    )> }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -204,16 +259,40 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login'>
+  )>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> }
+);
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
 };
 
 
-export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRepository: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>)> });
+export type SubmitRepositoryMutation = (
+  { __typename?: 'Mutation' }
+  & { submitRepository: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'createdAt'>
+  )> }
+);
 
-export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
+export type RepoInfoFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'createdAt'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>
+  ), postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'html_url' | 'login'>
+  ) }
+);
 
 export type SubmitCommentMutationVariables = {
   repoFullName: Scalars['String'],
@@ -221,9 +300,21 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> });
+export type SubmitCommentMutation = (
+  { __typename?: 'Mutation' }
+  & { submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > }
+);
 
-export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
+export type VoteButtonsFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'score'>
+  & { vote: (
+    { __typename?: 'Vote' }
+    & Pick<Vote, 'vote_value'>
+  ) }
+);
 
 export type VoteMutationVariables = {
   repoFullName: Scalars['String'],
@@ -231,7 +322,17 @@ export type VoteMutationVariables = {
 };
 
 
-export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
+export type VoteMutation = (
+  { __typename?: 'Mutation' }
+  & { vote: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'score' | 'id'>
+    & { vote: (
+      { __typename?: 'Vote' }
+      & Pick<Vote, 'vote_value'>
+    ) }
+  )> }
+);
 
 export const CommentsPageCommentFragmentDoc = gql`
     fragment CommentsPageComment on Comment {

--- a/dev-test/githunt/types.ts
+++ b/dev-test/githunt/types.ts
@@ -173,7 +173,17 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 
-export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
+export type OnCommentAddedSubscription = (
+  { __typename?: 'Subscription' }
+  & { commentAdded: Maybe<(
+    { __typename?: 'Comment' }
+    & Pick<Comment, 'id' | 'createdAt' | 'content'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ) }
+  )> }
+);
 
 export type CommentQueryVariables = {
   repoFullName: Scalars['String'],
@@ -182,16 +192,61 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>)>, entry: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>), comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count'>)) })> });
+export type CommentQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  )>, entry: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id' | 'createdAt' | 'commentCount'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ), comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: (
+      { __typename?: 'Repository' }
+      & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>
+    ) }
+  )> }
+);
 
-export type CommentsPageCommentFragment = ({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) });
+export type CommentsPageCommentFragment = (
+  { __typename?: 'Comment' }
+  & Pick<Comment, 'id' | 'createdAt' | 'content'>
+  & { postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  ) }
+);
 
 export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>)> });
+export type CurrentUserForProfileQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'avatar_url'>
+  )> }
+);
 
-export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & { owner: Maybe<({ __typename?: 'User' } & Pick<User, 'avatar_url'>)> }) } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'id' | 'commentCount'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'full_name' | 'html_url'>
+    & { owner: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'avatar_url'>
+    )> }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -200,16 +255,40 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login'>
+  )>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> }
+);
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
 };
 
 
-export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRepository: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>)> });
+export type SubmitRepositoryMutation = (
+  { __typename?: 'Mutation' }
+  & { submitRepository: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'createdAt'>
+  )> }
+);
 
-export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
+export type RepoInfoFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'createdAt'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>
+  ), postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'html_url' | 'login'>
+  ) }
+);
 
 export type SubmitCommentMutationVariables = {
   repoFullName: Scalars['String'],
@@ -217,9 +296,21 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> });
+export type SubmitCommentMutation = (
+  { __typename?: 'Mutation' }
+  & { submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > }
+);
 
-export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
+export type VoteButtonsFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'score'>
+  & { vote: (
+    { __typename?: 'Vote' }
+    & Pick<Vote, 'vote_value'>
+  ) }
+);
 
 export type VoteMutationVariables = {
   repoFullName: Scalars['String'],
@@ -227,4 +318,14 @@ export type VoteMutationVariables = {
 };
 
 
-export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
+export type VoteMutation = (
+  { __typename?: 'Mutation' }
+  & { vote: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'score' | 'id'>
+    & { vote: (
+      { __typename?: 'Vote' }
+      & Pick<Vote, 'vote_value'>
+    ) }
+  )> }
+);

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -178,7 +178,17 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 
-export type OnCommentAddedSubscription = ({ __typename?: 'Subscription' } & { commentAdded: Maybe<({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) })> });
+export type OnCommentAddedSubscription = (
+  { __typename?: 'Subscription' }
+  & { commentAdded: Maybe<(
+    { __typename?: 'Comment' }
+    & Pick<Comment, 'id' | 'createdAt' | 'content'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ) }
+  )> }
+);
 
 export type CommentQueryVariables = {
   repoFullName: Scalars['String'],
@@ -187,16 +197,61 @@ export type CommentQueryVariables = {
 };
 
 
-export type CommentQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>)>, entry: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>), comments: Array<Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)>>, repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count'>)) })> });
+export type CommentQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  )>, entry: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id' | 'createdAt' | 'commentCount'>
+    & { postedBy: (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'html_url'>
+    ), comments: Array<Maybe<{ __typename?: 'Comment' }
+      & CommentsPageCommentFragment
+    >>, repository: (
+      { __typename?: 'Repository' }
+      & Pick<Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>
+    ) }
+  )> }
+);
 
-export type CommentsPageCommentFragment = ({ __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & { postedBy: ({ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>) });
+export type CommentsPageCommentFragment = (
+  { __typename?: 'Comment' }
+  & Pick<Comment, 'id' | 'createdAt' | 'content'>
+  & { postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'html_url'>
+  ) }
+);
 
 export type CurrentUserForProfileQueryVariables = {};
 
 
-export type CurrentUserForProfileQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>)> });
+export type CurrentUserForProfileQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login' | 'avatar_url'>
+  )> }
+);
 
-export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & { owner: Maybe<({ __typename?: 'User' } & Pick<User, 'avatar_url'>)> }) } & (VoteButtonsFragment & RepoInfoFragment));
+export type FeedEntryFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'id' | 'commentCount'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'full_name' | 'html_url'>
+    & { owner: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'avatar_url'>
+    )> }
+  ) }
+)
+  & VoteButtonsFragment
+  & RepoInfoFragment
+;
 
 export type FeedQueryVariables = {
   type: FeedType,
@@ -205,16 +260,40 @@ export type FeedQueryVariables = {
 };
 
 
-export type FeedQuery = ({ __typename?: 'Query' } & { currentUser: Maybe<({ __typename?: 'User' } & Pick<User, 'login'>)>, feed: Maybe<Array<Maybe<({ __typename?: 'Entry' } & FeedEntryFragment)>>> });
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { currentUser: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'login'>
+  )>, feed: Maybe<Array<Maybe<{ __typename?: 'Entry' }
+    & FeedEntryFragment
+  >>> }
+);
 
 export type SubmitRepositoryMutationVariables = {
   repoFullName: Scalars['String']
 };
 
 
-export type SubmitRepositoryMutation = ({ __typename?: 'Mutation' } & { submitRepository: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>)> });
+export type SubmitRepositoryMutation = (
+  { __typename?: 'Mutation' }
+  & { submitRepository: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'createdAt'>
+  )> }
+);
 
-export type RepoInfoFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & { repository: ({ __typename?: 'Repository' } & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>), postedBy: ({ __typename?: 'User' } & Pick<User, 'html_url' | 'login'>) });
+export type RepoInfoFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'createdAt'>
+  & { repository: (
+    { __typename?: 'Repository' }
+    & Pick<Repository, 'description' | 'stargazers_count' | 'open_issues_count'>
+  ), postedBy: (
+    { __typename?: 'User' }
+    & Pick<User, 'html_url' | 'login'>
+  ) }
+);
 
 export type SubmitCommentMutationVariables = {
   repoFullName: Scalars['String'],
@@ -222,9 +301,21 @@ export type SubmitCommentMutationVariables = {
 };
 
 
-export type SubmitCommentMutation = ({ __typename?: 'Mutation' } & { submitComment: Maybe<({ __typename?: 'Comment' } & CommentsPageCommentFragment)> });
+export type SubmitCommentMutation = (
+  { __typename?: 'Mutation' }
+  & { submitComment: Maybe<{ __typename?: 'Comment' }
+    & CommentsPageCommentFragment
+  > }
+);
 
-export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) });
+export type VoteButtonsFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Entry, 'score'>
+  & { vote: (
+    { __typename?: 'Vote' }
+    & Pick<Vote, 'vote_value'>
+  ) }
+);
 
 export type VoteMutationVariables = {
   repoFullName: Scalars['String'],
@@ -232,7 +323,17 @@ export type VoteMutationVariables = {
 };
 
 
-export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Maybe<({ __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Vote, 'vote_value'>) })> });
+export type VoteMutation = (
+  { __typename?: 'Mutation' }
+  & { vote: Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'score' | 'id'>
+    & { vote: (
+      { __typename?: 'Vote' }
+      & Pick<Vote, 'vote_value'>
+    ) }
+  )> }
+);
 export const CommentsPageCommentFragmentDoc = gql`
     fragment CommentsPageComment on Comment {
   id

--- a/dev-test/githunt/vote-buttons.fragment.stencil-component.tsx
+++ b/dev-test/githunt/vote-buttons.fragment.stencil-component.tsx
@@ -4,7 +4,14 @@ import * as Types from './types.d';
 import gql from 'graphql-tag';
 
     declare global { 
-      export type VoteButtonsFragment = ({ __typename?: 'Entry' } & Pick<Types.Entry, 'score'> & { vote: ({ __typename?: 'Vote' } & Pick<Types.Vote, 'vote_value'>) });
+      export type VoteButtonsFragment = (
+  { __typename?: 'Entry' }
+  & Pick<Types.Entry, 'score'>
+  & { vote: (
+    { __typename?: 'Vote' }
+    & Pick<Types.Vote, 'vote_value'>
+  ) }
+);
  
     }
           

--- a/dev-test/githunt/vote.mutation.stencil-component.tsx
+++ b/dev-test/githunt/vote.mutation.stencil-component.tsx
@@ -12,7 +12,17 @@ import { Component, Prop, h } from '@stencil/core';
 };
 
 
-export type VoteMutation = ({ __typename?: 'Mutation' } & { vote: Types.Maybe<({ __typename?: 'Entry' } & Pick<Types.Entry, 'score' | 'id'> & { vote: ({ __typename?: 'Vote' } & Pick<Types.Vote, 'vote_value'>) })> });
+export type VoteMutation = (
+  { __typename?: 'Mutation' }
+  & { vote: Types.Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Types.Entry, 'score' | 'id'>
+    & { vote: (
+      { __typename?: 'Vote' }
+      & Pick<Types.Vote, 'vote_value'>
+    ) }
+  )> }
+);
  
     }
           

--- a/dev-test/star-wars/types.avoidOptionals.ts
+++ b/dev-test/star-wars/types.avoidOptionals.ts
@@ -252,42 +252,109 @@ export type CreateReviewForEpisodeMutationVariables = {
 };
 
 
-export type CreateReviewForEpisodeMutation = ({ __typename?: 'Mutation' } & { createReview: Maybe<({ __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>)> });
+export type CreateReviewForEpisodeMutation = (
+  { __typename?: 'Mutation' }
+  & { createReview: Maybe<(
+    { __typename?: 'Review' }
+    & Pick<Review, 'stars' | 'commentary'>
+  )> }
+);
 
 export type HeroAndFriendsNamesQueryVariables = {
   episode: Maybe<Episode>
 };
 
 
-export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>>> })> });
+export type HeroAndFriendsNamesQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 export type HeroAppearsInQueryVariables = {};
 
 
-export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name' | 'appearsIn'>)> });
+export type HeroAppearsInQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name' | 'appearsIn'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name' | 'appearsIn'>
+  )> }
+);
 
 export type HeroDetailsQueryVariables = {
   episode: Maybe<Episode>
 };
 
 
-export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
+export type HeroDetailsQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'height' | 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'primaryFunction' | 'name'>
+  )> }
+);
 
 export type HeroDetailsWithFragmentQueryVariables = {
   episode: Maybe<Episode>
 };
 
 
-export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> });
+export type HeroDetailsWithFragmentQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<({ __typename?: 'Human' } | { __typename?: 'Droid' })
+    & HeroDetailsFragment
+  > }
+);
 
-export type HeroDetailsFragment = ({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
+export type HeroDetailsFragment = (
+  { __typename?: 'Human' }
+  & Pick<Human, 'height' | 'name'>
+) | (
+  { __typename?: 'Droid' }
+  & Pick<Droid, 'primaryFunction' | 'name'>
+);
 
 export type HeroNameQueryVariables = {
   episode: Maybe<Episode>
 };
 
 
-export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode: Maybe<Episode>,
@@ -295,7 +362,16 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameConditionalInclusionQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode: Maybe<Episode>,
@@ -303,28 +379,90 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameConditionalExclusionQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroParentTypeDependentFieldQueryVariables = {
   episode: Maybe<Episode>
 };
 
 
-export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
+export type HeroParentTypeDependentFieldQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 export type HeroTypeDependentAliasedFieldQueryVariables = {
   episode: Maybe<Episode>
 };
 
 
-export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & (({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })))> });
+export type HeroTypeDependentAliasedFieldQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & { property: Human['homePlanet'] }
+  ) | (
+    { __typename?: 'Droid' }
+    & { property: Droid['primaryFunction'] }
+  )> }
+);
 
 export type HumanWithNullHeightQueryVariables = {};
 
 
-export type HumanWithNullHeightQuery = ({ __typename?: 'Query' } & { human: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name' | 'mass'>)> });
+export type HumanWithNullHeightQuery = (
+  { __typename?: 'Query' }
+  & { human: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name' | 'mass'>
+  )> }
+);
 
 export type TwoHeroesQueryVariables = {};
 
 
-export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>, luke: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type TwoHeroesQuery = (
+  { __typename?: 'Query' }
+  & { r2: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )>, luke: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);

--- a/dev-test/star-wars/types.d.ts
+++ b/dev-test/star-wars/types.d.ts
@@ -250,42 +250,109 @@ export type CreateReviewForEpisodeMutationVariables = {
 };
 
 
-export type CreateReviewForEpisodeMutation = ({ __typename?: 'Mutation' } & { createReview: Maybe<({ __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>)> });
+export type CreateReviewForEpisodeMutation = (
+  { __typename?: 'Mutation' }
+  & { createReview: Maybe<(
+    { __typename?: 'Review' }
+    & Pick<Review, 'stars' | 'commentary'>
+  )> }
+);
 
 export type HeroAndFriendsNamesQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>>> })> });
+export type HeroAndFriendsNamesQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 export type HeroAppearsInQueryVariables = {};
 
 
-export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name' | 'appearsIn'>)> });
+export type HeroAppearsInQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name' | 'appearsIn'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name' | 'appearsIn'>
+  )> }
+);
 
 export type HeroDetailsQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
+export type HeroDetailsQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'height' | 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'primaryFunction' | 'name'>
+  )> }
+);
 
 export type HeroDetailsWithFragmentQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> });
+export type HeroDetailsWithFragmentQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<({ __typename?: 'Human' } | { __typename?: 'Droid' })
+    & HeroDetailsFragment
+  > }
+);
 
-export type HeroDetailsFragment = ({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
+export type HeroDetailsFragment = (
+  { __typename?: 'Human' }
+  & Pick<Human, 'height' | 'name'>
+) | (
+  { __typename?: 'Droid' }
+  & Pick<Droid, 'primaryFunction' | 'name'>
+);
 
 export type HeroNameQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -293,7 +360,16 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameConditionalInclusionQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -301,28 +377,90 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameConditionalExclusionQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroParentTypeDependentFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
+export type HeroParentTypeDependentFieldQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 export type HeroTypeDependentAliasedFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & (({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })))> });
+export type HeroTypeDependentAliasedFieldQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & { property: Human['homePlanet'] }
+  ) | (
+    { __typename?: 'Droid' }
+    & { property: Droid['primaryFunction'] }
+  )> }
+);
 
 export type HumanWithNullHeightQueryVariables = {};
 
 
-export type HumanWithNullHeightQuery = ({ __typename?: 'Query' } & { human: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name' | 'mass'>)> });
+export type HumanWithNullHeightQuery = (
+  { __typename?: 'Query' }
+  & { human: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name' | 'mass'>
+  )> }
+);
 
 export type TwoHeroesQueryVariables = {};
 
 
-export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>, luke: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type TwoHeroesQuery = (
+  { __typename?: 'Query' }
+  & { r2: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )>, luke: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);

--- a/dev-test/star-wars/types.globallyAvailable.d.ts
+++ b/dev-test/star-wars/types.globallyAvailable.d.ts
@@ -250,42 +250,109 @@ type CreateReviewForEpisodeMutationVariables = {
 };
 
 
-type CreateReviewForEpisodeMutation = ({ __typename?: 'Mutation' } & { createReview: Maybe<({ __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>)> });
+type CreateReviewForEpisodeMutation = (
+  { __typename?: 'Mutation' }
+  & { createReview: Maybe<(
+    { __typename?: 'Review' }
+    & Pick<Review, 'stars' | 'commentary'>
+  )> }
+);
 
 type HeroAndFriendsNamesQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>>> })> });
+type HeroAndFriendsNamesQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 type HeroAppearsInQueryVariables = {};
 
 
-type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name' | 'appearsIn'>)> });
+type HeroAppearsInQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name' | 'appearsIn'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name' | 'appearsIn'>
+  )> }
+);
 
 type HeroDetailsQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
+type HeroDetailsQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'height' | 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'primaryFunction' | 'name'>
+  )> }
+);
 
 type HeroDetailsWithFragmentQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> });
+type HeroDetailsWithFragmentQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<({ __typename?: 'Human' } | { __typename?: 'Droid' })
+    & HeroDetailsFragment
+  > }
+);
 
-type HeroDetailsFragment = ({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
+type HeroDetailsFragment = (
+  { __typename?: 'Human' }
+  & Pick<Human, 'height' | 'name'>
+) | (
+  { __typename?: 'Droid' }
+  & Pick<Droid, 'primaryFunction' | 'name'>
+);
 
 type HeroNameQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+type HeroNameQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -293,7 +360,16 @@ type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+type HeroNameConditionalInclusionQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -301,28 +377,90 @@ type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+type HeroNameConditionalExclusionQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 type HeroParentTypeDependentFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
+type HeroParentTypeDependentFieldQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 type HeroTypeDependentAliasedFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & (({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })))> });
+type HeroTypeDependentAliasedFieldQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & { property: Human['homePlanet'] }
+  ) | (
+    { __typename?: 'Droid' }
+    & { property: Droid['primaryFunction'] }
+  )> }
+);
 
 type HumanWithNullHeightQueryVariables = {};
 
 
-type HumanWithNullHeightQuery = ({ __typename?: 'Query' } & { human: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name' | 'mass'>)> });
+type HumanWithNullHeightQuery = (
+  { __typename?: 'Query' }
+  & { human: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name' | 'mass'>
+  )> }
+);
 
 type TwoHeroesQueryVariables = {};
 
 
-type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>, luke: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+type TwoHeroesQuery = (
+  { __typename?: 'Query' }
+  & { r2: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )>, luke: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);

--- a/dev-test/star-wars/types.immutableTypes.ts
+++ b/dev-test/star-wars/types.immutableTypes.ts
@@ -252,42 +252,109 @@ export type CreateReviewForEpisodeMutationVariables = {
 };
 
 
-export type CreateReviewForEpisodeMutation = ({ readonly __typename?: 'Mutation' } & { readonly createReview: Maybe<({ readonly __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>)> });
+export type CreateReviewForEpisodeMutation = (
+  { readonly __typename?: 'Mutation' }
+  & { readonly createReview: Maybe<(
+    { readonly __typename?: 'Review' }
+    & Pick<Review, 'stars' | 'commentary'>
+  )> }
+);
 
 export type HeroAndFriendsNamesQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroAndFriendsNamesQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & { readonly friends: Maybe<ReadonlyArray<Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>>> })> });
+export type HeroAndFriendsNamesQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly hero: Maybe<(
+    { readonly __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { readonly friends: Maybe<ReadonlyArray<Maybe<(
+      { readonly __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { readonly __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { readonly __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { readonly friends: Maybe<ReadonlyArray<Maybe<(
+      { readonly __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { readonly __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 export type HeroAppearsInQueryVariables = {};
 
 
-export type HeroAppearsInQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name' | 'appearsIn'>)> });
+export type HeroAppearsInQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly hero: Maybe<(
+    { readonly __typename?: 'Human' }
+    & Pick<Human, 'name' | 'appearsIn'>
+  ) | (
+    { readonly __typename?: 'Droid' }
+    & Pick<Droid, 'name' | 'appearsIn'>
+  )> }
+);
 
 export type HeroDetailsQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ readonly __typename?: 'Human' } & Pick<Human, 'height'>) | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
+export type HeroDetailsQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly hero: Maybe<(
+    { readonly __typename?: 'Human' }
+    & Pick<Human, 'height' | 'name'>
+  ) | (
+    { readonly __typename?: 'Droid' }
+    & Pick<Droid, 'primaryFunction' | 'name'>
+  )> }
+);
 
 export type HeroDetailsWithFragmentQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsWithFragmentQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> });
+export type HeroDetailsWithFragmentQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly hero: Maybe<({ readonly __typename?: 'Human' } | { readonly __typename?: 'Droid' })
+    & HeroDetailsFragment
+  > }
+);
 
-export type HeroDetailsFragment = ({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ readonly __typename?: 'Human' } & Pick<Human, 'height'>) | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
+export type HeroDetailsFragment = (
+  { readonly __typename?: 'Human' }
+  & Pick<Human, 'height' | 'name'>
+) | (
+  { readonly __typename?: 'Droid' }
+  & Pick<Droid, 'primaryFunction' | 'name'>
+);
 
 export type HeroNameQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroNameQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly hero: Maybe<(
+    { readonly __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { readonly __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -295,7 +362,16 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalInclusionQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameConditionalInclusionQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly hero: Maybe<(
+    { readonly __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { readonly __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -303,28 +379,90 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalExclusionQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameConditionalExclusionQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly hero: Maybe<(
+    { readonly __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { readonly __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroParentTypeDependentFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroParentTypeDependentFieldQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ readonly __typename?: 'Human' } & { readonly friends: Maybe<ReadonlyArray<Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ readonly __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ readonly __typename?: 'Droid' } & { readonly friends: Maybe<ReadonlyArray<Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ readonly __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
+export type HeroParentTypeDependentFieldQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly hero: Maybe<(
+    { readonly __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { readonly friends: Maybe<ReadonlyArray<Maybe<(
+      { readonly __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { readonly __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { readonly __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { readonly friends: Maybe<ReadonlyArray<Maybe<(
+      { readonly __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { readonly __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 export type HeroTypeDependentAliasedFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroTypeDependentAliasedFieldQuery = ({ readonly __typename?: 'Query' } & { readonly hero: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & (({ readonly __typename?: 'Human' } & { readonly property: Human['homePlanet'] }) | ({ readonly __typename?: 'Droid' } & { readonly property: Droid['primaryFunction'] })))> });
+export type HeroTypeDependentAliasedFieldQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly hero: Maybe<(
+    { readonly __typename?: 'Human' }
+    & { readonly property: Human['homePlanet'] }
+  ) | (
+    { readonly __typename?: 'Droid' }
+    & { readonly property: Droid['primaryFunction'] }
+  )> }
+);
 
 export type HumanWithNullHeightQueryVariables = {};
 
 
-export type HumanWithNullHeightQuery = ({ readonly __typename?: 'Query' } & { readonly human: Maybe<({ readonly __typename?: 'Human' } & Pick<Human, 'name' | 'mass'>)> });
+export type HumanWithNullHeightQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly human: Maybe<(
+    { readonly __typename?: 'Human' }
+    & Pick<Human, 'name' | 'mass'>
+  )> }
+);
 
 export type TwoHeroesQueryVariables = {};
 
 
-export type TwoHeroesQuery = ({ readonly __typename?: 'Query' } & { readonly r2: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>, readonly luke: Maybe<({ readonly __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type TwoHeroesQuery = (
+  { readonly __typename?: 'Query' }
+  & { readonly r2: Maybe<(
+    { readonly __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { readonly __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )>, readonly luke: Maybe<(
+    { readonly __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { readonly __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);

--- a/dev-test/star-wars/types.preResolveTypes.ts
+++ b/dev-test/star-wars/types.preResolveTypes.ts
@@ -259,35 +259,37 @@ export type HeroAndFriendsNamesQueryVariables = {
 };
 
 
-export type HeroAndFriendsNamesQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human' | 'Droid', name: string, friends: Maybe<Array<Maybe<{ __typename?: 'Human' | 'Droid', name: string }>>> }> };
+export type HeroAndFriendsNamesQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human', name: string, friends: Maybe<Array<Maybe<{ __typename?: 'Human', name: string } | { __typename?: 'Droid', name: string }>>> } | { __typename?: 'Droid', name: string, friends: Maybe<Array<Maybe<{ __typename?: 'Human', name: string } | { __typename?: 'Droid', name: string }>>> }> };
 
 export type HeroAppearsInQueryVariables = {};
 
 
-export type HeroAppearsInQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human' | 'Droid', name: string, appearsIn: Array<Maybe<'NEWHOPE' | 'EMPIRE' | 'JEDI'>> }> };
+export type HeroAppearsInQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human', name: string, appearsIn: Array<Maybe<'NEWHOPE' | 'EMPIRE' | 'JEDI'>> } | { __typename?: 'Droid', name: string, appearsIn: Array<Maybe<'NEWHOPE' | 'EMPIRE' | 'JEDI'>> }> };
 
 export type HeroDetailsQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsQuery = { __typename?: 'Query', hero: Maybe<({ __typename?: 'Human' | 'Droid', name: string } & ({ __typename?: 'Human', height: Maybe<number> } | { __typename?: 'Droid', primaryFunction: Maybe<string> }))> };
+export type HeroDetailsQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human', height: Maybe<number>, name: string } | { __typename?: 'Droid', primaryFunction: Maybe<string>, name: string }> };
 
 export type HeroDetailsWithFragmentQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsWithFragmentQuery = { __typename?: 'Query', hero: Maybe<({ __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> };
+export type HeroDetailsWithFragmentQuery = { __typename?: 'Query', hero: Maybe<({ __typename?: 'Human' } | { __typename?: 'Droid' })
+    & HeroDetailsFragment
+  > };
 
-export type HeroDetailsFragment = ({ __typename?: 'Human' | 'Droid', name: string } & ({ __typename?: 'Human', height: Maybe<number> } | { __typename?: 'Droid', primaryFunction: Maybe<string> }));
+export type HeroDetailsFragment = { __typename?: 'Human', height: Maybe<number>, name: string } | { __typename?: 'Droid', primaryFunction: Maybe<string>, name: string };
 
 export type HeroNameQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroNameQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human' | 'Droid', name: string }> };
+export type HeroNameQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human', name: string } | { __typename?: 'Droid', name: string }> };
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -295,7 +297,7 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalInclusionQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human' | 'Droid', name: string }> };
+export type HeroNameConditionalInclusionQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human', name: string } | { __typename?: 'Droid', name: string }> };
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -303,21 +305,21 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalExclusionQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human' | 'Droid', name: string }> };
+export type HeroNameConditionalExclusionQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human', name: string } | { __typename?: 'Droid', name: string }> };
 
 export type HeroParentTypeDependentFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroParentTypeDependentFieldQuery = { __typename?: 'Query', hero: Maybe<({ __typename?: 'Human' | 'Droid', name: string } & ({ __typename?: 'Human', friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid', name: string } & { __typename?: 'Human', height: Maybe<number> })>>> } | { __typename?: 'Droid', friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid', name: string } & { __typename?: 'Human', height: Maybe<number> })>>> }))> };
+export type HeroParentTypeDependentFieldQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human', name: string, friends: Maybe<Array<Maybe<{ __typename?: 'Human', height: Maybe<number>, name: string } | { __typename?: 'Droid', name: string }>>> } | { __typename?: 'Droid', name: string, friends: Maybe<Array<Maybe<{ __typename?: 'Human', height: Maybe<number>, name: string } | { __typename?: 'Droid', name: string }>>> }> };
 
 export type HeroTypeDependentAliasedFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroTypeDependentAliasedFieldQuery = { __typename?: 'Query', hero: Maybe<({ __typename?: 'Human' | 'Droid' } & ({ __typename?: 'Human', property: Maybe<string> } | { __typename?: 'Droid', property: Maybe<string> }))> };
+export type HeroTypeDependentAliasedFieldQuery = { __typename?: 'Query', hero: Maybe<{ __typename?: 'Human', property: Maybe<string> } | { __typename?: 'Droid', property: Maybe<string> }> };
 
 export type HumanWithNullHeightQueryVariables = {};
 
@@ -327,4 +329,4 @@ export type HumanWithNullHeightQuery = { __typename?: 'Query', human: Maybe<{ __
 export type TwoHeroesQueryVariables = {};
 
 
-export type TwoHeroesQuery = { __typename?: 'Query', r2: Maybe<{ __typename?: 'Human' | 'Droid', name: string }>, luke: Maybe<{ __typename?: 'Human' | 'Droid', name: string }> };
+export type TwoHeroesQuery = { __typename?: 'Query', r2: Maybe<{ __typename?: 'Human', name: string } | { __typename?: 'Droid', name: string }>, luke: Maybe<{ __typename?: 'Human', name: string } | { __typename?: 'Droid', name: string }> };

--- a/dev-test/star-wars/types.skipSchema.ts
+++ b/dev-test/star-wars/types.skipSchema.ts
@@ -252,42 +252,109 @@ export type CreateReviewForEpisodeMutationVariables = {
 };
 
 
-export type CreateReviewForEpisodeMutation = ({ __typename?: 'Mutation' } & { createReview: Maybe<({ __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>)> });
+export type CreateReviewForEpisodeMutation = (
+  { __typename?: 'Mutation' }
+  & { createReview: Maybe<(
+    { __typename?: 'Review' }
+    & Pick<Review, 'stars' | 'commentary'>
+  )> }
+);
 
 export type HeroAndFriendsNamesQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>>> })> });
+export type HeroAndFriendsNamesQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 export type HeroAppearsInQueryVariables = {};
 
 
-export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name' | 'appearsIn'>)> });
+export type HeroAppearsInQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name' | 'appearsIn'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name' | 'appearsIn'>
+  )> }
+);
 
 export type HeroDetailsQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
+export type HeroDetailsQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'height' | 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'primaryFunction' | 'name'>
+  )> }
+);
 
 export type HeroDetailsWithFragmentQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> });
+export type HeroDetailsWithFragmentQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<({ __typename?: 'Human' } | { __typename?: 'Droid' })
+    & HeroDetailsFragment
+  > }
+);
 
-export type HeroDetailsFragment = ({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
+export type HeroDetailsFragment = (
+  { __typename?: 'Human' }
+  & Pick<Human, 'height' | 'name'>
+) | (
+  { __typename?: 'Droid' }
+  & Pick<Droid, 'primaryFunction' | 'name'>
+);
 
 export type HeroNameQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -295,7 +362,16 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameConditionalInclusionQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -303,28 +379,90 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameConditionalExclusionQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroParentTypeDependentFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
+export type HeroParentTypeDependentFieldQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 export type HeroTypeDependentAliasedFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & (({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })))> });
+export type HeroTypeDependentAliasedFieldQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & { property: Human['homePlanet'] }
+  ) | (
+    { __typename?: 'Droid' }
+    & { property: Droid['primaryFunction'] }
+  )> }
+);
 
 export type HumanWithNullHeightQueryVariables = {};
 
 
-export type HumanWithNullHeightQuery = ({ __typename?: 'Query' } & { human: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name' | 'mass'>)> });
+export type HumanWithNullHeightQuery = (
+  { __typename?: 'Query' }
+  & { human: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name' | 'mass'>
+  )> }
+);
 
 export type TwoHeroesQueryVariables = {};
 
 
-export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>, luke: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type TwoHeroesQuery = (
+  { __typename?: 'Query' }
+  & { r2: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )>, luke: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);

--- a/dev-test/star-wars/types.ts
+++ b/dev-test/star-wars/types.ts
@@ -252,42 +252,109 @@ export type CreateReviewForEpisodeMutationVariables = {
 };
 
 
-export type CreateReviewForEpisodeMutation = ({ __typename?: 'Mutation' } & { createReview: Maybe<({ __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>)> });
+export type CreateReviewForEpisodeMutation = (
+  { __typename?: 'Mutation' }
+  & { createReview: Maybe<(
+    { __typename?: 'Review' }
+    & Pick<Review, 'stars' | 'commentary'>
+  )> }
+);
 
 export type HeroAndFriendsNamesQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroAndFriendsNamesQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>>> })> });
+export type HeroAndFriendsNamesQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 export type HeroAppearsInQueryVariables = {};
 
 
-export type HeroAppearsInQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name' | 'appearsIn'>)> });
+export type HeroAppearsInQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name' | 'appearsIn'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name' | 'appearsIn'>
+  )> }
+);
 
 export type HeroDetailsQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)))> });
+export type HeroDetailsQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'height' | 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'primaryFunction' | 'name'>
+  )> }
+);
 
 export type HeroDetailsWithFragmentQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroDetailsWithFragmentQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & HeroDetailsFragment)> });
+export type HeroDetailsWithFragmentQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<({ __typename?: 'Human' } | { __typename?: 'Droid' })
+    & HeroDetailsFragment
+  > }
+);
 
-export type HeroDetailsFragment = ({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & Pick<Human, 'height'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction'>)));
+export type HeroDetailsFragment = (
+  { __typename?: 'Human' }
+  & Pick<Human, 'height' | 'name'>
+) | (
+  { __typename?: 'Droid' }
+  & Pick<Droid, 'primaryFunction' | 'name'>
+);
 
 export type HeroNameQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroNameQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroNameConditionalInclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -295,7 +362,16 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalInclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameConditionalInclusionQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroNameConditionalExclusionQueryVariables = {
   episode?: Maybe<Episode>,
@@ -303,28 +379,90 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 
-export type HeroNameConditionalExclusionQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type HeroNameConditionalExclusionQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);
 
 export type HeroParentTypeDependentFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroParentTypeDependentFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & (({ __typename?: 'Human' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> }) | ({ __typename?: 'Droid' } & { friends: Maybe<Array<Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'> & ({ __typename?: 'Human' } & Pick<Human, 'height'>))>>> })))> });
+export type HeroParentTypeDependentFieldQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+    & { friends: Maybe<Array<Maybe<(
+      { __typename?: 'Human' }
+      & Pick<Human, 'height' | 'name'>
+    ) | (
+      { __typename?: 'Droid' }
+      & Pick<Droid, 'name'>
+    )>>> }
+  )> }
+);
 
 export type HeroTypeDependentAliasedFieldQueryVariables = {
   episode?: Maybe<Episode>
 };
 
 
-export type HeroTypeDependentAliasedFieldQuery = ({ __typename?: 'Query' } & { hero: Maybe<({ __typename?: 'Human' | 'Droid' } & (({ __typename?: 'Human' } & { property: Human['homePlanet'] }) | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })))> });
+export type HeroTypeDependentAliasedFieldQuery = (
+  { __typename?: 'Query' }
+  & { hero: Maybe<(
+    { __typename?: 'Human' }
+    & { property: Human['homePlanet'] }
+  ) | (
+    { __typename?: 'Droid' }
+    & { property: Droid['primaryFunction'] }
+  )> }
+);
 
 export type HumanWithNullHeightQueryVariables = {};
 
 
-export type HumanWithNullHeightQuery = ({ __typename?: 'Query' } & { human: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name' | 'mass'>)> });
+export type HumanWithNullHeightQuery = (
+  { __typename?: 'Query' }
+  & { human: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name' | 'mass'>
+  )> }
+);
 
 export type TwoHeroesQueryVariables = {};
 
 
-export type TwoHeroesQuery = ({ __typename?: 'Query' } & { r2: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)>, luke: Maybe<({ __typename?: 'Human' | 'Droid' } & Pick<Character, 'name'>)> });
+export type TwoHeroesQuery = (
+  { __typename?: 'Query' }
+  & { r2: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )>, luke: Maybe<(
+    { __typename?: 'Human' }
+    & Pick<Human, 'name'>
+  ) | (
+    { __typename?: 'Droid' }
+    & Pick<Droid, 'name'>
+  )> }
+);

--- a/dev-test/test-schema/flow-types.flow.js
+++ b/dev-test/test-schema/flow-types.flow.js
@@ -2,6 +2,7 @@
 
 
 import { type GraphQLResolveInfo } from 'graphql';
+export type $RequireFields<Origin, Keys> = $Diff<Args, Keys> & $ObjMapi<Keys, <Key>(k: Key) => $NonMaybeType<$ElementType<Origin, Key>>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -49,14 +50,23 @@ export type SubscriptionResolveFn<Result, Parent, Context, Args> = (
   info: GraphQLResolveInfo
 ) => Result | Promise<Result>;
 
-export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
-  subscribe: SubscriptionSubscribeFn<Result, Parent, Context, Args>;
-  resolve?: SubscriptionResolveFn<Result, Parent, Context, Args>;
+export interface ISubscriptionSubscriberObject<Result, Key: string, Parent, Context, Args> {
+  subscribe: SubscriptionSubscribeFn<{ [key: Key]: Result }, Parent, Context, Args>;
+  resolve?: SubscriptionResolveFn<Result, { [key: Key]: Result }, Context, Args>;
 }
 
-export type SubscriptionResolver<Result, Parent = {}, Context = {}, Args = {}> =
-  | ((...args: Array<any>) => ISubscriptionResolverObject<Result, Parent, Context, Args>)
-  | ISubscriptionResolverObject<Result, Parent, Context, Args>;
+export interface ISubscriptionResolverObject<Result, Parent, Context, Args> {
+  subscribe: SubscriptionSubscribeFn<mixed, Parent, Context, Args>;
+  resolve: SubscriptionResolveFn<Result, mixed, Context, Args>;
+}
+
+export type ISubscriptionObject<Result, Key: string, Parent, Context, Args> =
+  | ISubscriptionSubscriberObject<Result, Key, Parent, Context, Args>
+  | ISubscriptionSubscribeResolveObject<Result, Parent, Context, Args>;
+
+export type SubscriptionResolver<Result, Key: string, Parent = {}, Context = {}, Args = {}> =
+  | ((...args: Array<any>) => ISubscriptionObject<Result, Key, Parent, Context, Args>)
+  | ISubscriptionObject<Result, Key, Parent, Context, Args>;
 
 export type TypeResolveFn<Types, Parent = {}, Context = {}> = (
   parent: Parent,
@@ -96,7 +106,7 @@ export type ResolversParentTypes = {
 
 export type QueryResolvers<ContextType = any, ParentType = $ElementType<ResolversParentTypes, 'Query'>> = {
   allUsers?: Resolver<Array<?$ElementType<ResolversTypes, 'User'>>, ParentType, ContextType>,
-  userById?: Resolver<?$ElementType<ResolversTypes, 'User'>, ParentType, ContextType, QueryUserByIdArgs>,
+  userById?: Resolver<?$ElementType<ResolversTypes, 'User'>, ParentType, ContextType, $RequireFields<QueryUserByIdArgs, { id: * }>>,
 };
 
 export type UserResolvers<ContextType = any, ParentType = $ElementType<ResolversParentTypes, 'User'>> = {

--- a/dev-test/test-schema/resolvers-federation.ts
+++ b/dev-test/test-schema/resolvers-federation.ts
@@ -67,14 +67,23 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, TParent, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
-export type SubscriptionResolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionResolverObject<TResult, TParent, TContext, TArgs>)
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,

--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -1,6 +1,7 @@
 // tslint:disable
 import { GraphQLResolveInfo } from 'graphql';
 export type Maybe<T> = T | null;
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -68,14 +69,23 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, TParent, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
-export type SubscriptionResolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionResolverObject<TResult, TParent, TContext, TArgs>)
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
@@ -115,12 +125,12 @@ export type ResolversParentTypes = {
 
 export type QueryRootResolvers<ContextType = any, ParentType extends ResolversParentTypes['QueryRoot'] = ResolversParentTypes['QueryRoot']> = {
   allUsers?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, ContextType>,
-  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, QueryRootUserByIdArgs>,
+  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryRootUserByIdArgs, 'id'>>,
   answer?: Resolver<Array<ResolversTypes['Int']>, ParentType, ContextType>,
 };
 
 export type SubscriptionRootResolvers<ContextType = any, ParentType extends ResolversParentTypes['SubscriptionRoot'] = ResolversParentTypes['SubscriptionRoot']> = {
-  newUser?: SubscriptionResolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
+  newUser?: SubscriptionResolver<Maybe<ResolversTypes['User']>, "newUser", ParentType, ContextType>,
 };
 
 export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {

--- a/dev-test/test-schema/resolvers-types.ts
+++ b/dev-test/test-schema/resolvers-types.ts
@@ -1,6 +1,7 @@
 // tslint:disable
 import { GraphQLResolveInfo } from 'graphql';
 export type Maybe<T> = T | null;
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -66,14 +67,23 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, TParent, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
-export type SubscriptionResolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionResolverObject<TResult, TParent, TContext, TArgs>)
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
@@ -111,7 +121,7 @@ export type ResolversParentTypes = {
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   allUsers?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, ContextType>,
-  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, QueryUserByIdArgs>,
+  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserByIdArgs, 'id'>>,
   answer?: Resolver<Array<ResolversTypes['Int']>, ParentType, ContextType>,
   testArr1?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>,
   testArr2?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>,

--- a/dev-test/test-schema/typings.ts
+++ b/dev-test/test-schema/typings.ts
@@ -1,6 +1,7 @@
 // tslint:disable
 import { GraphQLResolveInfo } from 'graphql';
 export type Maybe<T> = T | null;
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string,
@@ -62,14 +63,23 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, TParent, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
-export type SubscriptionResolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionResolverObject<TResult, TParent, TContext, TArgs>)
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
@@ -107,7 +117,7 @@ export type ResolversParentTypes = {
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   allUsers?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, ContextType>,
-  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, QueryUserByIdArgs>,
+  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserByIdArgs, 'id'>>,
 };
 
 export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -41,6 +41,8 @@
   },
   "homepage": "https://github.com/dotansimha/graphql-codegen#readme",
   "dependencies": {
+    "@types/debounce": "1.2.0",
+    "debounce": "1.2.0",
     "@babel/parser": "7.5.5",
     "@graphql-codegen/core": "1.5.0",
     "@graphql-codegen/plugin-helpers": "1.5.0",

--- a/packages/graphql-codegen-cli/src/cli.ts
+++ b/packages/graphql-codegen-cli/src/cli.ts
@@ -16,12 +16,15 @@ switch (cmd) {
       .catch(cliError);
     break;
 
-  default:
-    createConfig().then(config => {
+  default: {
+    const config = createConfig();
+
+    config.then(config => {
       return generate(config)
         .then(() => {
           process.exit(0);
         })
         .catch(cliError);
     });
+  }
 }

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -37,7 +37,7 @@ function getCustomConfigPath(cliFlags: YamlCliFlags): string | null | never {
   return null;
 }
 
-function loadAndParseConfig(filepath: string): Types.Config | never {
+export function loadAndParseConfig(filepath: string): Types.Config | never {
   const ext = filepath.substr(filepath.lastIndexOf('.') + 1);
   switch (ext) {
     case 'yml':
@@ -62,8 +62,8 @@ function collect<T = string>(val: T, memo: T[]): T[] {
   return memo;
 }
 
-export async function createConfig(argv = process.argv): Promise<Types.Config | never> {
-  const cliFlags = (new Command()
+export function parseArgv(argv = process.argv): Command & YamlCliFlags {
+  return (new Command()
     .usage('graphql-codegen [options]')
     .allowUnknownOption(true)
     .option('-c, --config <path>', 'Path to GraphQL codegen YAML config file, defaults to "codegen.yml" on the current directory')
@@ -72,7 +72,9 @@ export async function createConfig(argv = process.argv): Promise<Types.Config | 
     .option('-r, --require [value]', 'Loads specific require.extensions before running the codegen and reading the configuration', collect, [])
     .option('-o, --overwrite', 'Overwrites existing files')
     .parse(argv) as any) as Command & YamlCliFlags;
+}
 
+export async function createConfig(cliFlags: Command & YamlCliFlags = parseArgv(process.argv)): Promise<Types.Config | never> {
   const customConfigPath = getCustomConfigPath(cliFlags);
   const locations: string[] = [join(process.cwd(), './codegen.yml'), join(process.cwd(), './codegen.json')];
 
@@ -98,6 +100,7 @@ export async function createConfig(argv = process.argv): Promise<Types.Config | 
   }
 
   const parsedConfigFile = loadAndParseConfig(filepath);
+  parsedConfigFile.configFilePath = filepath;
 
   if (cliFlags.watch === true) {
     parsedConfigFile.watch = cliFlags.watch;

--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -1,12 +1,21 @@
 import { Types } from '@graphql-codegen/plugin-helpers';
 import { executeCodegen } from './codegen';
 import { createWatcher } from './utils/watcher';
-import { fileExists, writeSync } from './utils/file-system';
+import { fileExists, readSync, writeSync } from './utils/file-system';
 import { sync as mkdirpSync } from 'mkdirp';
 import { dirname } from 'path';
 import { debugLog } from './utils/debugging';
+import { createHash } from 'crypto';
+import { readFileSync } from 'fs';
+
+const hash = (content: string): string =>
+  createHash('sha1')
+    .update(content)
+    .digest('base64');
 
 export async function generate(config: Types.Config, saveToFile = true): Promise<Types.FileOutput[] | any> {
+  let recentOutputHash = new Map<string, string>();
+
   async function writeOutput(generationResult: Types.FileOutput[]) {
     if (!saveToFile) {
       return generationResult;
@@ -14,16 +23,31 @@ export async function generate(config: Types.Config, saveToFile = true): Promise
 
     await Promise.all(
       generationResult.map(async (result: Types.FileOutput) => {
-        if (!shouldOverwrite(config, result.filename) && fileExists(result.filename)) {
+        const exists = fileExists(result.filename);
+
+        if (!shouldOverwrite(config, result.filename) && exists) {
           return;
         }
 
         const content = result.content || '';
+        const currentHash = hash(content);
+        let previousHash = recentOutputHash.get(result.filename);
+
+        if (!previousHash && exists) {
+          previousHash = hash(readSync(result.filename, 'utf-8'));
+        }
+
+        if (previousHash && currentHash === previousHash) {
+          debugLog(`Skipping file (${result.filename}) writing due to indentical hash...`);
+
+          return;
+        }
 
         if (content.length === 0) {
           return;
         }
 
+        recentOutputHash.set(result.filename, currentHash);
         const basedir = dirname(result.filename);
         mkdirpSync(basedir);
         writeSync(result.filename, result.content);

--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -6,7 +6,6 @@ import { sync as mkdirpSync } from 'mkdirp';
 import { dirname } from 'path';
 import { debugLog } from './utils/debugging';
 import { createHash } from 'crypto';
-import { readFileSync } from 'fs';
 
 const hash = (content: string): string =>
   createHash('sha1')
@@ -34,7 +33,7 @@ export async function generate(config: Types.Config, saveToFile = true): Promise
         let previousHash = recentOutputHash.get(result.filename);
 
         if (!previousHash && exists) {
-          previousHash = hash(readSync(result.filename, 'utf-8'));
+          previousHash = hash(readSync(result.filename));
         }
 
         if (previousHash && currentHash === previousHash) {

--- a/packages/graphql-codegen-cli/src/utils/file-exists.ts
+++ b/packages/graphql-codegen-cli/src/utils/file-exists.ts
@@ -1,9 +1,0 @@
-import * as fs from 'fs';
-
-export function fileExists(filePath: string): boolean {
-  try {
-    return fs.statSync(filePath).isFile();
-  } catch (err) {
-    return false;
-  }
-}

--- a/packages/graphql-codegen-cli/src/utils/file-system.ts
+++ b/packages/graphql-codegen-cli/src/utils/file-system.ts
@@ -1,6 +1,17 @@
-import { writeFileSync } from 'fs';
-export { fileExists } from './file-exists';
+import { writeFileSync, statSync, readFileSync } from 'fs';
 
 export function writeSync(filepath: string, content: string) {
-  writeFileSync(filepath, content);
+  return writeFileSync(filepath, content);
+}
+
+export function readSync(filepath: string) {
+  return readFileSync(filepath, 'utf-8');
+}
+
+export function fileExists(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile();
+  } catch (err) {
+    return false;
+  }
 }

--- a/packages/graphql-codegen-cli/tests/cli-flags.spec.ts
+++ b/packages/graphql-codegen-cli/tests/cli-flags.spec.ts
@@ -1,5 +1,5 @@
 jest.mock('fs');
-import { createConfig } from '../src/config';
+import { createConfig, parseArgv } from '../src/config';
 import { join } from 'path';
 
 const mockFsFile = (file: string, content: string) => require('fs').__setMockFiles(file, content);
@@ -33,11 +33,9 @@ describe('CLI Flags', () => {
                 - plugin
     `);
     const args = createArgv();
-    const config = await createConfig(args);
-    expect(config).toEqual({
-      schema: 'schema.graphql',
-      generates: { 'file.ts': ['plugin'] },
-    });
+    const config = await createConfig(parseArgv(args));
+    expect(config.schema).toEqual('schema.graphql');
+    expect(config.generates).toEqual({ 'file.ts': ['plugin'] });
   });
 
   it('Should use different config file correctly with --config', async () => {
@@ -51,11 +49,9 @@ describe('CLI Flags', () => {
       'other.yml'
     );
     const args = createArgv('--config other.yml');
-    const config = await createConfig(args);
-    expect(config).toEqual({
-      schema: 'schema.graphql',
-      generates: { 'file.ts': ['plugin'] },
-    });
+    const config = await createConfig(parseArgv(args));
+    expect(config.schema).toEqual('schema.graphql');
+    expect(config.generates).toEqual({ 'file.ts': ['plugin'] });
   });
 
   it('Should set --watch with new YML api', async () => {
@@ -66,7 +62,7 @@ describe('CLI Flags', () => {
                 - plugin
     `);
     const args = createArgv('--watch');
-    const config = await createConfig(args);
+    const config = await createConfig(parseArgv(args));
     expect(config.watch).toBeTruthy();
   });
 
@@ -78,7 +74,7 @@ describe('CLI Flags', () => {
                 - plugin
     `);
     const args = createArgv();
-    const config = await createConfig(args);
+    const config = await createConfig(parseArgv(args));
     expect(config.watch).not.toBeTruthy();
     expect(config.overwrite).not.toBeTruthy();
   });
@@ -92,7 +88,7 @@ describe('CLI Flags', () => {
                 - plugin
     `);
     const args = createArgv('--watch');
-    const config = await createConfig(args);
+    const config = await createConfig(parseArgv(args));
     expect(config.watch).toBeTruthy();
   });
 
@@ -104,7 +100,7 @@ describe('CLI Flags', () => {
                 - plugin
     `);
     const args = createArgv('--overwrite');
-    const config = await createConfig(args);
+    const config = await createConfig(parseArgv(args));
     expect(config.overwrite).toBeTruthy();
   });
 
@@ -117,7 +113,7 @@ describe('CLI Flags', () => {
                 - plugin
     `);
     const args = createArgv('--overwrite');
-    const config = await createConfig(args);
+    const config = await createConfig(parseArgv(args));
     expect(config.schema).toBe('schema-env.graphql');
   });
 
@@ -131,7 +127,7 @@ describe('CLI Flags', () => {
                 - plugin
     `);
     const args = createArgv('--overwrite');
-    const config = await createConfig(args);
+    const config = await createConfig(parseArgv(args));
     expect(config.schema).toBe('schema.graphql');
   });
 
@@ -145,7 +141,7 @@ describe('CLI Flags', () => {
                 - plugin
     `);
     const args = createArgv('--overwrite');
-    const config = await createConfig(args);
+    const config = await createConfig(parseArgv(args));
     expect(config.schema).toBe('http://url-to-graphql-api');
   });
 
@@ -160,7 +156,7 @@ describe('CLI Flags', () => {
     const args = createArgv('--require my-extension');
 
     try {
-      await createConfig(args);
+      await createConfig(parseArgv(args));
       expect(true).toBeFalsy();
     } catch (e) {
       expect(e.message).toBe(`Cannot find module 'my-extension' from 'config.ts'`);

--- a/packages/graphql-codegen-cli/tests/generate-and-save.spec.ts
+++ b/packages/graphql-codegen-cli/tests/generate-and-save.spec.ts
@@ -12,6 +12,7 @@ describe('generate-and-save', () => {
   test('allow to specify overwrite for specific output (should write file)', async () => {
     const filename = 'overwrite.ts';
     const writeSpy = jest.spyOn(fs, 'writeSync').mockImplementation();
+    const readSpy = jest.spyOn(fs, 'readSync').mockImplementation();
 
     const output = await generate(
       {
@@ -124,6 +125,8 @@ describe('generate-and-save', () => {
   test('should overwrite a file by default', async () => {
     const filename = 'overwrite.ts';
     const writeSpy = jest.spyOn(fs, 'writeSync').mockImplementation();
+    const readSpy = jest.spyOn(fs, 'readSync').mockImplementation();
+    readSpy.mockImplementation(f => '');
     // forces file to exist
     const fileExistsSpy = jest.spyOn(fs, 'fileExists');
     fileExistsSpy.mockImplementation(file => file === filename);

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -93,6 +93,7 @@ export namespace Types {
     overwrite?: boolean;
     prettify?: boolean;
     watch?: boolean | string | string[];
+    configFilePath?: string;
     silent?: boolean;
     pluginLoader?: PackageLoaderFn<CodegenPlugin>;
     pluckConfig?: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2546,6 +2546,11 @@
   dependencies:
     "@types/express" "*"
 
+"@types/debounce@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.0.tgz#9ee99259f41018c640b3929e1bb32c3dcecdb192"
+  integrity sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==
+
 "@types/detect-indent@5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@types/detect-indent/-/detect-indent-5.0.0.tgz#8b1bbd7891268d5ed20d23ecd23ae333d33934cd"
@@ -5934,6 +5939,11 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
+
+debounce@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
This PR fixes and improves watch mode, by doing:
- Debounce change events and make sure to run the codegen only once when multiple file changes.
- Allow the codegen to respond to config file changes and re-run it with the new config file.
- Atomic file writing - avoid writing files to the file-system when not needed.

Related:
- [x] https://github.com/dotansimha/graphql-code-generator/issues/1735 
- [x] https://github.com/dotansimha/graphql-code-generator/issues/1827
- [x] https://github.com/dotansimha/graphql-code-generator/issues/1172