### PR TITLE
Use dotenv in examples

### DIFF
--- a/dev-test/.env
+++ b/dev-test/.env
@@ -1,0 +1,1 @@
+SCHEMA_PATH = ./dev-test/test-schema/schema.graphql

--- a/dev-test/codegen.yml
+++ b/dev-test/codegen.yml
@@ -50,6 +50,10 @@ generates:
           content: '}'
       - typescript
       - typescript-operations
+  ./dev-test/test-schema/env.types.ts:
+    schema: ${SCHEMA_PATH}
+    plugins:
+      - typescript
   ./dev-test/test-schema/typings.immutableTypes.ts:
     schema: ./dev-test/test-schema/schema.json
     config:

--- a/dev-test/generate-all.sh
+++ b/dev-test/generate-all.sh
@@ -1,3 +1,3 @@
 #/bin/sh
 
-node packages/graphql-codegen-cli/dist/commonjs/bin.js --config ./dev-test/codegen.yml
+DOTENV_CONFIG_PATH=$PWD/dev-test/.env node --require dotenv/config packages/graphql-codegen-cli/dist/commonjs/bin.js --config ./dev-test/codegen.yml

--- a/dev-test/generate-watch.sh
+++ b/dev-test/generate-watch.sh
@@ -1,3 +1,3 @@
 #/bin/sh
 
-node packages/graphql-codegen-cli/dist/commonjs/bin.js --config ./dev-test/codegen.yml -w
+DOTENV_CONFIG_PATH=$PWD/dev-test/.env node --require dotenv/config packages/graphql-codegen-cli/dist/commonjs/bin.js dotenv_config_path=./dev-test/.env --config ./dev-test/codegen.yml -w

--- a/dev-test/test-schema/env.types.ts
+++ b/dev-test/test-schema/env.types.ts
@@ -1,0 +1,30 @@
+export type Maybe<T> = T | null;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  allUsers: Array<Maybe<User>>;
+  userById?: Maybe<User>;
+  answer: Array<Scalars['Int']>;
+  testArr1?: Maybe<Array<Maybe<Scalars['String']>>>;
+  testArr2: Array<Maybe<Scalars['String']>>;
+  testArr3: Array<Scalars['String']>;
+};
+
+export type QueryUserByIdArgs = {
+  id: Scalars['Int'];
+};
+
+export type User = {
+  __typename?: 'User';
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  email: Scalars['String'];
+};

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -88,6 +88,7 @@
     "@types/listr": "0.14.2",
     "@types/log-symbols": "2.0.0",
     "bdd-stdin": "0.2.0",
+    "dotenv": "8.1.0",
     "graphql": "14.5.8",
     "js-yaml": "3.13.1",
     "make-dir": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6647,6 +6647,11 @@ dotenv@6.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
 
+dotenv@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.1.0.tgz#d811e178652bfb8a1e593c6dd704ec7e90d85ea2"
+  integrity sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==
+
 download@^6.2.2:
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/download/-/download-6.2.5.tgz#acd6a542e4cd0bb42ca70cfc98c9e43b07039714"


### PR DESCRIPTION
@dotansimha - was `graphql-codegen -r dotenv/config` working back then (#1757) or `dotenv/config` should be loaded before `graphql-codegen`?