### PR TITLE
Custom output default value based on the selected plugins

### DIFF
--- a/packages/graphql-codegen-cli/src/init/plugins.ts
+++ b/packages/graphql-codegen-cli/src/init/plugins.ts
@@ -9,6 +9,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'typescript/typescript',
     available: hasTag(Tags.typescript),
     shouldBeSelected: tags => oneOf(tags, Tags.angular, Tags.stencil) || allOf(tags, Tags.typescript, Tags.react) || noneOf(tags, Tags.flow),
+    defaultExtension: '.ts',
   },
   {
     name: `TypeScript Operations ${italic('(operations and fragments)')}`,
@@ -17,6 +18,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'typescript/operations',
     available: tags => allOf(tags, Tags.browser, Tags.typescript),
     shouldBeSelected: tags => oneOf(tags, Tags.angular, Tags.stencil) || allOf(tags, Tags.typescript, Tags.react),
+    defaultExtension: '.ts',
   },
   {
     name: `TypeScript Resolvers ${italic('(strongly typed resolve functions)')}`,
@@ -25,6 +27,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'typescript/resolvers',
     available: tags => allOf(tags, Tags.node, Tags.typescript),
     shouldBeSelected: tags => noneOf(tags, Tags.flow),
+    defaultExtension: '.ts',
   },
   {
     name: `Flow ${italic('(required by other flow plugins)')}`,
@@ -33,6 +36,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'flow/flow',
     available: hasTag(Tags.flow),
     shouldBeSelected: tags => noneOf(tags, Tags.typescript),
+    defaultExtension: '.js',
   },
   {
     name: `Flow Operations ${italic('(operations and fragments)')}`,
@@ -41,6 +45,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'flow/operations',
     available: tags => allOf(tags, Tags.browser, Tags.flow),
     shouldBeSelected: tags => noneOf(tags, Tags.typescript),
+    defaultExtension: '.js',
   },
   {
     name: `Flow Resolvers ${italic('(strongly typed resolve functions)')}`,
@@ -49,6 +54,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'flow/resolvers',
     available: tags => allOf(tags, Tags.node, Tags.flow),
     shouldBeSelected: tags => noneOf(tags, Tags.typescript),
+    defaultExtension: '.js',
   },
   {
     name: `TypeScript Apollo Angular ${italic('(typed GQL services)')}`,
@@ -57,6 +63,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'typescript/apollo-angular',
     available: hasTag(Tags.angular),
     shouldBeSelected: () => true,
+    defaultExtension: '.js',
   },
   {
     name: `TypeScript React Apollo ${italic('(typed components and HOCs)')}`,
@@ -65,6 +72,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'typescript/react-apollo',
     available: tags => allOf(tags, Tags.react, Tags.typescript),
     shouldBeSelected: () => true,
+    defaultExtension: '.tsx',
   },
   {
     name: `TypeScript Stencil Apollo ${italic('(typed components)')}`,
@@ -73,6 +81,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'typescript/stencil-apollo',
     available: hasTag(Tags.stencil),
     shouldBeSelected: () => true,
+    defaultExtension: '.tsx',
   },
   {
     name: `TypeScript MongoDB ${italic('(typed MongoDB objects)')}`,
@@ -81,6 +90,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'typescript/mongodb',
     available: tags => allOf(tags, Tags.node, Tags.typescript),
     shouldBeSelected: () => false,
+    defaultExtension: '.ts',
   },
   {
     name: `TypeScript GraphQL files modules ${italic('(declarations for .graphql files)')}`,
@@ -89,6 +99,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'typescript/graphql-files-modules',
     available: tags => allOf(tags, Tags.browser, Tags.typescript),
     shouldBeSelected: () => false,
+    defaultExtension: '.ts',
   },
   {
     name: `TypeScript GraphQL document nodes ${italic('(embedded GraphQL document)')}`,
@@ -97,6 +108,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'typescript/document-nodes',
     available: tags => allOf(tags, Tags.typescript),
     shouldBeSelected: () => false,
+    defaultExtension: '.ts',
   },
   {
     name: `Introspection Fragment Matcher ${italic('(for Apollo Client)')}`,
@@ -105,6 +117,7 @@ export const plugins: Array<PluginOption> = [
     pathInRepo: 'other/fragment-matcher',
     available: hasTag(Tags.browser),
     shouldBeSelected: () => false,
+    defaultExtension: '.ts',
   },
 ];
 

--- a/packages/graphql-codegen-cli/src/init/questions.ts
+++ b/packages/graphql-codegen-cli/src/init/questions.ts
@@ -45,7 +45,7 @@ export function getQuestions(possibleTargets: Record<Tags, boolean>): inquirer.Q
       type: 'input',
       name: 'output',
       message: 'Where to write the output:',
-      default: 'src/generated/graphql.ts',
+      default: getOutputDefaultValue,
       validate: (str: string) => str.length > 0,
     },
     {
@@ -135,4 +135,14 @@ export function getPluginChoices(answers: Answers) {
 
 function normalizeTargets(targets: Tags[] | Tags[][]): Tags[] {
   return [].concat(...targets);
+}
+
+export function getOutputDefaultValue(answers: Answers) {
+  if (answers.plugins.some(plugin => plugin.defaultExtension === '.tsx')) {
+    return 'src/generated/graphql.tsx';
+  } else if (answers.plugins.some(plugin => plugin.defaultExtension === '.ts')) {
+    return 'src/generated/graphql.ts';
+  } else {
+    return 'src/generated/graphql.js';
+  }
 }

--- a/packages/graphql-codegen-cli/src/init/types.ts
+++ b/packages/graphql-codegen-cli/src/init/types.ts
@@ -5,6 +5,7 @@ export interface PluginOption {
   pathInRepo: string;
   available(tags: Tags[]): boolean;
   shouldBeSelected(tags: Tags[]): boolean;
+  defaultExtension: string;
 }
 
 export interface Answers {

--- a/packages/graphql-codegen-cli/tests/init.spec.ts
+++ b/packages/graphql-codegen-cli/tests/init.spec.ts
@@ -158,9 +158,9 @@ describe('init', () => {
     const config = safeLoad(writeFileSpy.mock.calls[0][1] as string);
 
     // should use default output path
-    expect(config.generates['src/generated/graphql.ts']).toBeDefined();
+    expect(config.generates['src/generated/graphql.tsx']).toBeDefined();
 
-    const output: any = config.generates['src/generated/graphql.ts'];
+    const output: any = config.generates['src/generated/graphql.tsx'];
     expect(output.plugins).toContainEqual('typescript');
     expect(output.plugins).toContainEqual('typescript-operations');
     expect(output.plugins).toContainEqual('typescript-react-apollo');
@@ -201,9 +201,9 @@ describe('init', () => {
     const config = safeLoad(writeFileSpy.mock.calls[0][1] as string);
 
     // should use default output path
-    expect(config.generates['src/generated/graphql.ts']).toBeDefined();
+    expect(config.generates['src/generated/graphql.tsx']).toBeDefined();
 
-    const output: any = config.generates['src/generated/graphql.ts'];
+    const output: any = config.generates['src/generated/graphql.tsx'];
     expect(output.plugins).toContainEqual('typescript');
     expect(output.plugins).toContainEqual('typescript-operations');
     expect(output.plugins).toContainEqual('typescript-stencil-apollo');


### PR DESCRIPTION
Hey hey, another one from me 👋🏼

**The problem I had:**
When running `yarn graphql-codegen init`, you are prompted with a question: "Where to write the output:", with the default value thats always "src/generated/graphql.ts". A problem occurs if you have for example chosen `flow` plugin that requires its extension to be `.js` or the `react-apollo` plugin that requires its extension to be `.jsx`. 

**My solution:**
The default value should be inferred from the plugins you have selected. There is also an inferred hierarchy of the extensions.

For example: If you have multiple plugins selected and one of them requires `.tsx`, no matter what other plugins requires, `.tsx` will be the suggested default.

If you have multiple plugins selected and one of them requires `.ts` and no other requires `.tsx`, no matter what other plugins require, `.ts` will be the suggested default.

`.js` will be a suggested default only if no other plugins require `.ts` or `.tsx`.

**Example**
Before, when `react-apollo` plugin was selected, you were prompted with a default `.ts` output file:

<img width="510" alt="Screenshot 2019-10-05 at 18 02 54" src="https://user-images.githubusercontent.com/16746406/66258232-868edc00-e79a-11e9-8164-76de98207b34.png">

Now you are prompted with a default `.tsx` output file:
 
<img width="509" alt="Screenshot 2019-10-05 at 17 50 01" src="https://user-images.githubusercontent.com/16746406/66258236-94446180-e79a-11e9-9d9f-45adc7a6c0a4.png">

Let me know what you think ✌🏼