### PR TITLE
docs: hint how to use generated resolvers directly

### DIFF
--- a/docs/plugins/typescript-resolvers.md
+++ b/docs/plugins/typescript-resolvers.md
@@ -38,6 +38,8 @@ export const resolvers: QueryResolvers = {
 
 This will make the resolver fully typed and compatible with typescript compiler, including the handler's arguments and return value.
 
+Generated resolvers can be passed directly into [graph-tools](https://www.npmjs.com/package/graphql-tools) `makeExecutableSchema` function.
+
 ## Configuration
 
 {@import: ../docs/generated-config/base-visitor.md}


### PR DESCRIPTION
Thanks for the awesome work on graphql-codegen!

Added just a short hint in the docs on how to use generated resolvers directly since I had to do some substantial digging to find that bit of information. If you don't find that useful or it's already in the docs and I just missed it then feel free to close the PR.