### PR TITLE
Add sub-folder param to near-operation-file

### DIFF
--- a/dev-test/codegen.yml
+++ b/dev-test/codegen.yml
@@ -183,20 +183,6 @@ generates:
     preset: near-operation-file
     presetConfig:
       extension: .stencil-component.tsx
-      baseTypesPath: types.d.ts
-    plugins:
-      - add: // tslint:disable
-      - typescript-operations
-      - typescript-stencil-apollo
-    config: 
-      componentType: class
-      globalNamespace: true
-  ./dev-test/githunt:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    preset: near-operation-file
-    presetConfig:
-      extension: .stencil-component.tsx
       folder: __generated__
       baseTypesPath: types.d.ts
     plugins:

--- a/dev-test/codegen.yml
+++ b/dev-test/codegen.yml
@@ -191,6 +191,21 @@ generates:
     config: 
       componentType: class
       globalNamespace: true
+  ./dev-test/githunt:
+    schema: ./dev-test/githunt/schema.json
+    documents: ./dev-test/githunt/**/*.graphql
+    preset: near-operation-file
+    presetConfig:
+      extension: .stencil-component.tsx
+      folder: __generated__
+      baseTypesPath: types.d.ts
+    plugins:
+      - add: // tslint:disable
+      - typescript-operations
+      - typescript-stencil-apollo
+    config: 
+      componentType: class
+      globalNamespace: true
   ./dev-test/star-wars/types.ts:
     schema: ./dev-test/star-wars/schema.json
     documents: ./dev-test/star-wars/**/*.graphql

--- a/dev-test/githunt/__generated__/comment-added.subscription.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/comment-added.subscription.stencil-component.tsx
@@ -1,0 +1,40 @@
+// tslint:disable
+import * as Types from '../types.d';
+
+import gql from 'graphql-tag';
+import 'stencil-apollo';
+import { Component, Prop, h } from '@stencil/core';
+
+declare global {
+  export type OnCommentAddedSubscriptionVariables = {
+    repoFullName: Types.Scalars['String'];
+  };
+
+  export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
+    commentAdded: Types.Maybe<{ __typename?: 'Comment' } & Pick<Types.Comment, 'id' | 'createdAt' | 'content'> & { postedBy: { __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'> }>;
+  };
+}
+
+const OnCommentAddedDocument = gql`
+  subscription onCommentAdded($repoFullName: String!) {
+    commentAdded(repoFullName: $repoFullName) {
+      id
+      postedBy {
+        login
+        html_url
+      }
+      createdAt
+      content
+    }
+  }
+`;
+
+@Component({
+  tag: 'apollo-on-comment-added',
+})
+export class OnCommentAddedComponent {
+  @Prop() renderer: import('stencil-apollo').SubscriptionRenderer<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
+  render() {
+    return <apollo-subscription subscription={OnCommentAddedDocument} renderer={this.renderer} />;
+  }
+}

--- a/dev-test/githunt/__generated__/comment.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/comment.query.stencil-component.tsx
@@ -1,0 +1,67 @@
+// tslint:disable
+import * as Types from '../types.d';
+
+import gql from 'graphql-tag';
+import { CommentsPageCommentFragmentDoc } from '../comments-page-comment.fragment.stencil-component';
+import 'stencil-apollo';
+import { Component, Prop, h } from '@stencil/core';
+
+declare global {
+  export type CommentQueryVariables = {
+    repoFullName: Types.Scalars['String'];
+    limit?: Types.Maybe<Types.Scalars['Int']>;
+    offset?: Types.Maybe<Types.Scalars['Int']>;
+  };
+
+  export type CommentQuery = { __typename?: 'Query' } & {
+    currentUser: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'>>;
+    entry: Types.Maybe<
+      { __typename?: 'Entry' } & Pick<Types.Entry, 'id' | 'createdAt' | 'commentCount'> & {
+          postedBy: { __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'>;
+          comments: Array<Types.Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
+          repository: { __typename?: 'Repository' } & Pick<Types.Repository, 'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'>;
+        }
+    >;
+  };
+}
+
+const CommentDocument = gql`
+  query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
+    currentUser {
+      login
+      html_url
+    }
+    entry(repoFullName: $repoFullName) {
+      id
+      postedBy {
+        login
+        html_url
+      }
+      createdAt
+      comments(limit: $limit, offset: $offset) {
+        ...CommentsPageComment
+      }
+      commentCount
+      repository {
+        full_name
+        html_url
+        ... on Repository {
+          description
+          open_issues_count
+          stargazers_count
+        }
+      }
+    }
+  }
+  ${CommentsPageCommentFragmentDoc}
+`;
+
+@Component({
+  tag: 'apollo-comment',
+})
+export class CommentComponent {
+  @Prop() renderer: import('stencil-apollo').QueryRenderer<CommentQuery, CommentQueryVariables>;
+  render() {
+    return <apollo-query query={CommentDocument} renderer={this.renderer} />;
+  }
+}

--- a/dev-test/githunt/__generated__/comments-page-comment.fragment.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/comments-page-comment.fragment.stencil-component.tsx
@@ -1,0 +1,20 @@
+// tslint:disable
+import * as Types from '../types.d';
+
+import gql from 'graphql-tag';
+
+declare global {
+  export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Types.Comment, 'id' | 'createdAt' | 'content'> & { postedBy: { __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'> };
+}
+
+export const CommentsPageCommentFragmentDoc = gql`
+  fragment CommentsPageComment on Comment {
+    id
+    postedBy {
+      login
+      html_url
+    }
+    createdAt
+    content
+  }
+`;

--- a/dev-test/githunt/__generated__/current-user.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/current-user.query.stencil-component.tsx
@@ -1,0 +1,31 @@
+// tslint:disable
+import * as Types from '../types.d';
+
+import gql from 'graphql-tag';
+import 'stencil-apollo';
+import { Component, Prop, h } from '@stencil/core';
+
+declare global {
+  export type CurrentUserForProfileQueryVariables = {};
+
+  export type CurrentUserForProfileQuery = { __typename?: 'Query' } & { currentUser: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'login' | 'avatar_url'>> };
+}
+
+const CurrentUserForProfileDocument = gql`
+  query CurrentUserForProfile {
+    currentUser {
+      login
+      avatar_url
+    }
+  }
+`;
+
+@Component({
+  tag: 'apollo-current-user-for-profile',
+})
+export class CurrentUserForProfileComponent {
+  @Prop() renderer: import('stencil-apollo').QueryRenderer<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
+  render() {
+    return <apollo-query query={CurrentUserForProfileDocument} renderer={this.renderer} />;
+  }
+}

--- a/dev-test/githunt/__generated__/feed-entry.fragment.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/feed-entry.fragment.stencil-component.tsx
@@ -1,0 +1,32 @@
+// tslint:disable
+import * as Types from '../types.d';
+
+import gql from 'graphql-tag';
+import { VoteButtonsFragmentDoc } from '../vote-buttons.fragment.stencil-component';
+import { RepoInfoFragmentDoc } from '../repo-info.fragment.stencil-component';
+
+declare global {
+  export type FeedEntryFragment = ({ __typename?: 'Entry' } & Pick<Types.Entry, 'id' | 'commentCount'> & {
+      repository: { __typename?: 'Repository' } & Pick<Types.Repository, 'full_name' | 'html_url'> & { owner: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'avatar_url'>> };
+    }) &
+    VoteButtonsFragment &
+    RepoInfoFragment;
+}
+
+export const FeedEntryFragmentDoc = gql`
+  fragment FeedEntry on Entry {
+    id
+    commentCount
+    repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+    ...VoteButtons
+    ...RepoInfo
+  }
+  ${VoteButtonsFragmentDoc}
+  ${RepoInfoFragmentDoc}
+`;

--- a/dev-test/githunt/__generated__/feed.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/feed.query.stencil-component.tsx
@@ -1,0 +1,39 @@
+// tslint:disable
+import * as Types from '../types.d';
+
+import gql from 'graphql-tag';
+import { FeedEntryFragmentDoc } from '../feed-entry.fragment.stencil-component';
+import 'stencil-apollo';
+import { Component, Prop, h } from '@stencil/core';
+
+declare global {
+  export type FeedQueryVariables = {
+    type: Types.FeedType;
+    offset?: Types.Maybe<Types.Scalars['Int']>;
+    limit?: Types.Maybe<Types.Scalars['Int']>;
+  };
+
+  export type FeedQuery = { __typename?: 'Query' } & { currentUser: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'login'>>; feed: Types.Maybe<Array<Types.Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>> };
+}
+
+const FeedDocument = gql`
+  query Feed($type: FeedType!, $offset: Int, $limit: Int) {
+    currentUser {
+      login
+    }
+    feed(type: $type, offset: $offset, limit: $limit) {
+      ...FeedEntry
+    }
+  }
+  ${FeedEntryFragmentDoc}
+`;
+
+@Component({
+  tag: 'apollo-feed',
+})
+export class FeedComponent {
+  @Prop() renderer: import('stencil-apollo').QueryRenderer<FeedQuery, FeedQueryVariables>;
+  render() {
+    return <apollo-query query={FeedDocument} renderer={this.renderer} />;
+  }
+}

--- a/dev-test/githunt/__generated__/new-entry.mutation.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/new-entry.mutation.stencil-component.tsx
@@ -1,0 +1,32 @@
+// tslint:disable
+import * as Types from '../types.d';
+
+import gql from 'graphql-tag';
+import 'stencil-apollo';
+import { Component, Prop, h } from '@stencil/core';
+
+declare global {
+  export type SubmitRepositoryMutationVariables = {
+    repoFullName: Types.Scalars['String'];
+  };
+
+  export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & { submitRepository: Types.Maybe<{ __typename?: 'Entry' } & Pick<Types.Entry, 'createdAt'>> };
+}
+
+const SubmitRepositoryDocument = gql`
+  mutation submitRepository($repoFullName: String!) {
+    submitRepository(repoFullName: $repoFullName) {
+      createdAt
+    }
+  }
+`;
+
+@Component({
+  tag: 'apollo-submit-repository',
+})
+export class SubmitRepositoryComponent {
+  @Prop() renderer: import('stencil-apollo').MutationRenderer<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
+  render() {
+    return <apollo-mutation mutation={SubmitRepositoryDocument} renderer={this.renderer} />;
+  }
+}

--- a/dev-test/githunt/__generated__/repo-info.fragment.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/repo-info.fragment.stencil-component.tsx
@@ -1,0 +1,26 @@
+// tslint:disable
+import * as Types from '../types.d';
+
+import gql from 'graphql-tag';
+
+declare global {
+  export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Types.Entry, 'createdAt'> & {
+      repository: { __typename?: 'Repository' } & Pick<Types.Repository, 'description' | 'stargazers_count' | 'open_issues_count'>;
+      postedBy: { __typename?: 'User' } & Pick<Types.User, 'html_url' | 'login'>;
+    };
+}
+
+export const RepoInfoFragmentDoc = gql`
+  fragment RepoInfo on Entry {
+    createdAt
+    repository {
+      description
+      stargazers_count
+      open_issues_count
+    }
+    postedBy {
+      html_url
+      login
+    }
+  }
+`;

--- a/dev-test/githunt/__generated__/submit-comment.mutation.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/submit-comment.mutation.stencil-component.tsx
@@ -1,0 +1,35 @@
+// tslint:disable
+import * as Types from '../types.d';
+
+import gql from 'graphql-tag';
+import { CommentsPageCommentFragmentDoc } from '../comments-page-comment.fragment.stencil-component';
+import 'stencil-apollo';
+import { Component, Prop, h } from '@stencil/core';
+
+declare global {
+  export type SubmitCommentMutationVariables = {
+    repoFullName: Types.Scalars['String'];
+    commentContent: Types.Scalars['String'];
+  };
+
+  export type SubmitCommentMutation = { __typename?: 'Mutation' } & { submitComment: Types.Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment> };
+}
+
+const SubmitCommentDocument = gql`
+  mutation submitComment($repoFullName: String!, $commentContent: String!) {
+    submitComment(repoFullName: $repoFullName, commentContent: $commentContent) {
+      ...CommentsPageComment
+    }
+  }
+  ${CommentsPageCommentFragmentDoc}
+`;
+
+@Component({
+  tag: 'apollo-submit-comment',
+})
+export class SubmitCommentComponent {
+  @Prop() renderer: import('stencil-apollo').MutationRenderer<SubmitCommentMutation, SubmitCommentMutationVariables>;
+  render() {
+    return <apollo-mutation mutation={SubmitCommentDocument} renderer={this.renderer} />;
+  }
+}

--- a/dev-test/githunt/__generated__/vote-buttons.fragment.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/vote-buttons.fragment.stencil-component.tsx
@@ -1,0 +1,17 @@
+// tslint:disable
+import * as Types from '../types.d';
+
+import gql from 'graphql-tag';
+
+declare global {
+  export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Types.Entry, 'score'> & { vote: { __typename?: 'Vote' } & Pick<Types.Vote, 'vote_value'> };
+}
+
+export const VoteButtonsFragmentDoc = gql`
+  fragment VoteButtons on Entry {
+    score
+    vote {
+      vote_value
+    }
+  }
+`;

--- a/dev-test/githunt/__generated__/vote.mutation.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/vote.mutation.stencil-component.tsx
@@ -1,0 +1,37 @@
+// tslint:disable
+import * as Types from '../types.d';
+
+import gql from 'graphql-tag';
+import 'stencil-apollo';
+import { Component, Prop, h } from '@stencil/core';
+
+declare global {
+  export type VoteMutationVariables = {
+    repoFullName: Types.Scalars['String'];
+    type: Types.VoteType;
+  };
+
+  export type VoteMutation = { __typename?: 'Mutation' } & { vote: Types.Maybe<{ __typename?: 'Entry' } & Pick<Types.Entry, 'score' | 'id'> & { vote: { __typename?: 'Vote' } & Pick<Types.Vote, 'vote_value'> }> };
+}
+
+const VoteDocument = gql`
+  mutation vote($repoFullName: String!, $type: VoteType!) {
+    vote(repoFullName: $repoFullName, type: $type) {
+      score
+      id
+      vote {
+        vote_value
+      }
+    }
+  }
+`;
+
+@Component({
+  tag: 'apollo-vote',
+})
+export class VoteComponent {
+  @Prop() renderer: import('stencil-apollo').MutationRenderer<VoteMutation, VoteMutationVariables>;
+  render() {
+    return <apollo-mutation mutation={VoteDocument} renderer={this.renderer} />;
+  }
+}

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -2,6 +2,11 @@ import { parse, dirname, relative, join, isAbsolute } from 'path';
 import { DocumentNode, visit, FragmentSpreadNode, FragmentDefinitionNode, FieldNode, Kind, InputValueDefinitionNode } from 'graphql';
 import { FragmentNameToFile } from './index';
 
+export function defineFilepathSubfolder(baseFilePath: string, folder: string) {
+  const parsedPath = parse(baseFilePath);
+  return join(parsedPath.dir, folder, parsedPath.base).replace(/\\/g, '/');
+}
+
 export function appendExtensionToFilePath(baseFilePath: string, extension: string) {
   const parsedPath = parse(baseFilePath);
 

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -95,6 +95,30 @@ describe('near-operation-file preset', () => {
     ]);
   });
 
+  it('Should build the correct operation files paths with a subfolder', async () => {
+    const result = await preset.buildGeneratesSection({
+      baseOutputDir: './src/',
+      config: {},
+      presetConfig: {
+        folder: '__generated__',
+        baseTypesPath: 'types.ts',
+      },
+      schema: schemaDocumentNode,
+      documents: testDocuments,
+      plugins: [],
+      pluginMap: {},
+    });
+    expect(result.map(a => a.filename)).toEqual([
+      '/some/deep/path/src/graphql/__generated__/me-query.generated.ts',
+      '/some/deep/path/src/graphql/__generated__/user-fragment.generated.ts',
+      '/some/deep/path/src/graphql/__generated__/me.query.generated.ts',
+      '/some/deep/path/src/graphql/__generated__/something-query.generated.ts',
+      '/some/deep/path/src/graphql/nested/__generated__/somethingElse.generated.ts',
+      '/some/deep/path/src/graphql/nested/__generated__/from-js.generated.ts',
+      '/some/deep/path/src/graphql/__generated__/component.generated.ts',
+    ]);
+  });
+
   it('Should skip the duplicate documents validation', async () => {
     const result = await preset.buildGeneratesSection({
       baseOutputDir: './src/',


### PR DESCRIPTION
I was wondering if there was a way we could create a `sub-folder` to save all our code-generated files instead of just appending them into the same folder, and I stumbled across #2287  issue / comment by @RIP21.

And since I had a bit of free time, I made a PR for it

- A added a new [optional option `folder`](https://github.com/dotansimha/graphql-code-generator/compare/master...fforres:fforres/near_operation_file?expand=1#diff-1736635a0ac8752e8ba3cc2ee5c3e5c2R65) to the `near-operation-file` config
- It sets a relative sub-folder where to save the files generated by the code-generator.

Once thing I didn't know how to (Or what does the project use them for) is the files under `dev-test`. 
I did modified the `./dev-test/githunt` option under `dev-test/codegen.yml` option to test the plugin changes there... Buts I guess there must be a better option?

Anyways, Looking forward to comments / inputs on the PR.

All the best!

cc @dotansimha 

