### PR TITLE
Add query variables to stencil apollo plugin

### DIFF
--- a/packages/plugins/typescript/stencil-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/stencil-apollo/src/visitor.ts
@@ -73,8 +73,9 @@ export const ${componentName} = (props: ${propsTypeName}, children: [StencilApol
 })
 export class ${componentName} {
     @Prop() renderer: import('stencil-apollo').${rendererSignature}<${operationResultType}, ${operationVariablesTypes}>;
+    @Prop() variables: ${operationVariablesTypes};
     render() {
-        return <${apolloStencilComponentTag} ${operationType.toLowerCase()}={ ${documentVariableName} } renderer={ this.renderer } />;
+        return <${apolloStencilComponentTag} ${operationType.toLowerCase()}={ ${documentVariableName} } variables={ this.variables } renderer={ this.renderer } />;
     }
 }
       `;

--- a/packages/plugins/typescript/stencil-apollo/tests/stencil-apollo.spec.ts
+++ b/packages/plugins/typescript/stencil-apollo/tests/stencil-apollo.spec.ts
@@ -94,4 +94,37 @@ describe('Components', () => {
             }
       `);
   });
+
+  it('should generate Class Component with variables', async () => {
+    const documents = gql`
+      query Feed($limit: Int) {
+        feed(limit: $limit) {
+          id
+          commentCount
+          repository {
+            full_name
+            html_url
+            owner {
+              avatar_url
+            }
+          }
+        }
+      }
+    `;
+
+    const { content } = (await plugin(schema, [{ filePath: '', content: documents }], { componentType: StencilComponentType.class }, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(content).toBeSimilarStringTo(`
+            @Component({
+                tag: 'apollo-feed'
+            })
+            export class FeedComponent {
+                @Prop() renderer: import('stencil-apollo').QueryRenderer<FeedQuery, FeedQueryVariables>;
+                @Prop() variables: FeedQueryVariables;
+                render() {
+                    return <apollo-query query={ FeedDocument } variables={ this.variables } renderer={ this.renderer } />;
+                }
+            }
+      `);
+  });
 });

--- a/packages/plugins/typescript/stencil-apollo/tests/stencil-apollo.spec.ts
+++ b/packages/plugins/typescript/stencil-apollo/tests/stencil-apollo.spec.ts
@@ -88,8 +88,9 @@ describe('Components', () => {
             })
             export class FeedComponent {
                 @Prop() renderer: import('stencil-apollo').QueryRenderer<FeedQuery, FeedQueryVariables>;
+                @Prop() variables: FeedQueryVariables;
                 render() {
-                    return <apollo-query query={ FeedDocument } renderer={ this.renderer } />;
+                    return <apollo-query query={ FeedDocument } variables={ this.variables } renderer={ this.renderer } />;
                 }
             }
       `);


### PR DESCRIPTION
Fixes #2848 .

This PR adds query variables for the `typescript-stencil-apollo` plugin. Basically it just involved changing the generated template and adding `variables= { this.variables }` to the used `<apollo-query>` StencilJS component.

It has the drawback, that it does so for **all** queries, regardless whether they actually **have** _any_ variables or not - but this will work anyway, because `typescript-operations` will generate a _"proper"_ _empty_ QueryVariables type (actually `{}`) and queries will still work.

Therefore I had to change the old test case.

I would make the variables stuff generation _optional_, but I did not find an easy way on **how** to get to know about **whether** the passed schema contains any variables at all in the `StencilApolloVisitor`.

Docs are still off a bit; but I think this should be fixed separately.