### PR TITLE
Added `addDocBlocks` configuration option

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/index.ts
+++ b/packages/plugins/typescript/react-apollo/src/index.ts
@@ -171,6 +171,26 @@ export interface ReactApolloRawPluginConfig extends RawClientSideBasePluginConfi
    *
    */
   withMutationOptionsType?: boolean;
+  /**
+   * @name addDocBlocks
+   * @type boolean
+   * @description Allows you to enable/disable the generation of docblocks in generated code.
+   * Some IDE's (like VSCode) add extra inline information with docblocks, you can disable this feature if your prefered IDE does not.
+   * @default true
+   *
+   * @example
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *    - typescript-react-apollo
+   *  config:
+   *    addDocBlocks: true
+   *
+   */
+  addDocBlocks?: boolean;
 }
 
 export const plugin: PluginFunction<ReactApolloRawPluginConfig> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: ReactApolloRawPluginConfig) => {

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -19,6 +19,7 @@ export interface ReactApolloPluginConfig extends ClientSideBasePluginConfig {
   reactApolloVersion: 2 | 3;
   withResultType: boolean;
   withMutationOptionsType: boolean;
+  addDocBlocks: boolean;
 }
 
 export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPluginConfig, ReactApolloPluginConfig> {
@@ -39,6 +40,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
       reactApolloVersion: getConfigValue(rawConfig.reactApolloVersion, 2),
       withResultType: getConfigValue(rawConfig.withResultType, true),
       withMutationOptionsType: getConfigValue(rawConfig.withMutationOptionsType, true),
+      addDocBlocks: getConfigValue(rawConfig.addDocBlocks, true),
     });
 
     this._prefix = this.config.importOperationTypesFrom ? `${this.config.importOperationTypesFrom}.` : '';
@@ -212,11 +214,15 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     this.imports.add(this.getApolloReactHooksImport());
 
     const hookFns = [
-      this._buildHooksJSDoc(node, operationName, operationType),
       `export function use${operationName}(baseOptions?: ApolloReactHooks.${operationType}HookOptions<${operationResultType}, ${operationVariablesTypes}>) {
         return ApolloReactHooks.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${this.getDocumentNodeVariable(node, documentVariableName)}, baseOptions);
       }`,
     ];
+
+    if (this.config.addDocBlocks) {
+      hookFns.unshift(this._buildHooksJSDoc(node, operationName, operationType));
+    }
+
     const hookResults = [`export type ${operationName}HookResult = ReturnType<typeof use${operationName}>;`];
 
     if (operationType === 'Query') {

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -921,44 +921,40 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
-    const queryDocBlockSnapshot = `
-    "/**
-     * __useFeedQuery__
-     *
-     * To run a query within a React component, call \`useFeedQuery\` and pass it any options that fit your needs.
-     * When your component renders, \`useFeedQuery\` returns an object from Apollo Client that contains loading, error, and data properties 
-     * you can use to render your UI.
-     *
-     * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
-     *
-     * @example
-     * const { data, loading, error } = useFeedQuery({
-     *   variables: {
-     *      id: // value for 'id'
-     *   },
-     * });
-     */"
-    `;
+    const queryDocBlockSnapshot = `/**
+ * __useFeedQuery__
+ *
+ * To run a query within a React component, call \`useFeedQuery\` and pass it any options that fit your needs.
+ * When your component renders, \`useFeedQuery\` returns an object from Apollo Client that contains loading, error, and data properties 
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFeedQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */`;
 
-    const mutationDocBlockSnapshot = `
-    "/**
-     * __useSubmitRepositoryMutation__
-     *
-     * To run a mutation, you first call \`useSubmitRepositoryMutation\` within a React component and pass it any options that fit your needs.
-     * When your component renders, \`useSubmitRepositoryMutation\` returns a tuple that includes:
-     * - A mutate function that you can call at any time to execute the mutation
-     * - An object with fields that represent the current status of the mutation's execution
-     *
-     * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
-     *
-     * @example
-     * const [submitRepositoryMutation, { data, loading, error }] = useSubmitRepositoryMutation({
-     *   variables: {
-     *      name: // value for 'name'
-     *   },
-     * });
-     */"
-    `;
+    const mutationDocBlockSnapshot = `/**
+ * __useSubmitRepositoryMutation__
+ *
+ * To run a mutation, you first call \`useSubmitRepositoryMutation\` within a React component and pass it any options that fit your needs.
+ * When your component renders, \`useSubmitRepositoryMutation\` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [submitRepositoryMutation, { data, loading, error }] = useSubmitRepositoryMutation({
+ *   variables: {
+ *      name: // value for 'name'
+ *   },
+ * });
+ */`;
 
     it('Should generate JSDoc docblocks for hooks', async () => {
       const documents = parse(/* GraphQL */ `
@@ -987,11 +983,11 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       const queryDocBlock = extract(content.content.substr(content.content.indexOf('/**')));
 
-      expect(queryDocBlock).toMatchInlineSnapshot(queryDocBlockSnapshot);
+      expect(queryDocBlock).toEqual(queryDocBlockSnapshot);
 
       const mutationDocBlock = extract(content.content.substr(content.content.lastIndexOf('/**')));
 
-      expect(mutationDocBlock).toMatchInlineSnapshot(mutationDocBlockSnapshot);
+      expect(mutationDocBlock).toEqual(mutationDocBlockSnapshot);
     });
 
     it('Should NOT generate JSDoc docblocks for hooks if addDocBlocks is false', async () => {
@@ -1021,11 +1017,11 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       const queryDocBlock = extract(content.content.substr(content.content.indexOf('/**')));
 
-      expect(queryDocBlock).not.toMatchInlineSnapshot(queryDocBlockSnapshot);
+      expect(queryDocBlock).not.toEqual(queryDocBlockSnapshot);
 
       const mutationDocBlock = extract(content.content.substr(content.content.lastIndexOf('/**')));
 
-      expect(mutationDocBlock).not.toMatchInlineSnapshot(mutationDocBlockSnapshot);
+      expect(mutationDocBlock).not.toEqual(mutationDocBlockSnapshot);
     });
   });
 

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -921,7 +921,46 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('should generate JSDoc docblocks for hooks', async () => {
+    const queryDocBlockSnapshot = `
+    "/**
+     * __useFeedQuery__
+     *
+     * To run a query within a React component, call \`useFeedQuery\` and pass it any options that fit your needs.
+     * When your component renders, \`useFeedQuery\` returns an object from Apollo Client that contains loading, error, and data properties 
+     * you can use to render your UI.
+     *
+     * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+     *
+     * @example
+     * const { data, loading, error } = useFeedQuery({
+     *   variables: {
+     *      id: // value for 'id'
+     *   },
+     * });
+     */"
+    `;
+
+    const mutationDocBlockSnapshot = `
+    "/**
+     * __useSubmitRepositoryMutation__
+     *
+     * To run a mutation, you first call \`useSubmitRepositoryMutation\` within a React component and pass it any options that fit your needs.
+     * When your component renders, \`useSubmitRepositoryMutation\` returns a tuple that includes:
+     * - A mutate function that you can call at any time to execute the mutation
+     * - An object with fields that represent the current status of the mutation's execution
+     *
+     * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+     *
+     * @example
+     * const [submitRepositoryMutation, { data, loading, error }] = useSubmitRepositoryMutation({
+     *   variables: {
+     *      name: // value for 'name'
+     *   },
+     * });
+     */"
+    `;
+
+    it('Should generate JSDoc docblocks for hooks', async () => {
       const documents = parse(/* GraphQL */ `
         query feed($id: ID!) {
           feed(id: $id) {
@@ -948,46 +987,45 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       const queryDocBlock = extract(content.content.substr(content.content.indexOf('/**')));
 
-      expect(queryDocBlock).toMatchInlineSnapshot(`
-"/**
- * __useFeedQuery__
- *
- * To run a query within a React component, call \`useFeedQuery\` and pass it any options that fit your needs.
- * When your component renders, \`useFeedQuery\` returns an object from Apollo Client that contains loading, error, and data properties 
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useFeedQuery({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */"
-`);
+      expect(queryDocBlock).toMatchInlineSnapshot(queryDocBlockSnapshot);
 
       const mutationDocBlock = extract(content.content.substr(content.content.lastIndexOf('/**')));
 
-      expect(mutationDocBlock).toMatchInlineSnapshot(`
-"/**
- * __useSubmitRepositoryMutation__
- *
- * To run a mutation, you first call \`useSubmitRepositoryMutation\` within a React component and pass it any options that fit your needs.
- * When your component renders, \`useSubmitRepositoryMutation\` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [submitRepositoryMutation, { data, loading, error }] = useSubmitRepositoryMutation({
- *   variables: {
- *      name: // value for 'name'
- *   },
- * });
- */"
-`);
+      expect(mutationDocBlock).toMatchInlineSnapshot(mutationDocBlockSnapshot);
+    });
+
+    it('Should NOT generate JSDoc docblocks for hooks if addDocBlocks is false', async () => {
+      const documents = parse(/* GraphQL */ `
+        query feed($id: ID!) {
+          feed(id: $id) {
+            id
+          }
+        }
+        mutation submitRepository($name: String) {
+          submitRepository(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+
+      const docs = [{ filePath: '', content: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        { withHooks: true, withComponent: false, withHOC: false, addDocBlocks: false },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      const queryDocBlock = extract(content.content.substr(content.content.indexOf('/**')));
+
+      expect(queryDocBlock).not.toMatchInlineSnapshot(queryDocBlockSnapshot);
+
+      const mutationDocBlock = extract(content.content.substr(content.content.lastIndexOf('/**')));
+
+      expect(mutationDocBlock).not.toMatchInlineSnapshot(mutationDocBlockSnapshot);
     });
   });
 


### PR DESCRIPTION
A configuration option to disable docblocks was requested in PR: https://github.com/dotansimha/graphql-code-generator/pull/2572#issuecomment-539019085

- Added addDocBlocks config option
- Added a test that covers the config option

Are docs autogenerated from the **[docblocks](https://github.com/dotansimha/graphql-code-generator/pull/2717/files#diff-28a8359a9001055804c02e58d2430315R177)** (insert Xzibit meme) or are they required to be added somewhere else?

CC: @levrik does this suit your needs?