### PR TITLE
[BUG] transformUnderscore isn't working.

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/tests/plugins-common.spec.ts
+++ b/packages/plugins/other/visitor-plugin-common/tests/plugins-common.spec.ts
@@ -91,6 +91,19 @@ describe('convertFactory', () => {
     expect(factory('_Myname', { transformUnderscore: true })).toBe('Myname');
     expect(factory('My_name', { transformUnderscore: true })).toBe('MyName');
   });
+  
+  // TODO Not working!
+  it('Should allow to override underscore behaviour directly from configuration.', () => {
+    const factory = convertFactory({
+      namingConvention: {
+        transformUnderscore: true
+      },
+    });
+
+    expect(factory('My_Name')).toBe('MyName');
+    expect(factory('_Myname')).toBe('Myname');
+    expect(factory('My_name')).toBe('MyName');
+  });
 
   it('Should allow to override transformUnderscore in config', () => {
     const factory = convertFactory({


### PR DESCRIPTION
Hi, 
This is an issue, I made it in a pull request so you can see the test fail.

According the doc and your types, we could add a transformUnderscore option in the configuration, and it should replace all the `_` by ``.

I was able to find a way to do that, and confirmed by looking at the code, (and debugger help) that it was an issue.

Actually in https://github.com/dotansimha/graphql-code-generator/blob/52dea90ab619ed4868fc40f12cdfa5d2b78f7953/packages/plugins/other/visitor-plugin-common/src/naming.ts#L60 the transformUnderscore option is coming from opt, and not the config.

I've finally pulled the repo, added the test, and seen it failed.

Did I miss anything?

Feel free to ask if I can do anything to help.

Thanks,
Matt'.

PS: This PR can be the start of a fix (TDD FTW! 😉)