### PR TITLE
Fixed issue with fragment names when using near-operation-file + dedupeOperationSuffix

### DIFF
--- a/packages/plugins/flow/operations/src/visitor.ts
+++ b/packages/plugins/flow/operations/src/visitor.ts
@@ -60,7 +60,7 @@ export class FlowDocumentsVisitor extends BaseDocumentsVisitor<FlowDocumentsPlug
           useFlowReadOnlyTypes: this.config.useFlowReadOnlyTypes,
         });
     const enumsNames = Object.keys(schema.getTypeMap()).filter(typeName => isEnumType(schema.getType(typeName)));
-    this.setSelectionSetHandler(new SelectionSetToObject(processor, this.scalars, this.schema, this.convertName.bind(this), allFragments, this.config));
+    this.setSelectionSetHandler(new SelectionSetToObject(processor, this.scalars, this.schema, this.convertName.bind(this), this.getFragmentSuffix.bind(this), allFragments, this.config));
     this.setVariablesTransformer(new FlowOperationVariablesToObject(this.scalars, this.convertName.bind(this), this.config.namespacedImportName, enumsNames, this.config.enumPrefix));
   }
 

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -156,14 +156,6 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
     autoBind(this);
   }
 
-  protected _getFragmentName(fragment: FragmentDefinitionNode | string): string {
-    return this.convertName(fragment, {
-      suffix: this.config.fragmentVariableSuffix,
-      prefix: this.config.fragmentVariablePrefix,
-      useTypesPrefix: false,
-    });
-  }
-
   protected _extractFragments(document: FragmentDefinitionNode | OperationDefinitionNode, withNested = false): string[] {
     if (!document) {
       return [];
@@ -203,14 +195,14 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
   protected _transformFragments(document: FragmentDefinitionNode | OperationDefinitionNode): string[] {
     const includeNestedFragments = this.config.documentMode === DocumentMode.documentNode;
 
-    return this._extractFragments(document, includeNestedFragments).map(document => this._getFragmentName(document));
+    return this._extractFragments(document, includeNestedFragments).map(document => this.getFragmentVariableName(document));
   }
 
   protected _includeFragments(fragments: string[]): string {
     if (fragments && fragments.length > 0) {
       if (this.config.documentMode === DocumentMode.documentNode) {
         return this._fragments
-          .filter(f => fragments.includes(`${this.config.fragmentVariablePrefix}${f.name}${this.config.fragmentVariableSuffix}`))
+          .filter(f => fragments.includes(this.getFragmentVariableName(f.name)))
           .map(fragment => print(fragment.node))
           .join('\n');
       } else if (this.config.documentMode === DocumentMode.documentNodeImportFragments) {
@@ -250,8 +242,7 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
         delete (gqlObj as any).loc;
       }
       if (fragments.length > 0) {
-        const fragmentsSpreads = fragments.filter((name, i, all) => all.indexOf(name) === i).map(name => `...${name}.definitions`);
-        const definitions = [...gqlObj.definitions.map(t => JSON.stringify(t)), ...fragmentsSpreads].join();
+        const definitions = [...gqlObj.definitions.map(t => JSON.stringify(t)), ...fragments.map(name => `...${name}.definitions`)].join();
         return `{"kind":"${Kind.DOCUMENT}","definitions":[${definitions}]}`;
       }
       return JSON.stringify(gqlObj);
@@ -263,7 +254,7 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
   }
 
   protected _generateFragment(fragmentDocument: FragmentDefinitionNode): string | void {
-    const name = this._getFragmentName(fragmentDocument);
+    const name = this.getFragmentVariableName(fragmentDocument);
     const isDocumentNode = this.config.documentMode === DocumentMode.documentNode || this.config.documentMode === DocumentMode.documentNodeImportFragments;
     return `export const ${name}${isDocumentNode ? ': DocumentNode' : ''} = ${this._gql(fragmentDocument)};`;
   }
@@ -360,7 +351,7 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
       (this._fragments || [])
         .filter(f => f.isExternal && f.importFrom && !(f as any).level)
         .forEach(externalFragment => {
-          const identifierName = this._getFragmentName(externalFragment.name);
+          const identifierName = this.getFragmentName(externalFragment.name);
 
           imports.push(`import { ${identifierName} } from '${externalFragment.importFrom}';`);
         });
@@ -393,7 +384,7 @@ export class ClientSideBaseVisitor<TRawConfig extends RawClientSideBasePluginCon
     }
 
     const operationType: string = pascalCase(node.operation);
-    const operationTypeSuffix: string = this.config.dedupeOperationSuffix && node.name.value.toLowerCase().endsWith(node.operation) ? '' : this.config.omitOperationSuffix ? '' : operationType;
+    const operationTypeSuffix: string = this.getOperationSuffix(node, operationType);
 
     const operationResultType: string = this.convertName(node, {
       suffix: operationTypeSuffix + this._parsedConfig.operationResultSuffix,

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -7,6 +7,7 @@ export type ParsedScalarsMap = { [name: string]: ParsedMapper };
 export type EnumValuesMap<AdditionalProps = {}> = string | { [enumName: string]: string | ({ [key: string]: string | number } & AdditionalProps) };
 export type ParsedEnumValuesMap = { [enumName: string]: { mappedValues?: { [valueName: string]: string | number }; typeIdentifier: string; sourceIdentifier?: string; sourceFile?: string; isDefault?: boolean } };
 export type ConvertNameFn<T = {}> = ConvertFn<T>;
+export type GetFragmentSuffixFn = (node: FragmentDefinitionNode | string, suffix?: string) => string;
 
 export interface ConvertOptions {
   prefix?: string;

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -61,7 +61,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<TypeScriptD
       wrapTypeWithModifiers,
     };
     const processor = new (config.preResolveTypes ? PreResolveTypesProcessor : TypeScriptSelectionSetProcessor)(processorConfig);
-    this.setSelectionSetHandler(new SelectionSetToObject(processor, this.scalars, this.schema, this.convertName.bind(this), allFragments, this.config));
+    this.setSelectionSetHandler(new SelectionSetToObject(processor, this.scalars, this.schema, this.convertName.bind(this), this.getFragmentSuffix.bind(this), allFragments, this.config));
     const enumsNames = Object.keys(schema.getTypeMap()).filter(typeName => isEnumType(schema.getType(typeName)));
     this.setVariablesTransformer(
       new TypeScriptOperationVariablesToObject(this.scalars, this.convertName.bind(this), this.config.avoidOptionals, this.config.immutableTypes, this.config.namespacedImportName, enumsNames, this.config.enumPrefix, this.config.enumValues)

--- a/packages/plugins/typescript/react-apollo-offix/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo-offix/src/visitor.ts
@@ -79,7 +79,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<RawClientSideBaseP
     });
 
     const operationType = pascalCase(node.operation);
-    const operationTypeSuffix = this.config.dedupeOperationSuffix && node.name.value.toLowerCase().endsWith(node.operation) ? '' : operationType;
+    const operationTypeSuffix = this.getOperationSuffix(node, operationType);
     const operationResultType = this.convertName(node, {
       suffix: operationTypeSuffix + this._parsedConfig.operationResultSuffix,
     });

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -110,7 +110,6 @@ export type FragmentNameToFile = { [fragmentName: string]: { location: string; i
 
 export const preset: Types.OutputPreset<NearOperationFileConfig> = {
   buildGeneratesSection: options => {
-    const dedupeOperationSuffix = !!(options.config && options.config.dedupeOperationSuffix);
     const schemaObject: GraphQLSchema = options.schemaAst ? options.schemaAst : buildASTSchema(options.schema, options.config as any);
     const baseDir = options.presetConfig.cwd || process.cwd();
     const extension = options.presetConfig.extension || '.generated.ts';
@@ -145,13 +144,6 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
       generateFilePath(location: string) {
         const newFilePath = defineFilepathSubfolder(location, folder);
         return appendExtensionToFilePath(newFilePath, extension);
-      },
-      fragmentSuffix: name => {
-        if (name.toLowerCase().endsWith('fragment') && dedupeOperationSuffix) {
-          return '';
-        } else {
-          return 'Fragment';
-        }
       },
       generateImportStatement({ relativeOutputPath, importSource }) {
         const importPath = resolveImportPath(relativeOutputPath, importSource.path);

--- a/packages/presets/near-operation-file/src/resolve-document-imports.ts
+++ b/packages/presets/near-operation-file/src/resolve-document-imports.ts
@@ -31,10 +31,6 @@ export type DocumentImportResolverOptions = {
    */
   generateFilePath: (location: string) => string;
   /**
-   * String to append to all fragments
-   */
-  fragmentSuffix: (fragmentName: string) => string;
-  /**
    *
    */
   generateImportStatement: GenerateImportStatement;


### PR DESCRIPTION
In v1.13.0, there's an issue where the fragment imports generated by `near-file-operation` preset do not match the fragment spreads generated in `client-side-base-visitor`.
This is due to the fact that the logic used in the preset and the plugin does not match.
This PR is an attempt to unify the logic for generating fragment names, fragment variables names (fragment doc) and general operation naming.