### PR TITLE
[Plugin][typescript-apollo-angular]: Add configurable suffixes for operations

### DIFF
--- a/packages/plugins/typescript/apollo-angular/src/config.ts
+++ b/packages/plugins/typescript/apollo-angular/src/config.ts
@@ -65,7 +65,7 @@ export interface ApolloAngularRawPluginConfig extends RawClientSideBasePluginCon
    * @example graphql.macro
    * ```yml
    * config:
-   *   ngModule: 'QueryService'
+   *   querySuffix: 'QueryService'
    * ```
    */
   querySuffix?: string;
@@ -78,7 +78,7 @@ export interface ApolloAngularRawPluginConfig extends RawClientSideBasePluginCon
    * @example graphql.macro
    * ```yml
    * config:
-   *   ngModule: 'MutationService'
+   *   mutationSuffix: 'MutationService'
    * ```
    */
   mutationSuffix?: string;
@@ -91,7 +91,7 @@ export interface ApolloAngularRawPluginConfig extends RawClientSideBasePluginCon
    * @example graphql.macro
    * ```yml
    * config:
-   *   ngModule: 'SubscriptionService'
+   *   subscriptionSuffix: 'SubscriptionService'
    * ```
    */
   subscriptionSuffix?: string;

--- a/packages/plugins/typescript/apollo-angular/src/config.ts
+++ b/packages/plugins/typescript/apollo-angular/src/config.ts
@@ -56,4 +56,43 @@ export interface ApolloAngularRawPluginConfig extends RawClientSideBasePluginCon
    *
    */
   sdkClass?: boolean;
+  /**
+   * @name querySuffix
+   * @type string
+   * @description Allows to define a custom suffix for query operations.
+   * @default 'GQL'
+   *
+   * @example graphql.macro
+   * ```yml
+   * config:
+   *   ngModule: 'QueryService'
+   * ```
+   */
+  querySuffix?: string;
+  /**
+   * @name mutationSuffix
+   * @type string
+   * @description Allows to define a custom suffix for mutation operations.
+   * @default 'GQL'
+   *
+   * @example graphql.macro
+   * ```yml
+   * config:
+   *   ngModule: 'MutationService'
+   * ```
+   */
+  mutationSuffix?: string;
+  /**
+   * @name subscriptionSuffix
+   * @type string
+   * @description Allows to define a custom suffix for Subscription operations.
+   * @default 'GQL'
+   *
+   * @example graphql.macro
+   * ```yml
+   * config:
+   *   ngModule: 'SubscriptionService'
+   * ```
+   */
+  subscriptionSuffix?: string;
 }

--- a/packages/plugins/typescript/apollo-angular/src/visitor.ts
+++ b/packages/plugins/typescript/apollo-angular/src/visitor.ts
@@ -18,6 +18,9 @@ export interface ApolloAngularPluginConfig extends ClientSideBasePluginConfig {
   serviceName?: string;
   serviceProvidedInRoot?: boolean;
   sdkClass?: boolean;
+  querySuffix?: string;
+  mutationSuffix?: string;
+  subscriptionSuffix?: string;
 }
 
 export class ApolloAngularVisitor extends ClientSideBaseVisitor<ApolloAngularRawPluginConfig, ApolloAngularPluginConfig> {
@@ -41,6 +44,9 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<ApolloAngularRaw
         namedClient: rawConfig.namedClient,
         serviceName: rawConfig.serviceName,
         serviceProvidedInRoot: rawConfig.serviceProvidedInRoot,
+        querySuffix: rawConfig.querySuffix,
+        mutationSuffix: rawConfig.mutationSuffix,
+        subscriptionSuffix: rawConfig.subscriptionSuffix,
       },
       documents
     );
@@ -178,8 +184,22 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<ApolloAngularRaw
     return this.config.documentMode === DocumentMode.external ? `Operations.${node.name.value}` : documentVariableName;
   }
 
+  private _operationSuffix(operationType: string): string {
+    const defaultSuffix = 'GQL';
+    switch (operationType) {
+      case 'Query':
+        return this.config.querySuffix || defaultSuffix;
+      case 'Mutation':
+        return this.config.mutationSuffix || defaultSuffix;
+      case 'Subscription':
+        return this.config.subscriptionSuffix || defaultSuffix;
+      default:
+        return defaultSuffix;
+    }
+  }
+
   protected buildOperation(node: OperationDefinitionNode, documentVariableName: string, operationType: string, operationResultType: string, operationVariablesTypes: string): string {
-    const serviceName = `${this.convertName(node)}GQL`;
+    const serviceName = `${this.convertName(node)}${this._operationSuffix(operationType)}`;
     this._operationsToInclude.push({
       node,
       documentVariableName,

--- a/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
+++ b/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
@@ -263,6 +263,54 @@ describe('Apollo Angular', () => {
 
       validateTypeScript(content, modifiedSchema, docs, {});
     });
+    it('should be allowed to define custom operation suffixes in config', async () => {
+      const modifiedSchema = extendSchema(schema, addToSchema);
+      const myFeed = gql(`
+        query MyFeed {
+          feed {
+            id
+          }
+        }
+      `);
+      const upVotePost = gql(`
+        mutation upVotePost($postId: Int!) {
+          upVotePost(postId: $postId) {
+            id
+            votes
+          }
+        }
+      `);
+      const newPost = gql(`
+        subscription newPost {
+          newPost {
+            id
+            title
+          }
+        }
+      `);
+      const docs = [
+        { location: '', document: myFeed },
+        { location: '', document: upVotePost },
+        { location: '', document: newPost },
+      ];
+      const content = (await plugin(
+        modifiedSchema,
+        docs,
+        {
+          querySuffix: 'QueryService',
+          mutationSuffix: 'MutationService',
+          subscriptionSuffix: 'SubscriptionService',
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toContain(`export class MyFeedQueryService`);
+      expect(content.content).toContain(`export class UpVotePostMutationService`);
+      expect(content.content).toContain(`export class NewPostSubscriptionService`);
+      validateTypeScript(content, modifiedSchema, docs, {});
+    });
   });
 
   describe('SDK Service', () => {


### PR DESCRIPTION
This PR allows users to specify a naming scheme for operations other than the currently hard-coded suffix of `GQL` that is applied to everything and may not be suitable for every team/application.

We are currently using the changes in this PR* as a custom version of this plugin but we would love to get official support for this, and hope that this can offer some value to other users.

*_bar making `GQL` the default suffix, which was added to the PR so there are no breaking changes_