### PR TITLE
fix(java): Cast args to String for valueOfLabel

### DIFF
--- a/packages/plugins/java/java/src/visitor.ts
+++ b/packages/plugins/java/java/src/visitor.ts
@@ -184,7 +184,7 @@ public static ${enumName} valueOfLabel(String label) {
             `if (args.get("${arg.name.value}") instanceof ${typeToUse.typeName}) {
   this._${arg.name.value} = (${typeToUse.typeName}) args.get("${arg.name.value}");
 } else {
-  this._${arg.name.value} = ${typeToUse.typeName}.valueOfLabel(args.get("${arg.name.value}"));
+  this._${arg.name.value} = ${typeToUse.typeName}.valueOfLabel((String) args.get("${arg.name.value}"));
 }`,
             3
           );

--- a/packages/plugins/java/java/tests/java.spec.ts
+++ b/packages/plugins/java/java/tests/java.spec.ts
@@ -211,7 +211,7 @@ describe('Java', () => {
       expect(result).toBeSimilarStringTo(`if (args.get("sort") instanceof ResultSort) {
         this._sort = (ResultSort) args.get("sort");
       } else {
-        this._sort = ResultSort.valueOfLabel(args.get("sort"));
+        this._sort = ResultSort.valueOfLabel((String) args.get("sort"));
       }`);
     });
 
@@ -245,7 +245,7 @@ describe('Java', () => {
             if (args.get("sort") instanceof ResultSort) {
               this._sort = (ResultSort) args.get("sort");
             } else {
-              this._sort = ResultSort.valueOfLabel(args.get("sort"));
+              this._sort = ResultSort.valueOfLabel((String) args.get("sort"));
             }
             this._metadata = new MetadataSearchInput((Map<String, Object>) args.get("metadata"));
           }


### PR DESCRIPTION
`Enum.valueOfLabel` accept a String as parameter. `args.get("input")` return type `Object` thus, can not be passed to `Enum.valueOfLabel`. It has to explicitly casted to String before passing to the function.
Related #3616 