### PR TITLE
Update extensions in the docs

### DIFF
--- a/docs/generated-config/flow-operations.md
+++ b/docs/generated-config/flow-operations.md
@@ -8,7 +8,7 @@ Generates Flow types as Exact types.
 
 ```yml
 generates:
-path/to/file.ts:
+path/to/file.js:
  plugins:
    - flow
  config:
@@ -24,7 +24,7 @@ Generates read-only Flow types
 
 ```yml
 generates:
-path/to/file.ts:
+path/to/file.js:
  plugins:
    - flow
  config:
@@ -40,7 +40,7 @@ Flatten fragment spread and inline fragments into a simple selection set before 
 
 ```yml
 generates:
-path/to/file.ts:
+path/to/file.js:
  plugins:
    - typescript
    - typescript-operations

--- a/docs/generated-config/flow.md
+++ b/docs/generated-config/flow.md
@@ -8,7 +8,7 @@ Generates Flow types as Exact types.
 
 ```yml
 generates:
-path/to/file.ts:
+path/to/file.js:
  plugins:
    - flow
  config:
@@ -24,7 +24,7 @@ Generates read-only Flow types
 
 ```yml
 generates:
-path/to/file.ts:
+path/to/file.js:
  plugins:
    - flow
  config:

--- a/docs/generated-config/typescript-react-apollo.md
+++ b/docs/generated-config/typescript-react-apollo.md
@@ -26,7 +26,7 @@ Customized the output by enabling/disabling the HOC.
 
 ```yml
 generates:
-path/to/file.ts:
+path/to/file.tsx:
  plugins:
    - typescript
    - typescript-operations
@@ -44,7 +44,7 @@ Customized the output by enabling/disabling the generated React Hooks.
 
 ```yml
 generates:
-path/to/file.ts:
+path/to/file.tsx:
  plugins:
    - typescript
    - typescript-operations
@@ -62,7 +62,7 @@ Customized the output by enabling/disabling the generated mutation function sign
 
 ```yml
 generates:
-path/to/file.ts:
+path/to/file.tsx:
  plugins:
    - typescript
    - typescript-operations
@@ -111,7 +111,7 @@ Sets the version of react-apollo.
 
 ```yml
 generates:
-path/to/file.ts:
+path/to/file.tsx:
  plugins:
    - typescript
    - typescript-operations
@@ -129,7 +129,7 @@ Customized the output by enabling/disabling the generated result type.
 
 ```yml
 generates:
-path/to/file.ts:
+path/to/file.tsx:
  plugins:
    - typescript
    - typescript-operations
@@ -143,13 +143,16 @@ path/to/file.ts:
 Customized the output by enabling/disabling the generated mutation option type.
 
 
-#### Usage Example: yml
+#### Usage Example: 
+
+```yml
 generates:
-path/to/file.ts:
+path/to/file.tsx:
  plugins:
    - typescript
    - typescript-operations
    - typescript-react-apollo
  config:
    withMutationOptionsType: true
+```
 

--- a/docs/generated-config/typescript-stencil-apollo.md
+++ b/docs/generated-config/typescript-stencil-apollo.md
@@ -8,7 +8,7 @@ Customize the output of the plugin - you can choose to generate a Component clas
 
 ```yml
 generates:
-path/to/file.ts:
+path/to/file.tsx:
  plugins:
    - typescript
    - typescript-operations


### PR DESCRIPTION
Another one, kind of connected to #2689, I feel like extensions of output files in the docs should by corresponding to the plugins used.

Especially in the case of `apollo-react` where using a `.ts` output file throws an error.

Also, in the case of `flow` plugins, if you are using `flow` then you are probably not using `typescript` and the extension should be just `.js`.

Another small one I fixed, the last `yml` code snippet in the `react-apollo` plugin docs was wrongly formated, here is how it looked:
<img width="826" alt="Screenshot 2019-10-06 at 00 31 21" src="https://user-images.githubusercontent.com/16746406/66262041-a6d98d80-e7d0-11e9-864d-646404229d3f.png">
