### PR TITLE
fix: include undefined as type for all-optional argument lists

### DIFF
--- a/packages/plugins/flow/resolvers/src/visitor.ts
+++ b/packages/plugins/flow/resolvers/src/visitor.ts
@@ -23,6 +23,10 @@ export class FlowResolversVisitor extends BaseResolversVisitor<FlowResolversPlug
     return `$RequireFields<${argsType}, { ${fields.map(f => `${f.name.value}: *`).join(', ')} }>`;
   }
 
+  protected applyOptionalFields(argsType: string, fields: readonly InputValueDefinitionNode[]): string {
+    return argsType;
+  }
+
   protected buildMapperImport(source: string, types: { identifier: string; asDefault?: boolean }[]): string {
     if (types[0] && types[0].asDefault) {
       return `import type ${types[0].identifier} from '${source}';`;

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -795,6 +795,8 @@ export type IDirectiveResolvers${contextType} = ${name}<ContextType>;`
 
         if (argsToForceRequire.length > 0) {
           argsType = this.applyRequireFields(argsType, argsToForceRequire);
+        } else if (original.arguments.length > 0) {
+          argsType = this.applyOptionalFields(argsType, original.arguments);
         }
       }
 
@@ -829,6 +831,11 @@ export type IDirectiveResolvers${contextType} = ${name}<ContextType>;`
   protected applyRequireFields(argsType: string, fields: InputValueDefinitionNode[]): string {
     this._globalDeclarations.add(REQUIRE_FIELDS_TYPE);
     return `RequireFields<${argsType}, ${fields.map(f => `'${f.name.value}'`).join(' | ')}>`;
+  }
+
+  protected applyOptionalFields(argsType: string, fields: readonly InputValueDefinitionNode[]): string {
+    this._globalDeclarations.add(REQUIRE_FIELDS_TYPE);
+    return `RequireFields<${argsType}, never>`;
   }
 
   ObjectTypeDefinition(node: ObjectTypeDefinitionNode) {

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -726,8 +726,26 @@ describe('TypeScript Resolvers Plugin', () => {
     const config = { typesPrefix: 'T' };
     const result = (await plugin(testSchema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
 
-    expect(result.content).toBeSimilarStringTo(`f?: Resolver<Maybe<TResolversTypes['String']>, ParentType, ContextType, TMyTypeFArgs>,`);
+    expect(result.content).toBeSimilarStringTo(`f?: Resolver<Maybe<TResolversTypes['String']>, ParentType, ContextType, RequireFields<TMyTypeFArgs, never>>,`);
     await validate(result, config, testSchema);
+  });
+
+  // dotansimha/graphql-code-generator#3322
+  it('should make list of all-optional arguments include undefined types', async () => {
+    const testSchema = buildSchema(`type MyType { f(a: String, b: Int): String }`);
+    const result = (await plugin(testSchema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`f?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeFArgs, never>>,`);
+    await validate(result, {}, testSchema);
+  });
+
+  // dotansimha/graphql-code-generator#3322
+  it('should include generic wrapper type only when necessary', async () => {
+    const testSchema = buildSchema(`type MyType { f: String }`);
+    const result = (await plugin(testSchema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`f?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,`);
+    await validate(result, {}, testSchema);
   });
 
   it('should generate Resolvers interface', async () => {


### PR DESCRIPTION
The motivation behind this change is lined out in more detail in dotansimha/graphql-code-generator#3322. The basic problem is that `RequireFields` includes provisions to make non-required arguments optional (via `?:` mapping) but this wrapper type only gets applied when there is at least one required argument in the list.

However, argument lists with all-optional arguments must have the optional mapping applied as well. If not, they end up including only `null` but not `undefined` in their types which can lead to subtle runtime errors.

Related #3322 