### PR TITLE
Added start for webpack/babel compatible declarations

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/index.ts
+++ b/packages/plugins/typescript/react-apollo/src/index.ts
@@ -171,6 +171,7 @@ export interface ReactApolloRawPluginConfig extends RawClientSideBasePluginConfi
    *
    */
   withMutationOptionsType?: boolean;
+  asGraphqlModule?: boolean;
 }
 
 export const plugin: PluginFunction<ReactApolloRawPluginConfig> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: ReactApolloRawPluginConfig) => {

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -19,6 +19,7 @@ export interface ReactApolloPluginConfig extends ClientSideBasePluginConfig {
   reactApolloVersion: 2 | 3;
   withResultType: boolean;
   withMutationOptionsType: boolean;
+  asGraphqlModule: boolean;
 }
 
 export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPluginConfig, ReactApolloPluginConfig> {
@@ -39,6 +40,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
       reactApolloVersion: getConfigValue(rawConfig.reactApolloVersion, 2),
       withResultType: getConfigValue(rawConfig.withResultType, true),
       withMutationOptionsType: getConfigValue(rawConfig.withMutationOptionsType, true),
+      asGraphqlModule: getConfigValue(rawConfig.asGraphqlModule, false),
     });
 
     this._prefix = this.config.importOperationTypesFrom ? `${this.config.importOperationTypesFrom}.` : '';
@@ -288,6 +290,9 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     const resultType = this.config.withResultType ? this._buildResultType(node, operationType, operationResultType, operationVariablesTypes) : null;
     const mutationOptionsType = this.config.withMutationOptionsType ? this._buildWithMutationOptionsType(node, operationResultType, operationVariablesTypes) : null;
 
-    return [mutationFn, component, hoc, hooks, resultType, mutationOptionsType].filter(a => a).join('\n');
+    const declarationPrefix = this.config.asGraphqlModule ? 'declare module "foo.graphql" {' : '';
+    const declarationSuffix = this.config.asGraphqlModule ? '}' : '';
+
+    return [declarationPrefix, mutationFn, component, hoc, hooks, resultType, mutationOptionsType, declarationSuffix].filter(a => a).join('\n');
   }
 }

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1263,7 +1263,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
   });
 
   describe('Graphql Module', () => {
-    it('declare a graphql module if asGraphqlModule is true', async () => {
+    it('should declare a graphql module if asGraphqlModule is true', async () => {
       const documents = parse(/* GraphQL */ `
         query feed($id: ID!) {
           feed(id: $id) {
@@ -1282,13 +1282,13 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
       const content = (await plugin(
         schema,
         docs,
-        { withHooks: true, withComponent: false, withHOC: false },
+        { withHooks: true, withComponent: false, withHOC: false, asGraphqlModule: true },
         {
           outputFile: 'graphql.tsx',
         }
       )) as Types.ComplexPluginOutput;
 
-      expect(content).toEqual('foo');
+      expect(content.content).toEqual('foo');
     });
   });
 

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1262,6 +1262,36 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
     });
   });
 
+  describe('Graphql Module', () => {
+    it('declare a graphql module if asGraphqlModule is true', async () => {
+      const documents = parse(/* GraphQL */ `
+        query feed($id: ID!) {
+          feed(id: $id) {
+            id
+          }
+        }
+        mutation submitRepository($name: String) {
+          submitRepository(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+
+      const docs = [{ filePath: '', content: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        { withHooks: true, withComponent: false, withHOC: false },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content).toEqual('foo');
+    });
+  });
+
   describe('documentMode and importDocumentNodeExternallyFrom', () => {
     const multipleOperationDoc = parse(/* GraphQL */ `
       query testOne {


### PR DESCRIPTION
@dotansimha @mxstbr I've started working on making a plugin able to output "declarations only". In order to be compatible with something like a babel-macro or webpack-loader.

A few things I would like some feedback on before continuing:

I think there are two approaches we can take. Either we make "declarations only" a configuration option per plugin. Or we can adjust the graphql-module plugin to somehow include the modified output of specific compatible plugins.

I could also use some pointers on how to get the document file path inside a plugin nicely, that way we can declare the module with the path accordingly.

Would love to hear your thoughts 🙌 

