### PR TITLE
Use generated import definitions when writing typescript mappers

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -527,7 +527,7 @@ export class BaseResolversVisitor<TRawConfig extends RawResolversConfig = RawRes
       .map(gqlTypeName => this.config.mappers[gqlTypeName])
       .filter((gqlType): gqlType is ExternalParsedMapper => gqlType.isExternal)
       .forEach(mapper => {
-        const identifier = stripMapperTypeInterpolation(mapper.type);
+        const identifier = stripMapperTypeInterpolation(mapper.import);
         addMapper(mapper.source, identifier, mapper.default);
       });
 

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -314,7 +314,7 @@ export function getRootTypeNames(schema: GraphQLSchema): string[] {
 }
 
 export function stripMapperTypeInterpolation(identifier: string): string {
-  return identifier.trim().replace(/[^$\w].*$/, '');
+  return identifier.trim().replace(/<{.*}>/, '');
 }
 
 export const OMIT_TYPE = 'export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;';

--- a/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
@@ -415,6 +415,37 @@ describe('ResolversTypes', () => {
     await validate([mergeOutputs(result), usage].join('\n\n'), config, testSchema);
   });
 
+  it('Should build ResolversTypes with mapper set for concrete type using renamed external identifier', async () => {
+    const result = (await plugin(
+      schema,
+      [],
+      {
+        noSchemaStitching: true,
+        mappers: {
+          MyType: './my-type#MyType as DatabaseMyType',
+        },
+      },
+      { outputFile: '' }
+    )) as Types.ComplexPluginOutput;
+
+    expect(result.prepend).toContain(`import { MyType as DatabaseMyType } from './my-type';`);
+    expect(result.content).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: ResolverTypeWrapper<{}>,
+      MyType: ResolverTypeWrapper<DatabaseMyType>,
+      String: ResolverTypeWrapper<Scalars['String']>,
+      MyOtherType: ResolverTypeWrapper<MyOtherType>,
+      Subscription: ResolverTypeWrapper<{}>,
+      Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
+      Node: ResolverTypeWrapper<Node>,
+      ID: ResolverTypeWrapper<Scalars['ID']>,
+      SomeNode: ResolverTypeWrapper<SomeNode>,
+      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
+      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
+      Int: ResolverTypeWrapper<Scalars['Int']>,
+    };`);
+  });
+
   it('Should build ResolversTypes with defaultMapper set', async () => {
     const result = (await plugin(
       schema,


### PR DESCRIPTION
The previous PR https://github.com/dotansimha/graphql-code-generator/pull/2957 added the import definition in the mapper description, but doesn't actually use it when generating code. This fixes it.

Fixes https://github.com/dotansimha/graphql-code-generator/issues/2932