### PR TITLE
Add mapperTypeSuffix option

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -123,6 +123,18 @@ export interface RawResolversConfig extends RawConfig {
    */
   rootValueType?: string;
   /**
+   * @name mapperTypeSuffix
+   * @type string
+   * @description Adds a suffix to the imported names to prevent name clashes.
+   *
+   * ```yml
+   * plugins
+   *   config:
+   *     mapperTypeSuffix: Model
+   * ```
+   */
+  mapperTypeSuffix?: string;
+  /**
    * @name mappers
    * @type Object
    * @description Replaces a GraphQL type usage with a custom type, allowing you to return custom object from
@@ -297,7 +309,7 @@ export class BaseResolversVisitor<TRawConfig extends RawResolversConfig = RawRes
       rootValueType: parseMapper(rawConfig.rootValueType || '{}', 'RootValueType'),
       avoidOptionals: getConfigValue(rawConfig.avoidOptionals, false),
       defaultMapper: rawConfig.defaultMapper ? parseMapper(rawConfig.defaultMapper || 'any', 'DefaultMapperType') : null,
-      mappers: transformMappers(rawConfig.mappers || {}),
+      mappers: transformMappers(rawConfig.mappers || {}, rawConfig.mapperTypeSuffix),
       scalars: buildScalars(_schema, rawConfig.scalars, defaultScalars),
       ...(additionalConfig || {}),
     } as TPluginConfig);

--- a/packages/plugins/other/visitor-plugin-common/tests/parse-mapper.spec.ts
+++ b/packages/plugins/other/visitor-plugin-common/tests/parse-mapper.spec.ts
@@ -68,4 +68,75 @@ describe('parseMapper', () => {
       source: 'file',
     });
   });
+
+  describe('suffix', () => {
+    it('Should return the correct values for a simple named mapper', () => {
+      const result = parseMapper('MyType', null, 'Model');
+
+      expect(result).toEqual({
+        isExternal: false,
+        type: 'MyType',
+      });
+    });
+
+    it('Should return the correct values for a external named mapper', () => {
+      const result = parseMapper('file#Type', null, 'Model');
+
+      expect(result).toEqual({
+        default: false,
+        isExternal: true,
+        import: 'Type as TypeModel',
+        type: 'TypeModel',
+        source: 'file',
+      });
+    });
+
+    it('Should return the correct values for a external default mapper', () => {
+      const result = parseMapper('file#default', 'MyGqlType', 'Model');
+
+      expect(result).toEqual({
+        default: true,
+        isExternal: true,
+        import: 'MyGqlType',
+        type: 'MyGqlType',
+        source: 'file',
+      });
+    });
+
+    it('Should support generics', () => {
+      const result = parseMapper('file#Type<Generic>', 'SomeType', 'Model');
+
+      expect(result).toEqual({
+        default: false,
+        isExternal: true,
+        import: 'Type as TypeModel',
+        type: 'TypeModel<Generic>',
+        source: 'file',
+      });
+    });
+
+    it('Should not affect namespaces', () => {
+      const result = parseMapper('file#Namespace#Type', 'MyGqlType', 'Model');
+
+      expect(result).toEqual({
+        default: false,
+        isExternal: true,
+        import: 'Namespace',
+        type: 'Namespace.Type',
+        source: 'file',
+      });
+    });
+
+    it('Should not affect aliases', () => {
+      const result = parseMapper('file#Type as SomeOtherType', 'SomeType', 'Model');
+
+      expect(result).toEqual({
+        default: false,
+        isExternal: true,
+        import: 'Type as SomeOtherType',
+        type: 'SomeOtherType',
+        source: 'file',
+      });
+    });
+  });
 });


### PR DESCRIPTION
this option allows you to add a suffix to all imported types to prevent name clashes with graphql types.

Followup of my comment here: https://github.com/dotansimha/graphql-code-generator/issues/2932#issuecomment-582862732