### PR TITLE
Feat/vue apollo composable functions plugin

### DIFF
--- a/packages/plugins/typescript/vue-apollo/.gitignore
+++ b/packages/plugins/typescript/vue-apollo/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+dist
+temp
+yarn-error.log

--- a/packages/plugins/typescript/vue-apollo/.npmignore
+++ b/packages/plugins/typescript/vue-apollo/.npmignore
@@ -1,0 +1,5 @@
+src
+node_modules
+tests
+!dist
+example

--- a/packages/plugins/typescript/vue-apollo/package.json
+++ b/packages/plugins/typescript/vue-apollo/package.json
@@ -18,8 +18,8 @@
     "tslib": "1.10.0"
   },
   "devDependencies": {
-    "bob-the-bundler": "0.2.2",
     "@graphql-codegen/testing": "1.9.1",
+    "bob-the-bundler": "0.2.2",
     "graphql": "14.5.8",
     "jest": "24.9.0",
     "ts-jest": "24.2.0",

--- a/packages/plugins/typescript/vue-apollo/package.json
+++ b/packages/plugins/typescript/vue-apollo/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@graphql-codegen/typescript-vue-apollo",
+  "version": "1.0.0",
+  "description": "GraphQL Code Generator plugin for generating a ready-to-use Vue-Apollo composition functions based on GraphQL operations",
+  "repository": "git@github.com:dotansimha/graphql-code-generator.git",
+  "license": "MIT",
+  "scripts": {
+    "prepack": "bob-update-version",
+    "build": "bob",
+    "test": "jest --no-watchman --config ../../../../jest.config.js --forceExit"
+  },
+  "peerDependencies": {
+    "graphql-tag": "^2.0.0"
+  },
+  "dependencies": {
+    "@graphql-codegen/plugin-helpers": "1.9.1",
+    "@graphql-codegen/visitor-plugin-common": "1.9.1",
+    "tslib": "1.10.0"
+  },
+  "devDependencies": {
+    "bob-the-bundler": "0.2.2",
+    "@graphql-codegen/testing": "1.9.1",
+    "graphql": "14.5.8",
+    "jest": "24.9.0",
+    "ts-jest": "24.2.0",
+    "typescript": "3.7.3"
+  },
+  "sideEffects": false,
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "buildOptions": {
+    "input": "./src/index.ts"
+  },
+  "jest-junit": {
+    "outputDirectory": "../../../../test-results/typescript-vue-apollo"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/typescript/vue-apollo/package.json
+++ b/packages/plugins/typescript/vue-apollo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-codegen/typescript-vue-apollo",
-  "version": "1.0.0",
+  "version": "1.9.1",
   "description": "GraphQL Code Generator plugin for generating a ready-to-use Vue-Apollo composition functions based on GraphQL operations",
   "repository": "git@github.com:dotansimha/graphql-code-generator.git",
   "license": "MIT",
@@ -18,8 +18,8 @@
     "tslib": "1.10.0"
   },
   "devDependencies": {
-    "@graphql-codegen/testing": "1.9.1",
     "bob-the-bundler": "0.2.2",
+    "@graphql-codegen/testing": "1.9.1",
     "graphql": "14.5.8",
     "jest": "24.9.0",
     "ts-jest": "24.2.0",

--- a/packages/plugins/typescript/vue-apollo/src/index.ts
+++ b/packages/plugins/typescript/vue-apollo/src/index.ts
@@ -1,5 +1,5 @@
 import { Types, PluginValidateFn, PluginFunction } from '@graphql-codegen/plugin-helpers';
-import { visit, GraphQLSchema, concatAST, Kind, FragmentDefinitionNode } from 'graphql';
+import { visit, GraphQLSchema, concatAST, Kind, FragmentDefinitionNode, DocumentNode } from 'graphql';
 import { RawClientSideBasePluginConfig, LoadedFragment } from '@graphql-codegen/visitor-plugin-common';
 import { VueApolloVisitor } from './visitor';
 import { extname } from 'path';
@@ -56,8 +56,8 @@ export interface VueApolloRawPluginConfig extends RawClientSideBasePluginConfig 
 
 export const plugin: PluginFunction<VueApolloRawPluginConfig> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: VueApolloRawPluginConfig) => {
   const allAst = concatAST(
-    documents.reduce((prev, v) => {
-      return [...prev, v.content];
+    documents.reduce((accumulator: DocumentNode[], currentDocument) => {
+      return [...accumulator, currentDocument.content];
     }, [])
   );
 
@@ -71,11 +71,11 @@ export const plugin: PluginFunction<VueApolloRawPluginConfig> = (schema: GraphQL
 
   return {
     prepend: visitor.getImports(),
-    content: [visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n'),
+    content: [visitor.fragments, ...visitorResult.definitions.filter((definition: string) => typeof definition === 'string')].join('\n'),
   };
 };
 
-export const validate: PluginValidateFn<any> = async (schema: GraphQLSchema, documents: Types.DocumentFile[], config: VueApolloRawPluginConfig, outputFile: string) => {
+export const validate: PluginValidateFn<any> = async (_schema: GraphQLSchema, _documents: Types.DocumentFile[], _config: VueApolloRawPluginConfig, outputFile: string) => {
   if (extname(outputFile) !== '.ts') {
     throw new Error(`Plugin "vue-apollo" requires extension to be ".ts"!`);
   }

--- a/packages/plugins/typescript/vue-apollo/src/index.ts
+++ b/packages/plugins/typescript/vue-apollo/src/index.ts
@@ -1,0 +1,84 @@
+import { Types, PluginValidateFn, PluginFunction } from '@graphql-codegen/plugin-helpers';
+import { visit, GraphQLSchema, concatAST, Kind, FragmentDefinitionNode } from 'graphql';
+import { RawClientSideBasePluginConfig, LoadedFragment } from '@graphql-codegen/visitor-plugin-common';
+import { VueApolloVisitor } from './visitor';
+import { extname } from 'path';
+
+export interface VueApolloRawPluginConfig extends RawClientSideBasePluginConfig {
+  /**
+   * @name withCompositionFunctions
+   * @type boolean
+   * @description Customized the output by enabling/disabling the generated Vue composition functions.
+   * @default true
+   *
+   * @example
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *    - typescript-vue-apollo
+   *  config:
+   *    withCompositionFunctions: true
+   * ```
+   */
+  withCompositionFunctions?: boolean;
+
+  /**
+   * @name vueApolloComposableImportFrom
+   * @type string
+   * @default @vue/apollo-composable
+   */
+  vueApolloComposableImportFrom?: string;
+
+  /**
+   * @name addDocBlocks
+   * @type boolean
+   * @description Allows you to enable/disable the generation of docblocks in generated code.
+   * Some IDE's (like VSCode) add extra inline information with docblocks, you can disable this feature if your prefered IDE does not.
+   * @default true
+   *
+   * @example
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *    - typescript-vue-apollo
+   *  config:
+   *    addDocBlocks: true
+   *
+   */
+  addDocBlocks?: boolean;
+}
+
+export const plugin: PluginFunction<VueApolloRawPluginConfig> = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: VueApolloRawPluginConfig) => {
+  const allAst = concatAST(
+    documents.reduce((prev, v) => {
+      return [...prev, v.content];
+    }, [])
+  );
+
+  const allFragments: LoadedFragment[] = [
+    ...(allAst.definitions.filter(d => d.kind === Kind.FRAGMENT_DEFINITION) as FragmentDefinitionNode[]).map(fragmentDef => ({ node: fragmentDef, name: fragmentDef.name.value, onType: fragmentDef.typeCondition.name.value, isExternal: false })),
+    ...(config.externalFragments || []),
+  ];
+
+  const visitor = new VueApolloVisitor(schema, allFragments, config, documents);
+  const visitorResult = visit(allAst, { leave: visitor });
+
+  return {
+    prepend: visitor.getImports(),
+    content: [visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n'),
+  };
+};
+
+export const validate: PluginValidateFn<any> = async (schema: GraphQLSchema, documents: Types.DocumentFile[], config: VueApolloRawPluginConfig, outputFile: string) => {
+  if (extname(outputFile) !== '.ts') {
+    throw new Error(`Plugin "vue-apollo" requires extension to be ".ts"!`);
+  }
+};
+
+export { VueApolloVisitor };

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -1,0 +1,133 @@
+import { ClientSideBaseVisitor, ClientSideBasePluginConfig, getConfigValue, LoadedFragment, DocumentMode } from '@graphql-codegen/visitor-plugin-common';
+import { VueApolloRawPluginConfig } from './index';
+import autoBind from 'auto-bind';
+import { OperationDefinitionNode } from 'graphql';
+import { Types } from '@graphql-codegen/plugin-helpers';
+import { pascalCase } from 'change-case';
+import { GraphQLSchema } from 'graphql';
+
+export interface VueApolloPluginConfig extends ClientSideBasePluginConfig {
+  withCompositionFunctions: boolean;
+  vueApolloComposableImportFrom: string;
+  addDocBlocks: boolean;
+}
+
+export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginConfig, VueApolloPluginConfig> {
+  private _externalImportPrefix: string;
+  private imports = new Set<string>();
+
+  constructor(schema: GraphQLSchema, fragments: LoadedFragment[], rawConfig: VueApolloRawPluginConfig, documents: Types.DocumentFile[]) {
+    super(schema, fragments, rawConfig, {
+      withCompositionFunctions: getConfigValue(rawConfig.withCompositionFunctions, true),
+      vueApolloComposableImportFrom: getConfigValue(rawConfig.vueApolloComposableImportFrom, '@vue/apollo-composable'),
+      addDocBlocks: getConfigValue(rawConfig.addDocBlocks, true),
+    });
+
+    this._externalImportPrefix = this.config.importOperationTypesFrom ? `${this.config.importOperationTypesFrom}.` : '';
+    this._documents = documents;
+
+    autoBind(this);
+  }
+
+  private getVueApolloComposableImport(): string {
+    return `import * as VueApolloComposable from '${this.config.vueApolloComposableImportFrom}';`;
+  }
+
+  private getDocumentNodeVariable(node: OperationDefinitionNode, documentVariableName: string): string {
+    return this.config.documentMode === DocumentMode.external ? `Operations.${node.name.value}` : documentVariableName;
+  }
+
+  public getImports(): string[] {
+    const baseImports = super.getImports();
+    const hasOperations = this._collectedOperations.length > 0;
+
+    if (!hasOperations) {
+      return baseImports;
+    }
+    return [...baseImports, ...Array.from(this.imports)];
+  }
+
+  private _buildCompositionFunctionsJSDoc(node: OperationDefinitionNode, operationName: string, operationType: string): string {
+    const variableString = node.variableDefinitions.reduce((acc, item) => {
+      const name = item.variable.name.value;
+
+      return `${acc}\n *      ${name}: // value for '${name}'`;
+    }, '');
+
+    const queryDescription = `
+ * To run a query within a Vue component, call \`use${operationName}\` and pass it any options that fit your needs.
+ * When your component renders, \`use${operationName}\` returns an object from Apollo Client that contains loading, error, and result properties
+ * you can use to render your UI.`;
+
+    const queryExample = `
+ * const { result, loading, error } = use${operationName}({
+ *   variables: {${variableString}
+ *   },
+ * });`;
+
+    const mutationDescription = `
+ * To run a mutation, you first call \`use${operationName}\` within a Vue component and pass it any options that fit your needs.
+ * When your component renders, \`use${operationName}\` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution`;
+
+    const mutationExample = `
+ * const [{ mutate, result, loading, error }] = use${operationName}({
+ *   variables: {${variableString}
+ *   },
+ * });`;
+
+    return `
+/**
+ * __use${operationName}__
+ *${operationType === 'Mutation' ? mutationDescription : queryDescription}
+ *
+ * @param baseOptions options that will be passed into the ${operationType.toLowerCase()}, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/${operationType === 'Mutation' ? 'mutation' : 'query'}.html#options;
+ *
+ * @example${operationType === 'Mutation' ? mutationExample : queryExample}
+ */`;
+  }
+
+  private _buildCompositionFunctions(node: OperationDefinitionNode, operationType: string, documentVariableName: string, operationResultType: string, operationVariablesTypes: string): string {
+    const suffix = this._getCompositionFunctionSuffix(node.name.value, operationType);
+    const operationName: string = this.convertName(node.name.value, {
+      suffix,
+      useTypesPrefix: false,
+    });
+
+    this.imports.add(this.getVueApolloComposableImport());
+
+    const compositionFunctions = [
+      `export function use${operationName}(baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
+        return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${this.getDocumentNodeVariable(node, documentVariableName)}, baseOptions);
+      }`,
+    ];
+
+    if (this.config.addDocBlocks) {
+      compositionFunctions.unshift(this._buildCompositionFunctionsJSDoc(node, operationName, operationType));
+    }
+
+    const compositionFunctionResults = [`export type ${operationName}CompositionFunctionResult = ReturnType<typeof use${operationName}>;`];
+
+    return [...compositionFunctions, ...compositionFunctionResults].join('\n');
+  }
+
+  private _getCompositionFunctionSuffix(name: string, operationType: string) {
+    if (!this.config.dedupeOperationSuffix) {
+      return pascalCase(operationType);
+    }
+    if (name.includes('Query') || name.includes('Mutation') || name.includes('Subscription')) {
+      return '';
+    }
+    return pascalCase(operationType);
+  }
+
+  protected buildOperation(node: OperationDefinitionNode, documentVariableName: string, operationType: string, operationResultType: string, operationVariablesTypes: string): string {
+    operationResultType = this._externalImportPrefix + operationResultType;
+    operationVariablesTypes = this._externalImportPrefix + operationVariablesTypes;
+
+    const compositionFunctions = this.config.withCompositionFunctions ? this._buildCompositionFunctions(node, operationType, documentVariableName, operationResultType, operationVariablesTypes) : null;
+
+    return [compositionFunctions].filter(a => a).join('\n');
+  }
+}

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -98,7 +98,9 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
     this.imports.add(this.getVueApolloComposableImport());
 
     const compositionFunctions = [
-      `export function use${operationName}(baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
+      `export function use${operationName}(${
+        ['Query', 'Subscription'].includes(operationType) ? `variables?: ${operationVariablesTypes}, ` : ''
+      }baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
         return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${this.getDocumentNodeVariable(node, documentVariableName)}, baseOptions);
       }`,
     ];

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -158,9 +158,10 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
   private buildCompositionFunction({ operationName, operationType, operationHasNonNullableVariable, operationResultType, operationVariablesTypes, documentNodeVariable }: BuildCompositionFunctions): string {
     switch (operationType) {
       case 'Query':
-        return `export function use${operationName}(variables${
+        const reactiveFunctionTypeName = `ReactiveFunction${operationName}`;
+        return `type ${reactiveFunctionTypeName} = () => ${operationVariablesTypes}\nexport function use${operationName}(variables${
           operationHasNonNullableVariable ? '' : '?'
-        }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | VueApolloComposable.ReactiveFunction<${operationVariablesTypes}>, baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
+          }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ${reactiveFunctionTypeName}, baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
           return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, variables, baseOptions);
         }`;
       case 'Mutation':
@@ -170,7 +171,7 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
       case 'Subscription':
         return `export function use${operationName}(variables${
           operationHasNonNullableVariable ? '' : '?'
-        }: ${operationVariablesTypes}, baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
+          }: ${operationVariablesTypes}, baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
           return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, variables, baseOptions);
         }`;
     }

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -55,7 +55,7 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
 
     const queryDescription = `
  * To run a query within a Vue component, call \`use${operationName}\` and pass it any options that fit your needs.
- * When your component renders, \`use${operationName}\` returns an object from Apollo Client that contains loading, error, and result properties
+ * When your component renders, \`use${operationName}\` returns an object from Apollo Client that contains result, loading and error properties
  * you can use to render your UI.`;
 
     const queryExample = `

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -59,19 +59,19 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
  * you can use to render your UI.`;
 
     const queryExample = `
- * const { result, loading, error } = use${operationName}({
- *   variables: {${variableString}
- *   },
- * });`;
+ * const { result, loading, error } = use${operationName}(
+ *   {${variableString}
+ *   }
+ * );`;
 
     const mutationDescription = `
  * To run a mutation, you first call \`use${operationName}\` within a Vue component and pass it any options that fit your needs.
- * When your component renders, \`use${operationName}\` returns a tuple that includes:
+ * When your component renders, \`use${operationName}\` returns an object that includes:
  * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution`;
+ * - Several other properties: https://v4.apollo.vuejs.org/api/use-mutation.html#return`;
 
     const mutationExample = `
- * const [{ mutate, result, loading, error }] = use${operationName}({
+ * const { mutate, loading, error, onDone } = use${operationName}({
  *   variables: {${variableString}
  *   },
  * });`;

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -11,7 +11,6 @@ export interface VueApolloPluginConfig extends ClientSideBasePluginConfig {
   vueApolloComposableImportFrom: string;
   addDocBlocks: boolean;
 }
-
 export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginConfig, VueApolloPluginConfig> {
   private _externalImportPrefix: string;
   private imports = new Set<string>();

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -130,7 +130,8 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
       useTypesPrefix: false,
     });
 
-    this.imports.add(this.getVueApolloComposableImport());
+    this.imports.add(this.vueApolloComposableImport);
+    this.imports.add(this.vueCompositionApiImport);
 
     const documentNodeVariable = this.getDocumentNodeVariable(node, documentVariableName); // i.e. TestDocument
 

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -94,14 +94,13 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
       suffix,
       useTypesPrefix: false,
     });
+    const isQueryOrSubscription = ['Query', 'Subscription'].includes(operationType);
 
     this.imports.add(this.getVueApolloComposableImport());
 
     const compositionFunctions = [
-      `export function use${operationName}(${
-        ['Query', 'Subscription'].includes(operationType) ? `variables?: ${operationVariablesTypes}, ` : ''
-      }baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
-        return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${this.getDocumentNodeVariable(node, documentVariableName)}, baseOptions);
+      `export function use${operationName}(${isQueryOrSubscription ? `variables?: ${operationVariablesTypes}, ` : ''}baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
+        return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${this.getDocumentNodeVariable(node, documentVariableName)}, ${isQueryOrSubscription ? 'variables, ' : ''}baseOptions);
       }`,
     ];
 

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -154,7 +154,7 @@ describe('Vue Apollo', () => {
       const content = (await plugin(
         schema,
         docs,
-        { withCompositionFunctions: true, vueApolloComposableImportFrom: 'vue-apollo-composition-functions' },
+        { vueApolloComposableImportFrom: 'vue-apollo-composition-functions' },
         {
           outputFile: 'graphql.ts',
         }
@@ -421,7 +421,7 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
       const content = (await plugin(
         schema,
         docs,
-        { withCompositionFunctions: true, dedupeOperationSuffix: true },
+        { dedupeOperationSuffix: true },
         {
           outputFile: 'graphql.ts',
         }
@@ -468,9 +468,7 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
       const content = (await plugin(
         schema,
         docs,
-        {
-          withCompositionFunctions: true,
-        },
+        {},
         {
           outputFile: 'graphql.ts',
         }
@@ -488,7 +486,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const content = (await plugin(
         schema,
         docs,
-        { withCompositionFunctions: true, typesPrefix: 'I' },
+        { typesPrefix: 'I' },
         {
           outputFile: 'graphql.ts',
         }
@@ -628,7 +626,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const content = (await plugin(
         schema,
         docs,
-        { withCompositionFunctions: true, addDocBlocks: false },
+        { addDocBlocks: false },
         {
           outputFile: 'graphql.ts',
         }
@@ -819,7 +817,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents',
-        withCompositionFunctions: true,
       };
 
       const docs = [{ filePath: '', content: basicDoc }];
@@ -841,7 +838,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.ts',
-        withCompositionFunctions: true,
       };
 
       const docs = [{ filePath: '', content: mutationDoc }];
@@ -863,7 +859,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
-        withCompositionFunctions: true,
       };
 
       const docs = [{ filePath: '', content: subscriptionDoc }];
@@ -885,7 +880,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
-        withCompositionFunctions: true,
       };
 
       const docs = [{ filePath: '', content: multipleOperationDoc }];
@@ -918,7 +912,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
-        withCompositionFunctions: true,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: basicDoc }];
@@ -940,7 +933,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
-        withCompositionFunctions: true,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: mutationDoc }];
@@ -961,7 +953,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
-        withCompositionFunctions: true,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: subscriptionDoc }];
@@ -982,7 +973,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
-        withCompositionFunctions: true,
       };
 
       const docs = [{ filePath: 'path/to/document.graphql', content: multipleOperationDoc }];

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -369,7 +369,7 @@ query MyFeed {
         }
       )) as Types.ComplexPluginOutput;
       expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(variables?: FeedQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
+export function useFeedQuery(variables?: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | VueApolloComposable.ReactiveFunction<FeedQueryVariables>, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
   return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, baseOptions);
 }`);
 
@@ -414,7 +414,7 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(variables?: FeedQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
+export function useFeedQuery(variables?: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | VueApolloComposable.ReactiveFunction<FeedQueryVariables>, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
   return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedQueryDocument, variables, baseOptions);
 }`);
 

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -135,21 +135,6 @@ describe('Vue Apollo', () => {
       expect(((await plugin(schema, [{ filePath: 'test-file.ts', content: ast2 }], { dedupeOperationSuffix: false }, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotificationsQuery>;');
     });
 
-    it('should import VueApolloComposable dependencies', async () => {
-      const docs = [{ filePath: '', content: basicDoc }];
-      const content = (await plugin(
-        schema,
-        docs,
-        { withCompositionFunctions: true },
-        {
-          outputFile: 'graphql.ts',
-        }
-      )) as Types.ComplexPluginOutput;
-
-      expect(content.prepend).toContain(`import * as VueApolloComposable from '@vue/apollo-composable';`);
-      await validateTypeScript(content, schema, docs, {});
-    });
-
     it('should import VueApolloComposable from VueApolloComposableImportFrom config option', async () => {
       const docs = [{ filePath: '', content: basicDoc }];
       const content = (await plugin(

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -154,13 +154,13 @@ describe('Vue Apollo', () => {
       const content = (await plugin(
         schema,
         docs,
-        { withCompositionFunctions: true, vueApolloComposableImportFrom: 'vue-apollo-hooks' },
+        { withCompositionFunctions: true, vueApolloComposableImportFrom: 'vue-apollo-composition-functions' },
         {
           outputFile: 'graphql.ts',
         }
       )) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as VueApolloComposable from 'vue-apollo-hooks';`);
+      expect(content.prepend).toContain(`import * as VueApolloComposable from 'vue-apollo-composition-functions';`);
       await validateTypeScript(content, schema, docs, {});
     });
   });
@@ -350,7 +350,7 @@ query MyFeed {
   });
 
   describe('Composition functions', () => {
-    it('Should generate hooks for query and mutation', async () => {
+    it('Should generate composition functions for query and mutation', async () => {
       const documents = parse(/* GraphQL */ `
         query feed {
           feed {
@@ -394,7 +394,7 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('Should generate deduped hooks for query and mutation', async () => {
+    it('Should generate deduped composition functions for query and mutation', async () => {
       const documents = parse(/* GraphQL */ `
         query FeedQuery {
           feed {
@@ -439,7 +439,7 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('Should not generate hooks for query and mutation', async () => {
+    it('Should not generate composition functions for query and mutation', async () => {
       const docs = [{ filePath: '', content: basicDoc }];
       const content = (await plugin(
         schema,
@@ -454,7 +454,7 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('Should generate subscription hooks', async () => {
+    it('Should generate subscription composition functions', async () => {
       const documents = parse(/* GraphQL */ `
         subscription ListenToComments($name: String) {
           commentAdded(repoFullName: $name) {
@@ -483,7 +483,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('Should not add typesPrefix to hooks', async () => {
+    it('Should not add typesPrefix to composition functions', async () => {
       const docs = [{ filePath: '', content: basicDoc }];
       const content = (await plugin(
         schema,
@@ -497,7 +497,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       expect(content.content).toContain(`export function useTestQuery`);
     });
 
-    it('should generate hook result', async () => {
+    it('should generate composition function result', async () => {
       const documents = parse(/* GraphQL */ `
         query feed {
           feed {
@@ -531,11 +531,11 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-      export type FeedQueryHookResult = ReturnType<typeof useFeedQuery>;
+      export type FeedQueryCompositionFunctionResult = ReturnType<typeof useFeedQuery>;
       `);
 
       expect(content.content).toBeSimilarStringTo(`
-      export type SubmitRepositoryMutationHookResult = ReturnType<typeof useSubmitRepositoryMutation>;
+      export type SubmitRepositoryMutationCompositionFunctionResult = ReturnType<typeof useSubmitRepositoryMutation>;
       `);
       await validateTypeScript(content, schema, docs, {});
     });
@@ -575,7 +575,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
  * });
  */`;
 
-    it('Should generate JSDoc docblocks for hooks', async () => {
+    it('Should generate JSDoc docblocks for composition functions', async () => {
       const documents = parse(/* GraphQL */ `
         query feed($id: ID!) {
           feed(id: $id) {
@@ -609,7 +609,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       expect(mutationDocBlock).toEqual(mutationDocBlockSnapshot);
     });
 
-    it('Should NOT generate JSDoc docblocks for hooks if addDocBlocks is false', async () => {
+    it('Should NOT generate JSDoc docblocks for composition functions if addDocBlocks is false', async () => {
       const documents = parse(/* GraphQL */ `
         query feed($id: ID!) {
           feed(id: $id) {
@@ -863,7 +863,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
-
         withCompositionFunctions: true,
       };
 
@@ -882,11 +881,10 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('should import Operations from one external file and use it in multiple hooks', async () => {
+    it('should import Operations from one external file and use it in multiple composition functions', async () => {
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
-
         withCompositionFunctions: true,
       };
 
@@ -920,7 +918,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
-
         withCompositionFunctions: true,
       };
 
@@ -943,7 +940,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
-
         withCompositionFunctions: true,
       };
 
@@ -965,7 +961,6 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
-
         withCompositionFunctions: true,
       };
 
@@ -983,11 +978,10 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       await validateTypeScript(content, schema, docs, {});
     });
 
-    it('should import Operations from near operation file and use it in multiple hooks', async () => {
+    it('should import Operations from near operation file and use it in multiple composition functions', async () => {
       const config: VueApolloRawPluginConfig = {
         documentMode: DocumentMode.external,
         importDocumentNodeExternallyFrom: 'near-operation-file',
-
         withCompositionFunctions: true,
       };
 

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -694,6 +694,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
           }
         }
       }
+
       mutation testTwo($name: String) {
         submitRepository(repoFullName: $name) {
           id
@@ -738,7 +739,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
         }
       )) as Types.ComplexPluginOutput;
 
-      expect(content.content).toBeSimilarStringTo(`export const TestDocument: DocumentNode = {"kind":"Document","defin`);
+      expect(content.content).toBeSimilarStringTo(`export const TestDocument`);
 
       // For issue #1599 - make sure there are not `loc` properties
       expect(content.content).not.toContain(`loc":`);
@@ -777,7 +778,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
         }
       )) as Types.ComplexPluginOutput;
 
-      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
+      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc`);
 
       await validateTypeScript(content, schema, docs, {});
     });
@@ -814,7 +815,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
         }
       )) as Types.ComplexPluginOutput;
 
-      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
+      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc`);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -845,7 +846,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
         }
       )) as Types.ComplexPluginOutput;
 
-      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
+      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc`);
 
       await validateTypeScript(content, schema, docs, { ...config });
     });
@@ -863,11 +864,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       })) as Types.ComplexPluginOutput;
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestQuery(variables?: TestQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestQuery, TestQueryVariables>) {
-        return VueApolloComposable.useQuery<TestQuery, TestQueryVariables>(Operations.test, variables, baseOptions);
-      }
-      `);
+      expect(content.content).toBeSimilarStringTo(`export function useTestQuery`);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -884,11 +881,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       })) as Types.ComplexPluginOutput;
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestMutation(baseOptions?: VueApolloComposable.UseMutationOptions<TestMutation, TestMutationVariables>) {
-        return VueApolloComposable.useMutation<TestMutation, TestMutationVariables>(Operations.test, baseOptions);
-      }
-      `);
+      expect(content.content).toBeSimilarStringTo(`export function useTestMutation`);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -905,11 +898,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       })) as Types.ComplexPluginOutput;
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestSubscription(variables?: TestSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
-        return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, variables, baseOptions);
-      }
-      `);
+      expect(content.content).toBeSimilarStringTo(`export function useTestSubscription`);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -926,21 +915,9 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       })) as Types.ComplexPluginOutput;
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestOneQuery(variables?: TestOneQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestOneQuery, TestOneQueryVariables>) {
-        return VueApolloComposable.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, variables, baseOptions);
-      }
-      `);
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestTwoMutation(baseOptions?: VueApolloComposable.UseMutationOptions<TestTwoMutation, TestTwoMutationVariables>) {
-        return VueApolloComposable.useMutation<TestTwoMutation, TestTwoMutationVariables>(Operations.testTwo, baseOptions);
-      }
-      `);
-
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestThreeSubscription(variables?: TestThreeSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
-        return VueApolloComposable.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, variables, baseOptions);
-      }`);
+      expect(content.content).toBeSimilarStringTo(`export function useTestOneQuery`);
+      expect(content.content).toBeSimilarStringTo(`export function useTestTwoMutation`);
+      expect(content.content).toBeSimilarStringTo(`export function useTestThreeSubscription`);
 
       await validateTypeScript(content, schema, docs, {});
     });
@@ -958,11 +935,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       })) as Types.ComplexPluginOutput;
 
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestQuery(variables?: TestQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestQuery, TestQueryVariables>) {
-        return VueApolloComposable.useQuery<TestQuery, TestQueryVariables>(Operations.test, variables, baseOptions);
-      }
-      `);
+      expect(content.content).toBeSimilarStringTo(`export function useTestQuery`);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -979,10 +952,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       })) as Types.ComplexPluginOutput;
 
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestMutation(baseOptions?: VueApolloComposable.UseMutationOptions<TestMutation, TestMutationVariables>) {
-        return VueApolloComposable.useMutation<TestMutation, TestMutationVariables>(Operations.test, baseOptions);
-      }`);
+      expect(content.content).toBeSimilarStringTo(`export function useTestMutation`);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -999,10 +969,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       })) as Types.ComplexPluginOutput;
 
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestSubscription(variables?: TestSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
-        return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, variables, baseOptions);
-      }`);
+      expect(content.content).toBeSimilarStringTo(`export function useTestSubscription`);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -1019,20 +986,9 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       })) as Types.ComplexPluginOutput;
 
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestOneQuery(variables?: TestOneQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestOneQuery, TestOneQueryVariables>) {
-        return VueApolloComposable.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, variables, baseOptions);
-      }
-      `);
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestTwoMutation(baseOptions?: VueApolloComposable.UseMutationOptions<TestTwoMutation, TestTwoMutationVariables>) {
-        return VueApolloComposable.useMutation<TestTwoMutation, TestTwoMutationVariables>(Operations.testTwo, baseOptions);
-      }
-      `);
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestThreeSubscription(variables?: TestThreeSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
-        return VueApolloComposable.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, variables, baseOptions);
-      }`);
+      expect(content.content).toBeSimilarStringTo(`export function useTestOneQuery`);
+      expect(content.content).toBeSimilarStringTo(`export function useTestTwoMutation`);
+      expect(content.content).toBeSimilarStringTo(`export function useTestThreeSubscription`);
 
       await validateTypeScript(content, schema, docs, {});
     });

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -384,7 +384,7 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
       expect(content.content).toBeSimilarStringTo(`
 export function useFeedQuery(variables?: FeedQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
-  return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, baseOptions);
+  return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, baseOptions);
 }`);
 
       expect(content.content).toBeSimilarStringTo(`
@@ -429,7 +429,7 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
 
       expect(content.content).toBeSimilarStringTo(`
 export function useFeedQuery(variables?: FeedQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
-  return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedQueryDocument, baseOptions);
+  return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedQueryDocument, variables, baseOptions);
 }`);
 
       expect(content.content).toBeSimilarStringTo(`
@@ -476,7 +476,7 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
 
       expect(content.content).toBeSimilarStringTo(`
 export function useListenToCommentsSubscription(variables?: ListenToCommentsSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>) {
-  return VueApolloComposable.useSubscription<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>(ListenToCommentsDocument, baseOptions);
+  return VueApolloComposable.useSubscription<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>(ListenToCommentsDocument, variables, baseOptions);
 }`);
       await validateTypeScript(content, schema, docs, {});
     });
@@ -828,7 +828,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export function useTestQuery(variables?: TestQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestQuery, TestQueryVariables>) {
-        return VueApolloComposable.useQuery<TestQuery, TestQueryVariables>(Operations.test, baseOptions);
+        return VueApolloComposable.useQuery<TestQuery, TestQueryVariables>(Operations.test, variables, baseOptions);
       }
       `);
       await validateTypeScript(content, schema, docs, {});
@@ -870,7 +870,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export function useTestSubscription(variables?: TestSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
-        return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, baseOptions);
+        return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, variables, baseOptions);
       }
       `);
       await validateTypeScript(content, schema, docs, {});
@@ -891,7 +891,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
       export function useTestOneQuery(variables?: TestOneQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestOneQuery, TestOneQueryVariables>) {
-        return VueApolloComposable.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, baseOptions);
+        return VueApolloComposable.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, variables, baseOptions);
       }
       `);
       expect(content.content).toBeSimilarStringTo(`
@@ -902,7 +902,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
 
       expect(content.content).toBeSimilarStringTo(`
       export function useTestThreeSubscription(variables?: TestThreeSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
-        return VueApolloComposable.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, baseOptions);
+        return VueApolloComposable.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, variables, baseOptions);
       }`);
 
       await validateTypeScript(content, schema, docs, {});
@@ -923,7 +923,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
       expect(content.content).toBeSimilarStringTo(`
       export function useTestQuery(variables?: TestQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestQuery, TestQueryVariables>) {
-        return VueApolloComposable.useQuery<TestQuery, TestQueryVariables>(Operations.test, baseOptions);
+        return VueApolloComposable.useQuery<TestQuery, TestQueryVariables>(Operations.test, variables, baseOptions);
       }
       `);
       await validateTypeScript(content, schema, docs, {});
@@ -964,7 +964,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
       expect(content.content).toBeSimilarStringTo(`
       export function useTestSubscription(variables?: TestSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
-        return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, baseOptions);
+        return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, variables, baseOptions);
       }`);
       await validateTypeScript(content, schema, docs, {});
     });
@@ -984,7 +984,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
       expect(content.content).toBeSimilarStringTo(`
       export function useTestOneQuery(variables?: TestOneQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestOneQuery, TestOneQueryVariables>) {
-        return VueApolloComposable.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, baseOptions);
+        return VueApolloComposable.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, variables, baseOptions);
       }
       `);
       expect(content.content).toBeSimilarStringTo(`
@@ -994,7 +994,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       `);
       expect(content.content).toBeSimilarStringTo(`
       export function useTestThreeSubscription(variables?: TestThreeSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
-        return VueApolloComposable.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, baseOptions);
+        return VueApolloComposable.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, variables, baseOptions);
       }`);
 
       await validateTypeScript(content, schema, docs, {});

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -542,31 +542,31 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
  * __useFeedQuery__
  *
  * To run a query within a Vue component, call \`useFeedQuery\` and pass it any options that fit your needs.
- * When your component renders, \`useFeedQuery\` returns an object from Apollo Client that contains loading, error, and result properties
+ * When your component renders, \`useFeedQuery\` returns an object from Apollo Client that contains result, loading and error properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
  *
  * @example
- * const { result, loading, error } = useFeedQuery({
- *   variables: {
+ * const { result, loading, error } = useFeedQuery(
+ *   {
  *      id: // value for 'id'
- *   },
- * });
+ *   }
+ * );
  */`;
 
     const mutationDocBlockSnapshot = `/**
  * __useSubmitRepositoryMutation__
  *
  * To run a mutation, you first call \`useSubmitRepositoryMutation\` within a Vue component and pass it any options that fit your needs.
- * When your component renders, \`useSubmitRepositoryMutation\` returns a tuple that includes:
+ * When your component renders, \`useSubmitRepositoryMutation\` returns an object that includes:
  * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
+ * - Several other properties: https://v4.apollo.vuejs.org/api/use-mutation.html#return
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/mutation.html#options;
  *
  * @example
- * const [{ mutate, result, loading, error }] = useSubmitRepositoryMutation({
+ * const { mutate, loading, error, onDone } = useSubmitRepositoryMutation({
  *   variables: {
  *      name: // value for 'name'
  *   },

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -62,7 +62,7 @@ describe('Vue Apollo', () => {
   };
 
   describe('Imports', () => {
-    it('should import VueApollo dependencies', async () => {
+    it('should import VueApollo and VueCompositionApi dependencies', async () => {
       const docs = [{ filePath: '', content: basicDoc }];
       const content = (await plugin(
         schema,
@@ -74,6 +74,7 @@ describe('Vue Apollo', () => {
       )) as Types.ComplexPluginOutput;
 
       expect(content.prepend).toContain(`import * as VueApolloComposable from '@vue/apollo-composable';`);
+      expect(content.prepend).toContain(`import * as VueCompositionApi from '@vue/composition-api';`);
       expect(content.prepend).toContain(`import gql from 'graphql-tag';`);
       await validateTypeScript(content, schema, docs, {});
     });

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -383,7 +383,7 @@ query MyFeed {
         }
       )) as Types.ComplexPluginOutput;
       expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
+export function useFeedQuery(variables?: FeedQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
   return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, baseOptions);
 }`);
 
@@ -428,7 +428,7 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
+export function useFeedQuery(variables?: FeedQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
   return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedQueryDocument, baseOptions);
 }`);
 
@@ -475,7 +475,7 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-export function useListenToCommentsSubscription(baseOptions?: VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>) {
+export function useListenToCommentsSubscription(variables?: ListenToCommentsSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>) {
   return VueApolloComposable.useSubscription<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>(ListenToCommentsDocument, baseOptions);
 }`);
       await validateTypeScript(content, schema, docs, {});
@@ -827,7 +827,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestQuery(baseOptions?: VueApolloComposable.UseQueryOptions<TestQuery, TestQueryVariables>) {
+      export function useTestQuery(variables?: TestQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestQuery, TestQueryVariables>) {
         return VueApolloComposable.useQuery<TestQuery, TestQueryVariables>(Operations.test, baseOptions);
       }
       `);
@@ -869,7 +869,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestSubscription(baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
+      export function useTestSubscription(variables?: TestSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
         return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, baseOptions);
       }
       `);
@@ -890,7 +890,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestOneQuery(baseOptions?: VueApolloComposable.UseQueryOptions<TestOneQuery, TestOneQueryVariables>) {
+      export function useTestOneQuery(variables?: TestOneQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestOneQuery, TestOneQueryVariables>) {
         return VueApolloComposable.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, baseOptions);
       }
       `);
@@ -901,7 +901,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       `);
 
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestThreeSubscription(baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
+      export function useTestThreeSubscription(variables?: TestThreeSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
         return VueApolloComposable.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, baseOptions);
       }`);
 
@@ -922,7 +922,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
 
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestQuery(baseOptions?: VueApolloComposable.UseQueryOptions<TestQuery, TestQueryVariables>) {
+      export function useTestQuery(variables?: TestQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestQuery, TestQueryVariables>) {
         return VueApolloComposable.useQuery<TestQuery, TestQueryVariables>(Operations.test, baseOptions);
       }
       `);
@@ -963,7 +963,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
 
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestSubscription(baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
+      export function useTestSubscription(variables?: TestSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
         return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, baseOptions);
       }`);
       await validateTypeScript(content, schema, docs, {});
@@ -983,7 +983,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
 
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestOneQuery(baseOptions?: VueApolloComposable.UseQueryOptions<TestOneQuery, TestOneQueryVariables>) {
+      export function useTestOneQuery(variables?: TestOneQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<TestOneQuery, TestOneQueryVariables>) {
         return VueApolloComposable.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, baseOptions);
       }
       `);
@@ -993,7 +993,7 @@ export function useListenToCommentsSubscription(baseOptions?: VueApolloComposabl
       }
       `);
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestThreeSubscription(baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
+      export function useTestThreeSubscription(variables?: TestThreeSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
         return VueApolloComposable.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, baseOptions);
       }`);
 

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -1,0 +1,1084 @@
+import { compileTs, validateTs } from '@graphql-codegen/testing';
+import { plugin, VueApolloRawPluginConfig } from '../src/index';
+import { parse, GraphQLSchema, buildClientSchema, buildASTSchema } from 'graphql';
+import gql from 'graphql-tag';
+import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
+import { plugin as tsPlugin } from '../../typescript/src/index';
+import { plugin as tsDocumentsPlugin } from '../../operations/src/index';
+import { readFileSync } from 'fs';
+import { DocumentMode } from '@graphql-codegen/visitor-plugin-common';
+import { extract } from 'jest-docblock';
+
+describe('Vue Apollo', () => {
+  const schema = buildClientSchema(JSON.parse(readFileSync('../../../../dev-test/githunt/schema.json').toString()));
+  const basicDoc = parse(/* GraphQL */ `
+    query test {
+      feed {
+        id
+        commentCount
+        repository {
+          full_name
+          html_url
+          owner {
+            avatar_url
+          }
+        }
+      }
+    }
+  `);
+  const mutationDoc = parse(/* GraphQL */ `
+    mutation test($name: String) {
+      submitRepository(repoFullName: $name) {
+        id
+      }
+    }
+  `);
+
+  const subscriptionDoc = parse(/* GraphQL */ `
+    subscription test($name: String) {
+      commentAdded(repoFullName: $name) {
+        id
+      }
+    }
+  `);
+
+  const validateTypeScript = async (output: Types.PluginOutput, testSchema: GraphQLSchema, documents: Types.DocumentFile[], config: any, playground = false) => {
+    const tsOutput = await tsPlugin(testSchema, documents, config, { outputFile: '' });
+    const tsDocumentsOutput = await tsDocumentsPlugin(testSchema, documents, config, { outputFile: '' });
+    const merged = mergeOutputs([tsOutput, tsDocumentsOutput, output]);
+    validateTs(merged, undefined, true, false, playground);
+
+    return merged;
+  };
+
+  const validateAndCompile = async (content: Types.PluginOutput, config: any = {}, pluginSchema: GraphQLSchema, documents: Types.DocumentFile[], usage = '', playground = false) => {
+    const tsOutput = await tsPlugin(pluginSchema, documents, config, { outputFile: '' });
+    const tsDocumentsOutput = await tsDocumentsPlugin(pluginSchema, documents, config, { outputFile: '' });
+    const merged = mergeOutputs([tsOutput, tsDocumentsOutput, content]);
+
+    await compileTs(merged, {}, true, playground);
+
+    return merged;
+  };
+
+  describe('Imports', () => {
+    it('should import VueApollo dependencies', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as VueApolloComposable from '@vue/apollo-composable';`);
+      expect(content.prepend).toContain(`import gql from 'graphql-tag';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import DocumentNode when using noGraphQLTag', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          noGraphQLTag: true,
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import { DocumentNode } from 'graphql';`);
+      expect(content.prepend).not.toContain(`import gql from 'graphql-tag';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it(`should use gql import from gqlImport config option`, async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        { gqlImport: 'graphql.macro#gql' },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import { gql } from 'graphql.macro';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it(`tests for dedupeOperationSuffix`, async () => {
+      const ast = parse(/* GraphQL */ `
+        query notificationsQuery {
+          notifications {
+            id
+          }
+        }
+      `);
+      const ast2 = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            id
+          }
+        }
+      `);
+
+      expect(((await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], {}, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotificationsQueryQuery>;');
+      expect(((await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], { dedupeOperationSuffix: false }, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotificationsQueryQuery>;');
+      expect(((await plugin(schema, [{ filePath: 'test-file.ts', content: ast }], { dedupeOperationSuffix: true }, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotificationsQuery>;');
+      expect(((await plugin(schema, [{ filePath: 'test-file.ts', content: ast2 }], { dedupeOperationSuffix: true }, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotificationsQuery>;');
+      expect(((await plugin(schema, [{ filePath: 'test-file.ts', content: ast2 }], { dedupeOperationSuffix: false }, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotificationsQuery>;');
+    });
+
+    it('should import VueApolloComposable dependencies', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        { withCompositionFunctions: true },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as VueApolloComposable from '@vue/apollo-composable';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import VueApolloComposable from VueApolloComposableImportFrom config option', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        { withCompositionFunctions: true, vueApolloComposableImportFrom: 'vue-apollo-hooks' },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as VueApolloComposable from 'vue-apollo-hooks';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+  });
+
+  describe('Fragments', () => {
+    it('Should generate basic fragments documents correctly', async () => {
+      const docs = [
+        {
+          filePath: 'a.graphql',
+          content: parse(/* GraphQL */ `
+            fragment MyFragment on Repository {
+              full_name
+            }
+
+            query {
+              feed {
+                id
+              }
+            }
+          `),
+        },
+      ];
+      const result = (await plugin(schema, docs, {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+      expect(result.content).toBeSimilarStringTo(`
+      export const MyFragmentFragmentDoc = gql\`
+      fragment MyFragment on Repository {
+        full_name
+      }
+      \`;`);
+      await validateTypeScript(result, schema, docs, {});
+    });
+
+    it('should generate Document variables for inline fragments', async () => {
+      const repositoryWithOwner = gql`
+        fragment RepositoryWithOwner on Repository {
+          full_name
+          html_url
+          owner {
+            avatar_url
+          }
+        }
+      `;
+      const feedWithRepository = gql`
+        fragment FeedWithRepository on Entry {
+          id
+          commentCount
+          repository(search: "phrase") {
+            ...RepositoryWithOwner
+          }
+        }
+
+        ${repositoryWithOwner}
+      `;
+      const myFeed = gql`
+        query MyFeed {
+          feed {
+            ...FeedWithRepository
+          }
+        }
+
+        ${feedWithRepository}
+      `;
+
+      const docs = [{ filePath: '', content: myFeed }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`export const FeedWithRepositoryFragmentDoc = gql\`
+fragment FeedWithRepository on Entry {
+  id
+  commentCount
+  repository(search: "phrase") {
+    ...RepositoryWithOwner
+  }
+}
+\${RepositoryWithOwnerFragmentDoc}\`;`);
+      expect(content.content).toBeSimilarStringTo(`export const RepositoryWithOwnerFragmentDoc = gql\`
+fragment RepositoryWithOwner on Repository {
+  full_name
+  html_url
+  owner {
+    avatar_url
+  }
+}
+\`;`);
+
+      expect(content.content).toBeSimilarStringTo(`export const MyFeedDocument = gql\`
+query MyFeed {
+  feed {
+    ...FeedWithRepository
+  }
+}
+\${FeedWithRepositoryFragmentDoc}\`;`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should avoid generating duplicate fragments', async () => {
+      const simpleFeed = gql`
+        fragment Item on Entry {
+          id
+        }
+      `;
+      const myFeed = gql`
+        query MyFeed {
+          feed {
+            ...Item
+          }
+          allFeeds: feed {
+            ...Item
+          }
+        }
+      `;
+      const documents = [simpleFeed, myFeed];
+      const docs = documents.map(content => ({ content, filePath: '' }));
+      const content = (await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`
+        export const MyFeedDocument = gql\`
+        query MyFeed {
+            feed {
+              ...Item
+            }
+            allFeeds: feed {
+              ...Item
+            }
+          }
+          \${ItemFragmentDoc}\``);
+      expect(content.content).toBeSimilarStringTo(`
+        export const ItemFragmentDoc = gql\`
+        fragment Item on Entry {
+          id
+        }
+\`;`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should generate fragments in proper order (when one depends on other)', async () => {
+      const myFeed = gql`
+        fragment FeedWithRepository on Entry {
+          id
+          repository {
+            ...RepositoryWithOwner
+          }
+        }
+
+        fragment RepositoryWithOwner on Repository {
+          full_name
+        }
+
+        query MyFeed {
+          feed {
+            ...FeedWithRepository
+          }
+        }
+      `;
+      const documents = [myFeed];
+      const docs = documents.map(content => ({ content, filePath: '' }));
+      const content = (await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      const feedWithRepositoryPos = content.content.indexOf('fragment FeedWithRepository');
+      const repositoryWithOwnerPos = content.content.indexOf('fragment RepositoryWithOwner');
+      expect(repositoryWithOwnerPos).toBeLessThan(feedWithRepositoryPos);
+      await validateTypeScript(content, schema, docs, {});
+    });
+  });
+
+  describe('Composition functions', () => {
+    it('Should generate hooks for query and mutation', async () => {
+      const documents = parse(/* GraphQL */ `
+        query feed {
+          feed {
+            id
+            commentCount
+            repository {
+              full_name
+              html_url
+              owner {
+                avatar_url
+              }
+            }
+          }
+        }
+
+        mutation submitRepository($name: String) {
+          submitRepository(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+      const docs = [{ filePath: '', content: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        { withCompositionFunctions: true },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+      expect(content.content).toBeSimilarStringTo(`
+export function useFeedQuery(baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
+  return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, baseOptions);
+}`);
+
+      expect(content.content).toBeSimilarStringTo(`
+export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
+  return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, baseOptions);
+}`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should generate deduped hooks for query and mutation', async () => {
+      const documents = parse(/* GraphQL */ `
+        query FeedQuery {
+          feed {
+            id
+            commentCount
+            repository {
+              full_name
+              html_url
+              owner {
+                avatar_url
+              }
+            }
+          }
+        }
+
+        mutation SubmitRepositoryMutation($name: String) {
+          submitRepository(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+      const docs = [{ filePath: '', content: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        { withCompositionFunctions: true, dedupeOperationSuffix: true },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`
+export function useFeedQuery(baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
+  return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedQueryDocument, baseOptions);
+}`);
+
+      expect(content.content).toBeSimilarStringTo(`
+export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
+  return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryMutationDocument, baseOptions);
+}`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should not generate hooks for query and mutation', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        { withCompositionFunctions: false },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).not.toContain(`export function useTestQuery`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should generate subscription hooks', async () => {
+      const documents = parse(/* GraphQL */ `
+        subscription ListenToComments($name: String) {
+          commentAdded(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+
+      const docs = [{ filePath: '', content: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          withCompositionFunctions: true,
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`
+export function useListenToCommentsSubscription(baseOptions?: VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>) {
+  return VueApolloComposable.useSubscription<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>(ListenToCommentsDocument, baseOptions);
+}`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should not add typesPrefix to hooks', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        { withCompositionFunctions: true, typesPrefix: 'I' },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toContain(`export function useTestQuery`);
+    });
+
+    it('should generate hook result', async () => {
+      const documents = parse(/* GraphQL */ `
+        query feed {
+          feed {
+            id
+            commentCount
+            repository {
+              full_name
+              html_url
+              owner {
+                avatar_url
+              }
+            }
+          }
+        }
+
+        mutation submitRepository($name: String) {
+          submitRepository(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+      const docs = [{ filePath: '', content: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        { withCompositionFunctions: true },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`
+      export type FeedQueryHookResult = ReturnType<typeof useFeedQuery>;
+      `);
+
+      expect(content.content).toBeSimilarStringTo(`
+      export type SubmitRepositoryMutationHookResult = ReturnType<typeof useSubmitRepositoryMutation>;
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    const queryDocBlockSnapshot = `/**
+ * __useFeedQuery__
+ *
+ * To run a query within a Vue component, call \`useFeedQuery\` and pass it any options that fit your needs.
+ * When your component renders, \`useFeedQuery\` returns an object from Apollo Client that contains loading, error, and result properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
+ *
+ * @example
+ * const { result, loading, error } = useFeedQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */`;
+
+    const mutationDocBlockSnapshot = `/**
+ * __useSubmitRepositoryMutation__
+ *
+ * To run a mutation, you first call \`useSubmitRepositoryMutation\` within a Vue component and pass it any options that fit your needs.
+ * When your component renders, \`useSubmitRepositoryMutation\` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/mutation.html#options;
+ *
+ * @example
+ * const [{ mutate, result, loading, error }] = useSubmitRepositoryMutation({
+ *   variables: {
+ *      name: // value for 'name'
+ *   },
+ * });
+ */`;
+
+    it('Should generate JSDoc docblocks for hooks', async () => {
+      const documents = parse(/* GraphQL */ `
+        query feed($id: ID!) {
+          feed(id: $id) {
+            id
+          }
+        }
+        mutation submitRepository($name: String) {
+          submitRepository(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+
+      const docs = [{ filePath: '', content: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        { withCompositionFunctions: true },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      const queryDocBlock = extract(content.content.substr(content.content.indexOf('/**')));
+
+      expect(queryDocBlock).toEqual(queryDocBlockSnapshot);
+
+      const mutationDocBlock = extract(content.content.substr(content.content.lastIndexOf('/**')));
+
+      expect(mutationDocBlock).toEqual(mutationDocBlockSnapshot);
+    });
+
+    it('Should NOT generate JSDoc docblocks for hooks if addDocBlocks is false', async () => {
+      const documents = parse(/* GraphQL */ `
+        query feed($id: ID!) {
+          feed(id: $id) {
+            id
+          }
+        }
+        mutation submitRepository($name: String) {
+          submitRepository(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+
+      const docs = [{ filePath: '', content: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        { withCompositionFunctions: true, addDocBlocks: false },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      const queryDocBlock = extract(content.content.substr(content.content.indexOf('/**')));
+
+      expect(queryDocBlock).not.toEqual(queryDocBlockSnapshot);
+
+      const mutationDocBlock = extract(content.content.substr(content.content.lastIndexOf('/**')));
+
+      expect(mutationDocBlock).not.toEqual(mutationDocBlockSnapshot);
+    });
+  });
+
+  describe('documentMode and importDocumentNodeExternallyFrom', () => {
+    const multipleOperationDoc = parse(/* GraphQL */ `
+      query testOne {
+        feed {
+          id
+          commentCount
+          repository {
+            full_name
+            html_url
+            owner {
+              avatar_url
+            }
+          }
+        }
+      }
+      mutation testTwo($name: String) {
+        submitRepository(repoFullName: $name) {
+          id
+        }
+      }
+
+      subscription testThree($name: String) {
+        commentAdded(repoFullName: $name) {
+          id
+        }
+      }
+    `);
+
+    it('should import DocumentNode when documentMode is "documentNode"', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.documentNode,
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import { DocumentNode } from 'graphql';`);
+      expect(content.prepend).not.toContain(`import gql from 'graphql-tag';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should generate Document variable when documentMode is "documentNode"', async () => {
+      const docs = [{ filePath: '', content: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.documentNode,
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`export const TestDocument: DocumentNode = {"kind":"Document","defin`);
+
+      // For issue #1599 - make sure there are not `loc` properties
+      expect(content.content).not.toContain(`loc":`);
+      expect(content.content).not.toContain(`loc':`);
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should NOT generate inline fragment docs for external mode: file with operation using inline fragment', async () => {
+      const docs = [
+        {
+          filePath: '',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment on Entry {
+              id
+              commentCount
+            }
+            query testOne {
+              feed {
+                ...feedFragment
+              }
+            }
+          `),
+        },
+      ];
+      const config = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+      };
+      const content = (await plugin(
+        schema,
+        docs,
+        { ...config },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should NOT generate inline fragment docs for external mode: file with operation NOT using inline fragment', async () => {
+      const docs = [
+        {
+          filePath: '',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment on Entry {
+              id
+              commentCount
+            }
+            query testOne {
+              feed {
+                id
+              }
+            }
+          `),
+        },
+      ];
+      const config = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+      };
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          ...config,
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should NOT generate inline fragment docs for external mode: file with just fragment', async () => {
+      const docs = [
+        {
+          filePath: '',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment on Entry {
+              id
+              commentCount
+            }
+          `),
+        },
+      ];
+      const config = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+      };
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          ...config,
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).not.toBeSimilarStringTo(`export const FeedFragmentFragmentDoc = gql`);
+
+      await validateTypeScript(content, schema, docs, { ...config });
+    });
+
+    it('should import Operations from one external file and use it in useQuery', async () => {
+      const config: VueApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents',
+        withCompositionFunctions: true,
+      };
+
+      const docs = [{ filePath: '', content: basicDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestQuery(baseOptions?: VueApolloComposable.UseQueryOptions<TestQuery, TestQueryVariables>) {
+        return VueApolloComposable.useQuery<TestQuery, TestQueryVariables>(Operations.test, baseOptions);
+      }
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from one external file and use it in useMutation', async () => {
+      const config: VueApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.ts',
+        withCompositionFunctions: true,
+      };
+
+      const docs = [{ filePath: '', content: mutationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestMutation(baseOptions?: VueApolloComposable.UseMutationOptions<TestMutation, TestMutationVariables>) {
+        return VueApolloComposable.useMutation<TestMutation, TestMutationVariables>(Operations.test, baseOptions);
+      }
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from one external file and use it in useSubscription', async () => {
+      const config: VueApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+
+        withCompositionFunctions: true,
+      };
+
+      const docs = [{ filePath: '', content: subscriptionDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestSubscription(baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
+        return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, baseOptions);
+      }
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from one external file and use it in multiple hooks', async () => {
+      const config: VueApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+
+        withCompositionFunctions: true,
+      };
+
+      const docs = [{ filePath: '', content: multipleOperationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestOneQuery(baseOptions?: VueApolloComposable.UseQueryOptions<TestOneQuery, TestOneQueryVariables>) {
+        return VueApolloComposable.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, baseOptions);
+      }
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestTwoMutation(baseOptions?: VueApolloComposable.UseMutationOptions<TestTwoMutation, TestTwoMutationVariables>) {
+        return VueApolloComposable.useMutation<TestTwoMutation, TestTwoMutationVariables>(Operations.testTwo, baseOptions);
+      }
+      `);
+
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestThreeSubscription(baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
+        return VueApolloComposable.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, baseOptions);
+      }`);
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from near operation file for useQuery', async () => {
+      const config: VueApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+
+        withCompositionFunctions: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: basicDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestQuery(baseOptions?: VueApolloComposable.UseQueryOptions<TestQuery, TestQueryVariables>) {
+        return VueApolloComposable.useQuery<TestQuery, TestQueryVariables>(Operations.test, baseOptions);
+      }
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from near operation file for useMutation', async () => {
+      const config: VueApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+
+        withCompositionFunctions: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: mutationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestMutation(baseOptions?: VueApolloComposable.UseMutationOptions<TestMutation, TestMutationVariables>) {
+        return VueApolloComposable.useMutation<TestMutation, TestMutationVariables>(Operations.test, baseOptions);
+      }`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from near operation file for useSubscription', async () => {
+      const config: VueApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+
+        withCompositionFunctions: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: subscriptionDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestSubscription(baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
+        return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(Operations.test, baseOptions);
+      }`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import Operations from near operation file and use it in multiple hooks', async () => {
+      const config: VueApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+
+        withCompositionFunctions: true,
+      };
+
+      const docs = [{ filePath: 'path/to/document.graphql', content: multipleOperationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestOneQuery(baseOptions?: VueApolloComposable.UseQueryOptions<TestOneQuery, TestOneQueryVariables>) {
+        return VueApolloComposable.useQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, baseOptions);
+      }
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestTwoMutation(baseOptions?: VueApolloComposable.UseMutationOptions<TestTwoMutation, TestTwoMutationVariables>) {
+        return VueApolloComposable.useMutation<TestTwoMutation, TestTwoMutationVariables>(Operations.testTwo, baseOptions);
+      }
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestThreeSubscription(baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestThreeSubscription, TestThreeSubscriptionVariables>) {
+        return VueApolloComposable.useSubscription<TestThreeSubscription, TestThreeSubscriptionVariables>(Operations.testThree, baseOptions);
+      }`);
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it(`should NOT import Operations if no operation collected: external mode and one file`, async () => {
+      const docs = [
+        {
+          filePath: 'path/to/document.graphql',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment on Entry {
+              id
+              commentCount
+            }
+          `),
+        },
+      ];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.external,
+          importDocumentNodeExternallyFrom: 'near-operation-file',
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).not.toBeSimilarStringTo(`import * as Operations`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it(`should NOT import Operations if no operation collected: external mode and multiple files`, async () => {
+      const docs = [
+        {
+          filePath: 'a.graphql',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment1 on Entry {
+              id
+              commentCount
+            }
+          `),
+        },
+        {
+          filePath: 'b.graphql',
+          content: parse(/* GraphQL */ `
+            fragment feedFragment2 on Entry {
+              id
+              commentCount
+            }
+          `),
+        },
+      ];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.external,
+          importDocumentNodeExternallyFrom: 'path/to/documents.tsx',
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).not.toBeSimilarStringTo(`import * as Operations`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+  });
+});

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -526,7 +526,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
 
     it('Should generate required variables if required in graphql document', async () => {
       const documents = parse(/* GraphQL */ `
-        query feed($id: ID!) {
+        query feed($id: ID!, $name: String, $people: [String]!) {
           feed(id: $id) {
             id
           }
@@ -536,8 +536,9 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
             id
           }
         }
-        subscription subscribeToFeed($id: ID!) {
-          feedAdded(id: $id) {
+
+        subscription test($name: String!) {
+          commentAdded(repoFullName: $name) {
             id
           }
         }
@@ -555,20 +556,20 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
 
       // query with required variables
       expect(content.content).toBeSimilarStringTo(`
-      export function useFeedQuery(variables: FeedQueryVariables, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
+      export function useFeedQuery(variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | VueApolloComposable.ReactiveFunction<FeedQueryVariables>, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
         return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, baseOptions);
-      }`);
-
-      // subscription with required variables
-      expect(content.content).toBeSimilarStringTo(`
-      export function useSubscribeToFeedSubscription(variables: SubscribeToFeedSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<SubscribeToFeedSubscription, SubscribeToFeedSubscriptionVariables>) {
-        return VueApolloComposable.useSubscription<SubscribeToFeedSubscription, SubscribeToFeedSubscriptionVariables>(SubscribeToFeedDocument, variables, baseOptions);
       }`);
 
       // mutation with required variables
       expect(content.content).toBeSimilarStringTo(`
-      export function useSubmitRepositoryMutation(baseOptions: { Omit<VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation>, 'variables'>; variables: SubmitRepositoryMutationVariables }) {
+      export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
         return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, baseOptions);
+      }`);
+
+      // subscription with required variables
+      expect(content.content).toBeSimilarStringTo(`
+      export function useTestSubscription(variables: TestSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
+        return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(TestDocument, variables, baseOptions);
       }`);
 
       await validateTypeScript(content, schema, docs, {});

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -368,8 +368,8 @@ query MyFeed {
           outputFile: 'graphql.ts',
         }
       )) as Types.ComplexPluginOutput;
-      expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(variables?: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | VueApolloComposable.ReactiveFunction<FeedQueryVariables>, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
+      expect(content.content).toBeSimilarStringTo(`type ReactiveFunctionFeedQuery = () => FeedQueryVariables \n
+export function useFeedQuery(variables?: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunctionFeedQuery, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
   return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, baseOptions);
 }`);
 
@@ -414,7 +414,7 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(variables?: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | VueApolloComposable.ReactiveFunction<FeedQueryVariables>, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
+export function useFeedQuery(variables?: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunctionFeedQuery, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
   return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedQueryDocument, variables, baseOptions);
 }`);
 
@@ -556,7 +556,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
 
       // query with required variables
       expect(content.content).toBeSimilarStringTo(`
-      export function useFeedQuery(variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | VueApolloComposable.ReactiveFunction<FeedQueryVariables>, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
+      export function useFeedQuery(variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunctionFeedQuery, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
         return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, baseOptions);
       }`);
 

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -1,6 +1,6 @@
 import { compileTs, validateTs } from '@graphql-codegen/testing';
 import { plugin, VueApolloRawPluginConfig } from '../src/index';
-import { parse, GraphQLSchema, buildClientSchema, buildASTSchema } from 'graphql';
+import { parse, GraphQLSchema, buildClientSchema } from 'graphql';
 import gql from 'graphql-tag';
 import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 import { plugin as tsPlugin } from '../../typescript/src/index';

--- a/packages/plugins/typescript/vue-apollo/tsconfig.json
+++ b/packages/plugins/typescript/vue-apollo/tsconfig.json
@@ -1,21 +1,18 @@
 {
   "compilerOptions": {
+    "strict": true,
     "esModuleInterop": true,
     "importHelpers": true,
     "module": "esnext",
     "target": "es2018",
-    "lib": ["es6", "esnext", "es2015", "dom"],
-    "suppressImplicitAnyIndexErrors": true,
+    "lib": ["es6", "esnext", "es2015"],
     "moduleResolution": "node",
     "sourceMap": true,
     "declaration": true,
     "outDir": "./dist/",
-    "noImplicitAny": false,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
     "noImplicitReturns": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "exclude": ["node_modules", "tests", "dist", "example"]
 }

--- a/packages/plugins/typescript/vue-apollo/tsconfig.json
+++ b/packages/plugins/typescript/vue-apollo/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "importHelpers": true,
+    "module": "esnext",
+    "target": "es2018",
+    "lib": ["es6", "esnext", "es2015", "dom"],
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "./dist/",
+    "noImplicitAny": false,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "exclude": ["node_modules", "tests", "dist", "example"]
+}


### PR DESCRIPTION
Hi everybody 👋 
I've been working on a plugin to generate code for v4 of `vue-apollo`.
https://github.com/vuejs/vue-apollo/releases/tag/v4.0.0-alpha.1
V4 introduces an api very similar to react hooks for `react-apollo`, therefore the code in this PR was initially copied over from the `react-apollo` plugin and modified for vue.

Happy to hear any feedback and if you feel like this PR is in a good shape I'm willing to write docs for it as well. 🚀 

In use:
```vue
<template>
  <h1>{{ result }}</h1> <-- Hello World! -->
</template>

<script lang="ts">
import { createComponent } from "@vue/composition-api";
import { useHelloWorldQuery } from "../generated/graphqlOperations";

export default createComponent({
  setup() {
    const { result } = useHelloWorldQuery();
    return { result };
  },
  name: "home"
});
</script>
```

Related issues:
- https://github.com/dotansimha/graphql-code-generator/issues/1539

Todo:
- [x] fix `useQuery`, `useSubscription` and `useMutation` input types
- [x] fix required inputs/arguments in generated code