### PR TITLE
Make GraphQL operation alias unique from HOC name

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -116,7 +116,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
   ${operationVariablesTypes},
   ${propsTypeName}<TChildProps>>) {
     return ApolloReactHoc.with${titleCase(node.operation)}<TProps, ${operationResultType}, ${operationVariablesTypes}, ${propsTypeName}<TChildProps>>(${this.getDocumentNodeVariable(node, documentVariableName)}, {
-      alias: 'with${operationName}',
+      alias: 'with${operationName}Fn',
       ...operationOptions
     });
 };`;

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -3,7 +3,7 @@ import { ReactApolloRawPluginConfig } from './index';
 import * as autoBind from 'auto-bind';
 import { OperationDefinitionNode, Kind } from 'graphql';
 import { toPascalCase, Types } from '@graphql-codegen/plugin-helpers';
-import { titleCase } from 'change-case';
+import { titleCase, camelCase } from 'change-case';
 
 export interface ReactApolloPluginConfig extends ClientSideBasePluginConfig {
   withComponent: boolean;
@@ -116,7 +116,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
   ${operationVariablesTypes},
   ${propsTypeName}<TChildProps>>) {
     return ApolloReactHoc.with${titleCase(node.operation)}<TProps, ${operationResultType}, ${operationVariablesTypes}, ${propsTypeName}<TChildProps>>(${this.getDocumentNodeVariable(node, documentVariableName)}, {
-      alias: 'with${operationName}Fn',
+      alias: '${camelCase(operationName)}',
       ...operationOptions
     });
 };`;

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -642,7 +642,7 @@ query MyFeed {
   TestQueryVariables,
   TestProps<TChildProps>>) {
     return ApolloReactHoc.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps>>(TestDocument, {
-      alias: 'withTest',
+      alias: 'test',
       ...operationOptions
     });
 };`);
@@ -1434,7 +1434,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestQueryVariables,
         TestProps<TChildProps>>) {
           return ApolloReactHoc.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps>>(Operations.test, {
-            alias: 'withTest',
+            alias: 'test',
             ...operationOptions
           });
       };
@@ -1512,7 +1512,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestMutationVariables,
         TestProps<TChildProps>>) {
           return ApolloReactHoc.withMutation<TProps, TestMutation, TestMutationVariables, TestProps<TChildProps>>(Operations.test, {
-            alias: 'withTest',
+            alias: 'test',
             ...operationOptions
           });
       };
@@ -1590,7 +1590,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestSubscriptionVariables,
         TestProps<TChildProps>>) {
           return ApolloReactHoc.withSubscription<TProps, TestSubscription, TestSubscriptionVariables, TestProps<TChildProps>>(Operations.test, {
-            alias: 'withTest',
+            alias: 'test',
             ...operationOptions
           });
       };
@@ -1693,7 +1693,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestOneQueryVariables,
         TestOneProps<TChildProps>>) {
           return ApolloReactHoc.withQuery<TProps, TestOneQuery, TestOneQueryVariables, TestOneProps<TChildProps>>(Operations.testOne, {
-            alias: 'withTestOne',
+            alias: 'testOne',
             ...operationOptions
           });
       };
@@ -1705,7 +1705,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestTwoMutationVariables,
         TestTwoProps<TChildProps>>) {
           return ApolloReactHoc.withMutation<TProps, TestTwoMutation, TestTwoMutationVariables, TestTwoProps<TChildProps>>(Operations.testTwo, {
-            alias: 'withTestTwo',
+            alias: 'testTwo',
             ...operationOptions
           });
       };
@@ -1717,7 +1717,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestThreeSubscriptionVariables,
         TestThreeProps<TChildProps>>) {
           return ApolloReactHoc.withSubscription<TProps, TestThreeSubscription, TestThreeSubscriptionVariables, TestThreeProps<TChildProps>>(Operations.testThree, {
-            alias: 'withTestThree',
+            alias: 'testThree',
             ...operationOptions
           });
       };
@@ -1800,7 +1800,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestQueryVariables,
         TestProps<TChildProps>>) {
           return ApolloReactHoc.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps>>(Operations.test, {
-            alias: 'withTest',
+            alias: 'test',
             ...operationOptions
           });
       };
@@ -1877,7 +1877,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestMutationVariables,
         TestProps<TChildProps>>) {
           return ApolloReactHoc.withMutation<TProps, TestMutation, TestMutationVariables, TestProps<TChildProps>>(Operations.test, {
-            alias: 'withTest',
+            alias: 'test',
             ...operationOptions
           });
       };
@@ -1954,7 +1954,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestSubscriptionVariables,
         TestProps<TChildProps>>) {
           return ApolloReactHoc.withSubscription<TProps, TestSubscription, TestSubscriptionVariables, TestProps<TChildProps>>(Operations.test, {
-            alias: 'withTest',
+            alias: 'test',
             ...operationOptions
           });
       };`);
@@ -2055,7 +2055,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestOneQueryVariables,
         TestOneProps<TChildProps>>) {
           return ApolloReactHoc.withQuery<TProps, TestOneQuery, TestOneQueryVariables, TestOneProps<TChildProps>>(Operations.testOne, {
-            alias: 'withTestOne',
+            alias: 'testOne',
             ...operationOptions
           });
       };

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -2067,7 +2067,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestTwoMutationVariables,
         TestTwoProps<TChildProps>>) {
           return ApolloReactHoc.withMutation<TProps, TestTwoMutation, TestTwoMutationVariables, TestTwoProps<TChildProps>>(Operations.testTwo, {
-            alias: 'withTestTwo',
+            alias: 'testTwo',
             ...operationOptions
           });
       };
@@ -2079,7 +2079,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         TestThreeSubscriptionVariables,
         TestThreeProps<TChildProps>>) {
           return ApolloReactHoc.withSubscription<TProps, TestThreeSubscription, TestThreeSubscriptionVariables, TestThreeProps<TChildProps>>(Operations.testThree, {
-            alias: 'withTestThree',
+            alias: 'testThree',
             ...operationOptions
           });
       };


### PR DESCRIPTION
- The use of the same name for an HOC operation and its alias (i.e. `withCreateAppointment`) causes a shadowed variable problem when trying to call the alias function from props and requires an additional alias to be assigned under the `name` property of an operation like below:

```
export default withCreateAppointment({
  name: 'createAppointment',
})(MyComponent);
```
- This PR changes HOC aliases to the camel-cased version of their operation name to make them usable as intended