### PR TITLE
Use fragment prefix/suffix in client side base visitor

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -29,6 +29,8 @@ export interface RawClientSideBasePluginConfig extends RawConfig {
   operationResultSuffix?: string;
   documentVariablePrefix?: string;
   documentVariableSuffix?: string;
+  fragmentVariablePrefix: string;
+  fragmentVariableSuffix: string;
   documentMode?: DocumentMode;
   importOperationTypesFrom?: string;
   importDocumentNodeExternallyFrom?: string;
@@ -137,8 +139,8 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
       operationResultSuffix: getConfigValue(rawConfig.operationResultSuffix, ''),
       documentVariablePrefix: getConfigValue(rawConfig.documentVariablePrefix, ''),
       documentVariableSuffix: getConfigValue(rawConfig.documentVariableSuffix, 'Document'),
-      fragmentVariablePrefix: getConfigValue(rawConfig.documentVariablePrefix, ''),
-      fragmentVariableSuffix: getConfigValue(rawConfig.documentVariableSuffix, 'FragmentDoc'),
+      fragmentVariablePrefix: getConfigValue(rawConfig.fragmentVariablePrefix, ''),
+      fragmentVariableSuffix: getConfigValue(rawConfig.fragmentVariableSuffix, 'FragmentDoc'),
       documentMode: ((rawConfig: RawClientSideBasePluginConfig) => {
         if (typeof rawConfig.noGraphQLTag === 'boolean') {
           return rawConfig.noGraphQLTag ? DocumentMode.documentNode : DocumentMode.graphQLTag;


### PR DESCRIPTION
These config options are [declared in ClientSideBasePluginConfig](https://github.com/dotansimha/graphql-code-generator/blob/v1.12.2/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts#L72-L73) but not being used. Looks like a typo to use the document prefix/suffix.