### PR TITLE
Add "-D" installation flag

### DIFF
--- a/docs/plugins/typescript-resolvers.md
+++ b/docs/plugins/typescript-resolvers.md
@@ -7,7 +7,7 @@ This plugin generates types for resolve functions.
 
 ## Installation
 
-    $ yarn add @graphql-codegen/typescript-resolvers
+    $ yarn add -D @graphql-codegen/typescript-resolvers
 
 ## Usage
 


### PR DESCRIPTION
Getting Started contains `-D` flag, same should be done by the plugins guides.

![image](https://user-images.githubusercontent.com/4586392/74343338-f6057f80-4dbb-11ea-90de-02977a02a629.png)
