### PR TITLE
docs: fix config example in base-visitor.md (scalars - JSON)

### DIFF
--- a/docs/generated-config/base-visitor.md
+++ b/docs/generated-config/base-visitor.md
@@ -10,7 +10,7 @@ Extends or overrides the built-in scalars and custom GraphQL scalars to a custom
 config:
   scalars:
     DateTime: Date
-    JSON: { [key: string]: any }
+    JSON: "{ [key: string]: any }"
 ```
 
 ### namingConvention (`NamingConvention`, default value: `pascal-case#pascalCase`)

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -28,7 +28,7 @@ export interface RawConfig {
    * config:
    *   scalars:
    *     DateTime: Date
-   *     JSON: { [key: string]: any }
+   *     JSON: "{ [key: string]: any }"
    * ```
    */
   scalars?: ScalarsMap;


### PR DESCRIPTION
related: #3237 

```yaml
config:
  scalars:
    DateTime: Date
    JSON: { [key: string]: any }
```

This config file makes TS type definition file like this.

```typescript
export type Scalars = {
  ID: string;
  String: string;
  Boolean: boolean;
  Int: number;
  Float: number;
  JSON: {"[ key: string ]":"any"};
};
```

So it should be changed into this code.

```yaml
config:
  scalars:
    DateTime: Date
    JSON: "{ [key: string]: any }"
```

```typescript
export type Scalars = {
  ID: string;
  String: string;
  Boolean: boolean;
  Int: number;
  Float: number;
  JSON: { [key: string]: any };
};
```