### PR TITLE
Correct a typo in docs/getting-started

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -87,7 +87,7 @@ GraphQL Code Generator lets you setup everything by simply running the following
 
     $ graphql-codegen init
 
-Question by question, it will guide you through the whole process of setting up a schema, selecting and intalling plugins, picking a destination of a generated file and a lot more.
+Question by question, it will guide you through the whole process of setting up a schema, selecting and installing plugins, picking a destination of a generated file and a lot more.
 
 If you don't want to use the wizard, we've got you covered, just continue reading the next sections.
 


### PR DESCRIPTION
This fixes a typo in the Getting started part of the documentation.