### PR TITLE
Fix relative path to package.json in CLI init command

### DIFF
--- a/packages/graphql-codegen-cli/src/init/helpers.ts
+++ b/packages/graphql-codegen-cli/src/init/helpers.ts
@@ -52,8 +52,8 @@ export function writePackage(answers: Answers, configLocation: string) {
     // Works in tests
     version = require('../../package.json').version;
   } catch (e) {
-    // Works in production (because of esm and cjs directories)
-    version = require('../../../package.json').version;
+    // Works in production (package dist is flat, everything is in the same folder)
+    version = require('./package.json').version;
   }
 
   answers.plugins.forEach(plugin => {


### PR DESCRIPTION
There currently exists a small but annoying issue in CLI when bootstrapping a new project with `graphql-codegen init`. Instead of reading the version from CLI `package.json`, `writePackage` function reads it from the project package.json, assigning the wrong version to the plugins selected during ineracrtive init process.

To reproduce you can create a new empty project and init codegen there:

```sh
# create new empty folder
mkdir test-codegen-cli && cd test-codegen-cli
# generate package.json with version = 1.0.0
npm init -y
# install required dependencies
npm i -s graphql  && npm i -D @graphql-codegen/cli
# run interactive init and select a bunch of plugins
npx graphql-codegen init
```

You'll notice that selected plugins are added to package.json with the version of the project (1.0.0) , instead of the installed version of the CLI (1.9.1 at the moment of creating this issue)

Seems like the dist structure was changed at some point, but the path wasn't updated. This PR fixes the relative path to the cli `package.json`

Another approach could be to read the version of the installed CLI directly from the project package.json instead of checking the package.json in the CLI and relying on the relative path to the file. I'm happy to refactor this part of the code if you think that it will be a better solution.