### PR TITLE
Fix importDocumentNodeExternallyFrom on CRA TypeScript

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -285,7 +285,7 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
         if (this.config.importDocumentNodeExternallyFrom === 'near-operation-file' && this._documents.length === 1) {
           imports.push(`import * as Operations from './${basename(this._documents[0].filePath)}';`);
         } else {
-          imports.push(`import * as Operations from '${this.config.importDocumentNodeExternallyFrom}';`);
+          imports.push(`import * as Operations from '${this.config.importDocumentNodeExternallyFrom.replace(/\.tsx?$/, '')}';`);
         }
         break;
       default:

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -488,7 +488,7 @@ query MyFeed {
       `);
 
       expect(content.content).toBeSimilarStringTo(`
-      export const TestComponent = (props: TestComponentProps) => 
+      export const TestComponent = (props: TestComponentProps) =>
       (
           <ApolloReactComponents.Query<TestQuery, TestQueryVariables> query={TestDocument} {...props} />
       );
@@ -511,7 +511,7 @@ query MyFeed {
       export type TestQProps = Omit<ApolloReactComponents.QueryComponentOptions<TestQuery, TestQueryVariables>, 'query'>;
       `);
       expect(content.content).toBeSimilarStringTo(`
-      export const TestQ = (props: TestQProps) => 
+      export const TestQ = (props: TestQProps) =>
       (
           <ApolloReactComponents.Query<TestQuery, TestQueryVariables> query={TestDocument} {...props} />
       );
@@ -564,7 +564,7 @@ query MyFeed {
       `);
 
       expect(content.content).toBeSimilarStringTo(`
-      export const TestComponent = (props: TestComponentProps) => 
+      export const TestComponent = (props: TestComponentProps) =>
       (
           <ApolloReactComponents.Query<TestQuery, TestQueryVariables> query={TestDocument} {...props} />
       );
@@ -1374,7 +1374,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
         export const TestComponent = (props: TestComponentProps) => (
           <ApolloReactComponents.Query<TestQuery, TestQueryVariables> query={Operations.test} {...props} />
@@ -1385,7 +1385,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
     it('should import Operations from one external file and use it in useQuery and useLazyQuery', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
-        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        importDocumentNodeExternallyFrom: 'path/to/documents',
         withComponent: false,
         withHooks: true,
         withHOC: false,
@@ -1397,7 +1397,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export function useTestQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<TestQuery, TestQueryVariables>) {
         return ApolloReactHooks.useQuery<TestQuery, TestQueryVariables>(Operations.test, baseOptions);
@@ -1414,7 +1414,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
     it('should import Operations from one external file and use it in withQuery', async () => {
       const config: ReactApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
-        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        importDocumentNodeExternallyFrom: 'path/to/documents',
         withComponent: false,
         withHooks: false,
         withHOC: true,
@@ -1426,7 +1426,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
@@ -1457,7 +1457,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
         export const TestComponent = (props: TestComponentProps) => (
           <ApolloReactComponents.Mutation<TestMutation, TestMutationVariables> mutation={Operations.test} {...props} />
@@ -1480,7 +1480,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export function useTestMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<TestMutation, TestMutationVariables>) {
         return ApolloReactHooks.useMutation<TestMutation, TestMutationVariables>(Operations.test, baseOptions);
@@ -1504,7 +1504,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
@@ -1535,7 +1535,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
         export const TestComponent = (props: TestComponentProps) => (
           <ApolloReactComponents.Subscription<TestSubscription, TestSubscriptionVariables> subscription={Operations.test} {...props} />
@@ -1558,7 +1558,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export function useTestSubscription(baseOptions?: ApolloReactHooks.SubscriptionHookOptions<TestSubscription, TestSubscriptionVariables>) {
         return ApolloReactHooks.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, baseOptions);
@@ -1582,7 +1582,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
@@ -1613,7 +1613,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export const TestOneComponent = (props: TestOneComponentProps) => (
         <ApolloReactComponents.Query<TestOneQuery, TestOneQueryVariables> query={Operations.testOne} {...props} />
@@ -1645,7 +1645,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export function useTestOneQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<TestOneQuery, TestOneQueryVariables>) {
         return ApolloReactHooks.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, baseOptions);
@@ -1685,7 +1685,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
         outputFile: 'graphql.tsx',
       })) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents.tsx';`);
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export function withTestOne<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,


### PR DESCRIPTION
:wave: 

I have trouble when using graphql-codegen with CRA.

I tried to use `importDocumentNodeExternallyFrom: near-operation-file` with in-source-code documents becuase I don't wanna separate document file(`.graphql`) from component code.

in my config:
```yaml
documents:
  - src/**/*.{ts,tsx}
  - '!src/**/*.generated.{ts,tsx}'

generates
  ./src/generated/types.ts:
    plugins:
      - typescript
      - typescript-resolvers

  ./src/:
    preset: near-operation-file
    presetConfig:
      extension: .generated.tsx
      baseTypesPath: generated/types.ts
    plugins:
      - typescript-operations
      - typescript-react-apollo
    config:
      gqlImport: graphql.macro#gql
      documentMode: external
      importDocumentNodeExternallyFrom: near-operation-file
      reactApolloVersion: 3
      withComponent: false
      withHOC: false
      withHooks: true
```

But I got an error: `An import path cannot end with a '.tsx' extension`

![image](https://user-images.githubusercontent.com/9696352/63651636-bf966280-c791-11e9-8e4a-d9290b0aebb9.png)

I couldn't find a way to suppress/ignore the specific line without eject CRA or this change. CRA is force my tsconfig.json compilerOptions.moduleResolution to be `node`.

So...