### PR TITLE
Added support for custom scalars

### DIFF
--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -172,7 +172,20 @@ export class TypeGraphQLVisitor<TRawConfig extends TypeGraphQLPluginConfig = Typ
     const isArray = !!nonNullableType.match(ARRAY_REGEX);
     const singularType = nonNullableType.replace(ARRAY_REGEX, '$1');
     const isScalar = !!singularType.match(SCALAR_REGEX);
-    const type = singularType.replace(SCALAR_REGEX, (match, type) => (global[type] ? type : `TypeGraphQL.${type}`));
+    const type = singularType.replace(SCALAR_REGEX, (match, type) => {
+      if (TYPE_GRAPHQL_SCALARS.includes(type)) {
+        // This is a TypeGraphQL type
+        return `TypeGraphQL.${type}`;
+      } else if (global[type]) {
+        // This is a JS native type
+        return type;
+      } else if (this.scalars[type]) {
+        // This is a type specified in the configuration
+        return this.scalars[type];
+      } else {
+        throw new Error(`Unknown scalar type ${type}`);
+      }
+    });
 
     return { type, isNullable, isArray, isScalar };
   }

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -314,4 +314,28 @@ describe('type-graphql', () => {
         }
       `);
   });
+
+  it('should generate custom scalar types', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      scalar DateTime
+
+      type A {
+        date: DateTime
+        mandatoryDate: DateTime!
+      }
+    `);
+
+    const result = (await plugin(schema, [], { scalars: { DateTime: 'Date' } }, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.ObjectType()
+      export class A {
+        __typename?: 'A';
+        @TypeGraphQL.Field(type => Date, { nullable: true })
+        date!: Maybe<Scalars['DateTime']>;
+        @TypeGraphQL.Field(type => Date)
+        mandatoryDate!: Scalars['DateTime'];
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Hello, I did come across a problem that when I provided a custom scalar, it would try and find the type in the graphql-type package. This type did of course not exist and it would define it as any in the code generated graphql file. 

So I thought it would be nice to have custom scalar support in the plugin :)



