### PR TITLE
fix: resolvers can be values rather than functions

### DIFF
--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -96,7 +96,7 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
   const resolverFnUsage = `ResolverFn<TResult, TParent, TContext, TArgs>`;
   const stitchingResolverUsage = `StitchingResolver<TResult, TParent, TContext, TArgs>`;
 
-  const resolverDefParts = [resolverType, `  | TResult`, `  | Promise<TResult>`];
+  const resolverDefParts = [resolverType, `TResult`, `Promise<TResult>`, resolverFnUsage];
 
   if (visitor.hasFederation()) {
     defsToInclude.push(`export type ReferenceResolver<TResult, TReference, TContext> = (
@@ -106,13 +106,7 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
     ) => Promise<TResult> | TResult;`);
   }
 
-  if (noSchemaStitching) {
-    // Resolver =
-    // | TResult
-    // | Promise<TResult>
-    // | ResolverFn;
-    resolverDefParts.push(`  | ${resolverFnUsage};`);
-  } else {
+  if (!noSchemaStitching) {
     // StitchingResolver
     // Resolver =
     // | TResult
@@ -120,10 +114,9 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
     // | ResolverFn
     // | StitchingResolver;
     defsToInclude.push(stitchingResolverType);
-    resolverDefParts.push(`  | ${resolverFnUsage}`);
-    resolverDefParts.push(`  | ${stitchingResolverUsage};`);
+    resolverDefParts.push(stitchingResolverUsage);
   }
-  defsToInclude.push(resolverDefParts.join('\n'));
+  defsToInclude.push(resolverDefParts.join('\n  | ') + ';');
 
   const header = `${indexSignature}
 

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -96,6 +96,8 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
   const resolverFnUsage = `ResolverFn<TResult, TParent, TContext, TArgs>`;
   const stitchingResolverUsage = `StitchingResolver<TResult, TParent, TContext, TArgs>`;
 
+  const resolverDefParts = [resolverType, `  | TResult`, `  | Promise<TResult>`];
+
   if (visitor.hasFederation()) {
     defsToInclude.push(`export type ReferenceResolver<TResult, TReference, TContext> = (
       reference: TReference,
@@ -105,15 +107,23 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
   }
 
   if (noSchemaStitching) {
-    // Resolver = ResolverFn;
-    defsToInclude.push(`${resolverType} ${resolverFnUsage};`);
+    // Resolver =
+    // | TResult
+    // | Promise<TResult>
+    // | ResolverFn;
+    resolverDefParts.push(`  | ${resolverFnUsage};`);
   } else {
     // StitchingResolver
     // Resolver =
+    // | TResult
+    // | Promise<TResult>
     // | ResolverFn
     // | StitchingResolver;
-    defsToInclude.push([stitchingResolverType, resolverType, `  | ${resolverFnUsage}`, `  | ${stitchingResolverUsage};`].join('\n'));
+    defsToInclude.push(stitchingResolverType);
+    resolverDefParts.push(`  | ${resolverFnUsage}`);
+    resolverDefParts.push(`  | ${stitchingResolverUsage};`);
   }
+  defsToInclude.push(resolverDefParts.join('\n'));
 
   const header = `${indexSignature}
 

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -132,6 +132,8 @@ describe('TypeScript Resolvers Plugin', () => {
     `);
     expect(result.content).toBeSimilarStringTo(`
       export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+        | TResult
+        | Promise<TResult>
         | ResolverFn<TResult, TParent, TContext, TArgs>
         | StitchingResolver<TResult, TParent, TContext, TArgs>;
     `);
@@ -214,13 +216,17 @@ describe('TypeScript Resolvers Plugin', () => {
     `);
     expect(result.content).not.toBeSimilarStringTo(`
       export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+        | TResult
+        | Promise<TResult>
         | ResolverFn<TResult, TParent, TContext, TArgs>
         | StitchingResolver<TResult, TParent, TContext, TArgs>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
-        ResolverFn<TResult, TParent, TContext, TArgs>;
+        | TResult
+        | Promise<TResult>
+        | ResolverFn<TResult, TParent, TContext, TArgs>;
     `);
 
     await validate(result);


### PR DESCRIPTION
Allows `Resolver` to be a value rather than just a function by adding `TResult` and `Promise<TResult>` as possible types.

Resolvers are generally functions, but they are also allowed to be values.

Related: #3112