### PR TITLE
Add SDK service that exposes all generated services in Apollo Angular plugin

### DIFF
--- a/packages/plugins/typescript/apollo-angular/src/index.ts
+++ b/packages/plugins/typescript/apollo-angular/src/index.ts
@@ -30,6 +30,30 @@ export interface ApolloAngularRawPluginConfig extends RawClientSideBasePluginCon
    * ```
    */
   namedClient?: string;
+  /**
+   * @name serviceName
+   * @type string
+   * @description Defined the global value of `serviceName`.
+   *
+   * @example graphql.macro
+   * ```yml
+   * config:
+   *   serviceName: 'MySDK'
+   * ```
+   */
+  serviceName?: string;
+  /**
+   * @name serviceProvidedInRoot
+   * @type string
+   * @description Defined the global value of `serviceProvidedInRoot`.
+   *
+   * @example graphql.macro
+   * ```yml
+   * config:
+   *   serviceProvidedInRoot: false
+   * ```
+   */
+  serviceProvidedInRoot?: boolean;
 }
 
 export const plugin: PluginFunction<ApolloAngularRawPluginConfig> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config) => {
@@ -49,7 +73,7 @@ export const plugin: PluginFunction<ApolloAngularRawPluginConfig> = (schema: Gra
 
   return {
     prepend: visitor.getImports(),
-    content: [visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n'),
+    content: [visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string'), visitor.sdkClass].join('\n'),
   };
 };
 

--- a/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
+++ b/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
@@ -222,7 +222,10 @@ describe('Apollo Angular', () => {
           }
         }
       `);
-      const docs = [{ filePath: '', content: myFeed }, { filePath: 'a.ts', content: myExtraFeed }];
+      const docs = [
+        { filePath: '', content: myFeed },
+        { filePath: 'a.ts', content: myExtraFeed },
+      ];
       const content = (await plugin(
         modifiedSchema,
         docs,
@@ -258,6 +261,92 @@ describe('Apollo Angular', () => {
       expect(content.content).toBeSimilarStringTo(`client = 'extra';`);
       expect(content.content).not.toContain('@namedClient');
 
+      validateTypeScript(content, modifiedSchema, docs, {});
+    });
+  });
+
+  describe('SDK Service', () => {
+    it('should generate a SDK service', async () => {
+      const modifiedSchema = extendSchema(schema, addToSchema);
+      const myFeed = gql(`
+        query MyFeed {
+          feed {
+            id
+          }
+        }
+      `);
+      const docs = [{ filePath: '', content: myFeed }];
+      const content = (await plugin(
+        modifiedSchema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      // NgModule
+      expect(content.prepend).toContain(`import { MutationOptionsAlone, QueryOptionsAlone, SubscriptionOptionsAlone, WatchQueryOptionsAlone } from 'apollo-angular/types';`);
+      // console.log('content.content', content.content);
+      expect(content.content).toBeSimilarStringTo(`
+        @Injectable({ providedIn: 'root' })
+        export class ApolloAngularSDK {
+        constructor(
+          private myFeedGql: MyFeedGQL
+        ) {}
+        
+        myFeed(variables?: MyFeedQueryVariables, options?: QueryOptionsAlone<MyFeedQueryVariables>) {
+          return this.myFeedGql.fetch(variables, options)
+        }
+
+        myFeedWatch(variables?: MyFeedQueryVariables, options?: WatchQueryOptionsAlone<MyFeedQueryVariables>) {
+          return this.myFeedGql.watch(variables, options)
+        }
+        }
+      `);
+      validateTypeScript(content, modifiedSchema, docs, {});
+    });
+    it('should generate a SDK service with custom settings', async () => {
+      const modifiedSchema = extendSchema(schema, addToSchema);
+      const myFeed = gql(`
+        query MyFeed {
+          feed {
+            id
+          }
+        }
+      `);
+      const docs = [{ filePath: '', content: myFeed }];
+      const content = (await plugin(
+        modifiedSchema,
+        docs,
+        {
+          serviceName: 'MySDK',
+          serviceProvidedInRoot: false,
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      // NgModule
+      expect(content.prepend).toContain(`import { MutationOptionsAlone, QueryOptionsAlone, SubscriptionOptionsAlone, WatchQueryOptionsAlone } from 'apollo-angular/types';`);
+      // console.log('content.content', content.content);
+      expect(content.content).toBeSimilarStringTo(`
+        @Injectable()
+        export class MySDK {
+        constructor(
+          private myFeedGql: MyFeedGQL
+        ) {}
+        
+        myFeed(variables?: MyFeedQueryVariables, options?: QueryOptionsAlone<MyFeedQueryVariables>) {
+          return this.myFeedGql.fetch(variables, options)
+        }
+
+        myFeedWatch(variables?: MyFeedQueryVariables, options?: WatchQueryOptionsAlone<MyFeedQueryVariables>) {
+          return this.myFeedGql.watch(variables, options)
+        }
+        }
+      `);
       validateTypeScript(content, modifiedSchema, docs, {});
     });
   });


### PR DESCRIPTION
I've based this implementation on the `graphql-request` plugin, collecting all operations and creating a wrapper class with that data.

Open to feedback on how to improve the code or the tests. 

Related: #3005 . 