### PR TITLE
feat(typescript): support preceding comments

### DIFF
--- a/packages/graphql-codegen-cli/src/utils/try-to-build-schema.ts
+++ b/packages/graphql-codegen-cli/src/utils/try-to-build-schema.ts
@@ -3,7 +3,7 @@ import { debugLog } from './debugging';
 
 export function tryToBuildSchema(schema: DocumentNode): GraphQLSchema {
   try {
-    return buildASTSchema(schema);
+    return buildASTSchema(schema, { commentDescriptions: true });
   } catch (e) {
     debugLog(`Unable to build AST schema from DocumentNode, will try again later...`, e);
 


### PR DESCRIPTION
commentDescriptions: Provide true to use preceding comments as the description, eg "# comment"