### PR TITLE
Fixes for fields existences checks for selection set

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -294,7 +294,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
           }
 
           if (!selectedField) {
-            throw new TypeError(`Could not find field type. ${parentSchemaType}.${selectionNode.name.value}`);
+            continue;
           }
 
           const fieldName = getFieldNodeNameValue(selectionNode);

--- a/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
+++ b/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
@@ -125,3 +125,36 @@ exports[`TypeScript Operations Plugin Issues #2916 - Missing import prefix with 
 export type UserQuery = { user: { id: string, username: string, email: string, dep: Types.Department } };
 "
 `;
+
+exports[`TypeScript Operations Plugin Issues #3064 - fragments over interfaces causes issues with fields 1`] = `
+"type Venue_Hotel_Fragment = (
+  { __typename?: 'Hotel' }
+  & Pick<Hotel, 'id'>
+  & { gpsPosition: (
+    { __typename?: 'GPSPosition' }
+    & Pick<GpsPosition, 'lat' | 'lng'>
+  ) }
+);
+
+type Venue_Transport_Fragment = (
+  { __typename?: 'Transport' }
+  & Pick<Transport, 'id'>
+);
+
+export type VenueFragment = Venue_Hotel_Fragment | Venue_Transport_Fragment;
+
+export type QQueryVariables = {};
+
+
+export type QQuery = (
+  { __typename?: 'Query' }
+  & { hotel: (
+    { __typename?: 'Hotel' }
+    & Venue_Hotel_Fragment
+  ), transport: (
+    { __typename?: 'Transport' }
+    & Venue_Transport_Fragment
+  ) }
+);
+"
+`;


### PR DESCRIPTION
Related: https://github.com/dotansimha/graphql-code-generator/issues/3064

Codegen should let `graphql.js` handle validations, and ignore when it finds an invalid field (because inline fragments are allowed everywhere...) 