### PR TITLE
Fix apollo angular external mode

### DIFF
--- a/packages/plugins/typescript/apollo-angular/src/index.ts
+++ b/packages/plugins/typescript/apollo-angular/src/index.ts
@@ -76,7 +76,7 @@ export const plugin: PluginFunction<ApolloAngularRawPluginConfig> = (schema: Gra
     ...(config.externalFragments || []),
   ];
 
-  const visitor = new ApolloAngularVisitor(schema, allFragments, operations, config) as any;
+  const visitor = new ApolloAngularVisitor(schema, allFragments, operations, config, documents) as any;
   const visitorResult = visit(allAst, { leave: visitor });
 
   return {


### PR DESCRIPTION
There are currently 2 issues with generating apollo-angular operations with documentMode = external

1) It throws an exception in `ClientSideBaseVisitor` when it attempts to access `documents.length` because `ApolloAngularVisitor` is missing the `document` parameter when calling the parent constructor.
2) The document variable name is missing `Operations.` namespace which is defined by external mode.

This PR solves both issues.
For the second issue, it borrows from react's plugin implementation of the method `_getDocumentNodeVariable`

Finally, thanks for all the great work.