### PR TITLE
feat(type-graphql): allow overriding decorators

### DIFF
--- a/packages/plugins/typescript/type-graphql/src/index.ts
+++ b/packages/plugins/typescript/type-graphql/src/index.ts
@@ -1,10 +1,12 @@
 import { Types, PluginFunction } from '@graphql-codegen/plugin-helpers';
 import { parse, printSchema, visit, GraphQLSchema, TypeInfo, GraphQLNamedType, visitWithTypeInfo, getNamedType, isIntrospectionType, DocumentNode, printIntrospectionSchema, isObjectType } from 'graphql';
-import { TypeGraphQLVisitor } from './visitor';
+import { TypeGraphQLVisitor, DecoratorConfig } from './visitor';
 import { TsIntrospectionVisitor, includeIntrospectionDefinitions, TypeScriptPluginConfig } from '@graphql-codegen/typescript';
 export * from './visitor';
 
-export interface TypeGraphQLPluginConfig extends TypeScriptPluginConfig {}
+export interface TypeGraphQLPluginConfig extends TypeScriptPluginConfig {
+  decoratorName?: Partial<DecoratorConfig>;
+}
 
 const TYPE_GRAPHQL_IMPORT = `import * as TypeGraphQL from 'type-graphql';`;
 const DECORATOR_FIX = `type FixDecorator<T> = T;`;

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -130,4 +130,36 @@ describe('type-graphql', () => {
       }
     `);
   });
+  it('should generate type-graphql types as custom types', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Test {
+        id: ID
+        mandatoryStr: String!
+      }
+      interface ITest {
+        id: ID
+      }
+    `);
+
+    const result = (await plugin(schema, [], { decoratorName: { type: 'Foo', field: 'Bar', interface: 'FooBar' } }, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+        @TypeGraphQL.Foo()
+        export class Test {
+          __typename?: 'Test';
+          @TypeGraphQL.Bar(type => TypeGraphQL.ID, { nullable: true })
+          id!: Maybe<Scalars['ID']>;
+          @TypeGraphQL.Bar(type => String)
+          mandatoryStr!: Scalars['String'];
+        }
+      `);
+    expect(result.content).toBeSimilarStringTo(`
+        @TypeGraphQL.FooBar()
+        export abstract class ITest {
+          
+          @TypeGraphQL.Bar(type => TypeGraphQL.ID, { nullable: true })
+          id!: Maybe<Scalars['ID']>;
+        }
+      `);
+  });
 });


### PR DESCRIPTION
I'm looking to generate interface type objects with type-graphql so that I can implement them while simultaneously extending another type

I just threw this together, it might not be the best way to achieve this though.