### PR TITLE
Make errors thrown more descriptive

### DIFF
--- a/packages/graphql-codegen-cli/src/utils/listr-renderer.ts
+++ b/packages/graphql-codegen-cli/src/utils/listr-renderer.ts
@@ -51,7 +51,7 @@ export class Renderer {
           .map(({ msg, rawError }, i) => {
             const source: string | Source | undefined = (err.errors[i] as any).source;
 
-            msg = msg ? `${chalk.gray(indentString(stripIndent(`${msg}`), 4))}\n` : null;
+            msg = msg ? chalk.gray(indentString(stripIndent(`${msg}`), 4)) : null;
             const stack = rawError.stack ? chalk.gray(indentString(stripIndent(rawError.stack), 4)) : null;
 
             if (source) {

--- a/packages/graphql-codegen-cli/src/utils/listr-renderer.ts
+++ b/packages/graphql-codegen-cli/src/utils/listr-renderer.ts
@@ -46,22 +46,22 @@ export class Renderer {
           .map(error => {
             debugLog(`[CLI] Exited with an error`, error);
 
-            return { msg: isDetailedError(error) ? error.details : error, rawError: error };
+            return { msg: isDetailedError(error) ? error.details : null, rawError: error };
           })
           .map(({ msg, rawError }, i) => {
             const source: string | Source | undefined = (err.errors[i] as any).source;
 
-            msg = chalk.gray(indentString(stripIndent(`${msg}`), 4));
+            msg = msg ? `${chalk.gray(indentString(stripIndent(`${msg}`), 4))}\n` : null;
             const stack = rawError.stack ? chalk.gray(indentString(stripIndent(rawError.stack), 4)) : null;
 
             if (source) {
               const sourceOfError = typeof source === 'string' ? source : source.name;
               const title = indentString(`${logSymbol.error} ${sourceOfError}`, 2);
 
-              return [title, !stack ? msg : null, stack].filter(Boolean).join('\n');
+              return [title, msg, stack, stack].filter(Boolean).join('\n');
             }
 
-            return stack ? stack : msg;
+            return [msg, stack].filter(Boolean).join('\n');
           })
           .join('\n\n');
         logUpdate(['', count, details, ''].join('\n\n'));


### PR DESCRIPTION
Hey hey 👋🏼, first of all, I want to say I love `graphql-code-generator`, I have been using it a lot lately and it has made my life so much easier 😅I want to help improve it so here is my little contribution, hope you consider it 🤞🏼

**The problem I had:**
I was working on one of my projects when I decided to add the `typescript-react-apollo` plugin. It keept throwing an error (`Plugin "typescript-react-apollo" validation failed:`), which is kind of undescriptive.

After digging into the code I figured out the problem but also realized that there are details to the errors that are not being displayed. Especially in my case, it would have really helped me out.

**My solution**
Display the details of the errors and make it easier for the user to debug their program.

The `listr-renderer.ts` now includes the `errors`'s `details` field, later called `msg`, in all of the errors that are being thrown.

**Example**
The problem I was having was that `typescript-react-apollo` requires that the extension of the generated file is `.tsx`. So the error I was getting before was:

<img width="542" alt="Screenshot 2019-10-04 at 20 53 49" src="https://user-images.githubusercontent.com/16746406/66235913-212ee280-e6e9-11e9-934b-8281632cc735.png">

The error after my fix:

<img width="561" alt="Screenshot 2019-10-05 at 12 03 11" src="https://user-images.githubusercontent.com/16746406/66254005-2b43f600-e768-11e9-8e9b-bf49e526e528.png">

Way clearer, in my opinion! 

Also, here's the repo of the example from above: https://github.com/JureSotosek/graphql-codegen-errors-example

Let me know what you think 💪🏼