### PR TITLE
Fix Bug when using react-apollo and transformUnderscore

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -285,8 +285,16 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
   }
 
   protected buildOperation(node: OperationDefinitionNode, documentVariableName: string, operationType: string, operationResultType: string, operationVariablesTypes: string): string {
-    operationResultType = `${this._prefix}${operationResultType}`;
-    operationVariablesTypes = `${this._prefix}${operationVariablesTypes}`;
+    operationResultType = this.convertName(operationResultType, {
+      prefix: this._prefix,
+      useTypesPrefix: false,
+    });
+
+    operationVariablesTypes = this.convertName(operationVariablesTypes, {
+      prefix: this._prefix,
+      useTypesPrefix: false,
+    });
+
     const mutationFn = this.config.withMutationFn || this.config.withComponent ? this._buildMutationFn(node, operationResultType, operationVariablesTypes) : null;
     const component = this.config.withComponent ? this._buildComponent(node, documentVariableName, operationType, operationResultType, operationVariablesTypes) : null;
     const hoc = this.config.withHOC ? this._buildOperationHoc(node, documentVariableName, operationResultType, operationVariablesTypes) : null;


### PR DESCRIPTION
We encountered a bug when using hooks with typescript-react-apollo and the option transformUnderscore enabled.

Configuration file:
```
overwrite: true
schema: '...'
documents: ['...']
generates:
  something/:
    preset: near-operation-file
    presetConfig:
      extension: .generated.tsx
      baseTypesPath: types.ts
    plugins:
      - typescript-operations
      - typescript-react-apollo
    config:
      withHooks: true
      withComponent: false
      withHOC: false
      skipTypename: true
      namingConvention:
        typeNames: change-case#pascalCase
        enumValues: keep
        transformUnderscore: true
      documentMode: external
      importDocumentNodeExternallyFrom: near-operation-file
```

This generates the correct types (`GET_SOMEHTING` leads to `GetSomethingQuery`) and the correct hooks (`use_GET_SOMEHTING` leads to `useGetSomethingQuery`) but the generics are wrong (`Get_SomethingQuery` rather than `GetSomethingQuery`) and therefore can't be found.

With the fix provided in this PR the generics will be correctly generated as well.