### PR TITLE
Add assumeValidSDL config option

### DIFF
--- a/docs/getting-started/codegen-config.md
+++ b/docs/getting-started/codegen-config.md
@@ -65,6 +65,8 @@ Here are the supported options that you can define in the config file (see [sour
 
   - **`pluckConfig.globalIdentifier`** - Overrides the name of the default GraphQL name identifier.
 
+- **`assumeValidSDL`** - A flag to assume the SDL is valid
+
 ## Environment Variables
 
 You can use environment variables in your `codegen.yml` file::
@@ -100,6 +102,8 @@ The Codegen also supports several CLI flags that allow you to override the defau
 - **`--require` (`-r`)** - Specifies `require.extensions` before loading the `.yml` file.
 
 - **`--overwrite` (`-o`)** - Overrides the `overwrite` config to true.
+
+- **`--assumeValidSDL` (`-v`)** - Overrides the `assumeValidSDL` config to true.
 
 ## Debug Mode
 

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -13,6 +13,7 @@ export type YamlCliFlags = {
   require: string[];
   overwrite: boolean;
   project: string;
+  assumeValidSDL?: boolean;
 };
 
 function generateSearchPlaces(moduleName: string) {
@@ -140,6 +141,7 @@ export function parseArgv(argv = process.argv): Command & YamlCliFlags {
     .option('-r, --require [value]', 'Loads specific require.extensions before running the codegen and reading the configuration', collect, [])
     .option('-o, --overwrite', 'Overwrites existing files')
     .option('-p, --project <name>', 'Name of a project in GraphQL Config')
+    .option('-v, --assumeValidSDL', 'Assumes valid GraphQL SDL.')
     .parse(argv) as any) as Command & YamlCliFlags;
 }
 
@@ -170,6 +172,10 @@ export async function createContext(cliFlags: Command & YamlCliFlags = parseArgv
 
   if (cliFlags.project) {
     context.useProject(cliFlags.project);
+  }
+
+  if (cliFlags.assumeValidSDL === true) {
+    config.assumeValidSDL = cliFlags.assumeValidSDL;
   }
 
   context.updateConfig(config);

--- a/packages/graphql-codegen-core/src/execute-plugin.ts
+++ b/packages/graphql-codegen-core/src/execute-plugin.ts
@@ -12,6 +12,7 @@ export interface ExecutePluginOptions {
   outputFilename: string;
   allPlugins: Types.ConfiguredPlugin[];
   skipDocumentsValidation?: boolean;
+  assumeValidSDL?: true;
 }
 
 export async function executePlugin(options: ExecutePluginOptions, plugin: CodegenPlugin): Promise<Types.PluginOutput> {
@@ -34,7 +35,7 @@ export async function executePlugin(options: ExecutePluginOptions, plugin: Codeg
 
   const schema = options.schemaAst;
 
-  const outputSchema: GraphQLSchema = schema || buildASTSchema(options.schema);
+  const outputSchema: GraphQLSchema = schema || buildASTSchema(options.schema, { assumeValidSDL: options.assumeValidSDL || false });
   const documents = options.documents || [];
 
   if (plugin.validate && typeof plugin.validate === 'function') {

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -62,6 +62,7 @@ export namespace Types {
     schema?: InstanceOrArray<Schema>;
     config?: PluginConfig;
     hooks?: LifecycleHooksDefinition<string | string[]>;
+    assumeValidSDL?: boolean;
   };
 
   /* Output Builder Preset */
@@ -110,6 +111,7 @@ export namespace Types {
       globalIdentifier?: string;
     };
     hooks?: LifecycleHooksDefinition<string | string[]>;
+    assumeValidSDL?: boolean;
   }
 
   export type ComplexPluginOutput = { content: string; prepend?: string[]; append?: string[] };


### PR DESCRIPTION
To allow more flexibility, I've exposed `graphql`'s assumeValidSDL option. (ref: https://github.com/graphql/graphql-js/blob/master/src/utilities/buildASTSchema.d.ts#L45)

I am intentionally using multiple directives and have a custom schema compiler. There are PRs to allow multiple directives (https://github.com/sangria-graphql/sangria/issues/409 https://github.com/graphql/graphql-js/pull/1541), but adding this option allows for more possibilities and more flexibility for peoples' schemas.