### PR TITLE
[typescript-react-apollo] Fix external mode to avoid importing operations in files that don't have operations

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -282,11 +282,15 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
         imports.push(`import ${gqlImport.propName ? `{ ${gqlImport.propName === 'gql' ? 'gql' : `${gqlImport.propName} as gql`} }` : 'gql'} from '${gqlImport.moduleName}';`);
         break;
       case DocumentMode.external:
+          if (this._collectedOperations.length > 0) {
         if (this.config.importDocumentNodeExternallyFrom === 'near-operation-file' && this._documents.length === 1) {
-          imports.push(`import * as Operations from './${basename(this._documents[0].filePath)}';`);
+
+            imports.push(`import * as Operations from './${basename(this._documents[0].filePath)}';`);
+
         } else {
           imports.push(`import * as Operations from '${this.config.importDocumentNodeExternallyFrom}';`);
         }
+      }
         break;
       default:
         break;

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -2087,5 +2087,70 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       await validateTypeScript(content, schema, docs, {});
     });
+
+    it(`should NOT import Operations if no operation collected: external mode and one file`, async () => {
+      const docs = [
+        {
+          filePath: 'path/to/document.graphql',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment on Entry {
+              id
+              commentCount
+            }
+          `),
+        },
+      ];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.external,
+          importDocumentNodeExternallyFrom: 'near-operation-file',
+        },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).not.toBeSimilarStringTo(`import * as Operations`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it(`should NOT import Operations if no operation collected: external mode and multiple files`, async () => {
+      const docs = [
+        {
+          filePath: 'a.graphql',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment1 on Entry {
+              id
+              commentCount
+            }
+          `),
+        },
+        {
+          filePath: 'b.graphql',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment2 on Entry {
+              id
+              commentCount
+            }
+          `),
+        },
+      ];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.external,
+          importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).not.toBeSimilarStringTo(`import * as Operations`);
+      await validateTypeScript(content, schema, docs, {});
+    });
   });
 });


### PR DESCRIPTION
Currently, in external mode, we are importing nodes even for files without operations i.e. files with just fragments. This behaviour can be seen here: https://codesandbox.io/s/gcg-16-experiments-c8l15 in `src/webpack/GetProject_Id.fragment.generated.tsx`

This PR adds a check to make sure we don't import operations unnecessarily