### PR TITLE
feat: in watch mode remove stale files from the previous build

### DIFF
--- a/packages/graphql-codegen-cli/src/utils/file-system.ts
+++ b/packages/graphql-codegen-cli/src/utils/file-system.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, statSync, readFileSync } from 'fs';
+import { writeFileSync, statSync, readFileSync, unlink } from 'fs';
 
 export function writeSync(filepath: string, content: string) {
   return writeFileSync(filepath, content);
@@ -14,4 +14,8 @@ export function fileExists(filePath: string): boolean {
   } catch (err) {
     return false;
   }
+}
+
+export function unlinkFile(filePath: string, cb?: (err?: Error) => any): void {
+  unlink(filePath, cb);
 }


### PR DESCRIPTION
### In watch mode remove stale files from the previous build

Code is quite simple:
- ONLY in `watch` mode:
  - it remembers files from build to `previouslyGeneratedFilenames` array
  - for next builds it tries to find files in `previouslyGeneratedFilenames` which are not generated in the current build - such files are `stale`
  - if `overwrite: true` then `stale` files will be deleted.

I tested locally and it works perfectly. 

But I don't find a proper way how to write test cases for Jest. I didn't find any test for watch mode.