### PR TITLE
Added support for custom scalars

### DIFF
--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -172,7 +172,20 @@ export class TypeGraphQLVisitor<TRawConfig extends TypeGraphQLPluginConfig = Typ
     const isArray = !!nonNullableType.match(ARRAY_REGEX);
     const singularType = nonNullableType.replace(ARRAY_REGEX, '$1');
     const isScalar = !!singularType.match(SCALAR_REGEX);
-    const type = singularType.replace(SCALAR_REGEX, (match, type) => (global[type] ? type : `TypeGraphQL.${type}`));
+    const type = singularType.replace(SCALAR_REGEX, (match, type) => {
+      if (TYPE_GRAPHQL_SCALARS.includes(type)) {
+        // This is a TypeGraphQL type
+        return `TypeGraphQL.${type}`;
+      } else if (global[type]) {
+        // This is a JS native type
+        return type;
+      } else if (this.scalars[type]) {
+        // This is a type specified in the configuration
+        return this.scalars[type];
+      } else {
+        throw new Error(`Unknown scalar type ${type}`);
+      }
+    });
 
     return { type, isNullable, isArray, isScalar };
   }

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -314,4 +314,28 @@ describe('type-graphql', () => {
         }
       `);
   });
+
+  it('should generate custom scalar types', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      scalar DateTime
+
+      type A {
+        date: DateTime
+        mandatoryDate: DateTime!
+      }
+    `);
+
+    const result = (await plugin(schema, [], { scalars: { DateTime: 'Date' } }, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.ObjectType()
+      export class A {
+        __typename?: 'A';
+        @TypeGraphQL.Field(type => Date, { nullable: true })
+        date!: Maybe<Scalars['DateTime']>;
+        @TypeGraphQL.Field(type => Date)
+        mandatoryDate!: Scalars['DateTime'];
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Hello, I did come across a problem that when I provided a custom scalar, it would try and find the type in the graphql-type package. This type did of course not exist and it would define it as any in the code generated graphql file.

So I thought it would be nice to have custom scalar support in the plugin :)

```
    generate({
      overwrite: true,
      schema: `http://${minikubeIP.trim()}/micro-service/graphql`,
      documents: 'src/queries/micro-service/**/*.graphql',
      generates: {
        'src/generated/micro-service-graphql.ts': {
          plugins: [{ [TYPESCRIPT_TYPE_GRAPHQL_PLUGIN]: { scalars: { DateTime: "Date" } } }, TYPESCRIPT_OPERATIONS_PLUGIN]
        },
        'src/generated/micro-service-graphql-modules.d.ts': {
          plugins: [TYPESCRIPT_GRAPHQL_FILES_MODULES_PLUGIN]
        },
        'src/generated/micro-service.graphql': {
          plugins: [TYPESCRIPT_SCHEMA_AST_PLUGIN]
        }
      }
    })
```

Would generate something like this.

Added to the scalars with correct type;
```
export type Scalars = {
  ID: string,
  String: string,
  Boolean: boolean,
  Int: number,
  Float: number,
  DateTime: Date,
};
```

If it would find the type as a native js type it would produce a field like this.
```
@TypeGraphQL.ObjectType()
export class Class {
  __typename?: 'Class';

  @TypeGraphQL.Field(type => Date)
  field!: Scalars['DateTime'];
};
```

An important note to Apollo client users! 
I'm using Apollo client myself and there [isn't support to automatically interpret custom scalars](https://www.apollographql.com/docs/graphql-tools/scalars/#custom-scalars). So sadly you have to map the values to the correct type yourself. There also doesn't seem to be any plans for integrating it because of this [thread](https://github.com/apollographql/apollo-client/issues/585).

For example in a resolver, we have an Apollo client that does a call and get objects back. The field contains a date type but still needs to be converted so one way of doing this:

```
  const objects = (await microServiceClient.query<
      QueryType,
      QueryVariables
    >({
      query: QueryDoc,
      variables: {
        variable
      }  
    })).data.objects;

    return objects.map(object => ({
      ...object,
      field: new Date(object.field)
    }));
```