### PR TITLE
Fix declarationKind=interface, type syntax errors

### DIFF
--- a/packages/graphql-codegen-cli/tests/codegen.spec.ts
+++ b/packages/graphql-codegen-cli/tests/codegen.spec.ts
@@ -646,12 +646,12 @@ describe('Codegen Executor', () => {
 
       expect(output.length).toBe(1);
       expect(output[0].content).toBeSimilarStringTo(`export type Scalars = {
-        ID: string,
-        String: string,
-        Boolean: boolean,
-        Int: number,
-        Float: number,
-        UniqueID: any,
+        ID: string;
+        String: string;
+        Boolean: boolean;
+        Int: number;
+        Float: number;
+        UniqueID: any;
       };`);
     });
   });

--- a/packages/plugins/flow/flow/src/visitor.ts
+++ b/packages/plugins/flow/flow/src/visitor.ts
@@ -1,5 +1,5 @@
 import { NonNullTypeNode, ListTypeNode, ObjectTypeDefinitionNode, FieldDefinitionNode, EnumTypeDefinitionNode, NamedTypeNode, GraphQLSchema, InputValueDefinitionNode, Kind, GraphQLEnumType } from 'graphql';
-import { BaseTypesVisitor, DeclarationBlock, wrapWithSingleQuotes, indent, ParsedTypesConfig, transformComment, getConfigValue } from '@graphql-codegen/visitor-plugin-common';
+import { BaseTypesVisitor, DeclarationBlock, wrapWithSingleQuotes, indent, ParsedTypesConfig, transformComment, getConfigValue, DeclarationKind } from '@graphql-codegen/visitor-plugin-common';
 import autoBind from 'auto-bind';
 import { FlowPluginConfig } from './config';
 import { FlowOperationVariablesToObject } from './flow-variables-to-object';
@@ -144,5 +144,9 @@ export class FlowVisitor extends BaseTypesVisitor<FlowPluginConfig, FlowPluginPa
       .withContent(`$Values<typeof ${enumValuesName}>`).string;
 
     return [enumValues, enumType].join('\n\n');
+  }
+
+  protected getPunctuation(declarationKind: DeclarationKind): string {
+    return declarationKind === 'type' ? ',' : ';';
   }
 }

--- a/packages/plugins/flow/flow/tests/__snapshots__/flow.spec.ts.snap
+++ b/packages/plugins/flow/flow/tests/__snapshots__/flow.spec.ts.snap
@@ -22,7 +22,7 @@ export type TMutation = {|
 
 export type TMutationFooArgs = {|
   id?: ?$ElementType<Scalars, 'String'>,
-  input?: ?TInput
+  input?: ?TInput,
 |};
 "
 `;
@@ -47,7 +47,7 @@ export type MyTypeFooArgs = {|
   a: $ElementType<Scalars, 'String'>,
   b?: ?$ElementType<Scalars, 'String'>,
   c?: ?Array<?$ElementType<Scalars, 'String'>>,
-  d: Array<$ElementType<Scalars, 'Int'>>
+  d: Array<$ElementType<Scalars, 'Int'>>,
 |};
 "
 `;
@@ -71,7 +71,7 @@ export type MyType = {|
 export type MyTypeFooArgs = {|
   a: $ElementType<Scalars, 'String'>,
   b: $ElementType<Scalars, 'String'>,
-  c?: ?$ElementType<Scalars, 'String'>
+  c?: ?$ElementType<Scalars, 'String'>,
 |};
 "
 `;
@@ -101,7 +101,7 @@ export type MyTypeFooArgs = {|
   b: MyInput,
   c?: ?Array<?MyInput>,
   d: Array<?MyInput>,
-  e: Array<MyInput>
+  e: Array<MyInput>,
 |};
 "
 `;
@@ -173,7 +173,7 @@ export type Mutation = {|
 
 export type MutationUpdateUserArgs = {|
   userId: $ElementType<Scalars, 'ID'>,
-  update?: ?UpdateUser
+  update?: ?UpdateUser,
 |};
 
 export type UpdateUser = {|
@@ -440,7 +440,7 @@ export type Imytypefooargs = {|
   a: $ElementType<Scalars, 'String'>,
   b?: ?$ElementType<Scalars, 'String'>,
   c?: ?Array<?$ElementType<Scalars, 'String'>>,
-  d: Array<$ElementType<Scalars, 'Int'>>
+  d: Array<$ElementType<Scalars, 'Int'>>,
 |};
 "
 `;
@@ -465,7 +465,7 @@ export type mytypefooargs = {|
   a: $ElementType<Scalars, 'String'>,
   b?: ?$ElementType<Scalars, 'String'>,
   c?: ?Array<?$ElementType<Scalars, 'String'>>,
-  d: Array<$ElementType<Scalars, 'Int'>>
+  d: Array<$ElementType<Scalars, 'Int'>>,
 |};
 "
 `;
@@ -730,7 +730,7 @@ export type TMutation = {|
 
 export type TMutationFooArgs = {|
   id?: ?$ElementType<Scalars, 'String'>,
-  input?: ?TInput
+  input?: ?TInput,
 |};
 "
 `;
@@ -755,7 +755,7 @@ export type MyTypeFooArgs = {|
   a: $ElementType<Scalars, 'String'>,
   b?: ?$ElementType<Scalars, 'String'>,
   c?: ?Array<?$ElementType<Scalars, 'String'>>,
-  d: Array<$ElementType<Scalars, 'Int'>>
+  d: Array<$ElementType<Scalars, 'Int'>>,
 |};
 "
 `;
@@ -779,7 +779,7 @@ export type MyType = {|
 export type MyTypeFooArgs = {|
   a: $ElementType<Scalars, 'String'>,
   b: $ElementType<Scalars, 'String'>,
-  c?: ?$ElementType<Scalars, 'String'>
+  c?: ?$ElementType<Scalars, 'String'>,
 |};
 "
 `;
@@ -809,7 +809,7 @@ export type MyTypeFooArgs = {|
   b: MyInput,
   c?: ?Array<?MyInput>,
   d: Array<?MyInput>,
-  e: Array<MyInput>
+  e: Array<MyInput>,
 |};
 "
 `;
@@ -881,7 +881,7 @@ export type Mutation = {|
 
 export type MutationUpdateUserArgs = {|
   userId: $ElementType<Scalars, 'ID'>,
-  update?: ?UpdateUser
+  update?: ?UpdateUser,
 |};
 
 export type UpdateUser = {|
@@ -1148,7 +1148,7 @@ export type Imytypefooargs = {|
   a: $ElementType<Scalars, 'String'>,
   b?: ?$ElementType<Scalars, 'String'>,
   c?: ?Array<?$ElementType<Scalars, 'String'>>,
-  d: Array<$ElementType<Scalars, 'Int'>>
+  d: Array<$ElementType<Scalars, 'Int'>>,
 |};
 "
 `;
@@ -1173,7 +1173,7 @@ export type mytypefooargs = {|
   a: $ElementType<Scalars, 'String'>,
   b?: ?$ElementType<Scalars, 'String'>,
   c?: ?Array<?$ElementType<Scalars, 'String'>>,
-  d: Array<$ElementType<Scalars, 'Int'>>
+  d: Array<$ElementType<Scalars, 'Int'>>,
 |};
 "
 `;

--- a/packages/plugins/flow/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/flow/tests/flow.spec.ts
@@ -387,7 +387,7 @@ describe('Flow Plugin', () => {
           a: $ElementType<Scalars, 'String'>,
           b?: ?$ElementType<Scalars, 'String'>,
           c?: ?Array<?$ElementType<Scalars, 'String'>>,
-          d: Array<$ElementType<Scalars, 'Int'>>
+          d: Array<$ElementType<Scalars, 'Int'>>,
         |};
       `);
 

--- a/packages/plugins/flow/operations/src/visitor.ts
+++ b/packages/plugins/flow/operations/src/visitor.ts
@@ -2,7 +2,7 @@ import { FlowWithPickSelectionSetProcessor } from './flow-selection-set-processo
 import { GraphQLSchema, isListType, GraphQLObjectType, GraphQLNonNull, GraphQLList, isEnumType } from 'graphql';
 import { FlowDocumentsPluginConfig } from './config';
 import { FlowOperationVariablesToObject } from '@graphql-codegen/flow';
-import { PreResolveTypesProcessor, ParsedDocumentsConfig, BaseDocumentsVisitor, LoadedFragment, SelectionSetProcessorConfig, SelectionSetToObject, getConfigValue } from '@graphql-codegen/visitor-plugin-common';
+import { PreResolveTypesProcessor, ParsedDocumentsConfig, BaseDocumentsVisitor, LoadedFragment, SelectionSetProcessorConfig, SelectionSetToObject, getConfigValue, DeclarationKind } from '@graphql-codegen/visitor-plugin-common';
 import { isNonNullType } from 'graphql';
 import autoBind from 'auto-bind';
 
@@ -62,5 +62,9 @@ export class FlowDocumentsVisitor extends BaseDocumentsVisitor<FlowDocumentsPlug
     const enumsNames = Object.keys(schema.getTypeMap()).filter(typeName => isEnumType(schema.getType(typeName)));
     this.setSelectionSetHandler(new SelectionSetToObject(processor, this.scalars, this.schema, this.convertName.bind(this), allFragments, this.config));
     this.setVariablesTransformer(new FlowOperationVariablesToObject(this.scalars, this.convertName.bind(this), this.config.namespacedImportName, enumsNames, this.config.enumPrefix));
+  }
+
+  protected getPunctuation(declarationKind: DeclarationKind): string {
+    return declarationKind === 'type' ? ',' : ';';
   }
 }

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -759,7 +759,7 @@ describe('Flow Operations Plugin', () => {
       );
       expect(result).toBeSimilarStringTo(
         `export type MeQueryVariables = {
-          repoFullName: $ElementType<Scalars, 'String'>
+          repoFullName: $ElementType<Scalars, 'String'>,
         };`
       );
       expect(result).toBeSimilarStringTo(`
@@ -997,7 +997,7 @@ describe('Flow Operations Plugin', () => {
           mandatoryInput: InputType,
           testArray?: ?Array<?$ElementType<Scalars, 'String'>>,
           requireString: Array<?$ElementType<Scalars, 'String'>>,
-          innerRequired: Array<$ElementType<Scalars, 'String'>>
+          innerRequired: Array<$ElementType<Scalars, 'String'>>,
         };`
       );
       validateFlow(result);

--- a/packages/plugins/flow/resolvers/src/visitor.ts
+++ b/packages/plugins/flow/resolvers/src/visitor.ts
@@ -1,6 +1,6 @@
 import { ListTypeNode, NamedTypeNode, NonNullTypeNode, GraphQLSchema, ScalarTypeDefinitionNode, InputValueDefinitionNode } from 'graphql';
 import autoBind from 'auto-bind';
-import { RawResolversConfig, indent, ParsedResolversConfig, BaseResolversVisitor, DeclarationBlock } from '@graphql-codegen/visitor-plugin-common';
+import { RawResolversConfig, indent, ParsedResolversConfig, BaseResolversVisitor, DeclarationBlock, DeclarationKind } from '@graphql-codegen/visitor-plugin-common';
 import { FlowOperationVariablesToObject } from '@graphql-codegen/flow';
 import { FLOW_REQUIRE_FIELDS_TYPE } from './flow-util-types';
 
@@ -103,5 +103,9 @@ export class FlowResolversVisitor extends BaseResolversVisitor<RawResolversConfi
         })
       )
       .withBlock([indent(`...GraphQLScalarTypeConfig<${baseName}, any>`), indent(`name: '${node.name}'`)].join(', \n')).string;
+  }
+
+  protected getPunctuation(declarationKind: DeclarationKind): string {
+    return declarationKind === 'type' ? ',' : ';';
   }
 }

--- a/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
+++ b/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
@@ -95,7 +95,7 @@ export type ResolversParentTypes = {
 
 export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
   arg2: $ElementType<Scalars, 'String'>,
-  arg3: $ElementType<Scalars, 'Boolean'> };
+  arg3: $ElementType<Scalars, 'Boolean'>, };
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 

--- a/packages/plugins/flow/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/mapping.spec.ts
@@ -207,7 +207,7 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
-    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'> };
+    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'>, };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -285,7 +285,7 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { type MyCustomOtherType } from './my-file';`);
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
-    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'> };
+    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'>, };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -361,7 +361,7 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
-    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'> };
+    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'>, };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -435,7 +435,7 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
-    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'> };
+    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'>, };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -511,7 +511,7 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
-    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'> };
+    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'>, };
     `);
 
     expect(result.content).toBeSimilarStringTo(`

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -145,9 +145,9 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
       const scalarValue = this.config.scalars[scalarName].type;
       const scalarType = this._schema.getType(scalarName);
       const comment = scalarType && scalarType.astNode && scalarType.description ? transformComment(scalarType.description, 1) : '';
-      const { type } = this._parsedConfig.declarationKind;
+      const { scalar } = this._parsedConfig.declarationKind;
 
-      return comment + indent(`${scalarName}: ${scalarValue}${type === 'class' ? ';' : ','}`);
+      return comment + indent(`${scalarName}: ${scalarValue}${this.getPunctuation(scalar)}`);
     });
 
     return new DeclarationBlock(this._declarationBlockConfig)
@@ -187,8 +187,9 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
 
   InputValueDefinition(node: InputValueDefinitionNode): string {
     const comment = transformComment((node.description as any) as string, 1);
+    const { input } = this._parsedConfig.declarationKind;
 
-    return comment + indent(`${node.name}: ${node.type},`);
+    return comment + indent(`${node.name}: ${node.type}${this.getPunctuation(input)}`);
   }
 
   Name(node: NameNode): string {
@@ -200,7 +201,7 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
     const comment = transformComment((node.description as any) as string, 1);
     const { type } = this._parsedConfig.declarationKind;
 
-    return comment + indent(`${node.name}: ${typeString}${type === 'class' ? ';' : ','}`);
+    return comment + indent(`${node.name}: ${typeString}${this.getPunctuation(type)}`);
   }
 
   UnionTypeDefinition(node: UnionTypeDefinitionNode, key: string | number | undefined, parent: any): string {
@@ -227,7 +228,7 @@ export class BaseTypesVisitor<TRawConfig extends RawTypesConfig = RawTypesConfig
   getObjectTypeDeclarationBlock(node: ObjectTypeDefinitionNode, originalNode: ObjectTypeDefinitionNode): DeclarationBlock {
     const optionalTypename = this.config.nonOptionalTypename ? '__typename' : '__typename?';
     const { type } = this._parsedConfig.declarationKind;
-    const allFields = [...(this.config.addTypename ? [indent(`${this.config['immutableTypes'] ? 'readonly' : ''} ${optionalTypename}: '${node.name}'${type === 'class' ? ';' : ','}`)] : []), ...node.fields] as string[];
+    const allFields = [...(this.config.addTypename ? [indent(`${this.config['immutableTypes'] ? 'readonly' : ''} ${optionalTypename}: '${node.name}'${this.getPunctuation(type)}`)] : []), ...node.fields] as string[];
     const interfacesNames = originalNode.interfaces ? originalNode.interfaces.map(i => this.convertName(i)) : [];
 
     const declarationBlock = new DeclarationBlock(this._declarationBlockConfig)

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -1,4 +1,4 @@
-import { ScalarsMap, ParsedScalarsMap, NamingConvention, ConvertFn, ConvertOptions, LoadedFragment, NormalizedScalarsMap } from './types';
+import { ScalarsMap, ParsedScalarsMap, NamingConvention, ConvertFn, ConvertOptions, LoadedFragment, NormalizedScalarsMap, DeclarationKind } from './types';
 import { DeclarationBlockConfig } from './utils';
 import autoBind from 'auto-bind';
 import { convertFactory } from './naming';
@@ -147,5 +147,9 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
     const useTypesPrefix = typeof (options && options.useTypesPrefix) === 'boolean' ? options.useTypesPrefix : true;
 
     return (useTypesPrefix ? this.config.typesPrefix : '') + this.config.convert(node, options);
+  }
+
+  protected getPunctuation(declarationKind: DeclarationKind): string {
+    return '';
   }
 }

--- a/packages/plugins/other/visitor-plugin-common/src/variables-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/variables-to-object.ts
@@ -42,7 +42,7 @@ export class OperationVariablesToObject {
       return null;
     }
 
-    return variablesNode.map(variable => indent(this.transformVariable(variable))).join(',\n');
+    return variablesNode.map(variable => indent(this.transformVariable(variable))).join(`${this.getPunctuation()}\n`) + this.getPunctuation();
   }
 
   protected getScalar(name: string): string {
@@ -100,5 +100,9 @@ export class OperationVariablesToObject {
     }
 
     return fieldType;
+  }
+
+  protected getPunctuation(): string {
+    return ',';
   }
 }

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -6,56 +6,56 @@ import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string,
-  String: string,
-  Boolean: boolean,
-  Int: number,
-  Float: number,
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
 };
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
-   __typename?: 'Comment',
+   __typename?: 'Comment';
   /** The SQL ID of this entry */
-  id: Scalars['Int'],
+  id: Scalars['Int'];
   /** The GitHub user who posted the comment */
-  postedBy: User,
+  postedBy: User;
   /** A timestamp of when the comment was posted */
-  createdAt: Scalars['Float'],
+  createdAt: Scalars['Float'];
   /** The text of the comment */
-  content: Scalars['String'],
+  content: Scalars['String'];
   /** The repository which this comment is about */
-  repoName: Scalars['String'],
+  repoName: Scalars['String'];
 };
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
-   __typename?: 'Entry',
+   __typename?: 'Entry';
   /** Information about the repository from GitHub */
-  repository: Repository,
+  repository: Repository;
   /** The GitHub user who submitted this entry */
-  postedBy: User,
+  postedBy: User;
   /** A timestamp of when the entry was submitted */
-  createdAt: Scalars['Float'],
+  createdAt: Scalars['Float'];
   /** The score of this repository, upvotes - downvotes */
-  score: Scalars['Int'],
+  score: Scalars['Int'];
   /** The hot score of this repository */
-  hotScore: Scalars['Float'],
+  hotScore: Scalars['Float'];
   /** Comments posted about this repository */
-  comments: Array<Maybe<Comment>>,
+  comments: Array<Maybe<Comment>>;
   /** The number of comments posted about this repository */
-  commentCount: Scalars['Int'],
+  commentCount: Scalars['Int'];
   /** The SQL ID of this entry */
-  id: Scalars['Int'],
+  id: Scalars['Int'];
   /** XXX to be changed */
-  vote: Vote,
+  vote: Vote;
 };
 
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type EntryCommentsArgs = {
-  limit?: Maybe<Scalars['Int']>,
-  offset?: Maybe<Scalars['Int']>
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
 };
 
 /** A list of options for the sort order of the feed */
@@ -69,52 +69,52 @@ export enum FeedType {
 }
 
 export type Mutation = {
-   __typename?: 'Mutation',
+   __typename?: 'Mutation';
   /** Submit a new repository, returns the new submission */
-  submitRepository?: Maybe<Entry>,
+  submitRepository?: Maybe<Entry>;
   /** Vote on a repository submission, returns the submission that was voted on */
-  vote?: Maybe<Entry>,
+  vote?: Maybe<Entry>;
   /** Comment on a repository, returns the new comment */
-  submitComment?: Maybe<Comment>,
+  submitComment?: Maybe<Comment>;
 };
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: Scalars['String'],
-  type: VoteType
+  repoFullName: Scalars['String'];
+  type: VoteType;
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: Scalars['String'],
-  commentContent: Scalars['String']
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
 };
 
 export type Query = {
-   __typename?: 'Query',
+   __typename?: 'Query';
   /** A feed of repository submissions */
-  feed?: Maybe<Array<Maybe<Entry>>>,
+  feed?: Maybe<Array<Maybe<Entry>>>;
   /** A single entry */
-  entry?: Maybe<Entry>,
+  entry?: Maybe<Entry>;
   /** Return the currently logged in user, or null if nobody is logged in */
-  currentUser?: Maybe<User>,
+  currentUser?: Maybe<User>;
 };
 
 
 export type QueryFeedArgs = {
-  type: FeedType,
-  offset?: Maybe<Scalars['Int']>,
-  limit?: Maybe<Scalars['Int']>
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 /** 
@@ -122,49 +122,49 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
-   __typename?: 'Repository',
+   __typename?: 'Repository';
   /** Just the name of the repository, e.g. GitHunt-API */
-  name: Scalars['String'],
+  name: Scalars['String'];
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
-  full_name: Scalars['String'],
+  full_name: Scalars['String'];
   /** The description of the repository */
-  description?: Maybe<Scalars['String']>,
+  description?: Maybe<Scalars['String']>;
   /** The link to the repository on GitHub */
-  html_url: Scalars['String'],
+  html_url: Scalars['String'];
   /** The number of people who have starred this repository on GitHub */
-  stargazers_count: Scalars['Int'],
+  stargazers_count: Scalars['Int'];
   /** The number of open issues on this repository on GitHub */
-  open_issues_count?: Maybe<Scalars['Int']>,
+  open_issues_count?: Maybe<Scalars['Int']>;
   /** The owner of this repository on GitHub, e.g. apollostack */
-  owner?: Maybe<User>,
+  owner?: Maybe<User>;
 };
 
 export type Subscription = {
-   __typename?: 'Subscription',
+   __typename?: 'Subscription';
   /** Subscription fires on every comment added */
-  commentAdded?: Maybe<Comment>,
+  commentAdded?: Maybe<Comment>;
 };
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
-   __typename?: 'User',
+   __typename?: 'User';
   /** The name of the user, e.g. apollostack */
-  login: Scalars['String'],
+  login: Scalars['String'];
   /** The URL to a directly embeddable image for this user's avatar */
-  avatar_url: Scalars['String'],
+  avatar_url: Scalars['String'];
   /** The URL of this user's GitHub page */
-  html_url: Scalars['String'],
+  html_url: Scalars['String'];
 };
 
 /** XXX to be removed */
 export type Vote = {
-   __typename?: 'Vote',
-  vote_value: Scalars['Int'],
+   __typename?: 'Vote';
+  vote_value: Scalars['Int'];
 };
 
 /** The type of vote to record, when submitting a vote */
@@ -192,7 +192,7 @@ export type FeedQuery = (
 );
 
 export type Feed2QueryVariables = {
-  v: Scalars['String']
+  v: Scalars['String'];
 };
 
 
@@ -205,7 +205,7 @@ export type Feed2Query = (
 );
 
 export type Feed3QueryVariables = {
-  v?: Maybe<Scalars['String']>
+  v?: Maybe<Scalars['String']>;
 };
 
 
@@ -218,7 +218,7 @@ export type Feed3Query = (
 );
 
 export type Feed4QueryVariables = {
-  v?: Scalars['String']
+  v?: Scalars['String'];
 };
 
 
@@ -303,56 +303,56 @@ exports[`generic-sdk sdk Should generate a correct wrap method with documentMode
 "export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string,
-  String: string,
-  Boolean: boolean,
-  Int: number,
-  Float: number,
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
 };
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
-   __typename?: 'Comment',
+   __typename?: 'Comment';
   /** The SQL ID of this entry */
-  id: Scalars['Int'],
+  id: Scalars['Int'];
   /** The GitHub user who posted the comment */
-  postedBy: User,
+  postedBy: User;
   /** A timestamp of when the comment was posted */
-  createdAt: Scalars['Float'],
+  createdAt: Scalars['Float'];
   /** The text of the comment */
-  content: Scalars['String'],
+  content: Scalars['String'];
   /** The repository which this comment is about */
-  repoName: Scalars['String'],
+  repoName: Scalars['String'];
 };
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
-   __typename?: 'Entry',
+   __typename?: 'Entry';
   /** Information about the repository from GitHub */
-  repository: Repository,
+  repository: Repository;
   /** The GitHub user who submitted this entry */
-  postedBy: User,
+  postedBy: User;
   /** A timestamp of when the entry was submitted */
-  createdAt: Scalars['Float'],
+  createdAt: Scalars['Float'];
   /** The score of this repository, upvotes - downvotes */
-  score: Scalars['Int'],
+  score: Scalars['Int'];
   /** The hot score of this repository */
-  hotScore: Scalars['Float'],
+  hotScore: Scalars['Float'];
   /** Comments posted about this repository */
-  comments: Array<Maybe<Comment>>,
+  comments: Array<Maybe<Comment>>;
   /** The number of comments posted about this repository */
-  commentCount: Scalars['Int'],
+  commentCount: Scalars['Int'];
   /** The SQL ID of this entry */
-  id: Scalars['Int'],
+  id: Scalars['Int'];
   /** XXX to be changed */
-  vote: Vote,
+  vote: Vote;
 };
 
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type EntryCommentsArgs = {
-  limit?: Maybe<Scalars['Int']>,
-  offset?: Maybe<Scalars['Int']>
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
 };
 
 /** A list of options for the sort order of the feed */
@@ -366,52 +366,52 @@ export enum FeedType {
 }
 
 export type Mutation = {
-   __typename?: 'Mutation',
+   __typename?: 'Mutation';
   /** Submit a new repository, returns the new submission */
-  submitRepository?: Maybe<Entry>,
+  submitRepository?: Maybe<Entry>;
   /** Vote on a repository submission, returns the submission that was voted on */
-  vote?: Maybe<Entry>,
+  vote?: Maybe<Entry>;
   /** Comment on a repository, returns the new comment */
-  submitComment?: Maybe<Comment>,
+  submitComment?: Maybe<Comment>;
 };
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: Scalars['String'],
-  type: VoteType
+  repoFullName: Scalars['String'];
+  type: VoteType;
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: Scalars['String'],
-  commentContent: Scalars['String']
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
 };
 
 export type Query = {
-   __typename?: 'Query',
+   __typename?: 'Query';
   /** A feed of repository submissions */
-  feed?: Maybe<Array<Maybe<Entry>>>,
+  feed?: Maybe<Array<Maybe<Entry>>>;
   /** A single entry */
-  entry?: Maybe<Entry>,
+  entry?: Maybe<Entry>;
   /** Return the currently logged in user, or null if nobody is logged in */
-  currentUser?: Maybe<User>,
+  currentUser?: Maybe<User>;
 };
 
 
 export type QueryFeedArgs = {
-  type: FeedType,
-  offset?: Maybe<Scalars['Int']>,
-  limit?: Maybe<Scalars['Int']>
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 /** 
@@ -419,49 +419,49 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
-   __typename?: 'Repository',
+   __typename?: 'Repository';
   /** Just the name of the repository, e.g. GitHunt-API */
-  name: Scalars['String'],
+  name: Scalars['String'];
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
-  full_name: Scalars['String'],
+  full_name: Scalars['String'];
   /** The description of the repository */
-  description?: Maybe<Scalars['String']>,
+  description?: Maybe<Scalars['String']>;
   /** The link to the repository on GitHub */
-  html_url: Scalars['String'],
+  html_url: Scalars['String'];
   /** The number of people who have starred this repository on GitHub */
-  stargazers_count: Scalars['Int'],
+  stargazers_count: Scalars['Int'];
   /** The number of open issues on this repository on GitHub */
-  open_issues_count?: Maybe<Scalars['Int']>,
+  open_issues_count?: Maybe<Scalars['Int']>;
   /** The owner of this repository on GitHub, e.g. apollostack */
-  owner?: Maybe<User>,
+  owner?: Maybe<User>;
 };
 
 export type Subscription = {
-   __typename?: 'Subscription',
+   __typename?: 'Subscription';
   /** Subscription fires on every comment added */
-  commentAdded?: Maybe<Comment>,
+  commentAdded?: Maybe<Comment>;
 };
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
-   __typename?: 'User',
+   __typename?: 'User';
   /** The name of the user, e.g. apollostack */
-  login: Scalars['String'],
+  login: Scalars['String'];
   /** The URL to a directly embeddable image for this user's avatar */
-  avatar_url: Scalars['String'],
+  avatar_url: Scalars['String'];
   /** The URL of this user's GitHub page */
-  html_url: Scalars['String'],
+  html_url: Scalars['String'];
 };
 
 /** XXX to be removed */
 export type Vote = {
-   __typename?: 'Vote',
-  vote_value: Scalars['Int'],
+   __typename?: 'Vote';
+  vote_value: Scalars['Int'];
 };
 
 /** The type of vote to record, when submitting a vote */
@@ -489,7 +489,7 @@ export type FeedQuery = (
 );
 
 export type Feed2QueryVariables = {
-  v: Scalars['String']
+  v: Scalars['String'];
 };
 
 
@@ -502,7 +502,7 @@ export type Feed2Query = (
 );
 
 export type Feed3QueryVariables = {
-  v?: Maybe<Scalars['String']>
+  v?: Maybe<Scalars['String']>;
 };
 
 
@@ -515,7 +515,7 @@ export type Feed3Query = (
 );
 
 export type Feed4QueryVariables = {
-  v?: Scalars['String']
+  v?: Scalars['String'];
 };
 
 

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -7,56 +7,56 @@ import { print } from 'graphql';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string,
-  String: string,
-  Boolean: boolean,
-  Int: number,
-  Float: number,
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
 };
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
-   __typename?: 'Comment',
+   __typename?: 'Comment';
   /** The SQL ID of this entry */
-  id: Scalars['Int'],
+  id: Scalars['Int'];
   /** The GitHub user who posted the comment */
-  postedBy: User,
+  postedBy: User;
   /** A timestamp of when the comment was posted */
-  createdAt: Scalars['Float'],
+  createdAt: Scalars['Float'];
   /** The text of the comment */
-  content: Scalars['String'],
+  content: Scalars['String'];
   /** The repository which this comment is about */
-  repoName: Scalars['String'],
+  repoName: Scalars['String'];
 };
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
-   __typename?: 'Entry',
+   __typename?: 'Entry';
   /** Information about the repository from GitHub */
-  repository: Repository,
+  repository: Repository;
   /** The GitHub user who submitted this entry */
-  postedBy: User,
+  postedBy: User;
   /** A timestamp of when the entry was submitted */
-  createdAt: Scalars['Float'],
+  createdAt: Scalars['Float'];
   /** The score of this repository, upvotes - downvotes */
-  score: Scalars['Int'],
+  score: Scalars['Int'];
   /** The hot score of this repository */
-  hotScore: Scalars['Float'],
+  hotScore: Scalars['Float'];
   /** Comments posted about this repository */
-  comments: Array<Maybe<Comment>>,
+  comments: Array<Maybe<Comment>>;
   /** The number of comments posted about this repository */
-  commentCount: Scalars['Int'],
+  commentCount: Scalars['Int'];
   /** The SQL ID of this entry */
-  id: Scalars['Int'],
+  id: Scalars['Int'];
   /** XXX to be changed */
-  vote: Vote,
+  vote: Vote;
 };
 
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type EntryCommentsArgs = {
-  limit?: Maybe<Scalars['Int']>,
-  offset?: Maybe<Scalars['Int']>
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
 };
 
 /** A list of options for the sort order of the feed */
@@ -70,52 +70,52 @@ export enum FeedType {
 }
 
 export type Mutation = {
-   __typename?: 'Mutation',
+   __typename?: 'Mutation';
   /** Submit a new repository, returns the new submission */
-  submitRepository?: Maybe<Entry>,
+  submitRepository?: Maybe<Entry>;
   /** Vote on a repository submission, returns the submission that was voted on */
-  vote?: Maybe<Entry>,
+  vote?: Maybe<Entry>;
   /** Comment on a repository, returns the new comment */
-  submitComment?: Maybe<Comment>,
+  submitComment?: Maybe<Comment>;
 };
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: Scalars['String'],
-  type: VoteType
+  repoFullName: Scalars['String'];
+  type: VoteType;
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: Scalars['String'],
-  commentContent: Scalars['String']
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
 };
 
 export type Query = {
-   __typename?: 'Query',
+   __typename?: 'Query';
   /** A feed of repository submissions */
-  feed?: Maybe<Array<Maybe<Entry>>>,
+  feed?: Maybe<Array<Maybe<Entry>>>;
   /** A single entry */
-  entry?: Maybe<Entry>,
+  entry?: Maybe<Entry>;
   /** Return the currently logged in user, or null if nobody is logged in */
-  currentUser?: Maybe<User>,
+  currentUser?: Maybe<User>;
 };
 
 
 export type QueryFeedArgs = {
-  type: FeedType,
-  offset?: Maybe<Scalars['Int']>,
-  limit?: Maybe<Scalars['Int']>
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 /** 
@@ -123,49 +123,49 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
-   __typename?: 'Repository',
+   __typename?: 'Repository';
   /** Just the name of the repository, e.g. GitHunt-API */
-  name: Scalars['String'],
+  name: Scalars['String'];
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
-  full_name: Scalars['String'],
+  full_name: Scalars['String'];
   /** The description of the repository */
-  description?: Maybe<Scalars['String']>,
+  description?: Maybe<Scalars['String']>;
   /** The link to the repository on GitHub */
-  html_url: Scalars['String'],
+  html_url: Scalars['String'];
   /** The number of people who have starred this repository on GitHub */
-  stargazers_count: Scalars['Int'],
+  stargazers_count: Scalars['Int'];
   /** The number of open issues on this repository on GitHub */
-  open_issues_count?: Maybe<Scalars['Int']>,
+  open_issues_count?: Maybe<Scalars['Int']>;
   /** The owner of this repository on GitHub, e.g. apollostack */
-  owner?: Maybe<User>,
+  owner?: Maybe<User>;
 };
 
 export type Subscription = {
-   __typename?: 'Subscription',
+   __typename?: 'Subscription';
   /** Subscription fires on every comment added */
-  commentAdded?: Maybe<Comment>,
+  commentAdded?: Maybe<Comment>;
 };
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
-   __typename?: 'User',
+   __typename?: 'User';
   /** The name of the user, e.g. apollostack */
-  login: Scalars['String'],
+  login: Scalars['String'];
   /** The URL to a directly embeddable image for this user's avatar */
-  avatar_url: Scalars['String'],
+  avatar_url: Scalars['String'];
   /** The URL of this user's GitHub page */
-  html_url: Scalars['String'],
+  html_url: Scalars['String'];
 };
 
 /** XXX to be removed */
 export type Vote = {
-   __typename?: 'Vote',
-  vote_value: Scalars['Int'],
+   __typename?: 'Vote';
+  vote_value: Scalars['Int'];
 };
 
 /** The type of vote to record, when submitting a vote */
@@ -193,7 +193,7 @@ export type FeedQuery = (
 );
 
 export type Feed2QueryVariables = {
-  v: Scalars['String']
+  v: Scalars['String'];
 };
 
 
@@ -206,7 +206,7 @@ export type Feed2Query = (
 );
 
 export type Feed3QueryVariables = {
-  v?: Maybe<Scalars['String']>
+  v?: Maybe<Scalars['String']>;
 };
 
 
@@ -219,7 +219,7 @@ export type Feed3Query = (
 );
 
 export type Feed4QueryVariables = {
-  v?: Scalars['String']
+  v?: Scalars['String'];
 };
 
 
@@ -304,56 +304,56 @@ exports[`graphql-request sdk Should generate a correct wrap method with document
 import { GraphQLClient } from 'graphql-request';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string,
-  String: string,
-  Boolean: boolean,
-  Int: number,
-  Float: number,
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
 };
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
-   __typename?: 'Comment',
+   __typename?: 'Comment';
   /** The SQL ID of this entry */
-  id: Scalars['Int'],
+  id: Scalars['Int'];
   /** The GitHub user who posted the comment */
-  postedBy: User,
+  postedBy: User;
   /** A timestamp of when the comment was posted */
-  createdAt: Scalars['Float'],
+  createdAt: Scalars['Float'];
   /** The text of the comment */
-  content: Scalars['String'],
+  content: Scalars['String'];
   /** The repository which this comment is about */
-  repoName: Scalars['String'],
+  repoName: Scalars['String'];
 };
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
-   __typename?: 'Entry',
+   __typename?: 'Entry';
   /** Information about the repository from GitHub */
-  repository: Repository,
+  repository: Repository;
   /** The GitHub user who submitted this entry */
-  postedBy: User,
+  postedBy: User;
   /** A timestamp of when the entry was submitted */
-  createdAt: Scalars['Float'],
+  createdAt: Scalars['Float'];
   /** The score of this repository, upvotes - downvotes */
-  score: Scalars['Int'],
+  score: Scalars['Int'];
   /** The hot score of this repository */
-  hotScore: Scalars['Float'],
+  hotScore: Scalars['Float'];
   /** Comments posted about this repository */
-  comments: Array<Maybe<Comment>>,
+  comments: Array<Maybe<Comment>>;
   /** The number of comments posted about this repository */
-  commentCount: Scalars['Int'],
+  commentCount: Scalars['Int'];
   /** The SQL ID of this entry */
-  id: Scalars['Int'],
+  id: Scalars['Int'];
   /** XXX to be changed */
-  vote: Vote,
+  vote: Vote;
 };
 
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type EntryCommentsArgs = {
-  limit?: Maybe<Scalars['Int']>,
-  offset?: Maybe<Scalars['Int']>
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
 };
 
 /** A list of options for the sort order of the feed */
@@ -367,52 +367,52 @@ export enum FeedType {
 }
 
 export type Mutation = {
-   __typename?: 'Mutation',
+   __typename?: 'Mutation';
   /** Submit a new repository, returns the new submission */
-  submitRepository?: Maybe<Entry>,
+  submitRepository?: Maybe<Entry>;
   /** Vote on a repository submission, returns the submission that was voted on */
-  vote?: Maybe<Entry>,
+  vote?: Maybe<Entry>;
   /** Comment on a repository, returns the new comment */
-  submitComment?: Maybe<Comment>,
+  submitComment?: Maybe<Comment>;
 };
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: Scalars['String'],
-  type: VoteType
+  repoFullName: Scalars['String'];
+  type: VoteType;
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: Scalars['String'],
-  commentContent: Scalars['String']
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
 };
 
 export type Query = {
-   __typename?: 'Query',
+   __typename?: 'Query';
   /** A feed of repository submissions */
-  feed?: Maybe<Array<Maybe<Entry>>>,
+  feed?: Maybe<Array<Maybe<Entry>>>;
   /** A single entry */
-  entry?: Maybe<Entry>,
+  entry?: Maybe<Entry>;
   /** Return the currently logged in user, or null if nobody is logged in */
-  currentUser?: Maybe<User>,
+  currentUser?: Maybe<User>;
 };
 
 
 export type QueryFeedArgs = {
-  type: FeedType,
-  offset?: Maybe<Scalars['Int']>,
-  limit?: Maybe<Scalars['Int']>
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 /** 
@@ -420,49 +420,49 @@ export type QueryEntryArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
-   __typename?: 'Repository',
+   __typename?: 'Repository';
   /** Just the name of the repository, e.g. GitHunt-API */
-  name: Scalars['String'],
+  name: Scalars['String'];
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
-  full_name: Scalars['String'],
+  full_name: Scalars['String'];
   /** The description of the repository */
-  description?: Maybe<Scalars['String']>,
+  description?: Maybe<Scalars['String']>;
   /** The link to the repository on GitHub */
-  html_url: Scalars['String'],
+  html_url: Scalars['String'];
   /** The number of people who have starred this repository on GitHub */
-  stargazers_count: Scalars['Int'],
+  stargazers_count: Scalars['Int'];
   /** The number of open issues on this repository on GitHub */
-  open_issues_count?: Maybe<Scalars['Int']>,
+  open_issues_count?: Maybe<Scalars['Int']>;
   /** The owner of this repository on GitHub, e.g. apollostack */
-  owner?: Maybe<User>,
+  owner?: Maybe<User>;
 };
 
 export type Subscription = {
-   __typename?: 'Subscription',
+   __typename?: 'Subscription';
   /** Subscription fires on every comment added */
-  commentAdded?: Maybe<Comment>,
+  commentAdded?: Maybe<Comment>;
 };
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
-   __typename?: 'User',
+   __typename?: 'User';
   /** The name of the user, e.g. apollostack */
-  login: Scalars['String'],
+  login: Scalars['String'];
   /** The URL to a directly embeddable image for this user's avatar */
-  avatar_url: Scalars['String'],
+  avatar_url: Scalars['String'];
   /** The URL of this user's GitHub page */
-  html_url: Scalars['String'],
+  html_url: Scalars['String'];
 };
 
 /** XXX to be removed */
 export type Vote = {
-   __typename?: 'Vote',
-  vote_value: Scalars['Int'],
+   __typename?: 'Vote';
+  vote_value: Scalars['Int'];
 };
 
 /** The type of vote to record, when submitting a vote */
@@ -490,7 +490,7 @@ export type FeedQuery = (
 );
 
 export type Feed2QueryVariables = {
-  v: Scalars['String']
+  v: Scalars['String'];
 };
 
 
@@ -503,7 +503,7 @@ export type Feed2Query = (
 );
 
 export type Feed3QueryVariables = {
-  v?: Maybe<Scalars['String']>
+  v?: Maybe<Scalars['String']>;
 };
 
 
@@ -516,7 +516,7 @@ export type Feed3Query = (
 );
 
 export type Feed4QueryVariables = {
-  v?: Scalars['String']
+  v?: Scalars['String'];
 };
 
 

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -1,5 +1,5 @@
 import { GraphQLSchema, isListType, GraphQLObjectType, GraphQLNonNull, GraphQLList, isEnumType } from 'graphql';
-import { PreResolveTypesProcessor, ParsedDocumentsConfig, BaseDocumentsVisitor, LoadedFragment, getConfigValue, SelectionSetProcessorConfig, SelectionSetToObject } from '@graphql-codegen/visitor-plugin-common';
+import { PreResolveTypesProcessor, ParsedDocumentsConfig, BaseDocumentsVisitor, LoadedFragment, getConfigValue, SelectionSetProcessorConfig, SelectionSetToObject, DeclarationKind } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptOperationVariablesToObject } from './ts-operation-variables-to-object';
 import { TypeScriptDocumentsPluginConfig } from './config';
 import { isNonNullType } from 'graphql';
@@ -69,5 +69,9 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<TypeScriptD
     this._declarationBlockConfig = {
       ignoreExport: this.config.noExport,
     };
+  }
+
+  protected getPunctuation(declarationKind: DeclarationKind): string {
+    return ';';
   }
 }

--- a/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
+++ b/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`TypeScript Operations Plugin Issues #2699 - Issues with multiple interfaces and unions 1`] = `
 "export type GetEntityBrandDataQueryVariables = {
-  gid: Scalars['ID'],
-  brand: Scalars['ID']
+  gid: Scalars['ID'];
+  brand: Scalars['ID'];
 };
 
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -1735,7 +1735,7 @@ describe('TypeScript Operations Plugin', () => {
 
       expect(result).toBeSimilarStringTo(
         `export type MeQueryVariables = {
-          repoFullName: Scalars['String']
+          repoFullName: Scalars['String'];
         };`
       );
       expect(result).toBeSimilarStringTo(`
@@ -1864,7 +1864,7 @@ describe('TypeScript Operations Plugin', () => {
 
       const o = await validate(result, config, testSchema);
       expect(o).toBeSimilarStringTo(` export type ITestQueryVariables = {
-        e: Information_EntryType
+        e: Information_EntryType;
       };`);
       expect(o).toContain(`export type IQuery = {`);
       expect(o).toContain(`export enum Information_EntryType {`);
@@ -2025,14 +2025,14 @@ describe('TypeScript Operations Plugin', () => {
 
       expect(result).toBeSimilarStringTo(
         `export type TestQueryQueryVariables = {
-          username?: Maybe<Scalars['String']>,
-          email?: Maybe<Scalars['String']>,
-          password: Scalars['String'],
-          input?: Maybe<InputType>,
-          mandatoryInput: InputType,
-          testArray?: Maybe<Array<Maybe<Scalars['String']>>>,
-          requireString: Array<Maybe<Scalars['String']>>,
-          innerRequired: Array<Scalars['String']>
+          username?: Maybe<Scalars['String']>;
+          email?: Maybe<Scalars['String']>;
+          password: Scalars['String'];
+          input?: Maybe<InputType>;
+          mandatoryInput: InputType;
+          testArray?: Maybe<Array<Maybe<Scalars['String']>>>;
+          requireString: Array<Maybe<Scalars['String']>>;
+          innerRequired: Array<Scalars['String']>;
         };`
       );
       await validate(result, config);
@@ -2049,7 +2049,7 @@ describe('TypeScript Operations Plugin', () => {
 
       expect(result).toBeSimilarStringTo(
         `export type TestQueryQueryVariables = {
-          test?: Maybe<Scalars['DateTime']>
+          test?: Maybe<Scalars['DateTime']>;
         };`
       );
       await validate(result, config);
@@ -2359,7 +2359,7 @@ describe('TypeScript Operations Plugin', () => {
 
       expect(content).toBeSimilarStringTo(`
         export type PREFIX_UsersQueryVariables = {
-          filter: PREFIX_Filter
+          filter: PREFIX_Filter;
         };
       `);
       expect(content).toBeSimilarStringTo(`
@@ -2401,7 +2401,7 @@ describe('TypeScript Operations Plugin', () => {
 
       expect(content).toBeSimilarStringTo(`
         export type UsersQueryVariables = {
-          reverse?: Maybe<Scalars['Boolean']>
+          reverse?: Maybe<Scalars['Boolean']>;
         };
       `);
     });

--- a/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
+++ b/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
@@ -7,54 +7,54 @@ import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactHooks from '@apollo/react-hooks';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string,
-  String: string,
-  Boolean: boolean,
-  Int: number,
-  Float: number,
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
 };
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   /** The SQL ID of this entry */
-  id: Scalars['Int'],
+  id: Scalars['Int'];
   /** The GitHub user who posted the comment */
-  postedBy: User,
+  postedBy: User;
   /** A timestamp of when the comment was posted */
-  createdAt: Scalars['Float'],
+  createdAt: Scalars['Float'];
   /** The text of the comment */
-  content: Scalars['String'],
+  content: Scalars['String'];
   /** The repository which this comment is about */
-  repoName: Scalars['String'],
+  repoName: Scalars['String'];
 };
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
   /** Information about the repository from GitHub */
-  repository: Repository,
+  repository: Repository;
   /** The GitHub user who submitted this entry */
-  postedBy: User,
+  postedBy: User;
   /** A timestamp of when the entry was submitted */
-  createdAt: Scalars['Float'],
+  createdAt: Scalars['Float'];
   /** The score of this repository, upvotes - downvotes */
-  score: Scalars['Int'],
+  score: Scalars['Int'];
   /** The hot score of this repository */
-  hotScore: Scalars['Float'],
+  hotScore: Scalars['Float'];
   /** Comments posted about this repository */
-  comments: Array<Maybe<Comment>>,
+  comments: Array<Maybe<Comment>>;
   /** The number of comments posted about this repository */
-  commentCount: Scalars['Int'],
+  commentCount: Scalars['Int'];
   /** The SQL ID of this entry */
-  id: Scalars['Int'],
+  id: Scalars['Int'];
   /** XXX to be changed */
-  vote: Vote,
+  vote: Vote;
 };
 
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type EntryCommentsArgs = {
-  limit?: Maybe<Scalars['Int']>,
-  offset?: Maybe<Scalars['Int']>
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
 };
 
 /** A list of options for the sort order of the feed */
@@ -69,49 +69,49 @@ export enum FeedType {
 
 export type Mutation = {
   /** Submit a new repository, returns the new submission */
-  submitRepository?: Maybe<Entry>,
+  submitRepository?: Maybe<Entry>;
   /** Vote on a repository submission, returns the submission that was voted on */
-  vote?: Maybe<Entry>,
+  vote?: Maybe<Entry>;
   /** Comment on a repository, returns the new comment */
-  submitComment?: Maybe<Comment>,
+  submitComment?: Maybe<Comment>;
 };
 
 
 export type MutationSubmitRepositoryArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 
 export type MutationVoteArgs = {
-  repoFullName: Scalars['String'],
-  type: VoteType
+  repoFullName: Scalars['String'];
+  type: VoteType;
 };
 
 
 export type MutationSubmitCommentArgs = {
-  repoFullName: Scalars['String'],
-  commentContent: Scalars['String']
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
 };
 
 export type Query = {
   /** A feed of repository submissions */
-  feed?: Maybe<Array<Maybe<Entry>>>,
+  feed?: Maybe<Array<Maybe<Entry>>>;
   /** A single entry */
-  entry?: Maybe<Entry>,
+  entry?: Maybe<Entry>;
   /** Return the currently logged in user, or null if nobody is logged in */
-  currentUser?: Maybe<User>,
+  currentUser?: Maybe<User>;
 };
 
 
 export type QueryFeedArgs = {
-  type: FeedType,
-  offset?: Maybe<Scalars['Int']>,
-  limit?: Maybe<Scalars['Int']>
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
 };
 
 
 export type QueryEntryArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 /** 
@@ -120,44 +120,44 @@ export type QueryEntryArgs = {
  */
 export type Repository = {
   /** Just the name of the repository, e.g. GitHunt-API */
-  name: Scalars['String'],
+  name: Scalars['String'];
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
-  full_name: Scalars['String'],
+  full_name: Scalars['String'];
   /** The description of the repository */
-  description?: Maybe<Scalars['String']>,
+  description?: Maybe<Scalars['String']>;
   /** The link to the repository on GitHub */
-  html_url: Scalars['String'],
+  html_url: Scalars['String'];
   /** The number of people who have starred this repository on GitHub */
-  stargazers_count: Scalars['Int'],
+  stargazers_count: Scalars['Int'];
   /** The number of open issues on this repository on GitHub */
-  open_issues_count?: Maybe<Scalars['Int']>,
+  open_issues_count?: Maybe<Scalars['Int']>;
   /** The owner of this repository on GitHub, e.g. apollostack */
-  owner?: Maybe<User>,
+  owner?: Maybe<User>;
 };
 
 export type Subscription = {
   /** Subscription fires on every comment added */
-  commentAdded?: Maybe<Comment>,
+  commentAdded?: Maybe<Comment>;
 };
 
 
 export type SubscriptionCommentAddedArgs = {
-  repoFullName: Scalars['String']
+  repoFullName: Scalars['String'];
 };
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
   /** The name of the user, e.g. apollostack */
-  login: Scalars['String'],
+  login: Scalars['String'];
   /** The URL to a directly embeddable image for this user's avatar */
-  avatar_url: Scalars['String'],
+  avatar_url: Scalars['String'];
   /** The URL of this user's GitHub page */
-  html_url: Scalars['String'],
+  html_url: Scalars['String'];
 };
 
 /** XXX to be removed */
 export type Vote = {
-  vote_value: Scalars['Int'],
+  vote_value: Scalars['Int'];
 };
 
 /** The type of vote to record, when submitting a vote */

--- a/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
+++ b/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
@@ -166,25 +166,25 @@ export enum VoteType {
   DOWN = 'DOWN',
   CANCEL = 'CANCEL'
 }
-export type GetSomehtingQueryVariables = {};
+export type GetSomethingQueryVariables = {};
 
 
-export type GetSomehtingQuery = { feed: Maybe<Array<Maybe<Pick<Entry, 'id'>>>> };
+export type GetSomethingQuery = { feed: Maybe<Array<Maybe<Pick<Entry, 'id'>>>> };
 
-export const GetSomehtingDocument = gql\`
-    query GET_SOMEHTING {
+export const GetSomethingDocument = gql\`
+    query GET_SOMETHING {
   feed {
     id
   }
 }
     \`;
-export function useGetSomehtingQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetSomehtingQuery, GetSomehtingQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetSomehtingQuery, GetSomehtingQueryVariables>(GetSomehtingDocument, baseOptions);
+export function useGetSomethingQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetSomethingQuery, GetSomethingQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetSomethingQuery, GetSomethingQueryVariables>(GetSomethingDocument, baseOptions);
       }
-export function useGetSomehtingLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetSomehtingQuery, GetSomehtingQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetSomehtingQuery, GetSomehtingQueryVariables>(GetSomehtingDocument, baseOptions);
+export function useGetSomethingLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetSomethingQuery, GetSomethingQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetSomethingQuery, GetSomethingQueryVariables>(GetSomethingDocument, baseOptions);
         }
-export type GetSomehtingQueryHookResult = ReturnType<typeof useGetSomehtingQuery>;
-export type GetSomehtingLazyQueryHookResult = ReturnType<typeof useGetSomehtingLazyQuery>;
-export type GetSomehtingQueryResult = ApolloReactCommon.QueryResult<GetSomehtingQuery, GetSomehtingQueryVariables>;"
+export type GetSomethingQueryHookResult = ReturnType<typeof useGetSomethingQuery>;
+export type GetSomethingLazyQueryHookResult = ReturnType<typeof useGetSomethingLazyQuery>;
+export type GetSomethingQueryResult = ApolloReactCommon.QueryResult<GetSomethingQuery, GetSomethingQueryVariables>;"
 `;

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -67,7 +67,7 @@ describe('React Apollo', () => {
         {
           location: '',
           document: parse(/* GraphQL */ `
-            query GET_SOMEHTING {
+            query GET_SOMETHING {
               feed {
                 id
               }
@@ -89,7 +89,7 @@ describe('React Apollo', () => {
       })) as Types.ComplexPluginOutput;
 
       const output = await validateAndCompile(content, config, schema, docs, '');
-      expect(output).toContain(`export type Get_SomehtingQueryResult = ApolloReactCommon.QueryResult<Types.Get_SomehtingQuery, Types.Get_SomehtingQueryVariables>;`);
+      expect(output).toContain(`export type Get_SomethingQueryResult = ApolloReactCommon.QueryResult<Types.Get_SomethingQuery, Types.Get_SomethingQueryVariables>;`);
     });
 
     it('Issue #2826 - Incorrect prefix', async () => {
@@ -97,7 +97,7 @@ describe('React Apollo', () => {
         {
           location: '',
           document: parse(/* GraphQL */ `
-            query GET_SOMEHTING {
+            query GET_SOMETHING {
               feed {
                 id
               }
@@ -119,7 +119,7 @@ describe('React Apollo', () => {
       })) as Types.ComplexPluginOutput;
 
       const output = await validateAndCompile(content, config, schema, docs, '');
-      expect(output).toContain(`export type Get_SomehtingQueryResult = ApolloReactCommon.QueryResult<GQLGet_SomehtingQuery, GQLGet_SomehtingQueryVariables>;`);
+      expect(output).toContain(`export type Get_SomethingQueryResult = ApolloReactCommon.QueryResult<GQLGet_SomethingQuery, GQLGet_SomethingQueryVariables>;`);
     });
 
     it('PR #2725 - transformUnderscore: true causes invalid output', async () => {
@@ -127,7 +127,7 @@ describe('React Apollo', () => {
         {
           location: '',
           document: parse(/* GraphQL */ `
-            query GET_SOMEHTING {
+            query GET_SOMETHING {
               feed {
                 id
               }

--- a/packages/plugins/typescript/resolvers/src/visitor.ts
+++ b/packages/plugins/typescript/resolvers/src/visitor.ts
@@ -1,7 +1,7 @@
 import { TypeScriptResolversPluginConfig } from './config';
 import { ListTypeNode, NamedTypeNode, NonNullTypeNode, GraphQLSchema } from 'graphql';
 import autoBind from 'auto-bind';
-import { ParsedResolversConfig, BaseResolversVisitor, getConfigValue } from '@graphql-codegen/visitor-plugin-common';
+import { ParsedResolversConfig, BaseResolversVisitor, getConfigValue, DeclarationKind } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptOperationVariablesToObject } from '@graphql-codegen/typescript';
 
 export interface ParsedTypeScriptResolversConfig extends ParsedResolversConfig {
@@ -59,5 +59,9 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<TypeScriptR
     const baseValue = super.NonNullType(node);
 
     return this.clearOptional(baseValue);
+  }
+
+  protected getPunctuation(declarationKind: DeclarationKind): string {
+    return ';';
   }
 }

--- a/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
@@ -633,8 +633,8 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { MyCustomOtherType } from './my-file';`);
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'],
-    arg2: Scalars['String'], arg3: Scalars['Boolean'] };
+    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+    arg2: Scalars['String']; arg3: Scalars['Boolean']; };
     `);
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
@@ -711,8 +711,8 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { MyCustomOtherType } from './my-file';`);
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'],
-    arg2: Scalars['String'], arg3: Scalars['Boolean'] };
+    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+    arg2: Scalars['String']; arg3: Scalars['Boolean']; };
     `);
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
@@ -786,8 +786,8 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'],
-    arg2: Scalars['String'], arg3: Scalars['Boolean'] };
+    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+    arg2: Scalars['String']; arg3: Scalars['Boolean']; };
     `);
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -312,9 +312,9 @@ describe('TypeScript Resolvers Plugin', () => {
     const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'],
-    arg2: Scalars['String'],
-    arg3: Scalars['Boolean'] };
+    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+    arg2: Scalars['String'];
+    arg3: Scalars['Boolean']; };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -379,9 +379,9 @@ describe('TypeScript Resolvers Plugin', () => {
     const result = (await plugin(schema, [], { avoidOptionals: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'],
-    arg2: Scalars['String'],
-    arg3: Scalars['Boolean'] };`);
+    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+    arg2: Scalars['String'];
+    arg3: Scalars['Boolean']; };`);
 
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
@@ -452,9 +452,9 @@ describe('TypeScript Resolvers Plugin', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'],
-    arg2: Scalars['String'],
-    arg3: Scalars['Boolean'] };
+    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+    arg2: Scalars['String'];
+    arg3: Scalars['Boolean']; };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -540,9 +540,9 @@ describe('TypeScript Resolvers Plugin', () => {
     expect(result.prepend).toContain(`import { MyCustomCtx } from './my-file';`);
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'],
-    arg2: Scalars['String'],
-    arg3: Scalars['Boolean'] };
+    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+    arg2: Scalars['String'];
+    arg3: Scalars['Boolean']; };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -612,9 +612,9 @@ describe('TypeScript Resolvers Plugin', () => {
     expect(result.prepend).toContain(`import ContextType from './my-file';`);
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'],
-    arg2: Scalars['String'],
-    arg3: Scalars['Boolean'] };
+    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+    arg2: Scalars['String'];
+    arg3: Scalars['Boolean']; };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -1646,7 +1646,7 @@ describe('TypeScript Resolvers Plugin', () => {
         { outputFile: 'graphql.ts' }
       )) as Types.ComplexPluginOutput;
 
-      expect(output.content).toContain(`export type GqlAuthDirectiveArgs = {   role?: Maybe<UserRole> };`)
+      expect(output.content).toContain(`export type GqlAuthDirectiveArgs = {   role?: Maybe<UserRole>; };`)
       expect(output.content).toContain(`export type GqlAuthDirectiveResolver<Result, Parent, ContextType = any, Args = GqlAuthDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
     });
   });

--- a/packages/plugins/typescript/typescript/src/typescript-variables-to-object.ts
+++ b/packages/plugins/typescript/typescript/src/typescript-variables-to-object.ts
@@ -1,4 +1,4 @@
-import { ParsedEnumValuesMap, OperationVariablesToObject, NormalizedScalarsMap, ConvertNameFn } from '@graphql-codegen/visitor-plugin-common';
+import { ParsedEnumValuesMap, OperationVariablesToObject, NormalizedScalarsMap, ConvertNameFn, InterfaceOrVariable, indent } from '@graphql-codegen/visitor-plugin-common';
 import { TypeNode, Kind } from 'graphql';
 
 export class TypeScriptOperationVariablesToObject extends OperationVariablesToObject {
@@ -55,5 +55,9 @@ export class TypeScriptOperationVariablesToObject extends OperationVariablesToOb
     }
 
     return fieldType;
+  }
+
+  protected getPunctuation(): string {
+    return ';';
   }
 }

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -1,4 +1,4 @@
-import { transformComment, wrapWithSingleQuotes, DeclarationBlock, indent, BaseTypesVisitor, ParsedTypesConfig, getConfigValue } from '@graphql-codegen/visitor-plugin-common';
+import { transformComment, wrapWithSingleQuotes, DeclarationBlock, indent, BaseTypesVisitor, ParsedTypesConfig, getConfigValue, DeclarationKind } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptPluginConfig } from './config';
 import { AvoidOptionalsConfig } from './types';
 import autoBind from 'auto-bind';
@@ -75,7 +75,7 @@ export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPlu
     const comment = transformComment((node.description as any) as string, 1);
     const { type } = this.config.declarationKind;
 
-    return comment + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${addOptionalSign ? '?' : ''}: ${typeString}${type === 'class' ? ';' : ','}`);
+    return comment + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${addOptionalSign ? '?' : ''}: ${typeString}${this.getPunctuation(type)}`);
   }
 
   InputValueDefinition(node: InputValueDefinitionNode, key?: number | string, parent?: any): string {
@@ -83,7 +83,7 @@ export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPlu
     const addOptionalSign = !this.config.avoidOptionals.inputValue && originalFieldNode.type.kind !== Kind.NON_NULL_TYPE;
     const comment = transformComment((node.description as any) as string, 1);
     const { type } = this.config.declarationKind;
-    return comment + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${addOptionalSign ? '?' : ''}: ${node.type}${type === 'class' ? ';' : ','}`);
+    return comment + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${addOptionalSign ? '?' : ''}: ${node.type}${this.getPunctuation(type)}`);
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {
@@ -125,5 +125,9 @@ export class TsVisitor<TRawConfig extends TypeScriptPluginConfig = TypeScriptPlu
         .withComment((node.description as any) as string)
         .withBlock(this.buildEnumValuesBlock(enumName, node.values)).string;
     }
+  }
+
+  protected getPunctuation(declarationKind: DeclarationKind): string {
+    return ';';
   }
 }

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1886,7 +1886,7 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
-    it('Should imoprt all enums from a single file when specified as string', async () => {
+    it('Should import all enums from a single file when specified as string', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C } enum MyEnum2 { X, Y, Z }`);
       const result = (await plugin(schema, [], { enumValues: './my-file' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -23,13 +23,13 @@ describe('TypeScript', () => {
       expect(result.content).toBeSimilarStringTo(`
       /** All built-in and custom scalars, mapped to their actual values */
       export type Scalars = {
-          ID: string,
-          String: string,
-          Boolean: boolean,
-          Int: number,
-          Float: number,
+          ID: string;
+          String: string;
+          Boolean: boolean;
+          Int: number;
+          Float: number;
           /** My custom scalar */
-          A: any,
+          A: any;
         };
       `);
     });
@@ -62,7 +62,7 @@ describe('TypeScript', () => {
         /** MyInput */
         export type MyInput = {
           /** f is something */
-          f: Scalars['String'],
+          f: Scalars['String'];
         }`);
     });
 
@@ -138,9 +138,9 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
       export type B = {
-        __typename?: 'B',
+        __typename?: 'B';
         /** the id */
-        id?: Maybe<Scalars['ID']>,
+        id?: Maybe<Scalars['ID']>;
       };`);
     });
 
@@ -156,7 +156,7 @@ describe('TypeScript', () => {
       expect(result.content).toBeSimilarStringTo(`
       export type Node = {
         /** the id */
-        id: Scalars['ID'],
+        id: Scalars['ID'];
       };`);
     });
 
@@ -298,12 +298,12 @@ describe('TypeScript', () => {
 
       expect(output).toBeSimilarStringTo(`
       export type IUpdateFilterOptionInput = {
-        newOption: FilterOption,
+        newOption: FilterOption;
       };`);
       expect(output).toBeSimilarStringTo(`   
       export type IQueryExampleQueryArgs = {
-        i?: Maybe<IUpdateFilterOptionInput>,
-        t?: Maybe<FilterOption>
+        i?: Maybe<IUpdateFilterOptionInput>;
+        t?: Maybe<FilterOption>;
       };`);
     });
 
@@ -363,13 +363,13 @@ describe('TypeScript', () => {
       )) as Types.ComplexPluginOutput;
 
       expect(result.content).toBeSimilarStringTo(`export type ITest = {
-        __typename?: 'Test',
-       t?: Maybe<MyEnum>,
-       test?: Maybe<Scalars['String']>,
+        __typename?: 'Test';
+       t?: Maybe<MyEnum>;
+       test?: Maybe<Scalars['String']>;
      };`);
 
       expect(result.content).toBeSimilarStringTo(`export type ITestTestArgs = {
-      a?: Maybe<MyEnum>
+      a?: Maybe<MyEnum>;
     };`);
     });
 
@@ -403,7 +403,7 @@ describe('TypeScript', () => {
       )) as Types.ComplexPluginOutput;
       expect(result.prepend).toContain(`import { MyEnum } from './files';`);
       expect(result.content).toContain(`enum GQL_OtherEnum {`);
-      expect(result.content).toContain(`a?: Maybe<MyEnum>,`);
+      expect(result.content).toContain(`a?: Maybe<MyEnum>;`);
       expect(result.content).toContain(`b?: Maybe<GQL_OtherEnum>`);
     });
 
@@ -417,7 +417,7 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
       export type MyInput = {
-        readonly f: Scalars['String'],
+        readonly f: Scalars['String'];
       };`);
       validateTs(result);
     });
@@ -438,8 +438,8 @@ describe('TypeScript', () => {
       expect(result.content).toBeSimilarStringTo(`export type Any = Scalars['String'] | Scalars['Int'] | Scalars['Float'] | Scalars['ID'];`);
       expect(result.content).toBeSimilarStringTo(`
       export type CardEdge = {
-        __typename?: 'CardEdge',
-        count: Scalars['Int'],
+        __typename?: 'CardEdge';
+        count: Scalars['Int'];
       };`);
       validateTs(result);
     });
@@ -492,10 +492,10 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
           export interface ISuggestion {
-            id: Scalars['ID'],
-            userId: Scalars['ID'],
-            suggestionType: SuggestionType,
-            text: Scalars['String'],
+            id: Scalars['ID'];
+            userId: Scalars['ID'];
+            suggestionType: SuggestionType;
+            text: Scalars['String'];
           }
       `);
       expect(result.content).toBeSimilarStringTo(`
@@ -507,14 +507,14 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
           export interface IRootQueryType {
-            suggestionsForUser?: Maybe<Array<ISuggestion>>,
+            suggestionsForUser?: Maybe<Array<ISuggestion>>;
           }
       `);
 
       expect(result.content).toBeSimilarStringTo(`
           export interface IRootQueryTypeSuggestionsForUserArgs {
-            userId: Scalars['ID'],
-            suggestionType: SuggestionType
+            userId: Scalars['ID'];
+            suggestionType: SuggestionType;
           }
       `);
     });
@@ -532,9 +532,9 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
-          __typename?: 'MyType',
-          foo: Maybe<Scalars['String']>,
-          bar: Scalars['String'],
+          __typename?: 'MyType';
+          foo: Maybe<Scalars['String']>;
+          bar: Scalars['String'];
         };
       `);
       validateTs(result);
@@ -551,8 +551,8 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyInput = {
-          foo: Maybe<Scalars['String']>,
-          bar: Scalars['String'],
+          foo: Maybe<Scalars['String']>;
+          bar: Scalars['String'];
         }
       `);
 
@@ -568,8 +568,8 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
-          readonly  __typename?: 'MyType',
-          readonly foo: ReadonlyArray<Scalars['String']>,
+          readonly  __typename?: 'MyType';
+          readonly foo: ReadonlyArray<Scalars['String']>;
         };
       `);
       validateTs(result);
@@ -649,16 +649,16 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type mytypefooargs = {
-          a: Scalars['String'],
-          b?: Maybe<Scalars['String']>,
-          c?: Maybe<Array<Maybe<Scalars['String']>>>,
-          d: Array<Scalars['Int']>
+          a: Scalars['String'];
+          b?: Maybe<Scalars['String']>;
+          c?: Maybe<Array<Maybe<Scalars['String']>>>;
+          d: Array<Scalars['Int']>;
         };
     `);
       expect(result.content).toBeSimilarStringTo(`
         export type mytype = {
-          __typename?: 'MyType',
-          foo?: Maybe<foo>,
+          __typename?: 'MyType';
+          foo?: Maybe<foo>;
         };
     `);
 
@@ -724,17 +724,17 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyTypefooArgs = {
-          a: Scalars['String'],
-          b?: Maybe<Scalars['String']>,
-          c?: Maybe<Array<Maybe<Scalars['String']>>>,
-          d: Array<Scalars['Int']>
+          a: Scalars['String'];
+          b?: Maybe<Scalars['String']>;
+          c?: Maybe<Array<Maybe<Scalars['String']>>>;
+          d: Array<Scalars['Int']>;
         };
       `);
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
-          __typename?: 'MyType',
-          foo?: Maybe<Foo>,
+          __typename?: 'MyType';
+          foo?: Maybe<Foo>;
         };
       `);
 
@@ -861,16 +861,16 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyInput = {
-          id: Scalars['ID'],
-          displayName?: Maybe<Scalars['String']>,
+          id: Scalars['ID'];
+          displayName?: Maybe<Scalars['String']>;
         }
       `);
 
       expect(result.content).toBeSimilarStringTo(`
         export interface MyType {
-          __typename?: 'MyType',
-          id: Scalars['ID'],
-          displayName?: Maybe<Scalars['String']>,
+          __typename?: 'MyType';
+          id: Scalars['ID'];
+          displayName?: Maybe<Scalars['String']>;
         }
       `);
       validateTs(result);
@@ -901,16 +901,16 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export interface MyInput {
-          id: Scalars['ID'],
-          displayName?: Maybe<Scalars['String']>,
+          id: Scalars['ID'];
+          displayName?: Maybe<Scalars['String']>;
         }
       `);
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
-          __typename?: 'MyType',
-          id: Scalars['ID'],
-          displayName?: Maybe<Scalars['String']>,
+          __typename?: 'MyType';
+          id: Scalars['ID'];
+          displayName?: Maybe<Scalars['String']>;
         }
       `);
       validateTs(result);
@@ -937,16 +937,16 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
-          __typename?: 'MyType',
-          id: Scalars['ID'],
-          displayName?: Maybe<Scalars['String']>,
-          child?: Maybe<MyType>,
+          __typename?: 'MyType';
+          id: Scalars['ID'];
+          displayName?: Maybe<Scalars['String']>;
+          child?: Maybe<MyType>;
         }
       `);
 
       expect(result.content).toBeSimilarStringTo(`
         export interface MyTypeChildArgs {
-          id: Scalars['ID']
+          id: Scalars['ID'];
         }
       `);
       validateTs(result);
@@ -975,16 +975,16 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export interface MyInput {
-          id: Scalars['ID'],
-          displayName?: Maybe<Scalars['String']>,
+          id: Scalars['ID'];
+          displayName?: Maybe<Scalars['String']>;
         }
       `);
 
       expect(result.content).toBeSimilarStringTo(`
         export interface MyType {
-          __typename?: 'MyType',
-          id: Scalars['ID'],
-          displayName?: Maybe<Scalars['String']>,
+          __typename?: 'MyType';
+          id: Scalars['ID'];
+          displayName?: Maybe<Scalars['String']>;
         }
       `);
       validateTs(result);
@@ -1011,7 +1011,7 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export interface MyType {
-          __typename?: 'MyType',
+          __typename?: 'MyType';
         }
       `);
       validateTs(result);
@@ -1041,17 +1041,17 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export interface MyInterface {
-          id: Scalars['ID'],
-          displayName?: Maybe<Scalars['String']>,
+          id: Scalars['ID'];
+          displayName?: Maybe<Scalars['String']>;
         }
       `);
 
       expect(result.content).toBeSimilarStringTo(`
         export interface MyType extends MyInterface {
-          __typename?: 'MyType',
-          id: Scalars['ID'],
-          displayName?: Maybe<Scalars['String']>,
-          value?: Maybe<Scalars['Int']>,
+          __typename?: 'MyType';
+          id: Scalars['ID'];
+          displayName?: Maybe<Scalars['String']>;
+          value?: Maybe<Scalars['Int']>;
         }
       `);
       validateTs(result);
@@ -1085,23 +1085,23 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export interface MyInterface1 {
-          id: Scalars['ID'],
-          displayName?: Maybe<Scalars['String']>,
+          id: Scalars['ID'];
+          displayName?: Maybe<Scalars['String']>;
         }
       `);
 
       expect(result.content).toBeSimilarStringTo(`
         export interface MyInterface2 {
-          value?: Maybe<Scalars['Int']>,
+          value?: Maybe<Scalars['Int']>;
         }
       `);
 
       expect(result.content).toBeSimilarStringTo(`
         export interface MyType extends MyInterface1, MyInterface2 {
-          __typename?: 'MyType',
-          id: Scalars['ID'],
-          displayName?: Maybe<Scalars['String']>,
-          value?: Maybe<Scalars['Int']>,
+          __typename?: 'MyType';
+          id: Scalars['ID'];
+          displayName?: Maybe<Scalars['String']>;
+          value?: Maybe<Scalars['Int']>;
         }
       `);
       validateTs(result);
@@ -1119,18 +1119,18 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
       export type Scalars = {
-        ID: string,
-        String: string,
-        Boolean: boolean,
-        Int: number,
-        Float: number,
+        ID: string;
+        String: string;
+        Boolean: boolean;
+        Int: number;
+        Float: number;
       };`);
 
       expect(result.content).toBeSimilarStringTo(`
       export type MyType = {
-        __typename?: 'MyType',
-        foo?: Maybe<Scalars['String']>,
-        bar: Scalars['String'],
+        __typename?: 'MyType';
+        foo?: Maybe<Scalars['String']>;
+        bar: Scalars['String'];
       };`);
       validateTs(result);
     });
@@ -1155,19 +1155,19 @@ describe('TypeScript', () => {
       expect(result.prepend).toContain(`import { MyScalar } from '../../scalars';`);
       expect(result.content).toBeSimilarStringTo(`
       export type Scalars = {
-        ID: string,
-        String: String,
-        Boolean: Boolean,
-        Int: number,
-        Float: number,
-        MyScalar: MyScalar,
+        ID: string;
+        String: String;
+        Boolean: Boolean;
+        Int: number;
+        Float: number;
+        MyScalar: MyScalar;
       };`);
 
       expect(result.content).toBeSimilarStringTo(`
       export type MyType = {
-        __typename?: 'MyType',
-        foo?: Maybe<Scalars['String']>,
-        bar: Scalars['MyScalar'],
+        __typename?: 'MyType';
+        foo?: Maybe<Scalars['String']>;
+        bar: Scalars['MyScalar'];
       };`);
       validateTs(result);
     });
@@ -1184,19 +1184,19 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
       export type Scalars = {
-        ID: string,
-        String: string,
-        Boolean: boolean,
-        Int: number,
-        Float: number,
-        MyScalar: any,
+        ID: string;
+        String: string;
+        Boolean: boolean;
+        Int: number;
+        Float: number;
+        MyScalar: any;
       };`);
 
       expect(result.content).toBeSimilarStringTo(`
       export type MyType = {
-        __typename?: 'MyType',
-        foo?: Maybe<Scalars['String']>,
-        bar: Scalars['MyScalar'],
+        __typename?: 'MyType';
+        foo?: Maybe<Scalars['String']>;
+        bar: Scalars['MyScalar'];
       };`);
       validateTs(result);
     });
@@ -1213,19 +1213,19 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
       export type Scalars = {
-        ID: string,
-        String: string,
-        Boolean: boolean,
-        Int: number,
-        Float: number,
-        MyScalar: Date,
+        ID: string;
+        String: string;
+        Boolean: boolean;
+        Int: number;
+        Float: number;
+        MyScalar: Date;
       };`);
 
       expect(result.content).toBeSimilarStringTo(`
       export type MyType = {
-        __typename?: 'MyType',
-        foo?: Maybe<Scalars['String']>,
-        bar: Scalars['MyScalar'],
+        __typename?: 'MyType';
+        foo?: Maybe<Scalars['String']>;
+        bar: Scalars['MyScalar'];
       };`);
       validateTs(result);
     });
@@ -1242,9 +1242,9 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
-          __typename?: 'MyType',
-          foo?: Maybe<Scalars['String']>,
-          bar: Scalars['String'],
+          __typename?: 'MyType';
+          foo?: Maybe<Scalars['String']>;
+          bar: Scalars['String'];
         };
       `);
       validateTs(result);
@@ -1264,13 +1264,13 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
-          foo: Scalars['String'],
+          foo: Scalars['String'];
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = MyInterface & {
-          __typename?: 'MyType',
-          foo: Scalars['String'],
+          __typename?: 'MyType';
+          foo: Scalars['String'];
         };
       `);
       validateTs(result);
@@ -1295,19 +1295,19 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
-          foo: Scalars['String'],
+          foo: Scalars['String'];
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
         export type MyOtherInterface = {
-          bar: Scalars['String'],
+          bar: Scalars['String'];
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = MyInterface & MyOtherInterface & {
-          __typename?: 'MyType',
-          foo: Scalars['String'],
-          bar: Scalars['String'],
+          __typename?: 'MyType';
+          foo: Scalars['String'];
+          bar: Scalars['String'];
         };
       `);
       validateTs(result);
@@ -1325,12 +1325,12 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
-          foo: Scalars['String'],
+          foo: Scalars['String'];
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = MyInterface & {
-          __typename?: 'MyType',
+          __typename?: 'MyType';
         };
       `);
       validateTs(result);
@@ -1350,14 +1350,14 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
-          __typename?: 'MyType',
-          foo: MyOtherType,
+          __typename?: 'MyType';
+          foo: MyOtherType;
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
         export type MyOtherType = {
-          __typename?: 'MyOtherType',
-          bar: Scalars['String'],
+          __typename?: 'MyOtherType';
+          bar: Scalars['String'];
         };
       `);
       validateTs(result);
@@ -1397,8 +1397,8 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
-          foo?: Maybe<Scalars['String']>,
-          bar: Scalars['String'],
+          foo?: Maybe<Scalars['String']>;
+          bar: Scalars['String'];
         };
       `);
       validateTs(result);
@@ -1431,16 +1431,16 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type mytypefooargs = {
-          a: Scalars['String'],
-          b?: Maybe<Scalars['String']>,
-          c?: Maybe<Array<Maybe<Scalars['String']>>>,
-          d: Array<Scalars['Int']>
+          a: Scalars['String'];
+          b?: Maybe<Scalars['String']>;
+          c?: Maybe<Array<Maybe<Scalars['String']>>>;
+          d: Array<Scalars['Int']>;
         };
     `);
       expect(result.content).toBeSimilarStringTo(`
         export type mytype = {
-          __typename?: 'MyType',
-          foo?: Maybe<Scalars['String']>,
+          __typename?: 'MyType';
+          foo?: Maybe<Scalars['String']>;
         };
     `);
 
@@ -1453,17 +1453,17 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type Imytypefooargs = {
-          a: Scalars['String'],
-          b?: Maybe<Scalars['String']>,
-          c?: Maybe<Array<Maybe<Scalars['String']>>>,
-          d: Array<Scalars['Int']>
+          a: Scalars['String'];
+          b?: Maybe<Scalars['String']>;
+          c?: Maybe<Array<Maybe<Scalars['String']>>>;
+          d: Array<Scalars['Int']>;
         };
       `);
 
       expect(result.content).toBeSimilarStringTo(`
         export type Imytype = {
-          __typename?: 'MyType',
-          foo?: Maybe<Scalars['String']>,
+          __typename?: 'MyType';
+          foo?: Maybe<Scalars['String']>;
         };
       `);
 
@@ -1475,7 +1475,7 @@ describe('TypeScript', () => {
       const result = (await plugin(schema, [], { typesPrefix: 'I', enumPrefix: false }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
       expect(result.content).toContain(`export enum E {`);
-      expect(result.content).toContain(`e?: Maybe<E>,`);
+      expect(result.content).toContain(`e?: Maybe<E>;`);
 
       validateTs(result);
     });
@@ -1485,7 +1485,7 @@ describe('TypeScript', () => {
       const result = (await plugin(schema, [], { typesPrefix: 'I' }, { outputFile: '' })) as Types.ComplexPluginOutput;
 
       expect(result.content).toContain(`export enum IE {`);
-      expect(result.content).toContain(`e?: Maybe<IE>,`);
+      expect(result.content).toContain(`e?: Maybe<IE>;`);
 
       validateTs(result);
     });
@@ -1544,17 +1544,17 @@ describe('TypeScript', () => {
         `);
       expect(result.content).toBeSimilarStringTo(`
         export type mytype = {
-          __typename?: 'MyType',
-          f?: Maybe<Scalars['String']>,
-          bar?: Maybe<myenum>,
-          b_a_r?: Maybe<Scalars['String']>,
-          myOtherField?: Maybe<Scalars['String']>,
+          __typename?: 'MyType';
+          f?: Maybe<Scalars['String']>;
+          bar?: Maybe<myenum>;
+          b_a_r?: Maybe<Scalars['String']>;
+          myOtherField?: Maybe<Scalars['String']>;
         };
         `);
       expect(result.content).toBeSimilarStringTo(`
         export type my_type = {
-          __typename?: 'My_Type',
-          linkTest?: Maybe<mytype>,
+          __typename?: 'My_Type';
+          linkTest?: Maybe<mytype>;
         };
         `);
       expect(result.content).toBeSimilarStringTo(`
@@ -1562,32 +1562,32 @@ describe('TypeScript', () => {
         `);
       expect(result.content).toBeSimilarStringTo(`
         export type some_interface = {
-          id: Scalars['ID'],
+          id: Scalars['ID'];
         };
         `);
       expect(result.content).toBeSimilarStringTo(`
         export type impl1 = some_interface & {
-          __typename?: 'Impl1',
-          id: Scalars['ID'],
+          __typename?: 'Impl1';
+          id: Scalars['ID'];
         };
         `);
       expect(result.content).toBeSimilarStringTo(`
         export type impl_2 = some_interface & {
-          __typename?: 'Impl_2',
-          id: Scalars['ID'],
+          __typename?: 'Impl_2';
+          id: Scalars['ID'];
         };
         `);
       expect(result.content).toBeSimilarStringTo(`
         export type impl_3 = some_interface & {
-          __typename?: 'impl_3',
-          id: Scalars['ID'],
+          __typename?: 'impl_3';
+          id: Scalars['ID'];
         };
         `);
       expect(result.content).toBeSimilarStringTo(`
         export type query = {
-          __typename?: 'Query',
-          something?: Maybe<myunion>,
-          use_interface?: Maybe<some_interface>,
+          __typename?: 'Query';
+          something?: Maybe<myunion>;
+          use_interface?: Maybe<some_interface>;
         };
       `);
 
@@ -1606,17 +1606,17 @@ describe('TypeScript', () => {
       `);
       expect(result.content).toBeSimilarStringTo(`
       export type MyType = {
-        __typename?: 'MyType',
-        f?: Maybe<Scalars['String']>,
-        bar?: Maybe<MyEnum>,
-        b_a_r?: Maybe<Scalars['String']>,
-        myOtherField?: Maybe<Scalars['String']>,
+        __typename?: 'MyType';
+        f?: Maybe<Scalars['String']>;
+        bar?: Maybe<MyEnum>;
+        b_a_r?: Maybe<Scalars['String']>;
+        myOtherField?: Maybe<Scalars['String']>;
       };
       `);
       expect(result.content).toBeSimilarStringTo(`
       export type My_Type = {
-        __typename?: 'My_Type',
-        linkTest?: Maybe<MyType>,
+        __typename?: 'My_Type';
+        linkTest?: Maybe<MyType>;
       };
       `);
       expect(result.content).toBeSimilarStringTo(`
@@ -1624,32 +1624,32 @@ describe('TypeScript', () => {
       `);
       expect(result.content).toBeSimilarStringTo(`
       export type Some_Interface = {
-        id: Scalars['ID'],
+        id: Scalars['ID'];
       };
       `);
       expect(result.content).toBeSimilarStringTo(`
       export type Impl1 = Some_Interface & {
-        __typename?: 'Impl1',
-        id: Scalars['ID'],
+        __typename?: 'Impl1';
+        id: Scalars['ID'];
       };
       `);
       expect(result.content).toBeSimilarStringTo(`
       export type Impl_2 = Some_Interface & {
-        __typename?: 'Impl_2',
-        id: Scalars['ID'],
+        __typename?: 'Impl_2';
+        id: Scalars['ID'];
       };
       `);
       expect(result.content).toBeSimilarStringTo(`
       export type Impl_3 = Some_Interface & {
-        __typename?: 'impl_3',
-        id: Scalars['ID'],
+        __typename?: 'impl_3';
+        id: Scalars['ID'];
       };
       `);
       expect(result.content).toBeSimilarStringTo(`
       export type Query = {
-        __typename?: 'Query',
-        something?: Maybe<MyUnion>,
-        use_interface?: Maybe<Some_Interface>,
+        __typename?: 'Query';
+        something?: Maybe<MyUnion>;
+        use_interface?: Maybe<Some_Interface>;
       };
       `);
 
@@ -1668,47 +1668,47 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
       export type IMyType = {
-        __typename?: 'MyType',
-        f?: Maybe<Scalars['String']>,
-        bar?: Maybe<IMyEnum>,
-        b_a_r?: Maybe<Scalars['String']>,
-        myOtherField?: Maybe<Scalars['String']>,
+        __typename?: 'MyType';
+        f?: Maybe<Scalars['String']>;
+        bar?: Maybe<IMyEnum>;
+        b_a_r?: Maybe<Scalars['String']>;
+        myOtherField?: Maybe<Scalars['String']>;
       };`);
       expect(result.content).toBeSimilarStringTo(`
       export type IMy_Type = {
-        __typename?: 'My_Type',
-        linkTest?: Maybe<IMyType>,
+        __typename?: 'My_Type';
+        linkTest?: Maybe<IMyType>;
       };
   `);
       expect(result.content).toBeSimilarStringTo(`export type IMyUnion = IMy_Type | IMyType;`);
       expect(result.content).toBeSimilarStringTo(`
       export type ISome_Interface = {
-        id: Scalars['ID'],
+        id: Scalars['ID'];
       };
       `);
       expect(result.content).toBeSimilarStringTo(`
       export type IImpl1 = ISome_Interface & {
-        __typename?: 'Impl1',
-        id: Scalars['ID'],
+        __typename?: 'Impl1';
+        id: Scalars['ID'];
       };
       `);
       expect(result.content).toBeSimilarStringTo(`
       export type IImpl_2 = ISome_Interface & {
-        __typename?: 'Impl_2',
-        id: Scalars['ID'],
+        __typename?: 'Impl_2';
+        id: Scalars['ID'];
       };
       `);
       expect(result.content).toBeSimilarStringTo(`
       export type IImpl_3 = ISome_Interface & {
-        __typename?: 'impl_3',
-        id: Scalars['ID'],
+        __typename?: 'impl_3';
+        id: Scalars['ID'];
       };
       `);
       expect(result.content).toBeSimilarStringTo(`
       export type IQuery = {
-        __typename?: 'Query',
-        something?: Maybe<IMyUnion>,
-        use_interface?: Maybe<ISome_Interface>,
+        __typename?: 'Query';
+        something?: Maybe<IMyUnion>;
+        use_interface?: Maybe<ISome_Interface>;
       };
       `);
 
@@ -1724,10 +1724,10 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
-          a: Scalars['String'],
-          b?: Maybe<Scalars['String']>,
-          c?: Maybe<Array<Maybe<Scalars['String']>>>,
-          d: Array<Scalars['Int']>
+          a: Scalars['String'];
+          b?: Maybe<Scalars['String']>;
+          c?: Maybe<Array<Maybe<Scalars['String']>>>;
+          d: Array<Scalars['Int']>;
         };
     `);
 
@@ -1740,10 +1740,10 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
-          a?: Maybe<Scalars['String']>,
-          b?: Scalars['String'],
-          c?: Maybe<Scalars['String']>,
-          d: Scalars['String']
+          a?: Maybe<Scalars['String']>;
+          b?: Scalars['String'];
+          c?: Maybe<Scalars['String']>;
+          d: Scalars['String'];
         };
     `);
 
@@ -1756,10 +1756,10 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
-          a?: Maybe<Scalars['String']>,
-          b?: Scalars['String'],
-          c: Maybe<Scalars['String']>,
-          d: Scalars['String']
+          a?: Maybe<Scalars['String']>;
+          b?: Scalars['String'];
+          c: Maybe<Scalars['String']>;
+          d: Scalars['String'];
       };
     `);
 
@@ -1772,11 +1772,11 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
-          a?: Maybe<MyInput>,
-          b: MyInput,
-          c?: Maybe<Array<Maybe<MyInput>>>,
-          d: Array<Maybe<MyInput>>,
-          e: Array<MyInput>
+          a?: Maybe<MyInput>;
+          b: MyInput;
+          c?: Maybe<Array<Maybe<MyInput>>>;
+          d: Array<Maybe<MyInput>>;
+          e: Array<MyInput>;
         };
     `);
 
@@ -1789,19 +1789,19 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type TInput = {
-          name?: Maybe<Scalars['String']>,
+          name?: Maybe<Scalars['String']>;
         };
       `);
 
       expect(result.content).toBeSimilarStringTo(`
         export type TMutation = {
-          __typename?: 'Mutation',
-          foo?: Maybe<Scalars['String']>,
+          __typename?: 'Mutation';
+          foo?: Maybe<Scalars['String']>;
         };
 
         export type TMutationFooArgs = {
-          id?: Maybe<Scalars['ID']>,
-          input?: Maybe<TInput>
+          id?: Maybe<Scalars['ID']>;
+          input?: Maybe<TInput>;
         };
       `);
 
@@ -1827,8 +1827,8 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type NodeTextArgs = {
-          arg1: Scalars['String'],
-          arg2?: Maybe<Scalars['String']>
+          arg1: Scalars['String'];
+          arg2?: Maybe<Scalars['String']>;
         };
       `);
       await validateTs(result);
@@ -2074,15 +2074,15 @@ describe('TypeScript', () => {
     // Filter.contain should be optional
     expect(output.content).toBeSimilarStringTo(`
       export type Filter = {
-        contain?: Maybe<Scalars['String']>,
+        contain?: Maybe<Scalars['String']>;
       };
     `);
     // filter should be non-optional
     expect(output.content).toBeSimilarStringTo(`
       export type QueryListArgs = {
-        after?: Maybe<Scalars['String']>,
-        orderBy?: Maybe<OrderBy>,
-        filter: Filter
+        after?: Maybe<Scalars['String']>;
+        orderBy?: Maybe<OrderBy>;
+        filter: Filter;
       };
     `);
   });


### PR DESCRIPTION
related: #3102  #3183 

If declarationKind is `class`, `interface`, `type` in `typescript`, and `class`, `interface` in `flow`, the punctuation should be semicolon(;), not comma(,).
