### PR TITLE
Improve Flow types using spread operator

### DIFF
--- a/packages/plugins/flow/flow/src/visitor.ts
+++ b/packages/plugins/flow/flow/src/visitor.ts
@@ -79,6 +79,27 @@ export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginPa
     return `import { type ${identifier} } from '${source}';`;
   }
 
+  protected mergeInterfaces(interfaces: string[], hasOtherFields: boolean): string {
+    return interfaces.map(i => `...${i}`).join(', ');
+  }
+
+  appendInterfacesAndFieldsToBlock(block: DeclarationBlock, interfaces: string[], fields: string[]): void {
+    console.log(interfaces);
+    block.withBlock(interfaces + this.mergeAllFields(fields, interfaces.length === 0));
+  }
+
+  protected mergeAllFields(allFields: string[], hasInterfaces): string {
+    if (allFields.length === 0) {
+      return '';
+    }
+
+    if (!hasInterfaces) {
+      return allFields.join('\n');
+    }
+
+    return `...{ ${allFields.join('\n')}}`;
+  }
+
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {
     const typeName = (node.name as any) as string;
 

--- a/packages/plugins/flow/flow/src/visitor.ts
+++ b/packages/plugins/flow/flow/src/visitor.ts
@@ -80,15 +80,18 @@ export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginPa
   }
 
   protected mergeInterfaces(interfaces: string[], hasOtherFields: boolean): string {
-    return interfaces.map(i => `...${i}`).join(', ');
+    if (!interfaces.length) {
+      return '';
+    }
+
+    return interfaces.map(i => indent(`...${i}`)).join(',\n') + (hasOtherFields ? ',\n  ' : '');
   }
 
   appendInterfacesAndFieldsToBlock(block: DeclarationBlock, interfaces: string[], fields: string[]): void {
-    console.log(interfaces);
-    block.withBlock(interfaces + this.mergeAllFields(fields, interfaces.length === 0));
+    block.withBlock(this.mergeInterfaces(interfaces, fields.length > 0) + this.mergeAllFields(fields, interfaces.length > 0));
   }
 
-  protected mergeAllFields(allFields: string[], hasInterfaces): string {
+  protected mergeAllFields(allFields: string[], hasInterfaces: boolean): string {
     if (allFields.length === 0) {
       return '';
     }
@@ -97,7 +100,7 @@ export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginPa
       return allFields.join('\n');
     }
 
-    return `...{ ${allFields.join('\n')}}`;
+    return `...{\n${allFields.map(s => indent(s)).join('\n')}\n  }`;
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {

--- a/packages/plugins/flow/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/flow/tests/flow.spec.ts
@@ -482,20 +482,20 @@ describe('Flow Plugin', () => {
           id: $ElementType<Scalars, 'ID'>,
         };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type impl1 = some_interface & {
+      expect(result.content).toBeSimilarStringTo(`export type impl1 = {...some_interface, ...{
           __typename?: 'Impl1',
           id: $ElementType<Scalars, 'ID'>,
-        };`);
+        }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type impl_2 = some_interface & {
+      expect(result.content).toBeSimilarStringTo(`export type impl_2 = {...some_interface, ...{
           __typename?: 'Impl_2',
           id: $ElementType<Scalars, 'ID'>,
-        };`);
+        }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type impl_3 = some_interface & {
+      expect(result.content).toBeSimilarStringTo(`export type impl_3 = {...some_interface, ...{
           __typename?: 'impl_3',
           id: $ElementType<Scalars, 'ID'>,
-        };`);
+        }};`);
 
       expect(result.content).toBeSimilarStringTo(`export type query = {
           __typename?: 'Query',
@@ -537,20 +537,20 @@ describe('Flow Plugin', () => {
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type Impl1 = Some_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type Impl1 = {...Some_Interface, ...{
         __typename?: 'Impl1',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type Impl_2 = Some_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type Impl_2 = {...Some_Interface, ...{
         __typename?: 'Impl_2',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type Impl_3 = Some_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type Impl_3 = {...Some_Interface, ...{
         __typename?: 'impl_3',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
       expect(result.content).toBeSimilarStringTo(`export type Query = {
         __typename?: 'Query',
@@ -591,20 +591,20 @@ describe('Flow Plugin', () => {
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type IImpl1 = ISome_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type IImpl1 = {...ISome_Interface, ...{
         __typename?: 'Impl1',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type IImpl_2 = ISome_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type IImpl_2 = {...ISome_Interface, ...{
         __typename?: 'Impl_2',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
-      expect(result.content).toBeSimilarStringTo(`export type IImpl_3 = ISome_Interface & {
+      expect(result.content).toBeSimilarStringTo(`export type IImpl_3 = {...ISome_Interface, ...{
         __typename?: 'impl_3',
         id: $ElementType<Scalars, 'ID'>,
-      };`);
+      }};`);
 
       expect(result.content).toBeSimilarStringTo(`export type IQuery = {
         __typename?: 'Query',
@@ -869,10 +869,10 @@ describe('Flow Plugin', () => {
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
-        export type MyType = MyInterface & {
+        export type MyType = {...MyInterface, ...{
           __typename?: 'MyType',
           foo: $ElementType<Scalars, 'String'>,
-        };
+        }};
       `);
       validateFlow(result);
     });
@@ -905,11 +905,11 @@ describe('Flow Plugin', () => {
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
-        export type MyType = MyInterface & MyOtherInterface & {
+        export type MyType = {...MyInterface, ...MyOtherInterface, ...{
           __typename?: 'MyType',
           foo: $ElementType<Scalars, 'String'>,
           bar: $ElementType<Scalars, 'String'>,
-        };
+        }};
       `);
       validateFlow(result);
     });

--- a/packages/plugins/flow/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/flow/tests/flow.spec.ts
@@ -482,20 +482,29 @@ describe('Flow Plugin', () => {
           id: $ElementType<Scalars, 'ID'>,
         };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type impl1 = {...some_interface, ...{
-          __typename?: 'Impl1',
+      expect(result.content).toBeSimilarStringTo(`export type impl1 = {
+        ...some_interface,
+        ...{
+           __typename?: 'Impl1',
           id: $ElementType<Scalars, 'ID'>,
-        }};`);
+        }
+      };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type impl_2 = {...some_interface, ...{
-          __typename?: 'Impl_2',
+      expect(result.content).toBeSimilarStringTo(`export type impl_2 = {
+        ...some_interface,
+        ...{
+           __typename?: 'Impl_2',
           id: $ElementType<Scalars, 'ID'>,
-        }};`);
+        }
+      };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type impl_3 = {...some_interface, ...{
-          __typename?: 'impl_3',
+      expect(result.content).toBeSimilarStringTo(`export type impl_3 = {
+        ...some_interface,
+        ...{
+           __typename?: 'impl_3',
           id: $ElementType<Scalars, 'ID'>,
-        }};`);
+        }
+      };`);
 
       expect(result.content).toBeSimilarStringTo(`export type query = {
           __typename?: 'Query',
@@ -537,26 +546,35 @@ describe('Flow Plugin', () => {
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type Impl1 = {...Some_Interface, ...{
-        __typename?: 'Impl1',
-        id: $ElementType<Scalars, 'ID'>,
-      }};`);
+      expect(result.content).toBeSimilarStringTo(`export type Impl1 = {
+        ...Some_Interface,
+        ...{
+           __typename?: 'Impl1',
+          id: $ElementType<Scalars, 'ID'>,
+        }
+      };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type Impl_2 = {...Some_Interface, ...{
-        __typename?: 'Impl_2',
-        id: $ElementType<Scalars, 'ID'>,
-      }};`);
+      expect(result.content).toBeSimilarStringTo(`export type Impl_2 = {
+        ...Some_Interface,
+        ...{
+           __typename?: 'Impl_2',
+          id: $ElementType<Scalars, 'ID'>,
+        }
+      };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type Impl_3 = {...Some_Interface, ...{
-        __typename?: 'impl_3',
-        id: $ElementType<Scalars, 'ID'>,
-      }};`);
+      expect(result.content).toBeSimilarStringTo(`export type Impl_3 = {
+        ...Some_Interface,
+        ...{
+           __typename?: 'impl_3',
+          id: $ElementType<Scalars, 'ID'>,
+        }
+      };`);
 
       expect(result.content).toBeSimilarStringTo(`export type Query = {
         __typename?: 'Query',
-        something?: ?MyUnion,
-        use_interface?: ?Some_Interface,
-      };`);
+       something?: ?MyUnion,
+       use_interface?: ?Some_Interface,
+     };`);
 
       validateFlow(result);
     });
@@ -591,26 +609,35 @@ describe('Flow Plugin', () => {
         id: $ElementType<Scalars, 'ID'>,
       };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type IImpl1 = {...ISome_Interface, ...{
-        __typename?: 'Impl1',
-        id: $ElementType<Scalars, 'ID'>,
-      }};`);
+      expect(result.content).toBeSimilarStringTo(`export type IImpl1 = {
+        ...ISome_Interface,
+        ...{
+           __typename?: 'Impl1',
+          id: $ElementType<Scalars, 'ID'>,
+        }
+      };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type IImpl_2 = {...ISome_Interface, ...{
-        __typename?: 'Impl_2',
-        id: $ElementType<Scalars, 'ID'>,
-      }};`);
+      expect(result.content).toBeSimilarStringTo(`export type IImpl_2 = {
+        ...ISome_Interface,
+        ...{
+           __typename?: 'Impl_2',
+          id: $ElementType<Scalars, 'ID'>,
+        }
+      };`);
 
-      expect(result.content).toBeSimilarStringTo(`export type IImpl_3 = {...ISome_Interface, ...{
-        __typename?: 'impl_3',
-        id: $ElementType<Scalars, 'ID'>,
-      }};`);
+      expect(result.content).toBeSimilarStringTo(`export type IImpl_3 = {
+        ...ISome_Interface,
+        ...{
+           __typename?: 'impl_3',
+          id: $ElementType<Scalars, 'ID'>,
+        }
+      };`);
 
       expect(result.content).toBeSimilarStringTo(`export type IQuery = {
         __typename?: 'Query',
-        something?: ?IMyUnion,
-        use_interface?: ?ISome_Interface,
-      };`);
+       something?: ?IMyUnion,
+       use_interface?: ?ISome_Interface,
+     };`);
 
       validateFlow(result);
     });
@@ -869,10 +896,13 @@ describe('Flow Plugin', () => {
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
-        export type MyType = {...MyInterface, ...{
-          __typename?: 'MyType',
+      export type MyType = {
+        ...MyInterface,
+        ...{
+           __typename?: 'MyType',
           foo: $ElementType<Scalars, 'String'>,
-        }};
+        }
+      };
       `);
       validateFlow(result);
     });
@@ -905,11 +935,15 @@ describe('Flow Plugin', () => {
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
-        export type MyType = {...MyInterface, ...MyOtherInterface, ...{
-          __typename?: 'MyType',
+      export type MyType = {
+        ...MyInterface,
+        ...MyOtherInterface,
+        ...{
+           __typename?: 'MyType',
           foo: $ElementType<Scalars, 'String'>,
           bar: $ElementType<Scalars, 'String'>,
-        }};
+        }
+      };
       `);
       validateFlow(result);
     });

--- a/packages/plugins/flow/operations/src/flow-selection-set-processor.ts
+++ b/packages/plugins/flow/operations/src/flow-selection-set-processor.ts
@@ -1,4 +1,4 @@
-import { LinkField, PrimitiveField, PrimitiveAliasedFields, SelectionSetProcessorConfig, ProcessResult, BaseSelectionSetProcessor } from '@graphql-codegen/visitor-plugin-common';
+import { LinkField, PrimitiveField, PrimitiveAliasedFields, SelectionSetProcessorConfig, ProcessResult, BaseSelectionSetProcessor, indent } from '@graphql-codegen/visitor-plugin-common';
 import { GraphQLObjectType, GraphQLInterfaceType } from 'graphql';
 
 export interface FlowSelectionSetProcessorConfig extends SelectionSetProcessorConfig {
@@ -17,6 +17,20 @@ export class FlowWithPickSelectionSetProcessor extends BaseSelectionSetProcessor
     const parentName = this.config.convertName(schemaType.name, { useTypesPrefix: true });
 
     return [`{${useFlowExactObject ? '|' : ''} ${fields.map(aliasedField => `${useFlowReadOnlyTypes ? '+' : ''}${aliasedField.alias}: $ElementType<${parentName}, '${aliasedField.fieldName}'>`).join(', ')} ${useFlowExactObject ? '|' : ''}}`];
+  }
+
+  buildFieldsIntoObject(allObjectsMerged: string[]): string {
+    return `...{ ${allObjectsMerged.join(', ')} }`;
+  }
+
+  buildSelectionSetFromStrings(pieces: string[]): string {
+    if (pieces.length === 0) {
+      return null;
+    } else if (pieces.length === 1) {
+      return pieces[0];
+    } else {
+      return `({\n  ${pieces.map(t => indent(`...${t}`)).join(`,\n`)}\n})`;
+    }
   }
 
   transformLinkFields(fields: LinkField[]): ProcessResult {

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -106,20 +106,20 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type notificationsquery = (
-          { __typename?: 'Query' }
-          & { notifications: Array<(
-            { __typename?: 'TextNotification' }
-            & $Pick<textnotification, { text: *, id: * }>
-          ) | (
-            { __typename?: 'ImageNotification' }
-            & $Pick<imagenotification, { imageUrl: *, id: * }>
-            & { metadata: (
-              { __typename?: 'ImageMetadata' }
-              & $Pick<imagemetadata, { createdBy: * }>
-            ) }
-          )> }
-        );
+      export type notificationsquery = ({
+        ...{ __typename?: 'Query' },
+      ...{ notifications: Array<({
+          ...{ __typename?: 'TextNotification' },
+        ...$Pick<textnotification, { text: *, id: * }>
+      }) | ({
+          ...{ __typename?: 'ImageNotification' },
+        ...$Pick<imagenotification, { imageUrl: *, id: * }>,
+        ...{ metadata: ({
+            ...{ __typename?: 'ImageMetadata' },
+          ...$Pick<imagemetadata, { createdBy: * }>
+        }) }
+      })> }
+    });
       `);
       validateFlow(result);
     });
@@ -157,20 +157,20 @@ describe('Flow Operations Plugin', () => {
 
       expect(result).toBeSimilarStringTo(`export type inotificationsqueryvariables = {};`);
       expect(result).toBeSimilarStringTo(`
-        export type inotificationsquery = (
-          { __typename?: 'Query' }
-          & { notifications: Array<(
-            { __typename?: 'TextNotification' }
-            & $Pick<itextnotification, { text: *, id: * }>
-          ) | (
-            { __typename?: 'ImageNotification' }
-            & $Pick<iimagenotification, { imageUrl: *, id: * }>
-            & { metadata: (
-              { __typename?: 'ImageMetadata' }
-              & $Pick<iimagemetadata, { createdBy: * }>
-            ) }
-          )> }
-        );
+      export type inotificationsquery = ({
+        ...{ __typename?: 'Query' },
+      ...{ notifications: Array<({
+          ...{ __typename?: 'TextNotification' },
+        ...$Pick<itextnotification, { text: *, id: * }>
+      }) | ({
+          ...{ __typename?: 'ImageNotification' },
+        ...$Pick<iimagenotification, { imageUrl: *, id: * }>,
+        ...{ metadata: ({
+            ...{ __typename?: 'ImageMetadata' },
+          ...$Pick<iimagemetadata, { createdBy: * }>
+        }) }
+      })> }
+    });
       `);
       validateFlow(result);
     });
@@ -217,10 +217,10 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(`
-        export type Unnamed_1_Query = (
-          { __typename: 'Query' }
-          & $Pick<Query, { dummy: * }>
-        );
+      export type Unnamed_1_Query = ({
+        ...{ __typename: 'Query' },
+      ...$Pick<Query, { dummy: * }>
+    });
       `);
       validateFlow(result);
     });
@@ -243,10 +243,10 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(`
-        export type Unnamed_1_Query = (
-          { __typename?: 'Query' }
-          & $Pick<Query, { dummy: * }>
-        );
+      export type Unnamed_1_Query = ({
+        ...{ __typename?: 'Query' },
+      ...$Pick<Query, { dummy: * }>
+    });
       `);
       validateFlow(result);
     });
@@ -270,10 +270,10 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(`
-        export type Unnamed_1_Query = (
-          { __typename: 'Query' }
-          & $Pick<Query, { dummy: * }>
-        );
+      export type Unnamed_1_Query = ({
+        ...{ __typename: 'Query' },
+      ...$Pick<Query, { dummy: * }>
+    });
       `);
       validateFlow(result);
     });
@@ -305,16 +305,16 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type UnionTestQuery = (
-          { __typename?: 'Query' }
-          & { unionTest: ?(
-            { __typename?: 'User' }
-            & $Pick<User, { id: * }>
-          ) | (
-            { __typename?: 'Profile' }
-            & $Pick<Profile, { age: * }>
-          ) }
-        );
+      export type UnionTestQuery = ({
+        ...{ __typename?: 'Query' },
+      ...{ unionTest: ?({
+          ...{ __typename?: 'User' },
+        ...$Pick<User, { id: * }>
+      }) | ({
+          ...{ __typename?: 'Profile' },
+        ...$Pick<Profile, { age: * }>
+      }) }
+    });
       `);
       validateFlow(result);
     });
@@ -346,16 +346,16 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type UnionTestQuery = (
-          { __typename: 'Query' }
-          & { unionTest: ?(
-            { __typename: 'User' }
-            & $Pick<User, { id: * }>
-          ) | (
-            { __typename: 'Profile' }
-            & $Pick<Profile, { age: * }>
-          ) }
-        );
+      export type UnionTestQuery = ({
+        ...{ __typename: 'Query' },
+      ...{ unionTest: ?({
+          ...{ __typename: 'User' },
+        ...$Pick<User, { id: * }>
+      }) | ({
+          ...{ __typename: 'Profile' },
+        ...$Pick<Profile, { age: * }>
+      }) }
+    });
       `);
       validateFlow(result);
     });
@@ -391,20 +391,20 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(`
-        export type NotificationsQuery = (
-          { __typename?: 'Query' }
-          & { notifications: Array<(
-            { __typename?: 'TextNotification' }
-            & $Pick<TextNotification, { text: *, id: * }>
-          ) | (
-            { __typename?: 'ImageNotification' }
-            & $Pick<ImageNotification, { imageUrl: *, id: * }>
-            & { metadata: (
-              { __typename?: 'ImageMetadata' }
-              & $Pick<ImageMetadata, { createdBy: * }>
-            ) }
-          )> }
-        );
+      export type NotificationsQuery = ({
+        ...{ __typename?: 'Query' },
+      ...{ notifications: Array<({
+          ...{ __typename?: 'TextNotification' },
+        ...$Pick<TextNotification, { text: *, id: * }>
+      }) | ({
+          ...{ __typename?: 'ImageNotification' },
+        ...$Pick<ImageNotification, { imageUrl: *, id: * }>,
+        ...{ metadata: ({
+            ...{ __typename?: 'ImageMetadata' },
+          ...$Pick<ImageMetadata, { createdBy: * }>
+        }) }
+      })> }
+    });
       `);
       validateFlow(result);
     });
@@ -528,10 +528,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-      export type MeQuery = { me: ?(
-        $Pick<User, { username: * }>
-        & UserFieldsFragment
-      ) };
+      export type MeQuery = { me: ?({
+        ...$Pick<User, { username: * }>,
+      ...UserFieldsFragment
+    }) };
       `);
       validateFlow(result);
     });
@@ -570,11 +570,11 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-      export type MeQuery = { me: ?(
-        $Pick<User, { username: * }>
-        & UserFieldsFragment
-        & UserProfileFragment
-      ) };
+      export type MeQuery = { me: ?({
+        ...$Pick<User, { username: * }>,
+      ...UserFieldsFragment,
+      ...UserProfileFragment
+    }) };
       `);
       validateFlow(result);
     });
@@ -611,10 +611,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type NotificationsQuery = { notifications: Array<$Pick<TextNotification, { text: *, id: * }> | (
-          $Pick<ImageNotification, { imageUrl: *, id: * }>
-          & { metadata: $Pick<ImageMetadata, { createdBy: * }> }
-        )> };
+      export type NotificationsQuery = { notifications: Array<$Pick<TextNotification, { text: *, id: * }> | ({
+        ...$Pick<ImageNotification, { imageUrl: *, id: * }>,
+      ...{ metadata: $Pick<ImageMetadata, { createdBy: * }> }
+    })> };
       `);
       validateFlow(result);
     });
@@ -678,10 +678,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = { me: ?(
-          $Pick<User, { username: *, id: * }>
-          & { profile: ?$Pick<Profile, { age: * }> }
-        ) };
+      export type CurrentUserQuery = { me: ?({
+        ...$Pick<User, { username: *, id: * }>,
+      ...{ profile: ?$Pick<Profile, { age: * }> }
+    }) };
       `);
       validateFlow(result);
     });
@@ -720,10 +720,10 @@ describe('Flow Operations Plugin', () => {
         };`
       );
       expect(result).toBeSimilarStringTo(`
-        export type MeQuery = { currentUser: ?$Pick<User, { login: *, html_url: * }>, entry: ?(
-          $Pick<Entry, { id: *, createdAt: * }>
-          & { postedBy: $Pick<User, { login: *, html_url: * }> }
-        ) };
+      export type MeQuery = { currentUser: ?$Pick<User, { login: *, html_url: * }>, entry: ?({
+        ...$Pick<Entry, { id: *, createdAt: * }>,
+      ...{ postedBy: $Pick<User, { login: *, html_url: * }> }
+    }) };
       `);
       validateFlow(result);
     });
@@ -771,10 +771,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type DummyQuery = (
-          { customName: $ElementType<Query, 'dummy'> }
-          & { customName2: ?$Pick<Profile, { age: * }> }
-        );
+      export type DummyQuery = ({
+        ...{ customName: $ElementType<Query, 'dummy'> },
+      ...{ customName2: ?$Pick<Profile, { age: * }> }
+    });
       `);
       validateFlow(result);
     });
@@ -805,10 +805,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = { me: ?(
-          $Pick<User, { id: *, username: *, role: * }>
-          & { profile: ?$Pick<Profile, { age: * }> }
-        ) };
+      export type CurrentUserQuery = { me: ?({
+        ...$Pick<User, { id: *, username: *, role: * }>,
+      ...{ profile: ?$Pick<Profile, { age: * }> }
+    }) };
       `);
 
       validateFlow(result);
@@ -839,10 +839,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type UserFieldsFragment = (
-          $Pick<User, { id: *, username: * }>
-          & { profile: ?$Pick<Profile, { age: * }> }
-        );
+      export type UserFieldsFragment = ({
+        ...$Pick<User, { id: *, username: * }>,
+      ...{ profile: ?$Pick<Profile, { age: * }> }
+    });
       `);
       validateFlow(result);
     });
@@ -874,10 +874,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type LoginMutation = { login: ?(
-          $Pick<User, { id: *, username: * }>
-          & { profile: ?$Pick<Profile, { age: * }> }
-        ) };
+      export type LoginMutation = { login: ?({
+        ...$Pick<User, { id: *, username: * }>,
+      ...{ profile: ?$Pick<Profile, { age: * }> }
+    }) };
       `);
       validateFlow(result);
     });
@@ -1010,10 +1010,10 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = {| me: ?(
-          $Pick<User, {| id: *, username: *, role: * |}>
-          & {| profile: ?$Pick<Profile, {| age: * |}> |}
-        ) |};
+      export type CurrentUserQuery = {| me: ?({
+        ...$Pick<User, {| id: *, username: *, role: * |}>,
+      ...{| profile: ?$Pick<Profile, {| age: * |}> |}
+    }) |};
       `);
 
       validateFlow(result);
@@ -1044,10 +1044,10 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = { +me: ?(
-          $Pick<User, { +id: *, +username: *, +role: * }>
-          & { +profile: ?$Pick<Profile, { +age: * }> }
-        ) };
+      export type CurrentUserQuery = { +me: ?({
+        ...$Pick<User, { +id: *, +username: *, +role: * }>,
+      ...{ +profile: ?$Pick<Profile, { +age: * }> }
+    }) };
       `);
 
       validateFlow(result);

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -213,34 +213,48 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
       .withContent(possibleTypes).string;
   }
 
+  protected mergeInterfaces(interfaces: string[], hasOtherFields: boolean): string {
+    return interfaces.join(' & ') + (hasOtherFields ? ' & ' : '');
+  }
+
+  protected buildInterfaces(node: ObjectTypeDefinitionNode, originalNode: ObjectTypeDefinitionNode, type: DeclarationKind, hasOtherFields: boolean) {
+    if (!originalNode.interfaces || !node.interfaces.length) {
+      return '';
+    }
+
+    const interfaces = originalNode.interfaces.map(i => this.convertName(i));
+
+    if (type === 'interface' || type === 'class') {
+      return ' extends ' + interfaces.join(', ') + (hasOtherFields ? ' ' : ' {}');
+    }
+
+    return this.mergeInterfaces(interfaces, hasOtherFields);
+  }
+
+  appendInterfacesAndFieldsToBlock(block: DeclarationBlock, interfaces: string, fields: string[]): void {
+    block.withContent(t);
+    block.withBlock(this.mergeAllFields(fields, interfaces.length === 0));
+  }
+
   getObjectTypeDeclarationBlock(node: ObjectTypeDefinitionNode, originalNode: ObjectTypeDefinitionNode): DeclarationBlock {
     const optionalTypename = this.config.nonOptionalTypename ? '__typename' : '__typename?';
     const { type } = this._parsedConfig.declarationKind;
     const allFields = [...(this.config.addTypename ? [indent(`${this.config['immutableTypes'] ? 'readonly' : ''} ${optionalTypename}: '${node.name}'${type === 'class' ? ';' : ','}`)] : []), ...node.fields];
+    const interfaces = this.buildInterfaces(node, originalNode, type, allFields.length > 0);
 
-    const buildInterfaces = () => {
-      if (!originalNode.interfaces || !node.interfaces.length) {
-        return '';
-      }
-
-      const interfaces = originalNode.interfaces.map(i => this.convertName(i));
-
-      if (type === 'interface' || type === 'class') {
-        return ' extends ' + interfaces.join(', ') + (allFields.length ? ' ' : ' {}');
-      }
-
-      return interfaces.join(' & ') + (allFields.length ? ' & ' : '');
-    };
-    const interfaces = buildInterfaces();
-
-    let declarationBlock = new DeclarationBlock(this._declarationBlockConfig)
+    const declarationBlock = new DeclarationBlock(this._declarationBlockConfig)
       .export()
       .asKind(type)
       .withName(this.convertName(node))
-      .withContent(interfaces)
       .withComment((node.description as any) as string);
 
-    return declarationBlock.withBlock(allFields.join('\n'));
+    this.appendInterfacesAndFieldsToBlock(declarationBlock, interfaces, allFields as string[]);
+
+    return declarationBlock;
+  }
+
+  protected mergeAllFields(allFields: string[], hasInterfaces: boolean): string {
+    return allFields.join('\n');
   }
 
   ObjectTypeDefinition(node: ObjectTypeDefinitionNode, key: number | string | undefined, parent: any): string {
@@ -250,8 +264,6 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
   }
 
   getInterfaceTypeDeclarationBlock(node: InterfaceTypeDefinitionNode, originalNode: InterfaceTypeDefinitionNode): DeclarationBlock {
-    const argumentsBlock = this.buildArgumentsBlock(originalNode);
-
     let declarationBlock = new DeclarationBlock(this._declarationBlockConfig)
       .export()
       .asKind(this._parsedConfig.declarationKind.interface)

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/base.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/base.ts
@@ -19,6 +19,20 @@ export type SelectionSetProcessorConfig = {
 export class BaseSelectionSetProcessor<Config extends SelectionSetProcessorConfig> {
   constructor(public config: Config) {}
 
+  buildFieldsIntoObject(allObjectsMerged: string[]): string {
+    return `{ ${allObjectsMerged.join(', ')} }`;
+  }
+
+  buildSelectionSetFromStrings(pieces: string[]): string {
+    if (pieces.length === 0) {
+      return null;
+    } else if (pieces.length === 1) {
+      return pieces[0];
+    } else {
+      return `(\n  ${pieces.join(`\n  & `)}\n)`;
+    }
+  }
+
   transformPrimitiveFields(schemaType: GraphQLObjectType | GraphQLInterfaceType, fields: PrimitiveField[]): ProcessResult {
     throw new Error(`Please override "transformPrimitiveFields" as part of your BaseSelectionSetProcessor implementation!`);
   }

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -334,18 +334,12 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     let mergedObjectsAsString: string = null;
 
     if (allObjectsMerged.length > 0) {
-      mergedObjectsAsString = `{ ${allObjectsMerged.join(', ')} }`;
+      mergedObjectsAsString = this._processor.buildFieldsIntoObject(allObjectsMerged);
     }
 
     const fields = [...allStrings, mergedObjectsAsString, ...fragmentsSpreadUsages].filter(Boolean);
 
-    if (fields.length === 0) {
-      return null;
-    } else if (fields.length === 1) {
-      return fields[0];
-    } else {
-      return `(\n  ${fields.join(`\n  & `)}\n)`;
-    }
+    return this._processor.buildSelectionSetFromStrings(fields);
   }
 
   protected buildTypeNameField(


### PR DESCRIPTION
Based on @matikrk's awesome PR: https://github.com/dotansimha/graphql-code-generator/pull/2569 

I changed the implementation a bit in order to match the new selection set transformer, now the base library doesn't know about Flow, but allow if to override some parts of it's behaviour (related to rendering). 
So each plugin now provides it's whole logic to the transformer, without the need for `isFlow`. 

Thank you @matikrk! 