### PR TITLE
fix(mappers): suffix

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/tests/parse-mapper.spec.ts
+++ b/packages/plugins/other/visitor-plugin-common/tests/parse-mapper.spec.ts
@@ -1,4 +1,5 @@
-import { parseMapper } from '../src/mappers';
+import { parseMapper, transformMappers } from '../src/mappers';
+
 describe('parseMapper', () => {
   it('Should return the correct values for a simple named mapper', () => {
     const result = parseMapper('MyType');
@@ -93,7 +94,7 @@ describe('parseMapper', () => {
   });
 
   describe('suffix', () => {
-    it('Should return the correct values for a simple named mapper', () => {
+    it('Should not add a suffix to a simple named mapper', () => {
       const result = parseMapper('MyType', null, 'Model');
 
       expect(result).toEqual({
@@ -102,7 +103,7 @@ describe('parseMapper', () => {
       });
     });
 
-    it('Should return the correct values for a external named mapper', () => {
+    it('Should add a suffix to an external named mapper', () => {
       const result = parseMapper('file#Type', null, 'Model');
 
       expect(result).toEqual({
@@ -114,19 +115,19 @@ describe('parseMapper', () => {
       });
     });
 
-    it('Should return the correct values for a external default mapper', () => {
+    it('Should add a suffix to an external default mapper', () => {
       const result = parseMapper('file#default', 'MyGqlType', 'Model');
 
       expect(result).toEqual({
         default: true,
         isExternal: true,
-        import: 'MyGqlType',
-        type: 'MyGqlType',
+        import: 'MyGqlTypeModel',
+        type: 'MyGqlTypeModel',
         source: 'file',
       });
     });
 
-    it('Should support generics', () => {
+    it('Should add a suffix and support generics', () => {
       const result = parseMapper('file#Type<Generic>', 'SomeType', 'Model');
 
       expect(result).toEqual({
@@ -138,7 +139,7 @@ describe('parseMapper', () => {
       });
     });
 
-    it('Should not affect namespaces', () => {
+    it('Should not add a suffix to a namespace', () => {
       const result = parseMapper('file#Namespace.Type', 'MyGqlType', 'Model');
 
       expect(result).toEqual({
@@ -161,14 +162,33 @@ describe('parseMapper', () => {
       });
     });
 
-    it('Should not affect aliases', () => {
+    it('Should add a suffix next to an alias', () => {
       const result = parseMapper('file#Type as SomeOtherType', 'SomeType', 'Model');
 
       expect(result).toEqual({
         default: false,
         isExternal: true,
-        import: 'Type as SomeOtherType',
-        type: 'SomeOtherType',
+        import: 'Type as SomeOtherTypeModel',
+        type: 'SomeOtherTypeModel',
+        source: 'file',
+      });
+    });
+
+    it('transformMappers should apply a suffix to parseMapper', () => {
+      const mappers = transformMappers(
+        {
+          Type: 'file#Type as SomeOtherType',
+        },
+        'Suffix'
+      );
+
+      const result = mappers.Type;
+
+      expect(result).toEqual({
+        default: false,
+        isExternal: true,
+        import: 'Type as SomeOtherTypeSuffix',
+        type: 'SomeOtherTypeSuffix',
         source: 'file',
       });
     });


### PR DESCRIPTION
Suffix was only applied in regular imports (`file#Identifier`), not when there was an alias or a default import. 
With this PR we only skip adding the suffix to namespaces and internal types (reuse of generated types).