### PR TITLE
Fix edge cases from multiple fragment spreads in `typescript-compatibility` plugin

### DIFF
--- a/dev-test/githunt/types.preResolveTypes.compatibility.ts
+++ b/dev-test/githunt/types.preResolveTypes.compatibility.ts
@@ -304,7 +304,7 @@ export namespace Comment {
   export type CurrentUser = NonNullable<CommentQuery['currentUser']>;
   export type Entry = NonNullable<CommentQuery['entry']>;
   export type PostedBy = NonNullable<CommentQuery['entry']>['postedBy'];
-  export type Comments = CommentsPageCommentFragment;
+  export type Comments = NonNullable<NonNullable<CommentQuery['entry']>['comments'][0]>;
   export type Repository = NonNullable<CommentQuery['entry']>['repository'];
   export type RepositoryInlineFragment = { __typename: 'Repository' } & Pick<
     NonNullable<CommentQuery['entry']>['repository'],
@@ -324,7 +324,7 @@ export namespace CurrentUserForProfile {
 }
 
 export namespace FeedEntry {
-  export type Fragment = RepoInfoFragment;
+  export type Fragment = FeedEntryFragment;
   export type Repository = FeedEntryFragment['repository'];
   export type Owner = NonNullable<FeedEntryFragment['repository']['owner']>;
 }
@@ -333,7 +333,7 @@ export namespace Feed {
   export type Variables = FeedQueryVariables;
   export type Query = FeedQuery;
   export type CurrentUser = NonNullable<FeedQuery['currentUser']>;
-  export type Feed = FeedEntryFragment;
+  export type Feed = NonNullable<NonNullable<FeedQuery['feed']>[0]>;
 }
 
 export namespace SubmitRepository {
@@ -351,7 +351,7 @@ export namespace RepoInfo {
 export namespace SubmitComment {
   export type Variables = SubmitCommentMutationVariables;
   export type Mutation = SubmitCommentMutation;
-  export type SubmitComment = CommentsPageCommentFragment;
+  export type SubmitComment = NonNullable<SubmitCommentMutation['submitComment']>;
 }
 
 export namespace VoteButtons {

--- a/packages/plugins/typescript/compatibility/tests/__snapshots__/compatibility.spec.ts.snap
+++ b/packages/plugins/typescript/compatibility/tests/__snapshots__/compatibility.spec.ts.snap
@@ -65,7 +65,7 @@ export type AliasTestVariables = AliasTestQueryVariables;
 export type AliasTestCurrentUser = AliasTestQuery['currentUser'];
 export const useAliasTest = useAliasTestQuery;
 export type Me2Variables = Me2QueryVariables;
-export type Me2Me = UserFieldsFragment;
+export type Me2Me = Me2Query['me'];
 export const useMe2 = useMe2Query;
 export type Me3Variables = Me3QueryVariables;
 export type Me3Me = Me3Query['me'];
@@ -106,7 +106,7 @@ export namespace AliasTest {
 export namespace Me2 {
   export type Variables = Me2QueryVariables;
   export type Query = Me2Query;
-  export type Me = UserFieldsFragment;
+  export type Me = Me2Query['me'];
 }
 
 export namespace UserFields {
@@ -165,7 +165,7 @@ export namespace AliasTest {
 export namespace Me2 {
   export type Variables = Me2QueryVariables;
   export type Query = Me2Query;
-  export type Me = UserFieldsFragment;
+  export type Me = Me2Query['me'];
 }
 
 export namespace UserFields {

--- a/packages/plugins/typescript/compatibility/tests/compatibility.spec.ts
+++ b/packages/plugins/typescript/compatibility/tests/compatibility.spec.ts
@@ -624,7 +624,7 @@ describe('Compatibility Plugin', () => {
     const ast = [{ location: '', document: basicQuery }];
     const result = await plugin(schema, ast, {});
 
-    expect(result).toContain(`export type Me = UserFieldsFragment;`);
+    expect(result).toContain(`export type Me = MeQuery['me'];`);
     await validate(result, schema, ast, {});
   });
 

--- a/packages/plugins/typescript/compatibility/tests/compatibility.spec.ts
+++ b/packages/plugins/typescript/compatibility/tests/compatibility.spec.ts
@@ -894,7 +894,7 @@ describe('Compatibility Plugin', () => {
         }
       `);
 
-      const ast = [{ filePath: '', content: query }];
+      const ast = [{ location: '', document: query }];
       const result = await plugin(schema, ast, {});
 
       expect(result).toContain(`export type Me = MultipleSpreadsQuery['me'];`);
@@ -920,7 +920,7 @@ describe('Compatibility Plugin', () => {
         }
       `);
 
-      const ast = [{ filePath: '', content: query }];
+      const ast = [{ location: '', document: query }];
       const result = await plugin(schema, ast, {});
 
       expect(result).toBeSimilarStringTo(`
@@ -943,10 +943,12 @@ describe('Compatibility Plugin', () => {
         }
       `);
 
-      const ast = [{ filePath: '', content: query }];
+      const ast = [{ location: '', document: query }];
       const result = await plugin(schema, ast, {});
 
-      expect(result).toContain(`export type UserInlineFragment = ({ __typename: 'User' } & Pick<MultipleSpreadsQuery['me'], 'id' | keyof UserFieldsFragment | keyof UserFriendsFragment>);`);
+      expect(result).toContain(
+        `export type UserInlineFragment = ({ __typename: 'User' } & Pick<MultipleSpreadsQuery['me'], 'id' | keyof UserFieldsFragment | keyof UserFriendsFragment>);`
+      );
     });
 
     it('throws on nested inline fragments', async () => {
@@ -964,7 +966,7 @@ describe('Compatibility Plugin', () => {
         }
       `);
 
-      const ast = [{ filePath: '', content: query }];
+      const ast = [{ location: '', document: query }];
       await expect(plugin(schema, ast, {})).rejects.toThrow('Nested inline fragments');
     });
 
@@ -1026,7 +1028,7 @@ describe('Compatibility Plugin', () => {
         }
       `);
 
-      const ast = [{ filePath: '', content: query }];
+      const ast = [{ location: '', document: query }];
       const result = await plugin(schema, ast, {});
 
       expect(result).toBeSimilarStringTo(`

--- a/packages/plugins/typescript/compatibility/tests/compatibility.spec.ts
+++ b/packages/plugins/typescript/compatibility/tests/compatibility.spec.ts
@@ -864,4 +864,182 @@ describe('Compatibility Plugin', () => {
       await validate(mergeOutputs([raPluginResult, result]), schema, ast, config, true);
     });
   });
+
+  describe('multiple named fragments', () => {
+    it('supports query fields', async () => {
+      const query = parse(/* GraphQL */ `
+        query multipleSpreads {
+          me {
+            id
+            ...UserFields
+            ...UserFriends
+          }
+        }
+
+        fragment UserFields on User {
+          id
+          name
+        }
+
+        fragment UserFriends on User {
+          friends {
+            ...UserFields
+          }
+        }
+
+        fragment FullUser on User {
+          id
+          ...UserFields
+          ...UserFriends
+        }
+      `);
+
+      const ast = [{ filePath: '', content: query }];
+      const result = await plugin(schema, ast, {});
+
+      expect(result).toContain(`export type Me = MultipleSpreadsQuery['me'];`);
+    });
+
+    it('supports named fragments', async () => {
+      const query = parse(/* GraphQL */ `
+        fragment UserFields on User {
+          id
+          name
+        }
+
+        fragment UserFriends on User {
+          friends {
+            id
+          }
+        }
+
+        fragment FullUser on User {
+          id
+          ...UserFields
+          ...UserFriends
+        }
+      `);
+
+      const ast = [{ filePath: '', content: query }];
+      const result = await plugin(schema, ast, {});
+
+      expect(result).toBeSimilarStringTo(`
+        export namespace FullUser {
+          export type Fragment = FullUserFragment;
+        }
+      `);
+    });
+
+    it('supports inline fragments', async () => {
+      const query = parse(/* GraphQL */ `
+        query multipleSpreads {
+          me {
+            ... on User {
+              id
+              ...UserFields
+              ...UserFriends
+            }
+          }
+        }
+      `);
+
+      const ast = [{ filePath: '', content: query }];
+      const result = await plugin(schema, ast, {});
+
+      expect(result).toContain(`export type UserInlineFragment = ({ __typename: 'User' } & Pick<MultipleSpreadsQuery['me'], 'id' | keyof UserFieldsFragment | keyof UserFriendsFragment>);`);
+    });
+
+    it('throws on nested inline fragments', async () => {
+      const query = parse(/* GraphQL */ `
+        query multipleSpreads {
+          me {
+            ... on User {
+              ... on User {
+                id
+                ...UserFields
+                ...UserFriends
+              }
+            }
+          }
+        }
+      `);
+
+      const ast = [{ filePath: '', content: query }];
+      await expect(plugin(schema, ast, {})).rejects.toThrow('Nested inline fragments');
+    });
+
+    it('supports inline fragments on unions and interfaces', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        interface User {
+          id: ID!
+          name: String
+        }
+        type SocialUser implements User {
+          id: ID!
+          name: String
+          friends: [User!]!
+        }
+        type WorkplaceUser implements User {
+          id: ID!
+          name: String
+          colleagues: [User!]!
+        }
+
+        type Query {
+          me: User!
+        }
+      `);
+
+      const query = parse(/* GraphQL */ `
+        query multipleSpreads {
+          me {
+            id
+            ... on SocialUser {
+              friends {
+                ...UserBasics
+              }
+            }
+            ... on WorkplaceUser {
+              colleagues {
+                ...UserBasics
+              }
+            }
+          }
+        }
+
+        fragment UserBasics on User {
+          id
+          name
+        }
+
+        fragment UserNetwork on User {
+          ... on SocialUser {
+            friends {
+              ...UserBasics
+            }
+          }
+          ... on WorkplaceUser {
+            colleagues {
+              ...UserBasics
+            }
+          }
+        }
+      `);
+
+      const ast = [{ filePath: '', content: query }];
+      const result = await plugin(schema, ast, {});
+
+      expect(result).toBeSimilarStringTo(`
+        export namespace MultipleSpreads {
+          export type Variables = MultipleSpreadsQueryVariables;
+          export type Query = MultipleSpreadsQuery;
+          export type Me = MultipleSpreadsQuery['me'];
+          export type SocialUserInlineFragment = (DiscriminateUnion<RequireField<MultipleSpreadsQuery['me'], '__typename'>, { __typename: 'SocialUser' }>);
+          export type Friends = (DiscriminateUnion<RequireField<MultipleSpreadsQuery['me'], '__typename'>, { __typename: 'SocialUser' }>)['friends'][0];
+          export type WorkplaceUserInlineFragment = (DiscriminateUnion<RequireField<MultipleSpreadsQuery['me'], '__typename'>, { __typename: 'WorkplaceUser' }>);
+          export type Colleagues = (DiscriminateUnion<RequireField<MultipleSpreadsQuery['me'], '__typename'>, { __typename: 'WorkplaceUser' }>)['colleagues'][0];
+        }
+      `);
+    });
+  });
 });


### PR DESCRIPTION
We encountered some codegen issues in the `typescript-compatibility` plugin pertaining to multiple fragment spreads.

The primary problem can be illustrated through this simple example:

```graphql
fragment FullUser on User {
  id
  ...UserInfo
  ...UserFriends
}
```

This fragment will generate the following namespace:

```typescript
export namespace FullUser {
  export type Fragment = UserFriendsFragment; // This is wrong. It omits the fields from UserInfoFragment
  // ...
}
```

Effectively, when you have more than one named fragment spread, the type of the last fragment will become the type of the containing fragment.

Fixing this issue took me down a bit of a rabbit hole, because I had to work to intuit the purpose of the `Kind.FRAGMENT_SPREAD` case in the code generator. Ultimately, I discovered that that case was not specifically necessary, and that the `Kind.INLINE_FRAGMENT` case suffered from the same problem.

I added a number of regression tests to illustrate the various cases. There's one edge case that was very difficult to solve, which I've explained in the diff below.