### PR TITLE
[kotlin] Map ID to String instead of Any

### DIFF
--- a/packages/plugins/java/kotlin/src/visitor.ts
+++ b/packages/plugins/java/kotlin/src/visitor.ts
@@ -18,7 +18,7 @@ import {
 import { wrapTypeWithModifiers } from '@graphql-codegen/java-common';
 
 export const KOTLIN_SCALARS = {
-  ID: 'Any',
+  ID: 'String',
   String: 'String',
   Boolean: 'Boolean',
   Int: 'Int',

--- a/packages/plugins/java/kotlin/tests/kotlin.spec.ts
+++ b/packages/plugins/java/kotlin/tests/kotlin.spec.ts
@@ -158,7 +158,7 @@ describe('Kotlin', () => {
 
       // language=kotlin
       expect(result).toBeSimilarStringTo(`data class QueryUserArgs(
-        val id: Any
+        val id: String
       )`);
 
       // language=kotlin


### PR DESCRIPTION
As I looked into code generation logic for TypeScript it seems that `ID` is mapped to `string`.
However in Kotlin it was mapped to `Any` so I changed to `String`.

Thanks.
