### PR TITLE
Flow spread operator support

### DIFF
--- a/packages/plugins/flow/flow/src/visitor.ts
+++ b/packages/plugins/flow/flow/src/visitor.ts
@@ -7,6 +7,7 @@ import { FlowOperationVariablesToObject } from './flow-variables-to-object';
 export interface FlowPluginParsedConfig extends ParsedTypesConfig {
   useFlowExactObjects: boolean;
   useFlowReadOnlyTypes: boolean;
+  isFlow: boolean;
 }
 
 export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginParsedConfig> {
@@ -14,6 +15,7 @@ export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginPa
     super(schema, pluginConfig, {
       useFlowExactObjects: pluginConfig.useFlowExactObjects || false,
       useFlowReadOnlyTypes: pluginConfig.useFlowReadOnlyTypes || false,
+      isFlow: true,
     } as FlowPluginParsedConfig);
     autoBind(this);
 
@@ -93,6 +95,7 @@ export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginPa
 
     const enumValues = new DeclarationBlock(this._declarationBlockConfig)
       .export()
+      .withFlow(true)
       .asKind('const')
       .withName(enumValuesName)
       .withMethodCall('Object.freeze', true)
@@ -114,6 +117,7 @@ export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginPa
 
     const enumType = new DeclarationBlock(this._declarationBlockConfig)
       .export()
+      .withFlow(true)
       .asKind('type')
       .withName(this.convertName(node, { useTypesPrefix: this.config.enumPrefix }))
       .withComment((node.description as any) as string)

--- a/packages/plugins/flow/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/flow/tests/flow.spec.ts
@@ -482,20 +482,20 @@ describe('Flow Plugin', () => {
           id: $ElementType<Scalars, 'ID'>,
         };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type impl1 = some_interface & {
+      expect(result.content).toBeSimilarStringTo(`export type impl1 = {...some_interface, ...{
           __typename?: 'Impl1',
           id: $ElementType<Scalars, 'ID'>,
-        };`);
+        }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type impl_2 = some_interface & {
+      expect(result.content).toBeSimilarStringTo(`export type impl_2 = {...some_interface, ...{
           __typename?: 'Impl_2',
           id: $ElementType<Scalars, 'ID'>,
-        };`);
+        }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type impl_3 = some_interface & {
+      expect(result.content).toBeSimilarStringTo(`export type impl_3 = {...some_interface, ...{
           __typename?: 'impl_3',
           id: $ElementType<Scalars, 'ID'>,
-        };`);
+        }};`);
 
       expect(result.content).toBeSimilarStringTo(`export type query = {
           __typename?: 'Query',
@@ -537,20 +537,20 @@ describe('Flow Plugin', () => {
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type Impl1 = Some_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type Impl1 = {...Some_Interface, ...{
         __typename?: 'Impl1',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type Impl_2 = Some_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type Impl_2 = {...Some_Interface, ...{
         __typename?: 'Impl_2',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type Impl_3 = Some_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type Impl_3 = {...Some_Interface, ...{
         __typename?: 'impl_3',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
       expect(result.content).toBeSimilarStringTo(`export type Query = {
         __typename?: 'Query',
@@ -591,20 +591,20 @@ describe('Flow Plugin', () => {
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type IImpl1 = ISome_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type IImpl1 = {...ISome_Interface, ...{
         __typename?: 'Impl1',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type IImpl_2 = ISome_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type IImpl_2 = {...ISome_Interface, ...{
         __typename?: 'Impl_2',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type IImpl_3 = ISome_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type IImpl_3 = {...ISome_Interface, ...{
         __typename?: 'impl_3',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
       expect(result.content).toBeSimilarStringTo(`export type IQuery = {
         __typename?: 'Query',
@@ -869,10 +869,10 @@ describe('Flow Plugin', () => {
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
-        export type MyType = MyInterface & {
+        export type MyType = {...MyInterface, ...{
           __typename?: 'MyType',
           foo: $ElementType<Scalars, 'String'>,
-        };
+        }};
       `);
       validateFlow(result);
     });
@@ -905,11 +905,11 @@ describe('Flow Plugin', () => {
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
-        export type MyType = MyInterface & MyOtherInterface & {
+        export type MyType = {...MyInterface, ...MyOtherInterface, ...{
           __typename?: 'MyType',
           foo: $ElementType<Scalars, 'String'>,
           bar: $ElementType<Scalars, 'String'>,
-        };
+        }};
       `);
       validateFlow(result);
     });

--- a/packages/plugins/flow/operations/src/flow-selection-set-to-object.ts
+++ b/packages/plugins/flow/operations/src/flow-selection-set-to-object.ts
@@ -27,7 +27,8 @@ export class FlowSelectionSetToObject extends SelectionSetToObject {
       _visitorConfig.dedupeOperationSuffix,
       _visitorConfig.enumPrefix,
       _parentSchemaType,
-      _selectionSet
+      _selectionSet,
+      true
     );
   }
 

--- a/packages/plugins/flow/operations/src/flow-selection-set-to-object.ts
+++ b/packages/plugins/flow/operations/src/flow-selection-set-to-object.ts
@@ -28,7 +28,8 @@ export class FlowSelectionSetToObject extends SelectionSetToObject {
       _visitorConfig.enumPrefix,
       _parentSchemaType,
       _selectionSet,
-      true
+      true,
+      _visitorConfig.useFlowExactObjects
     );
   }
 

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -1008,10 +1008,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = {| me: ?{
+        export type CurrentUserQuery = {| me: ?{|
           ...$Pick<User, {| id: *, username: *, role: * |}>,
           ...{| profile: ?$Pick<Profile, {| age: * |}> |}
-        } |};
+        |} |};
       `);
 
       validateFlow(result);

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -106,20 +106,20 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type notificationsquery = (
-          { __typename?: 'Query' }
-          & { notifications: Array<(
-            { __typename?: 'TextNotification' }
-            & $Pick<textnotification, { text: *, id: * }>
-          ) | (
-            { __typename?: 'ImageNotification' }
-            & $Pick<imagenotification, { imageUrl: *, id: * }>
-            & { metadata: (
-              { __typename?: 'ImageMetadata' }
-              & $Pick<imagemetadata, { createdBy: * }>
-            ) }
-          )> }
-        );
+        export type notificationsquery = {
+          ...{ __typename?: 'Query' },
+          ...{ notifications: Array<{
+            ...{ __typename?: 'TextNotification' },
+            ...$Pick<textnotification, { text: *, id: * }>
+          } | {
+            ...{ __typename?: 'ImageNotification' },
+            ...$Pick<imagenotification, { imageUrl: *, id: * }>,
+            ...{ metadata: {
+              ...{ __typename?: 'ImageMetadata' },
+              ...$Pick<imagemetadata, { createdBy: * }>
+            } }
+          }> }
+        };
       `);
       validateFlow(result);
     });
@@ -157,20 +157,20 @@ describe('Flow Operations Plugin', () => {
 
       expect(result).toBeSimilarStringTo(`export type inotificationsqueryvariables = {};`);
       expect(result).toBeSimilarStringTo(`
-        export type inotificationsquery = (
-          { __typename?: 'Query' }
-          & { notifications: Array<(
-            { __typename?: 'TextNotification' }
-            & $Pick<itextnotification, { text: *, id: * }>
-          ) | (
-            { __typename?: 'ImageNotification' }
-            & $Pick<iimagenotification, { imageUrl: *, id: * }>
-            & { metadata: (
-              { __typename?: 'ImageMetadata' }
-              & $Pick<iimagemetadata, { createdBy: * }>
-            ) }
-          )> }
-        );
+        export type inotificationsquery = {
+          ...{ __typename?: 'Query' },
+          ...{ notifications: Array<{
+            ...{ __typename?: 'TextNotification' },
+            ...$Pick<itextnotification, { text: *, id: * }>
+          } | {
+            ...{ __typename?: 'ImageNotification' },
+            ...$Pick<iimagenotification, { imageUrl: *, id: * }>,
+            ...{ metadata: {
+              ...{ __typename?: 'ImageMetadata' },
+              ...$Pick<iimagemetadata, { createdBy: * }>
+            } }
+          }> }
+        };
       `);
       validateFlow(result);
     });
@@ -217,10 +217,10 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(`
-        export type Unnamed_1_Query = (
-          { __typename: 'Query' }
-          & $Pick<Query, { dummy: * }>
-        );
+        export type Unnamed_1_Query = {
+          ...{ __typename: 'Query' },
+          ...$Pick<Query, { dummy: * }>
+        };
       `);
       validateFlow(result);
     });
@@ -243,10 +243,10 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(`
-        export type Unnamed_1_Query = (
-          { __typename?: 'Query' }
-          & $Pick<Query, { dummy: * }>
-        );
+        export type Unnamed_1_Query = {
+          ...{ __typename?: 'Query' },
+          ...$Pick<Query, { dummy: * }>
+        };
       `);
       validateFlow(result);
     });
@@ -270,10 +270,10 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(`
-        export type Unnamed_1_Query = (
-          { __typename: 'Query' }
-          & $Pick<Query, { dummy: * }>
-        );
+        export type Unnamed_1_Query = {
+          ...{ __typename: 'Query' },
+          ...$Pick<Query, { dummy: * }>
+        };
       `);
       validateFlow(result);
     });
@@ -305,16 +305,16 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type UnionTestQuery = (
-          { __typename?: 'Query' }
-          & { unionTest: ?(
-            { __typename?: 'User' }
-            & $Pick<User, { id: * }>
-          ) | (
-            { __typename?: 'Profile' }
-            & $Pick<Profile, { age: * }>
-          ) }
-        );
+        export type UnionTestQuery = {
+          ...{ __typename?: 'Query' },
+          ...{ unionTest: ?{
+            ...{ __typename?: 'User' },
+            ...$Pick<User, { id: * }>
+          } | {
+            ...{ __typename?: 'Profile' },
+            ...$Pick<Profile, { age: * }>
+          } }
+        };
       `);
       validateFlow(result);
     });
@@ -346,16 +346,16 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type UnionTestQuery = (
-          { __typename: 'Query' }
-          & { unionTest: ?(
-            { __typename: 'User' }
-            & $Pick<User, { id: * }>
-          ) | (
-            { __typename: 'Profile' }
-            & $Pick<Profile, { age: * }>
-          ) }
-        );
+        export type UnionTestQuery = {
+          ...{ __typename: 'Query' },
+          ...{ unionTest: ?{
+            ...{ __typename: 'User' },
+            ...$Pick<User, { id: * }>
+          } | {
+            ...{ __typename: 'Profile' },
+            ...$Pick<Profile, { age: * }>
+          } }
+        };
       `);
       validateFlow(result);
     });
@@ -391,20 +391,20 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(`
-        export type NotificationsQuery = (
-          { __typename?: 'Query' }
-          & { notifications: Array<(
-            { __typename?: 'TextNotification' }
-            & $Pick<TextNotification, { text: *, id: * }>
-          ) | (
-            { __typename?: 'ImageNotification' }
-            & $Pick<ImageNotification, { imageUrl: *, id: * }>
-            & { metadata: (
-              { __typename?: 'ImageMetadata' }
-              & $Pick<ImageMetadata, { createdBy: * }>
-            ) }
-          )> }
-        );
+        export type NotificationsQuery = {
+          ...{ __typename?: 'Query' },
+          ...{ notifications: Array<{
+            ...{ __typename?: 'TextNotification' },
+            ...$Pick<TextNotification, { text: *, id: * }>
+          } | {
+            ...{ __typename?: 'ImageNotification' },
+            ...$Pick<ImageNotification, { imageUrl: *, id: * }>,
+            ...{ metadata: {
+              ...{ __typename?: 'ImageMetadata' },
+              ...$Pick<ImageMetadata, { createdBy: * }>
+            } }
+          }> }
+        };
       `);
       validateFlow(result);
     });
@@ -609,10 +609,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type NotificationsQuery = { notifications: Array<$Pick<TextNotification, { text: *, id: * }> | (
-          $Pick<ImageNotification, { imageUrl: *, id: * }>
-          & { metadata: $Pick<ImageMetadata, { createdBy: * }> }
-        )> };
+        export type NotificationsQuery = { notifications: Array<$Pick<TextNotification, { text: *, id: * }> | {
+          ...$Pick<ImageNotification, { imageUrl: *, id: * }>,
+          ...{ metadata: $Pick<ImageMetadata, { createdBy: * }> }
+        }> };
       `);
       validateFlow(result);
     });
@@ -676,10 +676,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = { me: ?(
-          $Pick<User, { username: *, id: * }>
-          & { profile: ?$Pick<Profile, { age: * }> }
-        ) };
+        export type CurrentUserQuery = { me: ?{
+          ...$Pick<User, { username: *, id: * }>,
+          ...{ profile: ?$Pick<Profile, { age: * }> }
+        } };
       `);
       validateFlow(result);
     });
@@ -718,10 +718,10 @@ describe('Flow Operations Plugin', () => {
         };`
       );
       expect(result).toBeSimilarStringTo(`
-        export type MeQuery = { currentUser: ?$Pick<User, { login: *, html_url: * }>, entry: ?(
-          $Pick<Entry, { id: *, createdAt: * }>
-          & { postedBy: $Pick<User, { login: *, html_url: * }> }
-        ) };
+        export type MeQuery = { currentUser: ?$Pick<User, { login: *, html_url: * }>, entry: ?{
+          ...$Pick<Entry, { id: *, createdAt: * }>,
+          ...{ postedBy: $Pick<User, { login: *, html_url: * }> }
+        } };
       `);
       validateFlow(result);
     });
@@ -769,10 +769,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type DummyQuery = (
-          { customName: $ElementType<Query, 'dummy'> }
-          & { customName2: ?$Pick<Profile, { age: * }> }
-        );
+        export type DummyQuery = {
+          ...{ customName: $ElementType<Query, 'dummy'> },
+          ...{ customName2: ?$Pick<Profile, { age: * }> }
+        };
       `);
       validateFlow(result);
     });
@@ -803,10 +803,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = { me: ?(
-          $Pick<User, { id: *, username: *, role: * }>
-          & { profile: ?$Pick<Profile, { age: * }> }
-        ) };
+        export type CurrentUserQuery = { me: ?{
+          ...$Pick<User, { id: *, username: *, role: * }>,
+          ...{ profile: ?$Pick<Profile, { age: * }> }
+        } };
       `);
 
       validateFlow(result);
@@ -837,10 +837,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type UserFieldsFragment = (
-          $Pick<User, { id: *, username: * }>
-          & { profile: ?$Pick<Profile, { age: * }> }
-        );
+        export type UserFieldsFragment = {
+              ...$Pick<User, { id: *, username: * }>,
+              ...{ profile: ?$Pick<Profile, { age: * }> }
+            };
       `);
       validateFlow(result);
     });
@@ -872,10 +872,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type LoginMutation = { login: ?(
-          $Pick<User, { id: *, username: * }>
-          & { profile: ?$Pick<Profile, { age: * }> }
-        ) };
+        export type LoginMutation = { login: ?{
+              ...$Pick<User, { id: *, username: * }>,
+              ...{ profile: ?$Pick<Profile, { age: * }> }
+            } };
       `);
       validateFlow(result);
     });
@@ -1008,10 +1008,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = {| me: ?(
-          $Pick<User, {| id: *, username: *, role: * |}>
-          & {| profile: ?$Pick<Profile, {| age: * |}> |}
-        ) |};
+        export type CurrentUserQuery = {| me: ?{
+          ...$Pick<User, {| id: *, username: *, role: * |}>,
+          ...{| profile: ?$Pick<Profile, {| age: * |}> |}
+        } |};
       `);
 
       validateFlow(result);
@@ -1042,10 +1042,10 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = { +me: ?(
-          $Pick<User, { +id: *, +username: *, +role: * }>
-          & { +profile: ?$Pick<Profile, { +age: * }> }
-        ) };
+        export type CurrentUserQuery = { +me: ?{
+          ...$Pick<User, { +id: *, +username: *, +role: * }>,
+          ...{ +profile: ?$Pick<Profile, { +age: * }> }
+        } };
       `);
 
       validateFlow(result);

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -528,8 +528,8 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type MeQuery = { me: ?$Pick<User, { username: * }>
-          & UserFieldsFragment
+        export type MeQuery = { me: ?{...$Pick<User, { username: * }>,
+          ...UserFieldsFragment}
         };
       `);
       validateFlow(result);
@@ -569,9 +569,9 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type MeQuery = { me: ?$Pick<User, { username: * }>
-          & UserFieldsFragment
-          & UserProfileFragment 
+        export type MeQuery = { me: ?{...$Pick<User, { username: * }>,
+          ...UserFieldsFragment,
+          ...UserProfileFragment}
         };
       `);
       validateFlow(result);

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -207,6 +207,7 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
 
     return new DeclarationBlock(this._declarationBlockConfig)
       .export()
+      .withFlow(this._parsedConfig.isFlow)
       .asKind('type')
       .withName(this.convertName(node))
       .withComment((node.description as any) as string)
@@ -229,12 +230,17 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
         return ' extends ' + interfaces.join(', ') + (allFields.length ? ' ' : ' {}');
       }
 
+      if (this._parsedConfig.isFlow) {
+        return '{' + '...' + interfaces.join(', ...') + (allFields.length ? ', ...' : '}');
+      }
+
       return interfaces.join(' & ') + (allFields.length ? ' & ' : '');
     };
     const interfaces = buildInterfaces();
 
     let declarationBlock = new DeclarationBlock(this._declarationBlockConfig)
       .export()
+      .withFlow(this._parsedConfig.isFlow)
       .asKind(type)
       .withName(this.convertName(node))
       .withContent(interfaces)

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -231,7 +231,10 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
       }
 
       if (this._parsedConfig.isFlow) {
-        return '{' + '...' + interfaces.join(', ...') + (allFields.length ? ', ...' : '}');
+        const useFlowExactObject = this._parsedConfig.useFlowExactObjects;
+        const optionalExactMark = useFlowExactObject ? '|' : '';
+
+        return '{' + optionalExactMark + '...' + interfaces.join(', ...') + (allFields.length ? ', ...' : optionalExactMark + '}');
       }
 
       return interfaces.join(' & ') + (allFields.length ? ' & ' : '');

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -17,6 +17,7 @@ export interface ParsedConfig {
   namespacedImportName: string | null;
   externalFragments: LoadedFragment[];
   isFlow: boolean;
+  useFlowExactObjects: boolean;
 }
 
 export interface RawConfig {
@@ -117,6 +118,7 @@ export interface RawConfig {
   namespacedImportName?: string;
   externalFragments?: LoadedFragment[];
   globalNamespace?: boolean;
+  useFlowExactObjects?: boolean;
 }
 
 export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig extends ParsedConfig = ParsedConfig> {
@@ -133,6 +135,7 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
       addTypename: !rawConfig.skipTypename,
       nonOptionalTypename: !!rawConfig.nonOptionalTypename,
       isFlow: false,
+      useFlowExactObjects: !!rawConfig.useFlowExactObjects,
       ...((additionalConfig || {}) as any),
     };
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -16,6 +16,7 @@ export interface ParsedConfig {
   nonOptionalTypename: boolean;
   namespacedImportName: string | null;
   externalFragments: LoadedFragment[];
+  isFlow: boolean;
 }
 
 export interface RawConfig {
@@ -131,6 +132,7 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
       externalFragments: rawConfig.externalFragments || [],
       addTypename: !rawConfig.skipTypename,
       nonOptionalTypename: !!rawConfig.nonOptionalTypename,
+      isFlow: false,
       ...((additionalConfig || {}) as any),
     };
 

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -92,7 +92,8 @@ export class SelectionSetToObject {
     protected _dedupeOperationSuffix: boolean,
     protected _enumPrefix: boolean,
     protected _parentSchemaType?: GraphQLNamedType,
-    protected _selectionSet?: SelectionSetNode
+    protected _selectionSet?: SelectionSetNode,
+    protected _isFlow?: boolean
   ) {}
 
   public createNext(parentSchemaType: GraphQLNamedType, selectionSet: SelectionSetNode): SelectionSetToObject {
@@ -425,6 +426,9 @@ export class SelectionSetToObject {
     } else if (result.length === 1) {
       return result[0];
     } else {
+      if (this._isFlow) {
+        return `{\n  ...` + result.join(`,\n   ...`) + `\n}`;
+      }
       return `(\n  ` + result.join(`\n  & `) + `\n)`;
     }
   }

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -93,7 +93,8 @@ export class SelectionSetToObject {
     protected _enumPrefix: boolean,
     protected _parentSchemaType?: GraphQLNamedType,
     protected _selectionSet?: SelectionSetNode,
-    protected _isFlow?: boolean
+    protected _isFlow?: boolean,
+    protected _useFlowExactObjects?: boolean
   ) {}
 
   public createNext(parentSchemaType: GraphQLNamedType, selectionSet: SelectionSetNode): SelectionSetToObject {
@@ -307,7 +308,9 @@ export class SelectionSetToObject {
     }
 
     if (this._isFlow) {
-      return '{...' + fieldSelectionString + `,\n  ...` + fragmentSelectionString + '}\n';
+      const optionalExactMark = this._useFlowExactObjects ? '|' : '';
+
+      return '{' + optionalExactMark + '...' + fieldSelectionString + `,\n  ...` + fragmentSelectionString + optionalExactMark + '}\n';
     }
     return fieldSelectionString + `\n  & ` + fragmentSelectionString + '\n';
   }
@@ -432,7 +435,9 @@ export class SelectionSetToObject {
       return result[0];
     } else {
       if (this._isFlow) {
-        return `{\n  ...` + result.join(`,\n   ...`) + `\n}`;
+        const optionalExactMark = this._useFlowExactObjects ? '|' : '';
+
+        return `{${optionalExactMark}\n  ...` + result.join(`,\n   ...`) + `\n${optionalExactMark}}`;
       }
       return `(\n  ` + result.join(`\n  & `) + `\n)`;
     }

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -306,6 +306,9 @@ export class SelectionSetToObject {
       return fragmentSelectionString;
     }
 
+    if (this._isFlow) {
+      return '{...' + fieldSelectionString + `,\n  ...` + fragmentSelectionString + '}\n';
+    }
     return fieldSelectionString + `\n  & ` + fragmentSelectionString + '\n';
   }
 
@@ -314,13 +317,15 @@ export class SelectionSetToObject {
       return null;
     }
 
+    const separator = this._isFlow ? `,\n  ...` : `\n  & `;
+
     return fragmentSpreadNodes
       .map(node => {
         const fragmentSuffix = this._dedupeOperationSuffix && node.name.value.toLowerCase().endsWith('fragment') ? '' : 'Fragment';
 
         return this._convertName(node.name.value, { useTypesPrefix: true, suffix: fragmentSuffix });
       })
-      .join(`\n  & `);
+      .join(separator);
   }
 
   protected buildSelectionSetString(parentSchemaType: GraphQLObjectType, selectionNodes: SelectionNode[]) {

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -89,6 +89,7 @@ export class DeclarationBlock {
   _nameGenerics = null;
   _comment = null;
   _ignoreBlockWrapper = false;
+  _flow = false;
 
   constructor(private _config: DeclarationBlockConfig) {
     this._config = {
@@ -109,6 +110,12 @@ export class DeclarationBlock {
     if (!this._config.ignoreExport) {
       this._export = exp;
     }
+
+    return this;
+  }
+
+  withFlow(withFlow: boolean): DeclarationBlock {
+    this._flow = withFlow;
 
     return this;
   }
@@ -193,6 +200,10 @@ export class DeclarationBlock {
         result += `${this._methodName}(${this._config.blockTransformer!(block)})`;
       } else {
         result += this._config.blockTransformer!(block);
+      }
+
+      if (this._flow && this._content) {
+        result += '}';
       }
     } else if (this._content) {
       result += this._content;

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -89,7 +89,7 @@ export class DeclarationBlock {
   _nameGenerics = null;
   _comment = null;
   _ignoreBlockWrapper = false;
-  _flow = false;
+  _isFlow = false;
 
   constructor(private _config: DeclarationBlockConfig) {
     this._config = {
@@ -115,7 +115,7 @@ export class DeclarationBlock {
   }
 
   withFlow(withFlow: boolean): DeclarationBlock {
-    this._flow = withFlow;
+    this._isFlow = withFlow;
 
     return this;
   }
@@ -202,8 +202,8 @@ export class DeclarationBlock {
         result += this._config.blockTransformer!(block);
       }
 
-      if (this._flow && this._content) {
-        result += '}';
+      if (this._isFlow && this._content) {
+        result += blockWrapper + '}';
       }
     } else if (this._content) {
       result += this._content;


### PR DESCRIPTION
Hi
Recently I worked on better flow support. In this PR I would like to introduce better flow syntax, using spread operator. This was requested in issue: https://github.com/dotansimha/graphql-code-generator/issues/1844

Using spread operator syntax in flow allows us to use more accurate types
ex. flow could recognize correct types from interface basing on __typename arg

 I've tried it my other project and works well
