### PR TITLE
[typescript-graphql-request] Enable to pass HTTP headers to GraphQL client

### DIFF
--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -29,6 +29,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<RawGraphQLReque
     }
 
     this._additionalImports.push(`import { SdkFunctionWrapper, defaultWrapper } from '@graphql-codegen/typescript-graphql-request';`);
+    this._additionalImports.push(`import { Headers } from 'graphql-request/dist/src/types';`);
   }
 
   protected buildOperation(node: OperationDefinitionNode, documentVariableName: string, operationType: string, operationResultType: string, operationVariablesTypes: string): string {
@@ -49,13 +50,15 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<RawGraphQLReque
         const optionalVariables = !o.node.variableDefinitions || o.node.variableDefinitions.length === 0 || o.node.variableDefinitions.every(v => v.type.kind !== Kind.NON_NULL_TYPE || v.defaultValue);
         const doc = this.config.documentMode === DocumentMode.string ? o.documentVariableName : `print(${o.documentVariableName})`;
         if (this.config.rawRequest) {
-          return `${o.node.name.value}(variables${optionalVariables ? '?' : ''}: ${o.operationVariablesTypes}): Promise<{ data?: ${
+          return `${o.node.name.value}(variables${optionalVariables ? '?' : ''}: ${o.operationVariablesTypes}, headers?: Headers): Promise<{ data?: ${
             o.operationResultType
           } | undefined; extensions?: any; headers: Headers; status: number; errors?: GraphQLError[] | undefined; }> {
+    headers !== undefined && client.setHeaders(headers);
     return withWrapper(() => client.rawRequest<${o.operationResultType}>(${doc}, variables));
 }`;
         } else {
-          return `${o.node.name.value}(variables${optionalVariables ? '?' : ''}: ${o.operationVariablesTypes}): Promise<${o.operationResultType}> {
+          return `${o.node.name.value}(variables${optionalVariables ? '?' : ''}: ${o.operationVariablesTypes}, headers?: Headers): Promise<${o.operationResultType}> {
+  headers !== undefined && client.setHeaders(headers);
   return withWrapper(() => client.request<${o.operationResultType}>(${doc}, variables));
 }`;
         }

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`graphql-request sdk Should allow passing wrapper arg to generated getSd
 "export type Maybe<T> = T | null;
 import { GraphQLClient } from 'graphql-request';
 import { SdkFunctionWrapper, defaultWrapper } from '@graphql-codegen/typescript-graphql-request';
+import { Headers } from 'graphql-request/dist/src/types';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -266,16 +267,20 @@ export const Feed4Document = \`
     \`;
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, headers?: Headers): Promise<FeedQuery> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<FeedQuery>(FeedDocument, variables));
     },
-    feed2(variables: Feed2QueryVariables): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, headers?: Headers): Promise<Feed2Query> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<Feed2Query>(Feed2Document, variables));
     },
-    feed3(variables?: Feed3QueryVariables): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, headers?: Headers): Promise<Feed3Query> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<Feed3Query>(Feed3Document, variables));
     },
-    feed4(variables?: Feed4QueryVariables): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, headers?: Headers): Promise<Feed4Query> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<Feed4Query>(Feed4Document, variables));
     }
   };
@@ -320,6 +325,7 @@ exports[`graphql-request sdk Should generate a correct wrap method 1`] = `
 import { GraphQLClient } from 'graphql-request';
 import { print } from 'graphql';
 import { SdkFunctionWrapper, defaultWrapper } from '@graphql-codegen/typescript-graphql-request';
+import { Headers } from 'graphql-request/dist/src/types';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -583,16 +589,20 @@ export const Feed4Document = gql\`
     \`;
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, headers?: Headers): Promise<FeedQuery> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<FeedQuery>(print(FeedDocument), variables));
     },
-    feed2(variables: Feed2QueryVariables): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, headers?: Headers): Promise<Feed2Query> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<Feed2Query>(print(Feed2Document), variables));
     },
-    feed3(variables?: Feed3QueryVariables): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, headers?: Headers): Promise<Feed3Query> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<Feed3Query>(print(Feed3Document), variables));
     },
-    feed4(variables?: Feed4QueryVariables): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, headers?: Headers): Promise<Feed4Query> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<Feed4Query>(print(Feed4Document), variables));
     }
   };
@@ -619,6 +629,7 @@ exports[`graphql-request sdk Should generate a correct wrap method with document
 "export type Maybe<T> = T | null;
 import { GraphQLClient } from 'graphql-request';
 import { SdkFunctionWrapper, defaultWrapper } from '@graphql-codegen/typescript-graphql-request';
+import { Headers } from 'graphql-request/dist/src/types';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -881,16 +892,20 @@ export const Feed4Document = \`
     \`;
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, headers?: Headers): Promise<FeedQuery> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<FeedQuery>(FeedDocument, variables));
     },
-    feed2(variables: Feed2QueryVariables): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, headers?: Headers): Promise<Feed2Query> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<Feed2Query>(Feed2Document, variables));
     },
-    feed3(variables?: Feed3QueryVariables): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, headers?: Headers): Promise<Feed3Query> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<Feed3Query>(Feed3Document, variables));
     },
-    feed4(variables?: Feed4QueryVariables): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, headers?: Headers): Promise<Feed4Query> {
+      headers !== undefined && client.setHeaders(headers);
       return withWrapper(() => client.request<Feed4Query>(Feed4Document, variables));
     }
   };


### PR DESCRIPTION
This patch makes it possible to pass HTTP request headers to GraphQL client via [`GraphQLClient#setHeaders`](https://github.com/prisma-labs/graphql-request/blob/0b467b8410a97526559a419b6cbaf4f5639a4f30/src/index.ts#L79).

### Motivation

I would like to pass some headers such as `Authorization` and `Cookie` from Client to an API Server through GraphQL Server.

Client (Web Browser) -----> GraphQL Server -----> Another API Server


