### PR TITLE
Added support for TypeGraphQL Input- and ArgTypes

### DIFF
--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -1,14 +1,16 @@
-import { transformComment, wrapWithSingleQuotes, DeclarationBlock, indent, BaseTypesVisitor, ParsedTypesConfig } from '@graphql-codegen/visitor-plugin-common';
+import { transformComment, indent, DeclarationBlock } from '@graphql-codegen/visitor-plugin-common';
 import { TypeGraphQLPluginConfig } from './index';
 import * as autoBind from 'auto-bind';
-import { FieldDefinitionNode, NamedTypeNode, ListTypeNode, NonNullTypeNode, EnumTypeDefinitionNode, Kind, InputValueDefinitionNode, GraphQLSchema, ObjectTypeDefinitionNode, InterfaceTypeDefinitionNode } from 'graphql';
-import { TypeScriptOperationVariablesToObject, TypeScriptPluginParsedConfig, TsVisitor } from '@graphql-codegen/typescript';
-import { AvoidOptionalsConfig } from '@graphql-codegen/typescript';
+import { FieldDefinitionNode, EnumTypeDefinitionNode, InputValueDefinitionNode, GraphQLSchema, ObjectTypeDefinitionNode, InterfaceTypeDefinitionNode, TypeNode, NameNode } from 'graphql';
+import { TypeScriptOperationVariablesToObject, TypeScriptPluginParsedConfig, TsVisitor, AvoidOptionalsConfig } from '@graphql-codegen/typescript';
+import { InputObjectTypeDefinitionNode } from 'graphql';
 
 export type DecoratorConfig = {
   type: string;
   interface: string;
   field: string;
+  input: string;
+  arguments: string;
 };
 
 export interface TypeGraphQLPluginParsedConfig extends TypeScriptPluginParsedConfig {
@@ -24,6 +26,15 @@ const MAYBE_REGEX = /^Maybe<(.*?)>$/;
 const ARRAY_REGEX = /^Array<(.*?)>$/;
 const SCALAR_REGEX = /^Scalars\['(.*?)'\]$/;
 const GRAPHQL_TYPES = ['Query', 'Mutation', 'Subscription'];
+const SCALARS = ['ID', 'String', 'Boolean', 'Int', 'Float'];
+const TYPE_GRAPHQL_SCALARS = ['ID', 'Int', 'Float'];
+
+interface Type {
+  type: string;
+  isNullable: boolean;
+  isArray: boolean;
+  isScalar: boolean;
+}
 
 export class TypeGraphQLVisitor<TRawConfig extends TypeGraphQLPluginConfig = TypeGraphQLPluginConfig, TParsedConfig extends TypeGraphQLPluginParsedConfig = TypeGraphQLPluginParsedConfig> extends TsVisitor<TRawConfig, TParsedConfig> {
   constructor(schema: GraphQLSchema, pluginConfig: TRawConfig, additionalConfig: Partial<TParsedConfig> = {}) {
@@ -36,15 +47,17 @@ export class TypeGraphQLVisitor<TRawConfig extends TypeGraphQLPluginConfig = Typ
       declarationKind: {
         type: 'class',
         interface: 'abstract class',
-        arguments: 'type',
-        input: 'type',
+        arguments: 'class',
+        input: 'class',
         scalar: 'type',
       },
       decoratorName: {
         type: 'ObjectType',
         interface: 'InterfaceType',
+        arguments: 'ArgsType',
         field: 'Field',
-        ...(pluginConfig.decoratorName || {})
+        input: 'InputType',
+        ...(pluginConfig.decoratorName || {}),
       },
       ...(additionalConfig || {}),
     } as TParsedConfig);
@@ -75,6 +88,37 @@ export class TypeGraphQLVisitor<TRawConfig extends TypeGraphQLPluginConfig = Typ
     return [declarationBlock.string, this.buildArgumentsBlock(originalNode)].filter(f => f).join('\n\n');
   }
 
+  InputObjectTypeDefinition(node: InputObjectTypeDefinitionNode): string {
+    const typeDecorator = this.config.decoratorName.input;
+
+    let declarationBlock = this.getInputObjectDeclarationBlock(node);
+
+    // Add type-graphql InputType decorator
+    declarationBlock = declarationBlock.withDecorator(`@TypeGraphQL.${typeDecorator}()`);
+
+    return declarationBlock.string;
+  }
+
+  getArgumentsObjectDeclarationBlock(node: InterfaceTypeDefinitionNode | ObjectTypeDefinitionNode, name: string, field: FieldDefinitionNode): DeclarationBlock {
+    return new DeclarationBlock(this._declarationBlockConfig)
+      .export()
+      .asKind(this._parsedConfig.declarationKind.arguments)
+      .withName(this.convertName(name))
+      .withComment(node.description)
+      .withBlock(field.arguments.map(argument => this.InputValueDefinition(argument)).join('\n'));
+  }
+
+  getArgumentsObjectTypeDefinition(node: InterfaceTypeDefinitionNode | ObjectTypeDefinitionNode, name: string, field: FieldDefinitionNode): string {
+    const typeDecorator = this.config.decoratorName.arguments;
+
+    let declarationBlock = this.getArgumentsObjectDeclarationBlock(node, name, field);
+
+    // Add type-graphql Args decorator
+    declarationBlock = declarationBlock.withDecorator(`@TypeGraphQL.${typeDecorator}()`);
+
+    return declarationBlock.string;
+  }
+
   InterfaceTypeDefinition(node: InterfaceTypeDefinitionNode, key: number | string, parent: any): string {
     const interfaceDecorator = this.config.decoratorName.interface;
     const originalNode = parent[key] as InterfaceTypeDefinitionNode;
@@ -84,15 +128,57 @@ export class TypeGraphQLVisitor<TRawConfig extends TypeGraphQLPluginConfig = Typ
     return [declarationBlock.string, this.buildArgumentsBlock(originalNode)].filter(f => f).join('\n\n');
   }
 
-  parseType(typeString: string) {
-    const isNullable = !!typeString.match(MAYBE_REGEX);
-    const nonNullableType = typeString.replace(MAYBE_REGEX, '$1');
+  buildTypeString(type: Type): string {
+    if (!type.isArray && !type.isScalar && !type.isNullable) {
+      type.type = `FixDecorator<${type.type}>`;
+    }
+    if (type.isScalar) {
+      type.type = `Scalars['${type.type}']`;
+    }
+    if (type.isArray) {
+      type.type = `Array<${type.type}>`;
+    }
+    if (type.isNullable) {
+      type.type = `Maybe<${type.type}>`;
+    }
+
+    return type.type;
+  }
+
+  parseType(rawType: TypeNode | string): Type {
+    const typeNode = rawType as TypeNode;
+    if (typeNode.kind === 'NamedType') {
+      return {
+        type: typeNode.name.value,
+        isNullable: true,
+        isArray: false,
+        isScalar: SCALARS.includes(typeNode.name.value),
+      };
+    } else if (typeNode.kind === 'NonNullType') {
+      return {
+        ...this.parseType(typeNode.type),
+        isNullable: false,
+      };
+    } else if (typeNode.kind === 'ListType') {
+      return {
+        ...this.parseType(typeNode.type),
+        isArray: true,
+        isNullable: true,
+      };
+    }
+
+    const isNullable = !!(rawType as string).match(MAYBE_REGEX);
+    const nonNullableType = (rawType as string).replace(MAYBE_REGEX, '$1');
     const isArray = !!nonNullableType.match(ARRAY_REGEX);
     const singularType = nonNullableType.replace(ARRAY_REGEX, '$1');
     const isScalar = !!singularType.match(SCALAR_REGEX);
     const type = singularType.replace(SCALAR_REGEX, (match, type) => (global[type] ? type : `TypeGraphQL.${type}`));
 
     return { type, isNullable, isArray, isScalar };
+  }
+
+  fixDecorator(type: Type, typeString: string) {
+    return type.isArray || type.isNullable || type.isScalar ? typeString : `FixDecorator<${typeString}>`;
   }
 
   FieldDefinition(node: FieldDefinitionNode, key?: number | string, parent?: any): string {
@@ -103,17 +189,24 @@ export class TypeGraphQLVisitor<TRawConfig extends TypeGraphQLPluginConfig = Typ
     const type = this.parseType(typeString);
     const decorator = '\n' + indent(`@TypeGraphQL.${fieldDecorator}(type => ${type.isArray ? `[${type.type}]` : type.type}${type.isNullable ? ', { nullable: true }' : ''})`) + '\n';
 
-    typeString = type.isArray || type.isNullable || type.isScalar ? typeString : `FixDecorator<${typeString}>`;
+    typeString = this.fixDecorator(type, typeString);
 
     return comment + decorator + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}!: ${typeString};`);
   }
 
   InputValueDefinition(node: InputValueDefinitionNode, key?: number | string, parent?: any): string {
-    const originalFieldNode = parent[key] as FieldDefinitionNode;
-    const addOptionalSign = !this.config.avoidOptionals.inputValue && originalFieldNode.type.kind !== Kind.NON_NULL_TYPE;
+    const fieldDecorator = this.config.decoratorName.field;
+    let rawType = node.type as TypeNode | string;
     const comment = transformComment((node.description as any) as string, 1);
 
-    return comment + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${addOptionalSign ? '?' : ''}: ${node.type},`);
+    const type = this.parseType(rawType);
+    const typeGraphQLType = type.isScalar && TYPE_GRAPHQL_SCALARS.includes(type.type) ? `TypeGraphQL.${type.type}` : type.type;
+    const decorator = '\n' + indent(`@TypeGraphQL.${fieldDecorator}(type => ${type.isArray ? `[${typeGraphQLType}]` : typeGraphQLType}${type.isNullable ? ', { nullable: true }' : ''})`) + '\n';
+
+    const nameString = (node.name as NameNode).kind ? (node.name as NameNode).value : node.name;
+    const typeString = (rawType as TypeNode).kind ? this.buildTypeString(type) : this.fixDecorator(type, rawType as string);
+
+    return comment + decorator + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${nameString}!: ${typeString};`);
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -36,7 +36,7 @@ describe('type-graphql', () => {
       TypeGraphQL.registerEnumType(MyEnum, { name: 'MyEnum' });`);
   });
 
-  it('should generate type-graphql classes', async () => {
+  it('should generate type-graphql classes for object types', async () => {
     const schema = buildSchema(/* GraphQL */ `
       type A {
         id: ID
@@ -97,7 +97,7 @@ describe('type-graphql', () => {
     `);
   });
 
-  it('should generate type-graphql classes implementing type-graphql interfaces', async () => {
+  it('should generate type-graphql classes implementing type-graphql interfaces for object types', async () => {
     const schema = buildSchema(/* GraphQL */ `
       type Test implements ITest {
         id: ID
@@ -130,6 +130,158 @@ describe('type-graphql', () => {
       }
     `);
   });
+
+  it('should generate type-graphql classes for input types', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input A {
+        id: ID
+        mandatoryId: ID!
+        str: String
+        mandatoryStr: String!
+        bool: Boolean
+        mandatoryBool: Boolean!
+        int: Int
+        mandatoryInt: Int!
+        float: Float
+        mandatoryFloat: Float!
+        b: B
+        mandatoryB: B!
+        arr: [String!]
+        mandatoryArr: [String!]!
+      }
+      input B {
+        id: ID
+      }
+    `);
+
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.InputType()
+      export class A {
+
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
+
+        @TypeGraphQL.Field(type => TypeGraphQL.ID)
+        mandatoryId!: Scalars['ID'];
+
+        @TypeGraphQL.Field(type => String, { nullable: true })
+        str!: Maybe<Scalars['String']>;
+
+        @TypeGraphQL.Field(type => String)
+        mandatoryStr!: Scalars['String'];
+
+        @TypeGraphQL.Field(type => Boolean, { nullable: true })
+        bool!: Maybe<Scalars['Boolean']>;
+
+        @TypeGraphQL.Field(type => Boolean)
+        mandatoryBool!: Scalars['Boolean'];
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
+        int!: Maybe<Scalars['Int']>;
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Int)
+        mandatoryInt!: Scalars['Int'];
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Float, { nullable: true })
+        float!: Maybe<Scalars['Float']>;
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Float)
+        mandatoryFloat!: Scalars['Float'];
+
+        @TypeGraphQL.Field(type => B, { nullable: true })
+        b!: Maybe<B>;
+
+        @TypeGraphQL.Field(type => B)
+        mandatoryB!: FixDecorator<B>;
+
+        @TypeGraphQL.Field(type => [String], { nullable: true })
+        arr!: Maybe<Array<Scalars['String']>>;
+        
+        @TypeGraphQL.Field(type => [String])
+        mandatoryArr!: Array<Scalars['String']>;
+      }
+    `);
+  });
+
+  it('should generate an args type', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Mutation {
+        test(
+          id: ID
+          mandatoryId: ID!
+          str: String
+          mandatoryStr: String!
+          bool: Boolean
+          mandatoryBool: Boolean!
+          int: Int
+          mandatoryInt: Int!
+          float: Float
+          mandatoryFloat: Float!
+          b: B
+          mandatoryB: B!
+          arr: [String!]
+          mandatoryArr: [String!]!
+        ): Boolean!
+      }
+
+      input B {
+        id: ID
+      }
+    `);
+
+    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.ArgsType()
+      export class MutationTestArgs {
+
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
+
+        @TypeGraphQL.Field(type => TypeGraphQL.ID)
+        mandatoryId!: Scalars['ID'];
+
+        @TypeGraphQL.Field(type => String, { nullable: true })
+        str!: Maybe<Scalars['String']>;
+
+        @TypeGraphQL.Field(type => String)
+        mandatoryStr!: Scalars['String'];
+
+        @TypeGraphQL.Field(type => Boolean, { nullable: true })
+        bool!: Maybe<Scalars['Boolean']>;
+
+        @TypeGraphQL.Field(type => Boolean)
+        mandatoryBool!: Scalars['Boolean'];
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
+        int!: Maybe<Scalars['Int']>;
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Int)
+        mandatoryInt!: Scalars['Int'];
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Float, { nullable: true })
+        float!: Maybe<Scalars['Float']>;
+
+        @TypeGraphQL.Field(type => TypeGraphQL.Float)
+        mandatoryFloat!: Scalars['Float'];
+
+        @TypeGraphQL.Field(type => B, { nullable: true })
+        b!: Maybe<B>;
+
+        @TypeGraphQL.Field(type => B)
+        mandatoryB!: FixDecorator<B>;
+
+        @TypeGraphQL.Field(type => [String], { nullable: true })
+        arr!: Maybe<Array<Scalars['String']>>;
+        
+        @TypeGraphQL.Field(type => [String])
+        mandatoryArr!: Array<Scalars['String']>;
+      }
+    `);
+  });
+
   it('should generate type-graphql types as custom types', async () => {
     const schema = buildSchema(/* GraphQL */ `
       type Test {


### PR DESCRIPTION
I have added support for TypeGraphQL `InputType`s and `ArgsType`s to the @graphql-codegen/typescript-type-graphql plugin, as requested in #2177.