### PR TITLE
Makes it possible to have multi module projects referenced via package name

### DIFF
--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -10,14 +10,7 @@ export {resolveDocumentImports, DocumentImportResolverOptions};
 
 export type NearOperationFileConfig = {
 
-    /**
-     * @name importTypeFromPackage
-     * @type boolean
-     * @description Optional, imports file from nearest package name, for use in monorepo situations.  Allows
-     * resolution to modules rather than relative and absolute paths
-     *
-     */
-    importTypeFromPackage?: boolean,
+
 
     /**
      * @name schemaTypesPath
@@ -96,6 +89,15 @@ export type NearOperationFileConfig = {
      */
     folder?: string;
     /**
+     * @name importTypeFromPackage
+     * @type boolean
+     * @description Optional, imports file from nearest package name, for use in monorepo situations.  Allows
+     * resolution to modules rather than relative and absolute paths
+     *
+     */
+    importTypeFromPackage?: boolean;
+
+    /**
      * @name importTypesNamespace
      * @type string
      * @description Optional, override the name of the import namespace used to import from the `baseTypesPath` file.
@@ -114,6 +116,8 @@ export type NearOperationFileConfig = {
      * ```
      */
     importTypesNamespace?: string;
+
+
 };
 
 export type FragmentNameToFile = { [fragmentName: string]: { location: string; importsNames: string[]; onType: string; node: FragmentDefinitionNode } };

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -438,7 +438,7 @@ describe('near-operation-file preset', () => {
           typescript: {},
         },
         {
-          add: `import { UserFieldsFragment } from './user-fragment.generated';`,
+          add: `import { UserFieldsFragment,UserFieldsFragmentDoc } from './user-fragment.generated';`,
         },
       ])
     );
@@ -468,7 +468,7 @@ describe('near-operation-file preset', () => {
     expect(result.map(o => o.plugins)[0]).toEqual(
       expect.arrayContaining([
         {
-          add: `import { UserFieldsFragment } from '../../../user-fragment.generated';`,
+          add: `import { UserFieldsFragment,UserFieldsFragmentDoc } from '../../../user-fragment.generated';`,
         },
       ])
     );
@@ -498,7 +498,7 @@ describe('near-operation-file preset', () => {
     expect(result.map(o => o.plugins)[0]).toEqual(
       expect.arrayContaining([
         {
-          add: `import { UserFieldsFragment } from './nested/down/here/user-fragment.generated';`,
+          add: `import { UserFieldsFragment,UserFieldsFragmentDoc } from './nested/down/here/user-fragment.generated';`,
         },
       ])
     );


### PR DESCRIPTION
In a (lerna) style monorepo its nice to refer to other packages rather than relative paths which are more fragile and can change when modules are installed.   

This patch makes it easier to use the package name for imports rather than relative paths. 

It gets turned on via   the switch `importTypeFromPackage`, when its on it attempts to resolve a path to the nearest package.json, walking up the tree.   When that is found it replaces, the rest of the path with the package name.

A tested configuration looks like 

```yml
overwrite: true
schema: "./schema.json"
documents:
    - "./utils/graphql-fragments/src/*.ts"
    - "./components/*/src/*graphql.ts"

generates:
    ./utils/graphql-schema/src/schema.ts:
      - typescript
    src/:
      preset: near-operation-file
      presetConfig:
        extension: .generated.tsx
        baseTypesPath: './utils/graphql-schema/src/schema.ts'
        importTypeFromPackage: true
      plugins:
        - typescript-operations
        - typescript-react-apollo
```

Where a project layout is 

```
codegen.yml
package.json
utils/
+graphql-schema/
++package.json
++src/schema.ts
+graphql-fragment/
++package.json -> (depends on graphql-schema)
++src/frag1.ts
+components/
++my-component/
+++package.json
+++src/graphql.ts --> (depends on graphql-schema, graphql-fragment) and its on
    
```


Due to its reliance on require.main.require it is kinda hard to test. --  Any guidance for that would be appreciated.
