### PR TITLE
[typescript-resolvers] `customResolverFn` option

### DIFF
--- a/dev-test/test-schema/resolvers-federation.ts
+++ b/dev-test/test-schema/resolvers-federation.ts
@@ -31,8 +31,6 @@ export type User = {
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-export type ResolverFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult;
-
 export type ReferenceResolver<TResult, TReference, TContext> = (reference: TReference, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult;
 
 export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
@@ -41,6 +39,8 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
 };
 
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | StitchingResolver<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult;
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
 

--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -38,14 +38,14 @@ export type User = {
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-export type ResolverFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult;
-
 export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
 
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | StitchingResolver<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult;
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
 

--- a/dev-test/test-schema/resolvers-types.ts
+++ b/dev-test/test-schema/resolvers-types.ts
@@ -39,14 +39,14 @@ export type User = {
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-export type ResolverFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult;
-
 export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
 
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | StitchingResolver<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult;
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
 

--- a/dev-test/test-schema/typings.ts
+++ b/dev-test/test-schema/typings.ts
@@ -31,14 +31,14 @@ export type User = {
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-export type ResolverFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult;
-
 export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
 
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | StitchingResolver<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult;
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
 

--- a/docs/generated-config/typescript-resolvers.md
+++ b/docs/generated-config/typescript-resolvers.md
@@ -1,19 +1,17 @@
-
 ### useIndexSignature (`boolean`, default value: `false`)
 
 Adds an index signature to any generates resolver.
-
 
 #### Usage Example
 
 ```yml
 generates:
 path/to/file.ts:
- plugins:
-   - typescript
-   - typescript-resolvers
- config:
-   useIndexSignature: true
+  plugins:
+    - typescript
+    - typescript-resolvers
+  config:
+    useIndexSignature: true
 ```
 
 ### noSchemaStitching (`boolean`, default value: `false`)
@@ -27,26 +25,76 @@ Disables Schema Stitching support
 ```yml
 generates:
 path/to/file.ts:
- plugins:
-   - typescript
-   - typescript-resolvers
- config:
-   noSchemaStitching: true
+  plugins:
+    - typescript
+    - typescript-resolvers
+  config:
+    noSchemaStitching: true
 ```
 
 ### customResolveInfo (`string`, default value: `"graphql#GraphQLResolveInfo"`)
 
 You can provide your custom GraphQLResolveInfo instead of the default one from graphql-js
 
+#### Usage Example
+
+```yml
+generates:
+path/to/file.ts:
+  plugins:
+    - typescript
+    - typescript-resolvers
+  config:
+    customResolveInfo: ./my-types#MyResolveInfo
+```
+
+### customResolverFn (`string`, default value: `"(parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult"`)
+
+You can provide your custom ResolverFn instead of the default one.
+
+The default is:
+
+```typescript
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult;
+```
+
+Most of the time, this is not needed, and `customResolveInfo` is enough to modify the `info`.
+
+One reason for this can be to make it compatible with other libraries in which the resolver functions are different than the rest, and for example the `info` type depends on the `TParent`.
+
+One example of this kind of libraries is Postgraphile, in which `info`'s type is:
+
+```typescript
+  info: GraphQLResolveInfo & {
+    graphile: GraphileHelpers<TParent>;
+  }
+```
 
 #### Usage Example
 
 ```yml
 generates:
 path/to/file.ts:
- plugins:
-   - typescript
-   - typescript-resolvers
- config:
-   customResolveInfo: ./my-types#MyResolveInfo
+  plugins:
+    - typescript
+    - typescript-resolvers
+  config:
+    customResolverFn: |
+      (
+        parent: TParent,
+        args: TArgs,
+        context: TContext,
+        info: GraphQLResolveInfo & { stuff: Stuff<TParent> }
+      ) => Promise<TResult> | TResult;
+```
+
+it will generate
+
+```typescript
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo & { stuff: Stuff<TParent> }
+) => Promise<TResult> | TResult;
 ```

--- a/packages/plugins/typescript/resolvers/src/config.ts
+++ b/packages/plugins/typescript/resolvers/src/config.ts
@@ -75,4 +75,40 @@ export interface TypeScriptResolversPluginConfig extends RawResolversConfig {
    * ```
    */
   customResolveInfo?: string;
+  /**
+   * @name customResolverFn
+   * @type string
+   * @description You can provide your custom ResolveFn instead the default. It has to be a type that uses the generics <TResult, TParent, TContext, TArgs>
+   * @default "(parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => Promise<TResult> | TResult"
+   *
+   * @example
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-resolvers
+   *  config:
+   *    customResolverFn: ./my-types#MyResolveFn
+   * ```
+   *
+   * @example
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - add: "import { GraphileHelpers } from 'graphile-utils/node8plus/fieldHelpers';"
+   *    - typescript
+   *    - typescript-resolvers
+   *  config:
+   *    customResolverFn: |
+   *      (
+   *        parent: TParent,
+   *        args: TArgs,
+   *        context: TContext,
+   *        info: GraphQLResolveInfo & { graphile: GraphileHelpers<TParent> }
+   *      ) => Promise<TResult> | TResult;
+   * ```
+   */
+  customResolverFn?: string;
 }


### PR DESCRIPTION
Allows the ability to fully customise the `ResolverFn` type.

You can provide your custom ResolverFn instead of the default one.

Most of the time, this is not needed, and `customResolveInfo` is enough to modify the `info`.

One reason for this can be to make it compatible with other libraries in which the resolver functions are different than the rest, and for example the `info` type depends on the `TParent`.

One example of this kind of libraries is Postgraphile, in which `info`'s type is:

```typescript
  info: GraphQLResolveInfo & {
    graphile: GraphileHelpers<TParent>;
  }
```