### PR TITLE
[Flow] Make interface implementing types exact when object spreading.

### DIFF
--- a/packages/plugins/flow/flow/src/visitor.ts
+++ b/packages/plugins/flow/flow/src/visitor.ts
@@ -100,7 +100,17 @@ export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginPa
       return allFields.join('\n');
     }
 
-    return `...{\n${allFields.map(s => indent(s)).join('\n')}\n  }`;
+    return (
+      new DeclarationBlock(this._declarationBlockConfig)
+        .withContent('...')
+        .withBlock(allFields.join('\n'))
+        .ignoreBlockSemicolon(true)
+        .string.slice(0, -1) // Removes trailing newline from stringified block.
+        .split('\n')
+        // First line gets indented independently when joined in appendInterfacesAndFieldsToBlock.
+        .map((s, i) => (i !== 0 ? indent(s) : s))
+        .join('\n')
+    );
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {

--- a/packages/plugins/flow/flow/tests/__snapshots__/flow.spec.ts.snap
+++ b/packages/plugins/flow/flow/tests/__snapshots__/flow.spec.ts.snap
@@ -202,26 +202,26 @@ export type Scalars = {|
 
 export type impl_2 = {|
   ...some_interface,
-  ...{
+  ...{|
      __typename?: 'Impl_2',
     id: $ElementType<Scalars, 'ID'>,
-  }
+  |}
 |};
 
 export type impl_3 = {|
   ...some_interface,
-  ...{
+  ...{|
      __typename?: 'impl_3',
     id: $ElementType<Scalars, 'ID'>,
-  }
+  |}
 |};
 
 export type impl1 = {|
   ...some_interface,
-  ...{
+  ...{|
      __typename?: 'Impl1',
     id: $ElementType<Scalars, 'ID'>,
-  }
+  |}
 |};
 
 export type my_type = {|
@@ -272,26 +272,26 @@ export type Scalars = {|
 
 export type Impl_2 = {|
   ...Some_Interface,
-  ...{
+  ...{|
      __typename?: 'Impl_2',
     id: $ElementType<Scalars, 'ID'>,
-  }
+  |}
 |};
 
 export type Impl_3 = {|
   ...Some_Interface,
-  ...{
+  ...{|
      __typename?: 'impl_3',
     id: $ElementType<Scalars, 'ID'>,
-  }
+  |}
 |};
 
 export type Impl1 = {|
   ...Some_Interface,
-  ...{
+  ...{|
      __typename?: 'Impl1',
     id: $ElementType<Scalars, 'ID'>,
-  }
+  |}
 |};
 
 export type My_Type = {|
@@ -342,26 +342,26 @@ export type Scalars = {|
 
 export type IImpl_2 = {|
   ...ISome_Interface,
-  ...{
+  ...{|
      __typename?: 'Impl_2',
     id: $ElementType<Scalars, 'ID'>,
-  }
+  |}
 |};
 
 export type IImpl_3 = {|
   ...ISome_Interface,
-  ...{
+  ...{|
      __typename?: 'impl_3',
     id: $ElementType<Scalars, 'ID'>,
-  }
+  |}
 |};
 
 export type IImpl1 = {|
   ...ISome_Interface,
-  ...{
+  ...{|
      __typename?: 'Impl1',
     id: $ElementType<Scalars, 'ID'>,
-  }
+  |}
 |};
 
 export type IMy_Type = {|
@@ -504,10 +504,10 @@ export type MyInterface = {|
 
 export type MyType = {|
   ...MyInterface,
-  ...{
+  ...{|
      __typename?: 'MyType',
     foo: $ElementType<Scalars, 'String'>,
-  }
+  |}
 |};
 "
 `;
@@ -533,11 +533,11 @@ export type MyOtherInterface = {|
 export type MyType = {|
   ...MyInterface,
   ...MyOtherInterface,
-  ...{
+  ...{|
      __typename?: 'MyType',
     foo: $ElementType<Scalars, 'String'>,
     bar: $ElementType<Scalars, 'String'>,
-  }
+  |}
 |};
 "
 `;

--- a/packages/plugins/flow/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/flow/tests/flow.spec.ts
@@ -484,26 +484,26 @@ describe('Flow Plugin', () => {
 
       expect(result.content).toBeSimilarStringTo(`export type Impl1 = {|
         ...Some_Interface,
-        ...{
+        ...{|
            __typename?: 'Impl1',
           id: $ElementType<Scalars, 'ID'>,
-        }
+        |}
       |};`);
 
       expect(result.content).toBeSimilarStringTo(`export type Impl_2 = {|
         ...Some_Interface,
-        ...{
+        ...{|
            __typename?: 'Impl_2',
           id: $ElementType<Scalars, 'ID'>,
-        }
+        |}
       |};`);
 
       expect(result.content).toBeSimilarStringTo(`export type Impl_3 = {|
         ...Some_Interface,
-        ...{
+        ...{|
            __typename?: 'impl_3',
           id: $ElementType<Scalars, 'ID'>,
-        }
+        |}
       |};`);
 
       expect(result.content).toBeSimilarStringTo(`export type Query = {|
@@ -549,26 +549,26 @@ describe('Flow Plugin', () => {
 
       expect(result.content).toBeSimilarStringTo(`export type IImpl1 = {|
         ...ISome_Interface,
-        ...{
+        ...{|
            __typename?: 'Impl1',
           id: $ElementType<Scalars, 'ID'>,
-        }
+        |}
       |};`);
 
       expect(result.content).toBeSimilarStringTo(`export type IImpl_2 = {|
         ...ISome_Interface,
-        ...{
+        ...{|
            __typename?: 'Impl_2',
           id: $ElementType<Scalars, 'ID'>,
-        }
+        |}
       |};`);
 
       expect(result.content).toBeSimilarStringTo(`export type IImpl_3 = {|
         ...ISome_Interface,
-        ...{
+        ...{|
            __typename?: 'impl_3',
           id: $ElementType<Scalars, 'ID'>,
-        }
+        |}
       |};`);
 
       expect(result.content).toBeSimilarStringTo(`export type IQuery = {|

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -110,6 +110,7 @@ export class DeclarationBlock {
   _nameGenerics = null;
   _comment = null;
   _ignoreBlockWrapper = false;
+  _ignoreBlockSemicolon = false;
 
   constructor(private _config: DeclarationBlockConfig) {
     this._config = {
@@ -174,6 +175,11 @@ export class DeclarationBlock {
     return this;
   }
 
+  ignoreBlockSemicolon(ignore: boolean): DeclarationBlock {
+    this._ignoreBlockSemicolon = ignore;
+    return this;
+  }
+
   public get string(): string {
     let result = '';
 
@@ -221,7 +227,7 @@ export class DeclarationBlock {
       result += '{}';
     }
 
-    return (this._comment ? this._comment : '') + result + (this._kind === 'interface' || this._kind === 'enum' || this._kind === 'namespace' ? '' : ';') + '\n';
+    return (this._comment ? this._comment : '') + result + (this._ignoreBlockSemicolon || this._kind === 'interface' || this._kind === 'enum' || this._kind === 'namespace' ? '' : ';') + '\n';
   }
 }
 


### PR DESCRIPTION
The issue described in #2772 is also visible with general Flow schema types generation. 

Due to that Flow checks will fail because inexact type is incompatible with exact overall type.

If these changes are OK, I can also dig into fixing it with `flow-operations`.

As side note: @dotansimha what do you think about the option to make interface types NOT exact (with option or not)? The issue here is that if we define a resolver return type with an exact type, we cannot return a type that is a superset to that interface. Making it inexact will help to return anything compliant with that actual interface.