### PR TITLE
Add rawRequest to graphql-request plugin documentation

### DIFF
--- a/docs/generated-config/typescript-graphql-request.md
+++ b/docs/generated-config/typescript-graphql-request.md
@@ -1,0 +1,18 @@
+
+### rawRequest (`boolean`, default value: `false`)
+
+By default the `request` method return the `data` or `errors` key from the response.
+If you need to access the `extensions` key you can use the `rawRequest` method.
+
+#### Usage Example
+
+```yml
+generates:
+path/to/file.ts:
+ plugins:
+   - typescript
+   - typescript-operations
+   - typescript-graphql-request
+ config:
+   rawRequest: true
+```

--- a/docs/plugins/typescript-graphql-request.md
+++ b/docs/plugins/typescript-graphql-request.md
@@ -64,6 +64,7 @@ async function main() {
 
 {@import: ../docs/generated-config/base-visitor.md}
 {@import: ../docs/generated-config/client-side-base-visitor.md}
+{@import: ../docs/generated-config/typescript-graphql-request.md}
 
 ## Simple Request Middleware
 

--- a/docs/plugins/typescript-oclif.md
+++ b/docs/plugins/typescript-oclif.md
@@ -1,6 +1,6 @@
 ---
-id: typescript-graphql-request
-title: TypeScript GraphQL-Request
+id: typescript-oclif
+title: TypeScript oclif
 ---
 
 This plugin generates [`oclif`](https://www.npmjs.com/package/oclif) CLI commands.


### PR DESCRIPTION
This adds the `rawRequest` option to the `typescript-graphql-request` plugin documentation.