### PR TITLE
feat: allow field definitions to be wrapped

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -787,6 +787,10 @@ export type IDirectiveResolvers${contextType} = ${name}<ContextType>;`
     return `${resolversType}['${name}']`;
   }
 
+  protected getParentTypeForSignature(node: FieldDefinitionNode) {
+    return 'ParentType';
+  }
+
   protected transformParentGenericType(parentType: string): string {
     return `ParentType extends ${parentType} = ${parentType}`;
   }
@@ -829,7 +833,11 @@ export type IDirectiveResolvers${contextType} = ${name}<ContextType>;`
         }
       }
 
-      const parentTypeSignature = this._federation.transformParentType({ fieldNode: original, parentType, parentTypeSignature: 'ParentType' });
+      const parentTypeSignature = this._federation.transformParentType({
+        fieldNode: original,
+        parentType,
+        parentTypeSignature: this.getParentTypeForSignature(node),
+      });
       const mappedTypeKey = isSubscriptionType ? `${mappedType}, "${node.name}"` : mappedType;
 
       let signature: {

--- a/packages/plugins/typescript/resolvers/src/config.ts
+++ b/packages/plugins/typescript/resolvers/src/config.ts
@@ -39,6 +39,25 @@ export interface TypeScriptResolversPluginConfig extends RawResolversConfig {
    */
   noSchemaStitching?: boolean;
   /**
+   * @name wrapFieldDefinitions
+   * @type boolean
+   * @description Set to `true` in order to wrap field definitions with `FieldWrapper`.
+   * This is useful to allow return types such as Promises and functions. Needed for
+   * compatibility with `federation: true` when
+   * @default true
+   *
+   * @example Enable wrapping fields
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    wrapFieldDefinitions: false
+   * ```
+   */
+  wrapFieldDefinitions?: boolean;
+  /**
    * @name customResolveInfo
    * @type string
    * @description You can provide your custom GraphQLResolveInfo instead of the default one from graphql-js

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -39,6 +39,13 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
   const stitchingResolverUsage = `StitchingResolver<TResult, TParent, TContext, TArgs>`;
 
   if (visitor.hasFederation()) {
+    if (visitor.config.wrapFieldDefinitions) {
+      defsToInclude.push(`export type UnwrappedObject<T> = {
+        [P in keyof T]: T[P] extends infer R | Promise<infer R> | (() => infer R2 | Promise<infer R2>)
+          ? R & R2 : T[P]
+      };`);
+    }
+
     defsToInclude.push(`export type ReferenceResolver<TResult, TReference, TContext> = (
       reference: TReference,
       context: TContext,

--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -69,6 +69,23 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    */
   enumsAsTypes?: boolean;
   /**
+   * @name fieldWrapperValue
+   * @type string
+   * @description Allow to override the type value of `FieldWrapper`.
+   * @default T | Promise<T> | (() => T | Promise<T>)
+   *
+   * @example Only allow values
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    fieldWrapperValue: T
+   * ```
+   */
+  fieldWrapperValue?: string;
+  /**
    * @name immutableTypes
    * @type boolean
    * @description Generates immutable types by adding `readonly` to properties and uses `ReadonlyArray`.
@@ -120,4 +137,22 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    * ```
    */
   noExport?: boolean;
+  /**
+   * @name wrapFieldDefinitions
+   * @type boolean
+   * @description Set the to `true` in order to wrap field definitions with `FieldWrapper`.
+   * This is useful to allow return types such as Promises and functions.
+   * @default true
+   *
+   * @example Enable wrapping fields
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    wrapFieldDefinitions: false
+   * ```
+   */
+  wrapFieldDefinitions?: boolean;
 }

--- a/packages/plugins/typescript/typescript/src/index.ts
+++ b/packages/plugins/typescript/typescript/src/index.ts
@@ -14,13 +14,12 @@ export const plugin: PluginFunction<TypeScriptPluginConfig> = (schema: GraphQLSc
   const visitor = new TsVisitor(schema, config);
   const printedSchema = printSchema(schema);
   const astNode = parse(printedSchema);
-  const maybeValue = visitor.getMaybeValue();
   const visitorResult = visit(astNode, { leave: visitor });
   const introspectionDefinitions = includeIntrospectionDefinitions(schema, documents, config);
   const scalars = visitor.scalarsDefinition;
 
   return {
-    prepend: [...visitor.getEnumsImports(), ...visitor.getScalarsImports(), maybeValue],
+    prepend: [...visitor.getEnumsImports(), ...visitor.getScalarsImports(), ...visitor.getWrapperDefinitions()],
     content: [scalars, ...visitorResult.definitions, ...introspectionDefinitions].join('\n'),
   };
 };

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -10,9 +10,11 @@ export interface TypeScriptPluginParsedConfig extends ParsedTypesConfig {
   avoidOptionals: AvoidOptionalsConfig;
   constEnums: boolean;
   enumsAsTypes: boolean;
+  fieldWrapperValue: string;
   immutableTypes: boolean;
   maybeValue: string;
   noExport: boolean;
+  wrapFieldDefinitions: boolean;
 }
 
 export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPluginConfig, TParsedConfig extends TypeScriptPluginParsedConfig = TypeScriptPluginParsedConfig> extends BaseTypesVisitor<TRawConfig, TParsedConfig> {
@@ -21,9 +23,11 @@ export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPlu
       noExport: getConfigValue(pluginConfig.noExport, false),
       avoidOptionals: normalizeAvoidOptionals(getConfigValue(pluginConfig.avoidOptionals, false)),
       maybeValue: getConfigValue(pluginConfig.maybeValue, 'T | null'),
+      fieldWrapperValue: getConfigValue(pluginConfig.fieldWrapperValue, 'T'),
       constEnums: getConfigValue(pluginConfig.constEnums, false),
       enumsAsTypes: getConfigValue(pluginConfig.enumsAsTypes, false),
       immutableTypes: getConfigValue(pluginConfig.immutableTypes, false),
+      wrapFieldDefinitions: getConfigValue(pluginConfig.wrapFieldDefinitions, false),
       ...(additionalConfig || {}),
     } as TParsedConfig);
 
@@ -38,8 +42,20 @@ export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPlu
     });
   }
 
+  public getWrapperDefinitions(): string[] {
+    const definitions: string[] = [this.getMaybeValue()];
+    if (this.config.wrapFieldDefinitions) {
+      definitions.push(this.getFieldWrapperValue());
+    }
+    return definitions;
+  }
+
   public getMaybeValue(): string {
     return `${this.config.noExport ? '' : 'export '}type Maybe<T> = ${this.config.maybeValue};`;
+  }
+
+  public getFieldWrapperValue(): string {
+    return `${this.config.noExport ? '' : 'export '}type FieldWrapper<T> = ${this.config.fieldWrapperValue};`;
   }
 
   protected clearOptional(str: string): string {
@@ -69,7 +85,7 @@ export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPlu
   }
 
   FieldDefinition(node: FieldDefinitionNode, key?: number | string, parent?: any): string {
-    const typeString = (node.type as any) as string;
+    const typeString = this.config.wrapFieldDefinitions ? `FieldWrapper<${node.type}>` : ((node.type as any) as string);
     const originalFieldNode = parent[key] as FieldDefinitionNode;
     const addOptionalSign = !this.config.avoidOptionals.object && originalFieldNode.type.kind !== Kind.NON_NULL_TYPE;
     const comment = transformComment((node.description as any) as string, 1);


### PR DESCRIPTION
Adds the optional (disabled by default) `FieldWrapper` type for wrapping field definitions on objects and interfaces (but _not_ input types).

In addition to returning a value of the actual type for a field, objects can also return Promises to that type or functions that do the same. It is currently not possible to achieve that by reconfiguring the code generator.

This adds the ability to wrap field definitions in a `FieldWrapper`, which defaults to `FieldWrapper<T> = T`, thus not changing behavior in any way. To get the above-described behavior, a user would need to set `fieldWrapperValue` to `T | Promise<T> | (() => T | Promise<T>)` or something similar in addition to enabling field wrapping by setting `wrapFieldDefinitions` to `true`.

That may be overkill, but I wanted to avoid altering the current existing behavior unexpectedly.

Closes: #3112