### PR TITLE
Language agnostic near-operation-file preset helpers

### DIFF
--- a/packages/presets/near-operation-file/package.json
+++ b/packages/presets/near-operation-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-codegen/near-operation-file-preset",
-  "version": "1.9.2",
+  "version": "1.9.2-alpha1",
   "description": "GraphQL Code Generator preset for generating operation code near the operation file",
   "repository": "git@github.com:dotansimha/graphql-code-generator.git",
   "license": "MIT",

--- a/packages/presets/near-operation-file/package.json
+++ b/packages/presets/near-operation-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-codegen/near-operation-file-preset",
-  "version": "1.9.3",
+  "version": "1.9.1",
   "description": "GraphQL Code Generator preset for generating operation code near the operation file",
   "repository": "git@github.com:dotansimha/graphql-code-generator.git",
   "license": "MIT",

--- a/packages/presets/near-operation-file/package.json
+++ b/packages/presets/near-operation-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-codegen/near-operation-file-preset",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "GraphQL Code Generator preset for generating operation code near the operation file",
   "repository": "git@github.com:dotansimha/graphql-code-generator.git",
   "license": "MIT",

--- a/packages/presets/near-operation-file/package.json
+++ b/packages/presets/near-operation-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-codegen/near-operation-file-preset",
-  "version": "1.9.2-alpha1",
+  "version": "1.9.3",
   "description": "GraphQL Code Generator preset for generating operation code near the operation file",
   "repository": "git@github.com:dotansimha/graphql-code-generator.git",
   "license": "MIT",

--- a/packages/presets/near-operation-file/src/fragment-resolver.ts
+++ b/packages/presets/near-operation-file/src/fragment-resolver.ts
@@ -1,0 +1,121 @@
+import { Types } from '@graphql-codegen/plugin-helpers';
+import { BaseVisitor, LoadedFragment, buildScalars, getPossibleTypes } from '@graphql-codegen/visitor-plugin-common';
+import { Kind, FragmentDefinitionNode, GraphQLSchema, DocumentNode } from 'graphql';
+
+import { extractExternalFragmentsInUse } from './utils';
+
+import { DocumentProcessorOptions } from './collect-sources';
+
+export type FragmentRegistry = { [fragmentName: string]: { filePath: string; importNames: string[]; onType: string; node: FragmentDefinitionNode } };
+
+/**
+ * Used by `buildFragmentResolver` to  build a mapping of fragmentNames to paths, importNames, and other useful info
+ */
+function buildFragmentRegistry<T>({ fragmentSuffix, generateFilePath }: DocumentProcessorOptions, { documents, config }: Types.PresetFnArgs<{}>, schemaObject: GraphQLSchema) {
+  const baseVisitor = new BaseVisitor(config, {
+    scalars: buildScalars(schemaObject, config.scalars),
+  });
+
+  const getAllFragmentSubTypes = (possbileTypes: string[], name: string, suffix: string): string[] => {
+    if (possbileTypes.length === 0) {
+      return [];
+    } else if (possbileTypes.length === 1) {
+      return [
+        baseVisitor.convertName(name, {
+          useTypesPrefix: true,
+          suffix: suffix,
+        }),
+      ];
+    } else {
+      return possbileTypes.map(typeName =>
+        baseVisitor.convertName(name, {
+          useTypesPrefix: true,
+          suffix: `_${typeName}_${suffix}`,
+        })
+      );
+    }
+  };
+
+  const duplicateFragmentNames: string[] = [];
+  return documents.reduce((prev: FragmentRegistry, documentRecord) => {
+    const fragments: FragmentDefinitionNode[] = documentRecord.content.definitions.filter(d => d.kind === Kind.FRAGMENT_DEFINITION) as FragmentDefinitionNode[];
+
+    if (fragments.length > 0) {
+      for (const fragment of fragments) {
+        const schemaType = schemaObject.getType(fragment.typeCondition.name.value);
+
+        if (!schemaType) {
+          throw new Error(`Fragment "${fragment.name.value}" is set on non-existing type "${fragment.typeCondition.name.value}"!`);
+        }
+
+        const possibleTypes = getPossibleTypes(schemaObject, schemaType);
+        const filePath = generateFilePath(documentRecord.filePath);
+        const importNames = getAllFragmentSubTypes(
+          possibleTypes.map(t => t.name),
+          fragment.name.value,
+          fragmentSuffix
+        );
+
+        if (prev[fragment.name.value]) {
+          duplicateFragmentNames.push(fragment.name.value);
+        }
+
+        prev[fragment.name.value] = { filePath, importNames, onType: fragment.typeCondition.name.value, node: fragment };
+      }
+    }
+
+    return prev;
+  }, {} as FragmentRegistry);
+}
+
+/**
+ *  Builds a fragment "resolver" that collects `externalFragments` definitions and `fragmentImportStatements`
+ */
+export default function buildFragmentResolver<T>(collectorOptions: DocumentProcessorOptions, presetOptions: Types.PresetFnArgs<T>, schemaObject: GraphQLSchema) {
+  const fragmentRegistry = buildFragmentRegistry(collectorOptions, presetOptions, schemaObject);
+
+  const { baseOutputDir } = presetOptions;
+  const { generateImportStatement } = collectorOptions;
+
+  function resolveFragments(generatedFilePath: string, documentFileContent: DocumentNode) {
+    const fragmentsInUse = extractExternalFragmentsInUse(documentFileContent, fragmentRegistry);
+
+    const externalFragments: LoadedFragment<{ level: number }>[] = [];
+    // fragment files to import names
+    const fragmentFileImports: { [fragmentFile: string]: Set<string> } = {};
+    for (const fragmentName of Object.keys(fragmentsInUse)) {
+      const level = fragmentsInUse[fragmentName];
+      const fragmentDetails = fragmentRegistry[fragmentName];
+      if (fragmentDetails) {
+        if (fragmentFileImports[fragmentDetails.filePath] === undefined) {
+          fragmentFileImports[fragmentDetails.filePath] = new Set(fragmentDetails.importNames);
+        } else {
+          fragmentFileImports[fragmentDetails.filePath].forEach(fragmentFileImports[fragmentDetails.filePath].add);
+        }
+        externalFragments.push({
+          level,
+          isExternal: true,
+          name: fragmentName,
+          onType: fragmentDetails.onType,
+          node: fragmentDetails.node,
+          // TODO replaced importFrom with importStatement for langauge agnosticism.
+          // reluctant to add cwd or another relative path injector here just to do
+          // relativePath({ from: fragment, to: generatedFilePath })
+          // importFrom : importStatement,
+        });
+      }
+    }
+    return {
+      externalFragments,
+      fragmentImportStatements: Object.entries(fragmentFileImports).map(([fragmentsFilePath, importNames]) =>
+        generateImportStatement({
+          baseOutputDir,
+          relativeOutputPath: generatedFilePath,
+          relativeImportPath: fragmentsFilePath,
+          importNames: [...importNames],
+        })
+      ),
+    };
+  }
+  return resolveFragments;
+}

--- a/packages/presets/near-operation-file/src/fragment-resolver.ts
+++ b/packages/presets/near-operation-file/src/fragment-resolver.ts
@@ -98,7 +98,7 @@ export default function buildFragmentResolver<T>(collectorOptions: DocumentImpor
           if (fragmentFileImports[fragmentDetails.filePath] === undefined) {
             fragmentFileImports[fragmentDetails.filePath] = new Set(fragmentDetails.importNames);
           } else {
-            fragmentFileImports[fragmentDetails.filePath].forEach(fragmentFileImports[fragmentDetails.filePath].add);
+            fragmentDetails.importNames.forEach(fragmentFileImports[fragmentDetails.filePath].add);
           }
         }
 

--- a/packages/presets/near-operation-file/src/fragment-resolver.ts
+++ b/packages/presets/near-operation-file/src/fragment-resolver.ts
@@ -98,7 +98,7 @@ export default function buildFragmentResolver<T>(collectorOptions: DocumentImpor
           if (fragmentFileImports[fragmentDetails.filePath] === undefined) {
             fragmentFileImports[fragmentDetails.filePath] = new Set(fragmentDetails.importNames);
           } else {
-            fragmentDetails.importNames.forEach(fragmentFileImports[fragmentDetails.filePath].add);
+            fragmentDetails.importNames.forEach(f => fragmentFileImports[fragmentDetails.filePath].add(f));
           }
         }
 

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -106,7 +106,7 @@ export type NearOperationFileConfig = {
    * @type string
    * @description Optional, override the template used to import from the `baseTypesPath` file.
    * templates
-   * @default "import * as ${importTypesNamespace} from '${relativeImportPath}';"
+   * @default "import * as {{importTypesNamespace}} from '{{relativeImportPath}}';"
    *
    * @example
    * ```yml
@@ -116,7 +116,7 @@ export type NearOperationFileConfig = {
    *  presetConfig:
    *    baseTypesPath: types.dart
    *    importTypesNamespace: ''
-   *    importTypesTemplate: "import '${relativeImportPath}.dart'${importTypesNamespace ? ' as ' : ''}${importTypesNamespace};"
+   *    importTypesTemplate: "import '{{relativeImportPath}}.dart'{{importTypesNamespace ? ' as ' : ''}}{{importTypesNamespace}};"
    *    # NOTE: The template can contain simple ternary (`if ? then : else` literal or variable statements,
    *    # but not nested templates or nested ternary operations
    *  plugins:
@@ -129,7 +129,7 @@ export type NearOperationFileConfig = {
    * @type string
    * @description Optional, override the template used to import from the `baseTypesPath` file.
    * templates
-   * @default "import { ${fragmentNames} } from '${fragmentImportPath}';"
+   * @default "import { {{fragmentNames}} } from '{{fragmentImportPath}}';"
    *
    * @example
    * ```yml
@@ -137,7 +137,7 @@ export type NearOperationFileConfig = {
    * src/:
    *  preset: near-operation-file
    *  presetConfig:
-   *    importFragmentsTemplate: "import '${fragmentImportPath}.dart' show ${fragmentNames};"
+   *    importFragmentsTemplate: "import '{{fragmentImportPath}}.dart' show {{fragmentNames}};"
    *    # NOTE: The template can contain simple ternary (`if ? then : else`) literal or variable statements,
    *    # but not nested templates or nested ternary operations
    *  plugins:
@@ -202,9 +202,9 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
     const extension = options.presetConfig.extension || '.generated.ts';
     const folder = options.presetConfig.folder || '';
     const importTypesNamespace = options.presetConfig.importTypesNamespace || 'Types';
-    const importTypesTemplate = options.presetConfig.importTypesTemplate || "import * as ${importTypesNamespace} from '${relativeImportPath}';";
-    const importFragmentsTemplate = options.presetConfig.importFragmentsTemplate || "import { ${fragmentNames} } from '${fragmentImportPath}';";
-    const fragmentImportSuffix = options.presetConfig.fragmentImportSuffix || 'Fragment';
+    const importTypesTemplate = options.presetConfig.importTypesTemplate || 'import * as {{importTypesNamespace}} from \'{{relativeImportPath}}\';';
+    const importFragmentsTemplate = options.presetConfig.importFragmentsTemplate || 'import { {{fragmentNames}} } from \'{{fragmentImportPath}}\';';
+    const fragmentImportSuffix = options.presetConfig.fragmentImportSuffix === undefined ? 'Fragment' : options.presetConfig.fragmentImportSuffix;
 
     const pluginMap: { [name: string]: CodegenPlugin } = {
       ...options.pluginMap,

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -10,7 +10,7 @@ export { resolveDocumentImports, DocumentImportResolverOptions };
 
 export type NearOperationFileConfig = {
   /**
-   * @name baseTypesPath
+   * @name schemaTypesPath
    * @type string
    * @description Required, should point to the base schema types file.
    * The key of the output is used a the base path for this file.
@@ -21,7 +21,7 @@ export type NearOperationFileConfig = {
    * src/:
    *  preset: near-operation-file
    *  presetConfig:
-   *    baseTypesPath: types.ts
+   *    schemaTypesPath: types.ts
    *  plugins:
    *    - typescript-operations
    * ```

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -1,9 +1,12 @@
-import { isUsingTypes, Types, CodegenPlugin } from '@graphql-codegen/plugin-helpers';
-import { BaseVisitor, LoadedFragment, buildScalars, getPossibleTypes } from '@graphql-codegen/visitor-plugin-common';
+import { Types, CodegenPlugin } from '@graphql-codegen/plugin-helpers';
 import addPlugin from '@graphql-codegen/add';
 import { join, resolve } from 'path';
-import { Kind, FragmentDefinitionNode, buildASTSchema, GraphQLSchema } from 'graphql';
-import { appendExtensionToFilePath, defineFilepathSubfolder, extractExternalFragmentsInUse, resolveRelativeImport, interpolate } from './utils';
+import { FragmentDefinitionNode, buildASTSchema, GraphQLSchema } from 'graphql';
+import { appendExtensionToFilePath, defineFilepathSubfolder, resolveRelativeImport } from './utils';
+
+import resolveDocumentImports, { DocumentImportResolverOptions } from './resolve-document-imports';
+
+export { resolveDocumentImports, DocumentImportResolverOptions };
 
 export type NearOperationFileConfig = {
   /**
@@ -45,25 +48,6 @@ export type NearOperationFileConfig = {
    */
   extension?: string;
   /**
-   * @name folder
-   * @type string
-   * @description Optional, defines a folder, (Relative to the source files) where the generated files will be created.
-   * @default ''
-   *
-   * @example
-   * ```yml
-   * generates:
-   * src/:
-   *  preset: near-operation-file
-   *  presetConfig:
-   *    baseTypesPath: types.ts
-   *    folder: __generated__
-   *  plugins:
-   *    - typescript-operations
-   * ```
-   */
-  folder?: string;
-  /**
    * @name cwd
    * @type string
    * @description Optional, override the `cwd` of the execution. We are using `cwd` to figure out the imports between files. Use this if your execuion path is not your project root directory.
@@ -77,6 +61,25 @@ export type NearOperationFileConfig = {
    *  presetConfig:
    *    baseTypesPath: types.ts
    *    cwd: /some/path
+   *  plugins:
+   *    - typescript-operations
+   * ```
+   */
+  folder?: string;
+  /**
+   * @name folder
+   * @type string
+   * @description Optional, defines a folder, (Relative to the source files) where the generated files will be created.
+   * @default ''
+   *
+   * @example
+   * ```yml
+   * generates:
+   * src/:
+   *  preset: near-operation-file
+   *  presetConfig:
+   *    baseTypesPath: types.ts
+   *    folder: __generated__
    *  plugins:
    *    - typescript-operations
    * ```
@@ -101,68 +104,6 @@ export type NearOperationFileConfig = {
    * ```
    */
   importTypesNamespace?: string;
-  /**
-   * @name importTypesTemplate
-   * @type string
-   * @description Optional, override the template used to import from the `baseTypesPath` file.
-   * templates
-   * @default "import * as {{importTypesNamespace}} from '{{relativeImportPath}}';"
-   *
-   * @example
-   * ```yml
-   * generates:
-   * src/:
-   *  preset: near-operation-file
-   *  presetConfig:
-   *    baseTypesPath: types.dart
-   *    importTypesNamespace: ''
-   *    importTypesTemplate: "import '{{relativeImportPath}}.dart'{{importTypesNamespace ? ' as ' : ''}}{{importTypesNamespace}};"
-   *    # NOTE: The template can contain simple ternary (`if ? then : else` literal or variable statements,
-   *    # but not nested templates or nested ternary operations
-   *  plugins:
-   *    - graphql-to-dart/documents
-   * ```
-   */
-  importTypesTemplate?: string;
-  /**
-   * @name importFragmentsTemplate
-   * @type string
-   * @description Optional, override the template used to import from the `baseTypesPath` file.
-   * templates
-   * @default "import { {{fragmentNames}} } from '{{fragmentImportPath}}';"
-   *
-   * @example
-   * ```yml
-   * generates:
-   * src/:
-   *  preset: near-operation-file
-   *  presetConfig:
-   *    importFragmentsTemplate: "import '{{fragmentImportPath}}.dart' show {{fragmentNames}};"
-   *    # NOTE: The template can contain simple ternary (`if ? then : else`) literal or variable statements,
-   *    # but not nested templates or nested ternary operations
-   *  plugins:
-   *    - graphql-to-dart/documents
-   * ```
-   */
-  importFragmentsTemplate?: string;
-  /**
-   * @name fragmentImportSuffix
-   * @type string
-   * @description Optional, override the suffix to add to fragment import types
-   * @default "Fragment"
-   *
-   * @example
-   * ```yml
-   * generates:
-   * src/:
-   *  preset: near-operation-file
-   *  presetConfig:
-   *    fragmentImportSuffix: ""
-   *  plugins:
-   *    - graphql-to-dart/documents
-   * ```
-   */
-  fragmentImportSuffix?: string;
 };
 
 export type FragmentNameToFile = { [fragmentName: string]: { filePath: string; importsNames: string[]; onType: string; node: FragmentDefinitionNode } };
@@ -170,152 +111,80 @@ export type FragmentNameToFile = { [fragmentName: string]: { filePath: string; i
 export const preset: Types.OutputPreset<NearOperationFileConfig> = {
   buildGeneratesSection: options => {
     const schemaObject: GraphQLSchema = options.schemaAst ? options.schemaAst : buildASTSchema(options.schema);
-    const baseVisitor = new BaseVisitor(options.config, {
-      scalars: buildScalars(schemaObject, options.config.scalars),
-    });
-
-    const getAllFragmentSubTypes = (possbileTypes: string[], name: string, suffix: string): string[] => {
-      if (possbileTypes.length === 0) {
-        return [];
-      } else if (possbileTypes.length === 1) {
-        return [
-          baseVisitor.convertName(name, {
-            useTypesPrefix: true,
-            suffix: suffix,
-          }),
-        ];
-      } else {
-        return possbileTypes.map(typeName =>
-          baseVisitor.convertName(name, {
-            useTypesPrefix: true,
-            suffix: `_${typeName}_${suffix}`,
-          })
-        );
-      }
-    };
-
-    if (!options.presetConfig.baseTypesPath) {
-      throw new Error(`Preset "near-operation-file" requires you to specify "baseTypesPath" configuration and point it to your base types file (generated by "typescript" plugin)!`);
-    }
 
     const baseDir = options.presetConfig.cwd || process.cwd();
     const extension = options.presetConfig.extension || '.generated.ts';
     const folder = options.presetConfig.folder || '';
     const importTypesNamespace = options.presetConfig.importTypesNamespace || 'Types';
-    const importTypesTemplate = options.presetConfig.importTypesTemplate || "import * as {{importTypesNamespace}} from '{{relativeImportPath}}';";
-    const importFragmentsTemplate = options.presetConfig.importFragmentsTemplate || "import { {{fragmentNames}} } from '{{fragmentImportPath}}';";
-    const fragmentImportSuffix = options.presetConfig.fragmentImportSuffix === undefined ? 'Fragment' : options.presetConfig.fragmentImportSuffix;
+
+    const baseTypesPath = options.presetConfig.baseTypesPath;
+
+    if (!baseTypesPath) {
+      throw new Error(`Preset "near-operation-file" requires you to specify "baseTypesPath" configuration and point it to your base types file (generated by "typescript" plugin)!`);
+    }
+
+    const shouldAbsolute = !baseTypesPath.startsWith('~');
 
     const pluginMap: { [name: string]: CodegenPlugin } = {
       ...options.pluginMap,
       add: addPlugin,
     };
 
-    const duplicateFragmentNames: string[] = [];
-    const fragmentNameToFile: FragmentNameToFile = options.documents.reduce((prev: FragmentNameToFile, documentRecord) => {
-      const fragments: FragmentDefinitionNode[] = documentRecord.content.definitions.filter(d => d.kind === Kind.FRAGMENT_DEFINITION) as FragmentDefinitionNode[];
-
-      if (fragments.length > 0) {
-        for (const fragment of fragments) {
-          const schemaType = schemaObject.getType(fragment.typeCondition.name.value);
-
-          if (!schemaType) {
-            throw new Error(`Fragment "${fragment.name.value}" is set on non-existing type "${fragment.typeCondition.name.value}"!`);
-          }
-
-          const possibleTypes = getPossibleTypes(schemaObject, schemaType);
-          const fragmentSuffix = options.config.dedupeOperationSuffix && fragment.name.value.toLowerCase().endsWith(fragmentImportSuffix.toLowerCase()) ? '' : fragmentImportSuffix;
-          const filePath = appendExtensionToFilePath(documentRecord.filePath, extension);
-          const importsNames = getAllFragmentSubTypes(
-            possibleTypes.map(t => t.name),
-            fragment.name.value,
-            fragmentSuffix
-          );
-
-          if (prev[fragment.name.value]) {
-            duplicateFragmentNames.push(fragment.name.value);
-          }
-
-          prev[fragment.name.value] = { filePath, importsNames, onType: fragment.typeCondition.name.value, node: fragment };
-        }
+    function resolveImportPath(baseOutputDir: string, relativeOutputPath: string, sourcePath: string) {
+      const shouldAbsolute = !sourcePath.startsWith('~');
+      if (shouldAbsolute) {
+        const absGeneratedFilePath = resolve(baseDir, relativeOutputPath);
+        const absImportFilePath = resolve(baseDir, sourcePath);
+        return resolveRelativeImport(absGeneratedFilePath, absImportFilePath);
+      } else {
+        return sourcePath.replace(`~`, '');
       }
-
-      return prev;
-    }, {} as FragmentNameToFile);
-
-    if (duplicateFragmentNames.length) {
-      throw new Error(`Multiple fragments with the name(s) "${duplicateFragmentNames.join(', ')}" were found.`);
     }
 
-    const shouldAbsolute = !options.presetConfig.baseTypesPath.startsWith('~');
+    const sources = resolveDocumentImports(options, schemaObject, {
+      generateFilePath(filePath: string) {
+        const newFilePath = defineFilepathSubfolder(filePath, folder);
+        return appendExtensionToFilePath(newFilePath, extension);
+      },
+      fragmentSuffix: 'Fragment',
+      generateImportStatement({ relativeOutputPath, importSource, baseOutputDir }) {
+        const importPath = resolveImportPath(baseOutputDir, relativeOutputPath, importSource.path);
+        const importNames = importSource.names && importSource.names.length ? `{ ${importSource.names} }` : '*';
+        const importAlias = importSource.namespace ? ` as ${importSource.namespace}` : '';
+        return `import ${importNames}${importAlias} from '${importPath}';${importAlias ? '\n' : ''}`;
+      },
 
-    return (options.documents as Types.DocumentFile[])
-      .map<Types.GenerateOptions | null>(documentFile => {
-        const newFilePath = defineFilepathSubfolder(documentFile.filePath, folder);
-        const generatedFilePath = appendExtensionToFilePath(newFilePath, extension);
-        const absGeneratedFilePath = resolve(baseDir, generatedFilePath);
-        const relativeImportPath = shouldAbsolute ? resolveRelativeImport(absGeneratedFilePath, resolve(baseDir, join(options.baseOutputDir, options.presetConfig.baseTypesPath))) : options.presetConfig.baseTypesPath.replace(`~`, '');
-        const fragmentsInUse = extractExternalFragmentsInUse(documentFile.content, fragmentNameToFile);
-        const plugins = [...options.plugins];
+      schemaTypesSource: {
+        path: shouldAbsolute ? join(options.baseOutputDir, baseTypesPath) : baseTypesPath,
+        namespace: importTypesNamespace,
+      },
+    });
 
-        const config = {
-          ...options.config,
-          // This is set here in order to make sure the fragment spreads sub types
-          // are exported from operations file
-          exportFragmentSpreadSubTypes: true,
-          namespacedImportName: importTypesNamespace,
-          externalFragments: [] as LoadedFragment<{ level: number }>[],
-        };
+    return sources.map<Types.GenerateOptions>(({ importStatements, externalFragments, ...source }) => {
+      const plugins = [
+        // TODO/NOTE I made globalNamespace include schema types - is that correct?
+        ...(options.config.globalNamespace ? [] : importStatements.map(importStatement => ({ add: importStatement }))),
+        ...options.plugins,
+      ];
+      const config = {
+        ...options.config,
+        // This is set here in order to make sure the fragment spreads sub types
+        // are exported from operations file
+        exportFragmentSpreadSubTypes: true,
+        namespacedImportName: importTypesNamespace,
+        externalFragments,
+      };
 
-        for (const fragmentName of Object.keys(fragmentsInUse)) {
-          const level = fragmentsInUse[fragmentName];
-          const fragmentDetails = fragmentNameToFile[fragmentName];
-
-          if (fragmentDetails) {
-            const fragmentGeneratedFilePath = defineFilepathSubfolder(fragmentDetails.filePath, folder);
-            const absFragmentFilePath = resolve(baseDir, fragmentGeneratedFilePath);
-            const fragmentImportPath = resolveRelativeImport(absGeneratedFilePath, absFragmentFilePath);
-
-            if (!options.config.globalNamespace && level === 0) {
-              const fragmentNames = fragmentDetails.importsNames.join(', ');
-              plugins.unshift({
-                add: interpolate(importFragmentsTemplate, { fragmentNames, fragmentImportPath }),
-              });
-            }
-
-            config.externalFragments.push({
-              level,
-              isExternal: true,
-              importFrom: fragmentImportPath,
-              name: fragmentName,
-              onType: fragmentDetails.onType,
-              node: fragmentDetails.node,
-            });
-          }
-        }
-
-        if (
-          isUsingTypes(
-            documentFile.content,
-            config.externalFragments.map(m => m.name),
-            schemaObject
-          )
-        ) {
-          plugins.unshift({ add: interpolate(importTypesTemplate, { importTypesNamespace, relativeImportPath }) });
-        }
-
-        return {
-          filename: generatedFilePath,
-          plugins,
-          pluginMap,
-          config,
-          schema: options.schema,
-          schemaAst: schemaObject,
-          documents: [documentFile],
-          skipDocumentsValidation: true,
-        };
-      })
-      .filter(f => f);
+      return {
+        ...source,
+        plugins,
+        pluginMap,
+        config,
+        schema: options.schema,
+        schemaAst: schemaObject,
+        skipDocumentsValidation: true,
+      };
+    });
   },
 };
 

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -116,7 +116,7 @@ export type NearOperationFileConfig = {
    *  presetConfig:
    *    baseTypesPath: types.dart
    *    importTypesNamespace: ''
-   *    importTypesTemplate: "import '${relativeImportPath}.dart'${importTypesNamespace ? ' as ' : ''}${importTypesNamespace}';"
+   *    importTypesTemplate: "import '${relativeImportPath}.dart'${importTypesNamespace ? ' as ' : ''}${importTypesNamespace};"
    *    # NOTE: The template can contain simple ternary (`if ? then : else` literal or variable statements,
    *    # but not nested templates or nested ternary operations
    *  plugins:

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -45,25 +45,6 @@ export type NearOperationFileConfig = {
    */
   extension?: string;
   /**
-   * @name cwd
-   * @type string
-   * @description Optional, override the `cwd` of the execution. We are using `cwd` to figure out the imports between files. Use this if your execuion path is not your project root directory.
-   * @default process.cwd()
-   *
-   * @example
-   * ```yml
-   * generates:
-   * src/:
-   *  preset: near-operation-file
-   *  presetConfig:
-   *    baseTypesPath: types.ts
-   *    cwd: /some/path
-   *  plugins:
-   *    - typescript-operations
-   * ```
-   */
-  folder?: string;
-  /**
    * @name folder
    * @type string
    * @description Optional, defines a folder, (Relative to the source files) where the generated files will be created.
@@ -77,6 +58,25 @@ export type NearOperationFileConfig = {
    *  presetConfig:
    *    baseTypesPath: types.ts
    *    folder: __generated__
+   *  plugins:
+   *    - typescript-operations
+   * ```
+   */
+  folder?: string;
+  /**
+   * @name cwd
+   * @type string
+   * @description Optional, override the `cwd` of the execution. We are using `cwd` to figure out the imports between files. Use this if your execuion path is not your project root directory.
+   * @default process.cwd()
+   *
+   * @example
+   * ```yml
+   * generates:
+   * src/:
+   *  preset: near-operation-file
+   *  presetConfig:
+   *    baseTypesPath: types.ts
+   *    cwd: /some/path
    *  plugins:
    *    - typescript-operations
    * ```
@@ -202,8 +202,8 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
     const extension = options.presetConfig.extension || '.generated.ts';
     const folder = options.presetConfig.folder || '';
     const importTypesNamespace = options.presetConfig.importTypesNamespace || 'Types';
-    const importTypesTemplate = options.presetConfig.importTypesTemplate || 'import * as {{importTypesNamespace}} from \'{{relativeImportPath}}\';';
-    const importFragmentsTemplate = options.presetConfig.importFragmentsTemplate || 'import { {{fragmentNames}} } from \'{{fragmentImportPath}}\';';
+    const importTypesTemplate = options.presetConfig.importTypesTemplate || "import * as {{importTypesNamespace}} from '{{relativeImportPath}}';";
+    const importFragmentsTemplate = options.presetConfig.importFragmentsTemplate || "import { {{fragmentNames}} } from '{{fragmentImportPath}}';";
     const fragmentImportSuffix = options.presetConfig.fragmentImportSuffix === undefined ? 'Fragment' : options.presetConfig.fragmentImportSuffix;
 
     const pluginMap: { [name: string]: CodegenPlugin } = {

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -65,7 +65,7 @@ export type NearOperationFileConfig = {
    *    - typescript-operations
    * ```
    */
-  folder?: string;
+  cwd?: string;
   /**
    * @name folder
    * @type string
@@ -84,7 +84,7 @@ export type NearOperationFileConfig = {
    *    - typescript-operations
    * ```
    */
-  cwd?: string;
+  folder?: string;
   /**
    * @name importTypesNamespace
    * @type string

--- a/packages/presets/near-operation-file/src/resolve-document-imports.ts
+++ b/packages/presets/near-operation-file/src/resolve-document-imports.ts
@@ -1,0 +1,60 @@
+import { Types } from '@graphql-codegen/plugin-helpers';
+import { FragmentDefinitionNode, GraphQLSchema } from 'graphql';
+import buildFragmentResolver from './fragment-resolver';
+
+export type FragmentRegistry = { [fragmentName: string]: { filePath: string; importNames: string[]; onType: string; node: FragmentDefinitionNode } };
+
+type generateImportStatement = (paths: { relativeOutputPath: string; relativeImportPath: string; baseOutputDir: string; importNames?: string[] }) => string;
+
+export type DocumentImportResolverOptions = {
+  /**
+   * Generates a target file path from the source `document.filePath`
+   */
+  generateFilePath: (filePath: string) => string;
+  /**
+   * String to append to all fragments
+   */
+  fragmentSuffix: string;
+  /**
+   *
+   */
+  generateImportStatement: generateImportStatement;
+  /**
+   *  List of other generated paths that this preset depends on.
+   */
+  generatedDependencyPaths: Array<string>;
+};
+
+/**
+ * Transform the preset's provided documents into single-file generator sources, while resolving fragment and user-defined imports
+ *
+ * Resolves user provided imports and fragment imports using the `DocumentImportResolverOptions`.
+ * Does not define specific plugins, but rather returns a string[] of `importStatements` for the calling plugin to make use of
+ */
+export default function resolveDocumentImportStatements<T>(collectorOptions: DocumentImportResolverOptions, presetOptions: Types.PresetFnArgs<T>, schemaObject: GraphQLSchema) {
+  const resolveFragments = buildFragmentResolver(collectorOptions, presetOptions, schemaObject);
+
+  const { baseOutputDir, documents } = presetOptions;
+  const { generateFilePath, generateImportStatement, generatedDependencyPaths } = collectorOptions;
+
+  return documents.map(documentFile => {
+    const generatedFilePath = generateFilePath(documentFile.filePath);
+
+    const userDefinedImportStatements = generatedDependencyPaths.map(relativeImportPath =>
+      generateImportStatement({
+        relativeImportPath,
+        baseOutputDir,
+        relativeOutputPath: generatedFilePath,
+      })
+    );
+
+    const { externalFragments, fragmentImportStatements } = resolveFragments(generatedFilePath, documentFile.content);
+
+    return {
+      filename: generatedFilePath,
+      documents: [documentFile],
+      importStatements: [...userDefinedImportStatements, ...fragmentImportStatements],
+      externalFragments,
+    };
+  });
+}

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -70,3 +70,58 @@ export function resolveRelativeImport(from: string, to: string): string {
   }
   return fixLocalFile(clearExtension(relative(dirname(from), to)));
 }
+
+/* mini template parser helpers */
+
+const INTEROPLATE_TEMPLATE_PATTERN = /\${\s*([^}]*)\s*}/g;
+
+const SINGLE_QUOTE = '\'';
+const DOUBLE_QUOTE = '"';
+
+function normalize(value: string) {
+  if (value.startsWith(SINGLE_QUOTE) && value.endsWith(SINGLE_QUOTE)) {
+    const raw = value.slice(1, value.length - 1);
+    return DOUBLE_QUOTE + raw.replace(/\\*"/g, '\\"') + DOUBLE_QUOTE;
+  }
+  return value;
+}
+
+function parseVar(expression: string, params: { [vars: string]: any }) {
+  let value = params[expression];
+  if (value !== undefined) {
+    return value;
+  }
+  try {
+    return JSON.parse(normalize(expression));
+  } catch (e) {
+    // invalid literal expression with no param
+    return undefined;
+  }
+}
+
+function parseExpression(expression: string, resolve: (param: string) => any) {
+  let [condition, blocks] = expression.split(/\s*\?\s*/, 2);
+  if (!blocks) {
+    return resolve(expression);
+  }
+
+  let [ifBlock, elseBlock] = blocks.split(/\s*\:\s*/, 2);
+  elseBlock = elseBlock.trim(); // other whitespace trimmed by regex
+
+  return resolve(condition) ? resolve(ifBlock) : resolve(elseBlock);
+}
+/**
+ * interpolate a simple template string with the given params
+ *
+ * ```js
+ * interpolate(
+ *   "${foo}, ${bar}, ${biz ? bar : 'bang'}, ${123}",
+ *   { foo: "f1", bar: "b2", biz: false }
+ * )
+ * // => "f1, b2, bang, 123"
+ * ```
+ */
+export function interpolate(template: string, params: { [vars: string]: any }) {
+  const resolve = (expression: string) => parseVar(expression, params);
+  return template.replace(INTEROPLATE_TEMPLATE_PATTERN, (matchedSubstring, expression) => parseExpression(expression, resolve));
+}

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -73,7 +73,7 @@ export function resolveRelativeImport(from: string, to: string): string {
 
 /* mini template parser helpers */
 
-const INTEROPLATE_TEMPLATE_PATTERN = /\${\s*([^}]*)\s*}/g;
+const INTEROPLATE_TEMPLATE_PATTERN = /{{\s*([^}]*)\s*}}/g;
 
 const SINGLE_QUOTE = '\'';
 const DOUBLE_QUOTE = '"';
@@ -115,7 +115,7 @@ function parseExpression(expression: string, resolve: (param: string) => any) {
  *
  * ```js
  * interpolate(
- *   "${foo}, ${bar}, ${biz ? bar : 'bang'}, ${123}",
+ *   "{{foo}}, {{bar}}, {{biz ? bar : 'bang'}}, {{123}}",
  *   { foo: "f1", bar: "b2", biz: false }
  * )
  * // => "f1, b2, bang, 123"

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -19,7 +19,6 @@ export function clearExtension(path: string): string {
   return join(parsedPath.dir, parsedPath.name).replace(/\\/g, '/');
 }
 
-// todo move to fragment-resolver
 export function extractExternalFragmentsInUse(
   documentNode: DocumentNode | FragmentDefinitionNode,
   fragmentNameToFile: FragmentRegistry,
@@ -70,59 +69,4 @@ export function resolveRelativeImport(from: string, to: string): string {
     throw new Error(`Argument 'to' must be an absolute path, '${to}' given.`);
   }
   return fixLocalFile(clearExtension(relative(dirname(from), to)));
-}
-
-/* mini template parser helpers */
-
-const INTEROPLATE_TEMPLATE_PATTERN = /{{\s*([^}]*)\s*}}/g;
-
-const SINGLE_QUOTE = "'";
-const DOUBLE_QUOTE = '"';
-
-function normalize(value: string) {
-  if (value.startsWith(SINGLE_QUOTE) && value.endsWith(SINGLE_QUOTE)) {
-    const raw = value.slice(1, value.length - 1);
-    return DOUBLE_QUOTE + raw.replace(/\\*"/g, '\\"') + DOUBLE_QUOTE;
-  }
-  return value;
-}
-
-function parseVar(expression: string, params: { [vars: string]: any }) {
-  let value = params[expression];
-  if (value !== undefined) {
-    return value;
-  }
-  try {
-    return JSON.parse(normalize(expression));
-  } catch (e) {
-    // invalid literal expression with no param
-    return undefined;
-  }
-}
-
-function parseExpression(expression: string, resolve: (param: string) => any) {
-  let [condition, blocks] = expression.split(/\s*\?\s*/, 2);
-  if (!blocks) {
-    return resolve(expression);
-  }
-
-  let [ifBlock, elseBlock] = blocks.split(/\s*\:\s*/, 2);
-  elseBlock = elseBlock.trim(); // other whitespace trimmed by regex
-
-  return resolve(condition) ? resolve(ifBlock) : resolve(elseBlock);
-}
-/**
- * interpolate a simple template string with the given params
- *
- * ```js
- * interpolate(
- *   "{{foo}}, {{bar}}, {{biz ? bar : 'bang'}}, {{123}}",
- *   { foo: "f1", bar: "b2", biz: false }
- * )
- * // => "f1, b2, bang, 123"
- * ```
- */
-export function interpolate(template: string, params: { [vars: string]: any }) {
-  const resolve = (expression: string) => parseVar(expression, params);
-  return template.replace(INTEROPLATE_TEMPLATE_PATTERN, (matchedSubstring, expression) => parseExpression(expression, resolve));
 }

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -1,6 +1,6 @@
 import { parse, dirname, relative, join, isAbsolute } from 'path';
 import { DocumentNode, visit, FragmentSpreadNode, FragmentDefinitionNode } from 'graphql';
-import { FragmentNameToFile } from './index';
+import { FragmentRegistry } from './fragment-resolver';
 
 export function defineFilepathSubfolder(baseFilePath: string, folder: string) {
   const parsedPath = parse(baseFilePath);
@@ -19,9 +19,10 @@ export function clearExtension(path: string): string {
   return join(parsedPath.dir, parsedPath.name).replace(/\\/g, '/');
 }
 
+// todo move to fragment-resolver
 export function extractExternalFragmentsInUse(
   documentNode: DocumentNode | FragmentDefinitionNode,
-  fragmentNameToFile: FragmentNameToFile,
+  fragmentNameToFile: FragmentRegistry,
   result: { [fragmentName: string]: number } = {},
   ignoreList: Set<string> = new Set(),
   level = 0
@@ -75,7 +76,7 @@ export function resolveRelativeImport(from: string, to: string): string {
 
 const INTEROPLATE_TEMPLATE_PATTERN = /{{\s*([^}]*)\s*}}/g;
 
-const SINGLE_QUOTE = '\'';
+const SINGLE_QUOTE = "'";
 const DOUBLE_QUOTE = '"';
 
 function normalize(value: string) {

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -65,14 +65,19 @@ export namespace Types {
   };
 
   /* Output Builder Preset */
-  export type PresetFnArgs<Config = any> = {
+  export type PresetFnArgs<
+    Config = any,
+    PluginConfig = {
+      [key: string]: any;
+    }
+  > = {
     presetConfig: Config;
     baseOutputDir: string;
     plugins: Types.ConfiguredPlugin[];
     schema: DocumentNode;
     schemaAst?: GraphQLSchema;
     documents: Types.DocumentFile[];
-    config: { [key: string]: any };
+    config: PluginConfig;
     pluginMap: {
       [name: string]: CodegenPlugin;
     };


### PR DESCRIPTION
I've refactored `near-operation-file` to extract the fragment resolution logic into `fragment-resolver.ts` and the main document processing logic into `resolve-document-imports.ts`, which is then re-exported as `resolveDocumentImports` for use by other preset builders, thus satisfying #3091.

This cuts the main plugin logic down to the following, aside from prep and post processing:
```typescript
function resolveImportPath(baseOutputDir: string, relativeOutputPath: string, sourcePath: string) {
  const shouldAbsolute = !sourcePath.startsWith('~');
  if (shouldAbsolute) {
    const absGeneratedFilePath = resolve(baseDir, relativeOutputPath);
    const absImportFilePath = resolve(baseDir, sourcePath);
    return resolveRelativeImport(absGeneratedFilePath, absImportFilePath);
  } else {
    return sourcePath.replace(`~`, '');
  }
}

const sources = resolveDocumentImports(options, schemaObject, {
  generateFilePath(filePath: string) {
    const newFilePath = defineFilepathSubfolder(filePath, folder);
    return appendExtensionToFilePath(newFilePath, extension);
  },
  fragmentSuffix: 'Fragment',
  generateImportStatement({ relativeOutputPath, importSource, baseOutputDir }) {
    const importPath = resolveImportPath(baseOutputDir, relativeOutputPath, importSource.path);
    const importNames = importSource.names && importSource.names.length ? `{ ${importSource.names} }` : '*';
    const importAlias = importSource.namespace ? ` as ${importSource.namespace}` : '';
    return `import ${importNames}${importAlias} from '${importPath}';${importAlias ? '\n' : ''}`;
  },

  schemaTypesSource: {
    path: shouldAbsolute ? join(options.baseOutputDir, baseTypesPath) : baseTypesPath,
    namespace: importTypesNamespace,
  },
});
```

<details>
<summary>Old Description</summary>

This is a first pass at #3091, but I'm not sure it's the right way to go. Really, it might be better to export a function that takes the arguments I added to the config here, to make it easier for plugin publishers to implement their own preset. That approach:
* would actually be better for my use case
* would allow for the usage of function arguments instead of the templates

I still like the idea of exposing the template strings in the end user config, as even with the "preset wrapper" approach end users might want to customize the `import` statements. However, the fact that we're already interpolating environment variables makes the API awkward (didn't this was the case at first)
</details>