### PR TITLE
Fix docs for reactApolloVersion

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/index.ts
+++ b/packages/plugins/typescript/react-apollo/src/index.ts
@@ -117,7 +117,7 @@ export interface ReactApolloRawPluginConfig extends RawClientSideBasePluginConfi
   /**
    * @name reactApolloVersion
    * @type 2 | 3
-   * @description Customized the output by enabling/disabling the HOC.
+   * @description Sets the version of react-apollo.
    * @default 2
    *
    * @example


### PR DESCRIPTION
This fixes a copy/paste mistake for the docs for the reactApolloVersion config option.