### PR TITLE
make fragment-matcher compatible with Apollo Client 3

### DIFF
--- a/packages/plugins/other/fragment-matcher/tests/plugin.spec.ts
+++ b/packages/plugins/other/fragment-matcher/tests/plugin.spec.ts
@@ -1,7 +1,9 @@
 import '@graphql-codegen/testing';
-import { buildASTSchema, parse } from 'graphql';
+
 import { codegen } from '@graphql-codegen/core';
+import { buildASTSchema, parse } from 'graphql';
 import gql from 'graphql-tag';
+
 import { plugin, validate } from '../src';
 
 const schema = buildASTSchema(gql`
@@ -27,24 +29,8 @@ const schema = buildASTSchema(gql`
 // should only contain Unions and Interfaces
 const introspection = JSON.stringify(
   {
-    __schema: {
-      types: [
-        {
-          kind: 'UNION',
-          name: 'People',
-          possibleTypes: [
-            {
-              name: 'Character',
-            },
-            {
-              name: 'Jedi',
-            },
-            {
-              name: 'Droid',
-            },
-          ],
-        },
-      ],
+    possibleTypes: {
+      People: ['Character', 'Jedi', 'Droid'],
     },
   },
   null,
@@ -176,19 +162,13 @@ describe('Fragment Matcher Plugin', () => {
         }
       );
       const output = `
-        export interface IntrospectionResultData {
-          __schema: {
-            types: {
-              kind: string;
-              name: string;
-              possibleTypes: {
-                name: string;
-              }[];
-            }[];
-          };
+      export interface PossibleTypesResultData {
+        possibleTypes: {
+          [key: string]: string[]
         }
+      }
 
-        const result: IntrospectionResultData = ${introspection};  
+        const result: PossibleTypesResultData = ${introspection};  
 
         export default result;
       `;


### PR DESCRIPTION
Apollo announced Client version 3. It is in beta right now. The configuration for the fragment matcher has been changed. 

The new configuration can be found [here](https://www.apollographql.com/docs/react/v3.0-beta/data/fragments/#defining-possibletypes-manually)

This pull request aims to make fragment-matcher plugin compatible with the new Apollo Client v3.