### PR TITLE
add filename to target file

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -138,7 +138,7 @@ async function doSomething() {
       schema: 'http://127.0.0.1:3000/graphql',
       documents: './src/**/*.graphql',
       generates: {
-        [process.cwd() + '/models/']: {
+        [process.cwd() + '/models/types.d.ts']: {
           plugins: ['typescript'],
         },
       },


### PR DESCRIPTION
In the [Using in runtime](https://graphql-code-generator.com/docs/getting-started/#using-in-runtime) section, the `generates` file points to a directory and hence throws:
`Error: EISDIR: illegal operation on a directory`

It gets fixed by providing the file name.