### PR TITLE
[typescript-react-apollo] Fix problem with unnecessary fragment imports for external mode

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -250,7 +250,7 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
   }
 
   public get fragments(): string {
-    if (this._fragments.length === 0) {
+    if (this._fragments.length === 0 || this.config.documentMode === DocumentMode.external) {
       return '';
     }
 

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1288,7 +1288,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
 
       // Unable to do get this validation to pass :(
-      // await validateTypeScript(content, schema, docs, {});
+      await validateTypeScript(content, schema, docs, {});
     });
 
     it('should NOT generate inline fragment docs for external mode: file with operation NOT using inline fragment', async () => {
@@ -1323,7 +1323,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
 
       // Unable to do get this validation to pass :(
-      // await validateTypeScript(content, schema, docs, {});
+      await validateTypeScript(content, schema, docs, {});
     });
 
     it('should NOT generate inline fragment docs for external mode: file with just fragment', async () => {
@@ -1353,7 +1353,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
 
       // Unable to do get this validation to pass :(
-      // await validateTypeScript(content, schema, docs, {});
+      await validateTypeScript(content, schema, docs, {});
     });
 
     it('should import Operations from one external file and use it in Query component', async () => {

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1273,13 +1273,14 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
           `),
         },
       ];
+      const config = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+      };
       const content = (await plugin(
         schema,
         docs,
-        {
-          documentMode: DocumentMode.external,
-          importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
-        },
+        { ...config },
         {
           outputFile: 'graphql.tsx',
         }
@@ -1288,7 +1289,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
 
       // Unable to do get this validation to pass :(
-      await validateTypeScript(content, schema, docs, {});
+      await validateTypeScript(content, schema, docs, { ...config });
     });
 
     it('should NOT generate inline fragment docs for external mode: file with operation NOT using inline fragment', async () => {
@@ -1308,12 +1309,15 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
           `),
         },
       ];
+      const config = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+      };
       const content = (await plugin(
         schema,
         docs,
         {
-          documentMode: DocumentMode.external,
-          importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+          ...config,
         },
         {
           outputFile: 'graphql.tsx',
@@ -1323,7 +1327,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
 
       // Unable to do get this validation to pass :(
-      await validateTypeScript(content, schema, docs, {});
+      await validateTypeScript(content, schema, docs, { ...config });
     });
 
     it('should NOT generate inline fragment docs for external mode: file with just fragment', async () => {
@@ -1338,12 +1342,15 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
           `),
         },
       ];
+      const config = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+      };
       const content = (await plugin(
         schema,
         docs,
         {
-          documentMode: DocumentMode.external,
-          importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+          ...config,
         },
         {
           outputFile: 'graphql.tsx',
@@ -1353,7 +1360,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
 
       // Unable to do get this validation to pass :(
-      await validateTypeScript(content, schema, docs, {});
+      await validateTypeScript(content, schema, docs, { ...config });
     });
 
     it('should import Operations from one external file and use it in Query component', async () => {

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1256,6 +1256,106 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should NOT generate inline fragment docs for external mode: file with operation using inline fragment', async () => {
+      const docs = [
+        {
+          filePath: '',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment on feed {
+              id
+              commentCount
+            }
+            query testOne {
+              feed {
+                ...feedFragment
+              }
+            }
+          `),
+        },
+      ];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.external,
+          importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
+
+      // Unable to do get this validation to pass :(
+      // await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should NOT generate inline fragment docs for external mode: file with operation NOT using inline fragment', async () => {
+      const docs = [
+        {
+          filePath: '',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment on feed {
+              id
+              commentCount
+            }
+            query testOne {
+              feed {
+                id
+              }
+            }
+          `),
+        },
+      ];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.external,
+          importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
+
+      // Unable to do get this validation to pass :(
+      // await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should NOT generate inline fragment docs for external mode: file with just fragment', async () => {
+      const docs = [
+        {
+          filePath: '',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment on feed {
+              id
+              commentCount
+            }
+          `),
+        },
+      ];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.external,
+          importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
+
+      // Unable to do get this validation to pass :(
+      // await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should import Operations from one external file and use it in Query component', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1261,7 +1261,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         {
           filePath: '',
           content: parse(/* GraphQL */ `
-            fragment feedFragment on feed {
+            fragment feedFragment on Entry {
               id
               commentCount
             }
@@ -1288,8 +1288,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
 
-      // Unable to do get this validation to pass :(
-      await validateTypeScript(content, schema, docs, { ...config });
+      await validateTypeScript(content, schema, docs, {});
     });
 
     it('should NOT generate inline fragment docs for external mode: file with operation NOT using inline fragment', async () => {
@@ -1297,7 +1296,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         {
           filePath: '',
           content: parse(/* GraphQL */ `
-            fragment feedFragment on feed {
+            fragment feedFragment on Entry {
               id
               commentCount
             }
@@ -1325,9 +1324,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
-
-      // Unable to do get this validation to pass :(
-      await validateTypeScript(content, schema, docs, { ...config });
+      await validateTypeScript(content, schema, docs, {});
     });
 
     it('should NOT generate inline fragment docs for external mode: file with just fragment', async () => {
@@ -1335,7 +1332,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         {
           filePath: '',
           content: parse(/* GraphQL */ `
-            fragment feedFragment on feed {
+            fragment feedFragment on Entry {
               id
               commentCount
             }
@@ -1359,7 +1356,6 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
 
-      // Unable to do get this validation to pass :(
       await validateTypeScript(content, schema, docs, { ...config });
     });
 


### PR DESCRIPTION
Normally, fragments are turned into document nodes so we can include them in the operations document nodes they are used in. In the case of `documentMode = 'external'`, the operation document nodes are created externally and imported into the generated files. Therefore, there's no need to print fragment variables in the generated file anymore

This problem can be seen in this sandbox: https://codesandbox.io/s/gcg-15-experiments-c8l15. There are fragments in `webpack/GetProject_Status.fragment.graphql` and `webpack/CreateProject.operation.graphql`, and these will be converted into variables with suffix `FragmentDoc` in generated files (Note that we are not even importing the `graphql-tag` module).

This PR ensures that no fragments are generated when `external` mode is used. 

NOTE: I'm having problem running `validateTypeScript` in the new tests. I've tried looking at the implementation of `tsDocumentsPlugin` and still not able to figure out what it's supposed to do. Would love some pointer please :) 

TODO:

- [ ] Check why `validateTypeScript` does not work