### PR TITLE
Parse & stringify gql when documentMode=string

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -175,7 +175,7 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
 
   protected _includeFragments(fragments: string[]): string {
     if (fragments && fragments.length > 0) {
-      if (this.config.documentMode === DocumentMode.documentNode) {
+      if (this.config.documentMode === DocumentMode.documentNode || this.config.documentMode === DocumentMode.string) {
         return `${fragments
           .filter((name, i, all) => all.indexOf(name) === i)
           .map(name => {
@@ -222,7 +222,7 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
 
       return JSON.stringify(gqlObj);
     } else if (this.config.documentMode === DocumentMode.string) {
-      return '`' + doc + '`';
+      return '`' + print(gqlTag(doc)) + '`';
     }
 
     return 'gql`' + doc + '`';

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -528,8 +528,7 @@ export type Feed4Query = (
   )>>> }
 );
 
-export const FeedDocument = \`
-    query feed {
+export const FeedDocument = \`query feed {
   feed {
     id
     commentCount
@@ -540,28 +539,25 @@ export const FeedDocument = \`
     }
   }
 }
-    \`;
-export const Feed2Document = \`
-    query feed2($v: String!) {
+\`;
+export const Feed2Document = \`query feed2($v: String!) {
   feed {
     id
   }
 }
-    \`;
-export const Feed3Document = \`
-    query feed3($v: String) {
+\`;
+export const Feed3Document = \`query feed3($v: String) {
   feed {
     id
   }
 }
-    \`;
-export const Feed4Document = \`
-    query feed4($v: String! = \\"TEST\\") {
+\`;
+export const Feed4Document = \`query feed4($v: String! = \\"TEST\\") {
   feed {
     id
   }
 }
-    \`;
+\`;
 export function getSdk(client: GraphQLClient) {
   return {
     feed(variables?: FeedQueryVariables): Promise<FeedQuery> {


### PR DESCRIPTION
documentMode=string is perfect for graphql-request, but it simply
inlines any referenced fragments. This means that fragments that
are included more than once in a single query for example, by being
included by another fragment in that query, as well as at the top level -
are thus duplicated in the query, and then fail when send to the server.

This PR parses and stringifies queries ahead of time such that
no duplicates occur.