### PR TITLE
mappers: put default import next to named identifiers

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -644,11 +644,16 @@ export class BaseResolversVisitor<TRawConfig extends RawResolversConfig = RawRes
       return null;
     }
 
-    if (types[0] && types[0].asDefault) {
-      return `import ${types[0].identifier} from '${source}';`;
-    }
+    const defaultType = types.find(t => t.asDefault === true);
+    const namedTypes = types.filter(t => !t.asDefault);
 
-    return `import { ${types.map(t => t.identifier).join(', ')} } from '${source}';`;
+    // { Foo, Bar as BarModel }
+    const namedImports = namedTypes.length ? `{ ${namedTypes.map(t => t.identifier).join(', ')} }` : '';
+    // Baz
+    const defaultImport = defaultType ? defaultType.identifier : '';
+
+    // Baz, { Foo, Bar as BarModel }
+    return `import ${[defaultImport, namedImports].filter(Boolean).join(', ')} from '${source}';`;
   }
 
   setDeclarationBlockConfig(config: DeclarationBlockConfig): void {
@@ -964,11 +969,10 @@ export type IDirectiveResolvers${contextType} = ${name}<ContextType>;`
           return block;
         },
       })
-      .export()
-      .asKind('type')
-      .withName(directiveArgsTypeName)
-      .withContent(`{ ${(hasArguments ? this._variablesTransfomer.transform<InputValueDefinitionNode>(sourceNode.arguments) : '')} }`)
-      .string,
+        .export()
+        .asKind('type')
+        .withName(directiveArgsTypeName)
+        .withContent(`{ ${hasArguments ? this._variablesTransfomer.transform<InputValueDefinitionNode>(sourceNode.arguments) : ''} }`).string,
       new DeclarationBlock({
         ...this._declarationBlockConfig,
         blockTransformer(block) {

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -293,7 +293,7 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
         const mappedValue = this.config.enumValues[enumName];
 
         if (mappedValue.sourceFile) {
-          if (mappedValue.sourceIdentifier === 'default') {
+          if (mappedValue.isDefault) {
             return this._buildTypeImport(mappedValue.typeIdentifier, mappedValue.sourceFile, true);
           }
           let identifier = mappedValue.sourceIdentifier;

--- a/packages/plugins/other/visitor-plugin-common/src/enum-values.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/enum-values.ts
@@ -35,6 +35,7 @@ export function parseEnumValues(schema: GraphQLSchema, mapOrStr: EnumValuesMap =
         return {
           ...prev,
           [gqlIdentifier]: {
+            isDefault: mapper.isExternal && mapper.default,
             typeIdentifier: gqlIdentifier,
             sourceFile: mapper.isExternal ? mapper.source : undefined,
             sourceIdentifier: isExternalMapperType(mapper) ? mapper.import : mapper.type,
@@ -45,6 +46,7 @@ export function parseEnumValues(schema: GraphQLSchema, mapOrStr: EnumValuesMap =
         return {
           ...prev,
           [gqlIdentifier]: {
+            isDefault: false,
             typeIdentifier: gqlIdentifier,
             sourceFile: null,
             sourceIdentifier: null,
@@ -62,6 +64,7 @@ export function parseEnumValues(schema: GraphQLSchema, mapOrStr: EnumValuesMap =
         return {
           ...prev,
           [enumName]: {
+            isDefault: false,
             typeIdentifier: enumName,
             sourceFile: mapOrStr,
             sourceIdentifier: enumName,

--- a/packages/plugins/other/visitor-plugin-common/src/mappers.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/mappers.ts
@@ -121,6 +121,7 @@ function addSuffix(element: string, suffix: string): string {
 }
 
 export function isExternalMapper(value: string): boolean {
+  // tslint:disable-next-line:quotemark
   return value.includes('#') && !value.includes('"') && !value.includes("'");
 }
 

--- a/packages/plugins/other/visitor-plugin-common/src/mappers.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/mappers.ts
@@ -17,46 +17,90 @@ export function isExternalMapperType(m: ParsedMapper): m is ExternalParsedMapper
   return !!m['import'];
 }
 
+enum MapperKind {
+  Namespace,
+  Default,
+  Regular,
+}
+
 export function parseMapper(mapper: string, gqlTypeName: string | null = null, suffix?: string): ParsedMapper {
   if (isExternalMapper(mapper)) {
     const items = mapper.split('#');
     const isNamespace = items.length === 3;
-    const source = items[0];
-    let type,
-      importElement,
-      asDefault = false;
+    const isDefault = items[1].trim() === 'default' || items[1].startsWith('default ');
+    const hasAlias = items[1].includes(' as ');
 
-    if (isNamespace) {
-      const ns = items[1];
-      type = `${ns}.${items[2]}`;
-      importElement = ns;
-    } else {
-      const namedDefault = items[1].includes('default as');
-      asDefault = items[1] === 'default';
-      if (asDefault || namedDefault) {
-        type = `${gqlTypeName}`;
-        importElement = namedDefault ? `default as ${gqlTypeName}` : `${gqlTypeName}`;
-      } else {
-        if (items[1].includes(' as ')) {
-          const [importedType, aliasType] = items[1].split(' as ');
-          type = aliasType;
-          importElement = `${importedType} as ${aliasType}`;
-        } else {
-          if (suffix) {
-            type = addSuffix(items[1], suffix);
-            importElement = `${items[1]} as ${type}`;
-          } else {
-            type = items[1];
-            importElement = items[1];
+    const mapperKind: MapperKind = isNamespace ? MapperKind.Namespace : isDefault ? MapperKind.Default : MapperKind.Regular;
+
+    function handleAlias(isDefault = false) {
+      const [importedType, aliasType] = items[1].split(/\s+as\s+/);
+
+      return {
+        importElement: isDefault ? aliasType : `${importedType} as ${aliasType}`,
+        type: aliasType,
+      };
+    }
+
+    function handle(): {
+      importElement: string;
+      type: string;
+    } {
+      switch (mapperKind) {
+        // ./my/module#Namespace#Identifier
+        case MapperKind.Namespace: {
+          const [, ns, identifier] = items;
+
+          return {
+            type: `${ns}.${identifier}`,
+            importElement: ns,
+          };
+        }
+
+        case MapperKind.Default: {
+          // ./my/module#Namespace#default as alias
+          if (hasAlias) {
+            return handleAlias(true);
           }
+
+          // ./my/module#Namespace#default
+          return {
+            importElement: `${gqlTypeName}`,
+            type: `${gqlTypeName}`,
+          };
+        }
+
+        case MapperKind.Regular: {
+          // ./my/module#Identifier as alias
+          if (hasAlias) {
+            return handleAlias();
+          }
+
+          const identifier = items[1];
+
+          if (suffix) {
+            const type = addSuffix(identifier, suffix);
+
+            return {
+              type,
+              importElement: `${identifier} as ${type}`,
+            };
+          }
+
+          // ./my/module#Identifier
+          return {
+            type: identifier,
+            importElement: identifier,
+          };
         }
       }
     }
 
+    const { type, importElement } = handle();
+
     return {
-      default: asDefault,
+      default: isDefault,
       isExternal: true,
-      source,
+      source: items[0],
       type,
       import: importElement.replace(/<(.*?)>/g, ''),
     };
@@ -77,7 +121,7 @@ function addSuffix(element: string, suffix: string): string {
 }
 
 export function isExternalMapper(value: string): boolean {
-  return value.includes('#') && !value.includes('"') && !value.includes('\'');
+  return value.includes('#') && !value.includes('"') && !value.includes("'");
 }
 
 export function transformMappers(rawMappers: RawResolversConfig['mappers'], mapperTypeSuffix?: string): ParsedResolversConfig['mappers'] {

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -5,7 +5,7 @@ export type ScalarsMap = string | { [name: string]: string };
 export type NormalizedScalarsMap = { [name: string]: string };
 export type ParsedScalarsMap = { [name: string]: ParsedMapper };
 export type EnumValuesMap<AdditionalProps = {}> = string | { [enumName: string]: string | ({ [key: string]: string | number } & AdditionalProps) };
-export type ParsedEnumValuesMap = { [enumName: string]: { mappedValues?: { [valueName: string]: string | number }; typeIdentifier: string; sourceIdentifier?: string; sourceFile?: string } };
+export type ParsedEnumValuesMap = { [enumName: string]: { mappedValues?: { [valueName: string]: string | number }; typeIdentifier: string; sourceIdentifier?: string; sourceFile?: string; isDefault?: boolean } };
 export type ConvertNameFn<T = {}> = ConvertFn<T>;
 
 export interface ConvertOptions {

--- a/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
@@ -446,6 +446,38 @@ describe('ResolversTypes', () => {
     };`);
   });
 
+  it('Should build ResolversTypes with mapper set for concrete type using renamed external identifier (with default)', async () => {
+    const result = (await plugin(
+      schema,
+      [],
+      {
+        noSchemaStitching: true,
+        mappers: {
+          MyOtherType: './my-type#default as DatabaseMyOtherType',
+          MyType: './my-type#MyType as DatabaseMyType',
+        },
+      },
+      { outputFile: '' }
+    )) as Types.ComplexPluginOutput;
+
+    expect(result.prepend).toContain(`import DatabaseMyOtherType, { MyType as DatabaseMyType } from './my-type';`);
+    expect(result.content).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: ResolverTypeWrapper<{}>,
+      MyType: ResolverTypeWrapper<DatabaseMyType>,
+      String: ResolverTypeWrapper<Scalars['String']>,
+      MyOtherType: ResolverTypeWrapper<DatabaseMyOtherType>,
+      Subscription: ResolverTypeWrapper<{}>,
+      Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
+      Node: ResolverTypeWrapper<Node>,
+      ID: ResolverTypeWrapper<Scalars['ID']>,
+      SomeNode: ResolverTypeWrapper<SomeNode>,
+      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
+      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
+      Int: ResolverTypeWrapper<Scalars['Int']>,
+    };`);
+  });
+
   it('Should build ResolversTypes with defaultMapper set', async () => {
     const result = (await plugin(
       schema,

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -333,7 +333,7 @@ describe('TypeScript', () => {
         { outputFile: '' }
       )) as Types.ComplexPluginOutput;
 
-      expect(result.prepend[0]).toBe(`import { default as MyEnum } from './files';`);
+      expect(result.prepend[0]).toBe(`import MyEnum from './files';`);
     });
 
     it('#2976 - Issues with mapped enumValues and type prefix in args', async () => {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1172,6 +1172,58 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
+    it('Should import a type of a mapped scalar', async () => {
+      const schema = buildSchema(`
+      scalar MyScalar
+      scalar MyOtherScalar
+      scalar MyAliasedScalar
+
+      type MyType {
+        foo: String
+        bar: MyScalar!
+        baz: MyOtherScalar!
+        qux: MyAliasedScalar!
+      }`);
+      const result = (await plugin(
+        schema,
+        [],
+        {
+          scalars: {
+            MyScalar: '../../scalars#default',
+            MyOtherScalar: '../../scalars#MyOtherScalar',
+            MyAliasedScalar: '../../scalars#MyAliasedScalar as AliasedScalar',
+          },
+        },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      // It seems like we don't group imports...
+      expect(result.prepend).toContain(`import MyScalar from '../../scalars';`);
+      expect(result.prepend).toContain(`import { MyOtherScalar } from '../../scalars';`);
+      expect(result.prepend).toContain(`import { MyAliasedScalar as AliasedScalar } from '../../scalars';`);
+      expect(result.content).toBeSimilarStringTo(`
+      export type Scalars = {
+        ID: string,
+        String: string,
+        Boolean: boolean,
+        Int: number,
+        Float: number,
+        MyScalar: MyScalar,
+        MyOtherScalar: MyOtherScalar,
+        MyAliasedScalar: AliasedScalar,
+      };`);
+
+      expect(result.content).toBeSimilarStringTo(`
+      export type MyType = {
+        __typename?: 'MyType',
+        foo?: Maybe<Scalars['String']>,
+        bar: Scalars['MyScalar'],
+        baz: Scalars['MyOtherScalar'],
+        qux: Scalars['MyAliasedScalar'],
+      };`);
+      validateTs(result);
+    });
+
     it('Should generate a scalars mapping correctly for custom scalars', async () => {
       const schema = buildSchema(`
       scalar MyScalar


### PR DESCRIPTION
Related #3466

Produces:

```typescript
import DatabaseMyOtherType, { MyType as DatabaseMyType } from './my-type';
```

It also fixes a bug where named imports weren't even produced if there was a default import of the same module...

I cleaned up a bit the parseMappers logic so later on it will be easier to introduce the new syntax.