### PR TITLE
feat: add option `omitOperationSuffix`

### DIFF
--- a/docs/generated-config/base-documents-visitor.md
+++ b/docs/generated-config/base-documents-visitor.md
@@ -39,6 +39,12 @@ Set this configuration to `true` if you wish to make sure to remove duplicate op
 
 
 
+### omitOperationSuffix (`boolean`, default value: `false`)
+
+Set this configuration to `true` if you wish to disable auto add suffix of operation name, like `Query`, `Mutation`, `Subscription`, `Fragment`.
+
+
+
 ### exportFragmentSpreadSubTypes (`boolean`, default value: `false`)
 
 If set to true, it will export the sub-types created in order to make it easier to access fields declared under fragment spread.

--- a/docs/generated-config/client-side-base-visitor.md
+++ b/docs/generated-config/client-side-base-visitor.md
@@ -31,6 +31,13 @@ Set this configuration to `true` if you wish to make sure to remove duplicate op
 
 
 
+### omitOperationSuffix (`boolean`, default value: `false`)
+
+Set this configuration to `true` if you wish to disable auto add suffix of operation name, like `Query`, `Mutation`, `Subscription`, `Fragment`.
+
+
+
+
 ### documentMode (`'graphQLTag' | 'documentNode' | 'external'`, default value: `'graphQLTag'`)
 
 Declares how DocumentNode are created: - `graphQLTag`: `graphql-tag` or other modules (check `gqlImport`) will be used to generate document nodes. If this is used, document nodes are generated on client side i.e. the module used to generate this will be shipped to the client - `documentNode`: document nodes will be generated as objects when we generate the templates. - `external`: document nodes are imported from an external file. To be used with `importDocumentNodeExternallyFrom`

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -24,6 +24,7 @@ export interface RawClientSideBasePluginConfig extends RawConfig {
   gqlImport?: string;
   noExport?: boolean;
   dedupeOperationSuffix?: boolean;
+  omitOperationSuffix?: boolean;
   operationResultSuffix?: string;
   documentVariablePrefix?: string;
   documentVariableSuffix?: string;
@@ -66,6 +67,13 @@ export interface ClientSideBasePluginConfig extends ParsedConfig {
    * @description Set this configuration to `true` if you wish to make sure to remove duplicate operation name suffix.
    */
   dedupeOperationSuffix: boolean;
+  /**
+   * @name omitOperationSuffix
+   * @type boolean
+   * @default false
+   * @description Set this configuration to `true` if you wish to disable auto add suffix of operation name, like `Query`, `Mutation`, `Subscription`, `Fragment`.
+   */
+  omitOperationSuffix: boolean;
   noExport: boolean;
   documentVariablePrefix: string;
   documentVariableSuffix: string;
@@ -120,6 +128,7 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
     super(rawConfig, {
       scalars: buildScalars(_schema, rawConfig.scalars, DEFAULT_SCALARS),
       dedupeOperationSuffix: getConfigValue(rawConfig.dedupeOperationSuffix, false),
+      omitOperationSuffix: getConfigValue(rawConfig.omitOperationSuffix, false),
       gqlImport: rawConfig.gqlImport || null,
       noExport: !!rawConfig.noExport,
       importOperationTypesFrom: getConfigValue(rawConfig.importOperationTypesFrom, null),
@@ -354,7 +363,7 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
     }
 
     const operationType: string = pascalCase(node.operation);
-    const operationTypeSuffix: string = this.config.dedupeOperationSuffix && node.name.value.toLowerCase().endsWith(node.operation) ? '' : operationType;
+    const operationTypeSuffix: string = this.config.dedupeOperationSuffix && node.name.value.toLowerCase().endsWith(node.operation) ? '' : this.config.omitOperationSuffix ? '' : operationType;
 
     const operationResultType: string = this.convertName(node, {
       suffix: operationTypeSuffix + this._parsedConfig.operationResultSuffix,

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -166,7 +166,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
         const possibleTypesForFragment = getPossibleTypes(this._schema, schemaType);
 
         for (const possibleType of possibleTypesForFragment) {
-          const fragmentSuffix = this._config.dedupeOperationSuffix && spread.name.value.toLowerCase().endsWith('fragment') ? '' : 'Fragment';
+          const fragmentSuffix = this._config.omitOperationSuffix ? '' : this._config.dedupeOperationSuffix && spread.name.value.toLowerCase().endsWith('fragment') ? '' : 'Fragment';
           const usage = this.buildFragmentTypeName(spread.name.value, fragmentSuffix, possibleTypesForFragment.length === 1 ? null : possibleType.name);
 
           if (!selectionNodesByTypeName[possibleType.name]) {

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -243,6 +243,9 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
   }
 
   private _getHookSuffix(name: string, operationType: string) {
+    if (this.config.omitOperationSuffix) {
+      return '';
+    }
     if (!this.config.dedupeOperationSuffix) {
       return pascalCase(operationType);
     }

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -272,6 +272,31 @@ describe('React Apollo', () => {
       expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast2 }], { dedupeOperationSuffix: false }, { outputFile: '' })) as any).content).toContain('ApolloReactCommon.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
     });
 
+    it(`tests for omitOperationSuffix`, async () => {
+      const ast = parse(/* GraphQL */ `
+        query notificationsQuery {
+          notifications {
+            id
+          }
+        }
+      `);
+      const ast2 = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            id
+          }
+        }
+      `);
+
+      expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })) as any).content).toContain('ApolloReactCommon.QueryResult<NotificationsQueryQuery, NotificationsQueryQueryVariables>;');
+      expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast }], { omitOperationSuffix: false }, { outputFile: '' })) as any).content).toContain(
+        'ApolloReactCommon.QueryResult<NotificationsQueryQuery, NotificationsQueryQueryVariables>'
+      );
+      expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast }], { omitOperationSuffix: true }, { outputFile: '' })) as any).content).toContain('ApolloReactCommon.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
+      expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast2 }], { omitOperationSuffix: true }, { outputFile: '' })) as any).content).toContain('ApolloReactCommon.QueryResult<Notifications, NotificationsVariables>');
+      expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast2 }], { omitOperationSuffix: false }, { outputFile: '' })) as any).content).toContain('ApolloReactCommon.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
+    });
+
     it('should import ApolloReactHooks dependencies', async () => {
       const docs = [{ location: '', document: basicDoc }];
       const content = (await plugin(

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -106,6 +106,9 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
   }
 
   private getCompositionFunctionSuffix(name: string, operationType: string) {
+    if (this.config.omitOperationSuffix) {
+      return '';
+    }
     if (!this.config.dedupeOperationSuffix) {
       return pascalCase(operationType);
     }

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -136,6 +136,29 @@ describe('Vue Apollo', () => {
       expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast2 }], { dedupeOperationSuffix: false }, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotificationsQuery>;');
     });
 
+    it(`tests for omitOperationSuffix`, async () => {
+      const ast = parse(/* GraphQL */ `
+        query notificationsQuery {
+          notifications {
+            id
+          }
+        }
+      `);
+      const ast2 = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            id
+          }
+        }
+      `);
+
+      expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotificationsQueryQuery>;');
+      expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast }], { omitOperationSuffix: false }, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotificationsQueryQuery>;');
+      expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast }], { omitOperationSuffix: true }, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotificationsQuery>;');
+      expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast2 }], { omitOperationSuffix: true }, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotifications>;');
+      expect(((await plugin(schema, [{ location: 'test-file.ts', document: ast2 }], { omitOperationSuffix: false }, { outputFile: '' })) as any).content).toContain('ReturnType<typeof useNotificationsQuery>;');
+    });
+
     it('should import VueApolloComposable from VueApolloComposableImportFrom config option', async () => {
       const docs = [{ location: '', document: basicDoc }];
       const content = (await plugin(


### PR DESCRIPTION
### omitOperationSuffix (`boolean`, default value: `false`)

Set this configuration to `true` if you wish to disable auto add suffix of operation name, like `Query`, `Mutation`, `Subscription`, `Fragment`.

----

This option is a companion of `dedupeOperationSuffix`. So code was modified where was used this option.