### PR TITLE
fix: do not strip properties from federation resolvers parents

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/federation.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/federation.ts
@@ -90,7 +90,7 @@ export class ApolloFederation {
   }
 
   translateParentType({ fieldNode, parentType, parentTypeSignature }: { fieldNode: FieldDefinitionNode; parentType: GraphQLNamedType; parentTypeSignature: string }) {
-    if (this.enabled && isObjectType(parentType) && isFederationObjectType(parentType)) {
+    if (this.enabled && isObjectType(parentType) && isFederationObjectType(parentType) && fieldNode.name.value === '__resolveReference') {
       const keys = getDirectivesByName('key', parentType);
 
       if (keys.length) {

--- a/packages/plugins/typescript/resolvers/tests/federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/federation.spec.ts
@@ -142,8 +142,8 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
         __resolveReference?: Resolver<Maybe<ResolversTypes['User']>, Pick<ParentType, 'id'>, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], Pick<ParentType, 'id'>, ContextType>,
-        username?: Resolver<Maybe<ResolversTypes['String']>, Pick<ParentType, 'id'> & Pick<ParentType, 'name' | 'age'>, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
       };
     `);
   });
@@ -189,8 +189,8 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
         __resolveReference?: Resolver<Maybe<ResolversTypes['User']>, Pick<ParentType, 'id'>, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], Pick<ParentType, 'id'>, ContextType>,
-        name?: Resolver<Maybe<ResolversTypes['String']>, Pick<ParentType, 'id'>, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
       };
     `);
   });
@@ -367,9 +367,9 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
         __resolveReference?: Resolver<Maybe<ResolversTypes['User']>, (Pick<ParentType, 'id'> | Pick<ParentType, 'name'>), ContextType>,
-        id?: Resolver<ResolversTypes['ID'], (Pick<ParentType, 'id'> | Pick<ParentType, 'name'>), ContextType>,
-        name?: Resolver<Maybe<ResolversTypes['String']>, (Pick<ParentType, 'id'> | Pick<ParentType, 'name'>), ContextType>,
-        username?: Resolver<Maybe<ResolversTypes['String']>, (Pick<ParentType, 'id'> | Pick<ParentType, 'name'>), ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+        username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
       };
     `);
   });
@@ -415,8 +415,8 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
         __resolveReference?: Resolver<Maybe<ResolversTypes['User']>, Pick<ParentType, 'id'>, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], UserExtension & Pick<ParentType, 'id'>, ContextType>,
-        username?: Resolver<Maybe<ResolversTypes['String']>, UserExtension & Pick<ParentType, 'id'> & Pick<ParentType, 'name', 'age'>, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], UserExtension & ParentType, ContextType>,
+        username?: Resolver<Maybe<ResolversTypes['String']>, UserExtension & ParentType & Pick<ParentType, 'name', 'age'>, ContextType>,
       };
     `);
   });

--- a/packages/utils/graphql-codegen-testing/src/index.ts
+++ b/packages/utils/graphql-codegen-testing/src/index.ts
@@ -15,17 +15,17 @@ function compareStrings(a: string, b: string): boolean {
   return a.includes(b);
 }
 
-function toBeSimilarStringTo(received: string, argument: string) {
-  const strippedA = oneLine`${received}`.replace(/\s\s+/g, ' ');
-  const strippedB = oneLine`${argument}`.replace(/\s\s+/g, ' ');
+function toBeSimilarStringTo(received: string, expected: string) {
+  const strippedReceived = oneLine`${received}`.replace(/\s\s+/g, ' ');
+  const strippedExpected = oneLine`${expected}`.replace(/\s\s+/g, ' ');
 
-  if (compareStrings(strippedA, strippedB)) {
+  if (compareStrings(strippedReceived, strippedExpected)) {
     return {
       message: () =>
         `expected 
  ${received}
- not to be similar (strip-indent) string to
- ${argument}`,
+ not to be a string containing (ignoring indents)
+ ${expected}`,
       pass: true,
     };
   } else {
@@ -33,8 +33,8 @@ function toBeSimilarStringTo(received: string, argument: string) {
       message: () =>
         `expected 
  ${received}
- to be similar (strip-indent) string to
- ${argument}`,
+ to be a string containing (ignoring indents)
+ ${expected}`,
       pass: false,
     };
   }


### PR DESCRIPTION
These properties should only actually be stripped when there is no `__resolveReference` present. Since there's no way to know if `__resolveReference` is set, we have to assume it is.


[closes #2530]