### PR TITLE
Fix typos and improve wording in Getting Started docs

### DIFF
--- a/docs/getting-started/codegen-config.md
+++ b/docs/getting-started/codegen-config.md
@@ -21,53 +21,53 @@ generates:
       - typescript-operations
 ```
 
-A more robust config file can be seen [here](https://github.com/dotansimha/graphql-code-generator/blob/master/dev-test/codegen.yml).
+A very large config file can be seen [here](https://github.com/dotansimha/graphql-code-generator/blob/master/dev-test/codegen.yml).
 
 ## Available Options
 
-Here are the supported options that you can define in the config file (see [source code](https://github.com/dotansimha/graphql-code-generator/blob/master/packages/utils/plugins-helpers/src/types.ts#L51)):
+Here are the supported options that you can define in the config file (see [source code](https://github.com/dotansimha/graphql-code-generator/blob/master/packages/utils/plugins-helpers/src/types.ts#L92)):
 
-- [**`schema` (required)**](./schema-field#root-level) - A URL to your GraphQL endpoint, a local path to `.graphql` file, a glob pattern to your GraphQL schema files, or a JavaScript file that exports the schema to generate code from. This can also be an array which specifies multiple schemas to generate code from. [You can read more about the supported formats here](./schema-field#available-formats)
+- [**`schema` (required)**](./schema-field#root-level) - A URL to your GraphQL endpoint, a local path to `.graphql` file, a glob pattern to your GraphQL schema files, or a JavaScript file that exports the schema to generate code from. This can also be an array which specifies multiple schemas to generate code from. You can read more about the supported formats [here](./schema-field#available-formats).
 
-- [**`documents`**](./documents-field#root-level) - Array of paths or glob patterns for files which export GraphQL documents using a `gql` tag or a plain string; for example: `./src/**/*.graphql`. You can also provide this options with a string instead of an array, in case you're dealing with a single document. [You can read more about the supported formats here](./documents-field#available-formats)
+- [**`documents`**](./documents-field#root-level) - Array of paths or glob patterns for files which export GraphQL documents using a `gql` tag or a plain string; for example: `./src/**/*.graphql`. You can also provide this options with a string instead of an array, in case you're dealing with a single document. You can read more about the supported formats [here](./documents-field#available-formats).
 
 - **`generates` (required)** - A map where the key represents an output path for the generated code and the value represents a set of options which are relevant for that specific file. Below are the possible options that can be specified:
 
-  - **`generates.plugins` (required)** - A list of plug-ins to use when generating the file. Templates are also considered as plug-ins and they can be specified in this section. A full list of supported plugins can be found [here](../plugins). You can also point to a custom plugin in a local file (see [Custom Plugins](../custom-codegen/index) section)
-
-  - [**`generates.documents`**](./documents-field#output-file-level) - Same as root `documents`, but applies only for the specific output file.
+  - **`generates.plugins` (required)** - A list of plugins to use when generating the file. Templates are also considered as plugins and they can be specified in this section. A full list of supported plugins can be found [here](../plugins). You can also point to a custom plugin in a local file (see [Custom Plugins](../custom-codegen/index)).
 
   - [**`generates.schema`**](./schema-field#output-file-level) - Same as root `schema`, but applies only for the specific output file.
 
+  - [**`generates.documents`**](./documents-field#output-file-level) - Same as root `documents`, but applies only for the specific output file.
+
   - [**`generates.config`**](./config-field#output-level) - Same as root `config`, but applies only for the specific output file.
 
-  - [**`generates.overwrite`**](./config-field#output-level) - Same as root `overwrite`, but applies only for the specific output file.
+  - **`generates.overwrite`** - Same as root `overwrite`, but applies only for the specific output file.
 
 - [**`require`**](./require-field) - A path to a file which defines custom Node.JS `require()` handlers for custom file extensions. This is essential if the code generator has to go through files which require other files in an unsupported format (by default). See [more information](https://gist.github.com/jamestalmage/df922691475cff66c7e6). Note that values that specified in your `.yml` file will get loaded after loading the `.yml` file.
 
-- [**`config`**](./config-field#root-level) - Options that we would like to provide to the specified plug-ins. The options may vary depends on what plug-ins you specified. Read the documentation of that specific plug-in for more information. [You can read more about how to pass configuration to plugins here](./config-field)
+- [**`config`**](./config-field#root-level) - Options that we would like to provide to the specified plugins. The options may vary depends on what plugins you specified. Read the documentation of that specific plugin for more information. You can read more about how to pass configuration to plugins [here](./config-field).
 
-- **`overwrite`** - A flag to overwrite files in case they're already exist when generating code (`true` by default)
+- **`overwrite`** - A flag to overwrite files if they already exist when generating code (`true` by default).
 
-- **`watch`** - A flag to watch for changes in the specified GraphQL schemas and re-generate code any that happens. You can either specify a boolean to turn it on/off, or specify an array of glob patterns to add custom files to the watch.
+- **`watch`** - A flag to trigger codegen when there are changes in the specified GraphQL schemas. You can either specify a boolean to turn it on/off or specify an array of glob patterns to add custom files to the watch.
 
-- **`silent`** - A flag to not print errors in case they occur.
+- **`silent`** - A flag to suppress printing errors when they occur.
 
-- **`hooks`** - Specifies scripts to run when events are happening in the codegen's core. [You can read more about lifecycle hooks here here](./lifecycle-hooks). You can specify this on your root configuration, or per each output.
+- **`hooks`** - Specifies scripts to run when events are happening in the codegen's core. You can read more about lifecycle hooks [here](./lifecycle-hooks). You can specify this on your root configuration or on each output.
 
-- **`pluginLoader`** - If you are using the programmatic API in browser environment, you can override this configuration to load your plugins in a way different then `require`.
-  \
-- **`pluckConfig`** - Allow you to override the configuration for `graphql-tag-pluck` (the tool that extracts your GraphQL operations from your code files).
+- **`pluginLoader`** - If you are using the programmatic API in a browser environment, you can override this configuration to load your plugins in a way different than `require`.
 
-  - **`pluckConfig.modules`** - An array of `{ name: string, identifier: string }` that will be used to track down your `gql` usages and imports. Use this if your code files imports `gql` from another library, or you have a custom `gql` tag.
+- **`pluckConfig`** - Allows you to override the configuration for `graphql-tag-pluck`, the tool that extracts your GraphQL operations from your code files.
 
-  - **`pluckConfig.magicComment`** - Configure the magic GraphQL comments to look for (the default is `/* GraphQL */`).
+  - **`pluckConfig.modules`** - An array of `{ name: string, identifier: string }` that will be used to track down your `gql` usages and imports. Use this if your code files imports `gql` from another library or you have a custom `gql` tag.
+
+  - **`pluckConfig.magicComment`** - Configures the magic GraphQL comments to look for. The default is `/* GraphQL */`).
 
   - **`pluckConfig.globalIdentifier`** - Overrides the name of the default GraphQL name identifier.
 
 ## Environment Variables
 
-You can use environment variables in your `codegen.yml` file like that:
+You can use environment variables in your `codegen.yml` file::
 
 ```yml
 schema: ${SCHEMA_PATH}
@@ -79,9 +79,9 @@ generates:
       - typescript-operations
 ```
 
-If you wish, you can also load `.env` file by adding `-r dotenv/config` flag to your CLI execution.
+You can load an `.env` file by adding the `-r dotenv/config` option to your CLI command.
 
-Additionally, you can specify default value in case of a missing environment variable:
+You can specify a default value in case an environment variable is missing:
 
 ```yml
 schema: ${SCHEMA_PATH:schema.graphql}
@@ -89,20 +89,20 @@ schema: ${SCHEMA_PATH:schema.graphql}
 
 ## CLI Flags
 
-The Codegen also supports several CLI flags, that allow you to override the default behaviour specified in your `.yml` config file:
+The Codegen also supports several CLI flags that allow you to override the default behaviour specified in your `.yml` config file:
 
-- **`--config`** (`-c`) - Overrides the Codegen configuration file path.
+- **`--config` (`-c`)** - Specifies the codegen config file to use.
 
-- **`--watch`** (`-w`) - Allow you to override the `watch` mode set by the config file.
+- **`--watch` (`-w`)** - Overrides the `watch` config to true.
 
-- **`--silent`** (`-s`) - Silents the command line output.
+- **`--silent` (`-s`)** - Overrides the `silent` config to true.
 
-- **`--require`** (`-r`) - Allow you to load `require.extensions` before loading the `.yml` file.
+- **`--require` (`-r`)** - Specifies `require.extensions` before loading the `.yml` file.
 
-- **`--overwrite`** (`-o`) - Allow you to override the `overwrite` configuration flag.
+- **`--overwrite` (`-o`)** - Overrides the `overwrite` config to true.
 
 ## Debug Mode
 
-You can set the `DEBUG` environment to `1` in order to tell the Codegen to print debug information.
+You can set the `DEBUG` environment variable to `1` in order to tell the codegen to print debug information.
 
-You can set the `VERBOSE` environment to `1` in order to tell the codegen to print more information regarding the CLI output (`listr`).
+You can set the `VERBOSE` environment variable to `1` in order to tell the codegen to print more information regarding the CLI output (`listr`).

--- a/docs/getting-started/config-field.md
+++ b/docs/getting-started/config-field.md
@@ -5,11 +5,11 @@ title: `config` field
 
 The `config` field is used to pass configuration to Plugins. You can specify it in multiple levels of your `.yml` file.
 
-It's a basic Key->Value map.
+It's a basic key-value map.
 
 ### Root Level
 
-If you specify it in your root level, all plugins, of all output files will get the config value:
+If you specify it in your root level, every plugin for each output file will get the config value:
 
 ```yml
 schema: schema.graphql
@@ -23,7 +23,7 @@ generates:
 
 ### Output Level
 
-You can also specify the `config` field per output, and then all plugins of that specific output will get the config value:
+If you specify it at the output file level, every plugin for specific output will get the config value:
 
 ```yml
 schema: schema.graphql
@@ -36,11 +36,11 @@ generates:
       - plugin2
 ```
 
-> Output level configuration overrides root-level config.
+> Output level configuration overrides root level configuration.
 
 ### Plugin Level
 
-You can also specify configuration directly for specific plugin:
+If you specify it at the plugin level, only that plugin will get the config value:
 
 ```yml
 schema: schema.graphql
@@ -52,4 +52,4 @@ generates:
         configKey: otherValue
 ```
 
-> Plugin level configuration overrides output-level and root-level config.
+> Plugin level configuration overrides output-level and root-level configuration.

--- a/docs/getting-started/documents-field.md
+++ b/docs/getting-started/documents-field.md
@@ -13,7 +13,7 @@ You can specify either a `string` pointing to your documents, or `string[]` poin
 
 ### Root level
 
-You can specify the `documents` field in your root level config, as follow:
+You can specify the `documents` field in your root level config:
 
 ```yml
 schema: http://localhost:3000/graphql
@@ -27,7 +27,7 @@ generates:
 
 ### Output-file level
 
-Or, you can specify it per-output file level.
+You can also specify the `documents` field in your generated file config:
 
 ```yml
 schema: http://server1.com/graphql
@@ -41,20 +41,18 @@ generates:
 
 ### Document Scanner
 
-The code-generator has a built-in document scanner, which means that you can specify a `.graphql` file, or code files, that contains GraphQL documents.
+The code-generator has a built-in document scanner, which means that you can specify a `.graphql` file or code files that contains GraphQL documents.
 
-You can use this this way:
+You can tell it to find documents in TypeScript files:
 
 ```yml
 schema: http://server1.com/graphql
 documents: "src/**/*.{ts,tsx}"
 ```
 
-And the code-generator will look for GraphQL documents inside your code files.
-
 ## Available formats
 
-The following can be specified as a single value, or as an array with mixed values.
+The following can be specified as a single value or as an array with mixed values.
 
 - ### Filename
 
@@ -80,7 +78,7 @@ You can specify a Glob expresion in order to load multiple files:
 documents: './src/**/*.graphql'
 ```
 
-You can also specify multiple Glob expressions, as array:
+You can also specify multiple Glob expressions as an array:
 
 ```yml
 documents:
@@ -88,7 +86,7 @@ documents:
   - './src/dir2/*.graphql'
 ```
 
-And, you can specify files to exclude: 
+You can specify files to exclude by prefixing the Glob expression with `!`:
 
 ```yml
 documents:
@@ -96,16 +94,16 @@ documents:
   - '!*.generated.graphql'
 ```
 
-> All provided glob expressions are being evaludated together - the usage is similar to `.gitingore` file.
+> All provided glob expressions are evaluated together. The usage is similar to `.gitignore`.
 
-Additionally, you can use code files and the codegen will try to extract the GraphQL operations from it:
+Additionally, you can use code files and the codegen will try to extract the GraphQL documents from it:
 
 ```yml
 documents:
   - './src/*.jsx'
 ```
 
-The codegen will try to load the file as AST and look for explicit GraphQL operations strings, but if it can't find those, it will try to `require` the file and looks for operations in the default export.
+The codegen will try to load the file as an AST and look for explicit GraphQL operations strings, but if it can't find those, it will try to `require` the file and look for operations in the default export.
 
 You can disable the `require` if it causes errors for you (for example, because of different module system):
 
@@ -115,11 +113,11 @@ documents:
     noRequire: true
 ```
 
-> Your operations should be declared as template string with `gql` tag (you can customize is with `pluckConfig`), or with a magic GraphQL comment (`const myQuery = /* GraphQL*/\`query { ... }\``)
+> Your operations should be declared as template strings with the `gql` tag or with a GraphQL comment (`` const myQuery = /* GraphQL*/\`query { ... }` ``). This can be configured with `pluckConfig`.
 
 - ### String
 
-You can specify your GraphQL documents directly as AST string in your config file. It's very useful for testing.
+You can specify your GraphQL documents directly as an AST string in your config file. It's very useful for testing.
 
 ```yml
 documents:
@@ -129,7 +127,7 @@ documents:
 
 ## Custom Document Loader
 
-If you documents has a different, or complicated way of loading, you can specify a custom loader (with the `loader` field) for your documents, by pointing to a code file that exports a `function` as default, in each documents that your are loading.
+If your schema has a different or complicated way of loading, you can specify a custom loader with the `loader` field.
 
 ```yml
 documents:
@@ -137,7 +135,7 @@ documents:
         loader: my-documents-loader.js
 ```
 
-Your custom loader should export a default function, and return an array of `{ filePath: string, content: DocumentNode }`. For example:
+Your custom loader should export a default function that returns an array of objects like `{ filePath: string, content: DocumentNode }`. For example:
 
 ```js
 const { parse } = require('graphql');

--- a/docs/getting-started/require-field.md
+++ b/docs/getting-started/require-field.md
@@ -3,7 +3,7 @@ id: require-field
 title: `require` field
 ---
 
-The GraphQL Code-Generator also support `require` extensions - that means that you can load any external files without the need to transpile it before.
+The `require` field allows you to load any external files without the need to transpile them before.
 
 ## How to use it?
 
@@ -19,7 +19,7 @@ Adding `require` extension is useful if you are loading your `GraphQLSchema` or 
 
 ## TypeScript Support
 
-If you wish to use TypeScript, just add [`ts-node`](https://github.com/TypeStrong/ts-node) from npm, and specify it's register export in your config file:
+If you wish to use TypeScript, just add [`ts-node`](https://github.com/TypeStrong/ts-node) from npm and specify its register export in your config file:
 
 ```yml
 require:
@@ -28,12 +28,12 @@ require:
 
 ## Specifying from the command line
 
-You can also specify `require.extensions` as a cli flag, using `-r`.
+You can also specify `require.extensions` as a cli flag using `-r`.
 
-Specifying `-r` using a CLI flag will load your `require.extension` _before_ loading the `.yml` file, and this way you can load environment variables using `dotenv`,and use those environment variables in your `.yml` config file.
+Specifying `-r` using a CLI flag will load your `require.extension` _before_ loading the `.yml` file, and this way you can load environment variables using `dotenv` and use those environment variables in your `.yml` config file.
 
 ### `dotenv` Integration
 
-If you wish to use [dotenv](https://github.com/motdotla/dotenv) to load environment variables, you can install `dotenv` from npm, and then to use `require` cli flag to preload the `dotenv` require extensions: `-r dotenv/config`.
+If you wish to use [dotenv](https://github.com/motdotla/dotenv) to load environment variables, you can install `dotenv` from npm and then to use the `require` cli flag to preload the `dotenv` require extensions: `-r dotenv/config`.
 
 It will make sure to load your `.env` file before executing the codegen and loading your `.yml` file.

--- a/docs/getting-started/schema-field.md
+++ b/docs/getting-started/schema-field.md
@@ -100,7 +100,7 @@ You can also point to multiple `.graphql` files, and the Code Generator will mer
 schema: src/**/*.graphql
 ```
 
-You can also specify multiplep patterns:
+You can also specify multiple patterns:
 
 ```yml
 schema:
@@ -116,7 +116,7 @@ schema:
   - '!*.generated.graphql'
 ```
 
-> All provided glob expressions are being evaludated together - the usage is similar to `.gitingore` file.
+> All provided glob expressions are evaluated together. The usage is similar to `.gitignore`.
 
 Additionally, you can use code files and the codegen will try to extract the GraphQL schema from it:
 
@@ -124,7 +124,7 @@ Additionally, you can use code files and the codegen will try to extract the Gra
 schema: './src/**/*.ts'
 ```
 
-The codegen will try to load the file as AST and look for explicit GraphQL strings, but if it can't find those, it will try to `require` the file and looks for operations in the default export.
+The codegen will try to load the file as an AST and look for explicit GraphQL strings, but if it can't find those, it will try to `require` the file and looks for operations in the default export.
 
 You can disable the `require` if it causes errors for you (for example, because of different module system or missing deps):
 
@@ -160,7 +160,7 @@ module.exports = buildSchema(/* GraphQL */ `
 
 - ### String
 
-You can specify your schema directly as AST string in your config file. It's very useful for testing.
+You can specify your schema directly as an AST string in your config file. It's very useful for testing.
 
 ```yml
 schema: 'type MyType { foo: String }    type Query { myType: MyType }'
@@ -168,7 +168,7 @@ schema: 'type MyType { foo: String }    type Query { myType: MyType }'
 
 ## Custom Schema Loader
 
-If you schema has a different, or complicated way of loading, you can specify a custom loader (with the `loader` field) for your schema, by pointing to a code file that exports a `function` as default, in each schema that your are loading.
+If your schema has a different or complicated way of loading, you can specify a custom loader with the `loader` field.
 
 ```yml
 schema:
@@ -178,7 +178,7 @@ schema:
       loader: my-file-loader.js
 ```
 
-Your custom loader should export a default function, and return `GraphQLSchema` object. For example:
+Your custom loader should export a default function that returns `GraphQLSchema` object. For example:
 
 ```js
 const { buildSchema } = require('graphql');


### PR DESCRIPTION
This fixes typos, improves wording, fixes links, and fixes formatting in configuration-related pages of the Getting Started docs.