### PR TITLE
Fix optional types in queries

### DIFF
--- a/dev-test/githunt/__generated__/comment-added.subscription.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/comment-added.subscription.stencil-component.tsx
@@ -8,7 +8,7 @@ declare global {
   };
 
   export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
-    commentAdded: Types.Maybe<
+    commentAdded?: Types.Maybe<
       { __typename?: 'Comment' } & Pick<Types.Comment, 'id' | 'createdAt' | 'content'> & {
           postedBy: { __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'>;
         }

--- a/dev-test/githunt/__generated__/comment.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/comment.query.stencil-component.tsx
@@ -10,8 +10,8 @@ declare global {
   };
 
   export type CommentQuery = { __typename?: 'Query' } & {
-    currentUser: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'>>;
-    entry: Types.Maybe<
+    currentUser?: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'>>;
+    entry?: Types.Maybe<
       { __typename?: 'Entry' } & Pick<Types.Entry, 'id' | 'createdAt' | 'commentCount'> & {
           postedBy: { __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'>;
           comments: Array<Types.Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;

--- a/dev-test/githunt/__generated__/current-user.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/current-user.query.stencil-component.tsx
@@ -6,7 +6,7 @@ declare global {
   export type CurrentUserForProfileQueryVariables = {};
 
   export type CurrentUserForProfileQuery = { __typename?: 'Query' } & {
-    currentUser: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'login' | 'avatar_url'>>;
+    currentUser?: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'login' | 'avatar_url'>>;
   };
 }
 

--- a/dev-test/githunt/__generated__/feed-entry.fragment.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/feed-entry.fragment.stencil-component.tsx
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 declare global {
   export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Types.Entry, 'id' | 'commentCount'> & {
       repository: { __typename?: 'Repository' } & Pick<Types.Repository, 'full_name' | 'html_url'> & {
-          owner: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'avatar_url'>>;
+          owner?: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'avatar_url'>>;
         };
     } & VoteButtonsFragment &
     RepoInfoFragment;

--- a/dev-test/githunt/__generated__/feed.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/feed.query.stencil-component.tsx
@@ -10,8 +10,8 @@ declare global {
   };
 
   export type FeedQuery = { __typename?: 'Query' } & {
-    currentUser: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'login'>>;
-    feed: Types.Maybe<Array<Types.Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+    currentUser?: Types.Maybe<{ __typename?: 'User' } & Pick<Types.User, 'login'>>;
+    feed?: Types.Maybe<Array<Types.Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
   };
 }
 

--- a/dev-test/githunt/__generated__/new-entry.mutation.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/new-entry.mutation.stencil-component.tsx
@@ -8,7 +8,7 @@ declare global {
   };
 
   export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & {
-    submitRepository: Types.Maybe<{ __typename?: 'Entry' } & Pick<Types.Entry, 'createdAt'>>;
+    submitRepository?: Types.Maybe<{ __typename?: 'Entry' } & Pick<Types.Entry, 'createdAt'>>;
   };
 }
 

--- a/dev-test/githunt/__generated__/submit-comment.mutation.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/submit-comment.mutation.stencil-component.tsx
@@ -9,7 +9,7 @@ declare global {
   };
 
   export type SubmitCommentMutation = { __typename?: 'Mutation' } & {
-    submitComment: Types.Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+    submitComment?: Types.Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
   };
 }
 

--- a/dev-test/githunt/__generated__/vote.mutation.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/vote.mutation.stencil-component.tsx
@@ -9,7 +9,7 @@ declare global {
   };
 
   export type VoteMutation = { __typename?: 'Mutation' } & {
-    vote: Types.Maybe<
+    vote?: Types.Maybe<
       { __typename?: 'Entry' } & Pick<Types.Entry, 'score' | 'id'> & {
           vote: { __typename?: 'Vote' } & Pick<Types.Vote, 'vote_value'>;
         }

--- a/dev-test/githunt/types.apolloAngular.sdk.ts
+++ b/dev-test/githunt/types.apolloAngular.sdk.ts
@@ -171,7 +171,7 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
-  commentAdded: Maybe<
+  commentAdded?: Maybe<
     { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
       }
@@ -185,8 +185,8 @@ export type CommentQueryVariables = {
 };
 
 export type CommentQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
-  entry: Maybe<
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  entry?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
         comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
@@ -205,12 +205,12 @@ export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Comm
 export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
 };
 
 export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
     repository: { __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
-        owner: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+        owner?: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
       };
   } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -222,8 +222,8 @@ export type FeedQueryVariables = {
 };
 
 export type FeedQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -231,7 +231,7 @@ export type SubmitRepositoryMutationVariables = {
 };
 
 export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & {
-  submitRepository: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+  submitRepository?: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
 };
 
 export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
@@ -248,7 +248,7 @@ export type SubmitCommentMutationVariables = {
 };
 
 export type SubmitCommentMutation = { __typename?: 'Mutation' } & {
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Entry, 'score'> & {
@@ -261,7 +261,7 @@ export type VoteMutationVariables = {
 };
 
 export type VoteMutation = { __typename?: 'Mutation' } & {
-  vote: Maybe<
+  vote?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
         vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
       }

--- a/dev-test/githunt/types.apolloAngular.ts
+++ b/dev-test/githunt/types.apolloAngular.ts
@@ -170,7 +170,7 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
-  commentAdded: Maybe<
+  commentAdded?: Maybe<
     { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
       }
@@ -184,8 +184,8 @@ export type CommentQueryVariables = {
 };
 
 export type CommentQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
-  entry: Maybe<
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  entry?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
         comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
@@ -204,12 +204,12 @@ export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Comm
 export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
 };
 
 export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
     repository: { __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
-        owner: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+        owner?: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
       };
   } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -221,8 +221,8 @@ export type FeedQueryVariables = {
 };
 
 export type FeedQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -230,7 +230,7 @@ export type SubmitRepositoryMutationVariables = {
 };
 
 export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & {
-  submitRepository: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+  submitRepository?: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
 };
 
 export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
@@ -247,7 +247,7 @@ export type SubmitCommentMutationVariables = {
 };
 
 export type SubmitCommentMutation = { __typename?: 'Mutation' } & {
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Entry, 'score'> & {
@@ -260,7 +260,7 @@ export type VoteMutationVariables = {
 };
 
 export type VoteMutation = { __typename?: 'Mutation' } & {
-  vote: Maybe<
+  vote?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
         vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
       }

--- a/dev-test/githunt/types.d.ts
+++ b/dev-test/githunt/types.d.ts
@@ -162,7 +162,7 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
-  commentAdded: Maybe<
+  commentAdded?: Maybe<
     { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
       }
@@ -176,8 +176,8 @@ export type CommentQueryVariables = {
 };
 
 export type CommentQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
-  entry: Maybe<
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  entry?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
         comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
@@ -196,12 +196,12 @@ export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Comm
 export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
 };
 
 export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
     repository: { __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
-        owner: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+        owner?: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
       };
   } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -213,8 +213,8 @@ export type FeedQueryVariables = {
 };
 
 export type FeedQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -222,7 +222,7 @@ export type SubmitRepositoryMutationVariables = {
 };
 
 export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & {
-  submitRepository: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+  submitRepository?: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
 };
 
 export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
@@ -239,7 +239,7 @@ export type SubmitCommentMutationVariables = {
 };
 
 export type SubmitCommentMutation = { __typename?: 'Mutation' } & {
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Entry, 'score'> & {
@@ -252,7 +252,7 @@ export type VoteMutationVariables = {
 };
 
 export type VoteMutation = { __typename?: 'Mutation' } & {
-  vote: Maybe<
+  vote?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
         vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
       }

--- a/dev-test/githunt/types.enumsAsTypes.ts
+++ b/dev-test/githunt/types.enumsAsTypes.ts
@@ -162,7 +162,7 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
-  commentAdded: Maybe<
+  commentAdded?: Maybe<
     { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
       }
@@ -176,8 +176,8 @@ export type CommentQueryVariables = {
 };
 
 export type CommentQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
-  entry: Maybe<
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  entry?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
         comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
@@ -196,12 +196,12 @@ export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Comm
 export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
 };
 
 export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
     repository: { __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
-        owner: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+        owner?: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
       };
   } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -213,8 +213,8 @@ export type FeedQueryVariables = {
 };
 
 export type FeedQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -222,7 +222,7 @@ export type SubmitRepositoryMutationVariables = {
 };
 
 export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & {
-  submitRepository: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+  submitRepository?: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
 };
 
 export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
@@ -239,7 +239,7 @@ export type SubmitCommentMutationVariables = {
 };
 
 export type SubmitCommentMutation = { __typename?: 'Mutation' } & {
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Entry, 'score'> & {
@@ -252,7 +252,7 @@ export type VoteMutationVariables = {
 };
 
 export type VoteMutation = { __typename?: 'Mutation' } & {
-  vote: Maybe<
+  vote?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
         vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
       }

--- a/dev-test/githunt/types.flatten.preResolveTypes.ts
+++ b/dev-test/githunt/types.flatten.preResolveTypes.ts
@@ -168,7 +168,7 @@ export type OnCommentAddedSubscriptionVariables = {
 
 export type OnCommentAddedSubscription = {
   __typename?: 'Subscription';
-  commentAdded: Maybe<{
+  commentAdded?: Maybe<{
     __typename?: 'Comment';
     id: number;
     createdAt: number;
@@ -185,8 +185,8 @@ export type CommentQueryVariables = {
 
 export type CommentQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string; html_url: string }>;
-  entry: Maybe<{
+  currentUser?: Maybe<{ __typename?: 'User'; login: string; html_url: string }>;
+  entry?: Maybe<{
     __typename?: 'Entry';
     id: number;
     createdAt: number;
@@ -205,8 +205,8 @@ export type CommentQuery = {
       __typename?: 'Repository';
       full_name: string;
       html_url: string;
-      description: Maybe<string>;
-      open_issues_count: Maybe<number>;
+      description?: Maybe<string>;
+      open_issues_count?: Maybe<number>;
       stargazers_count: number;
     };
   }>;
@@ -216,7 +216,7 @@ export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string; avatar_url: string }>;
+  currentUser?: Maybe<{ __typename?: 'User'; login: string; avatar_url: string }>;
 };
 
 export type FeedQueryVariables = {
@@ -227,8 +227,8 @@ export type FeedQueryVariables = {
 
 export type FeedQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string }>;
-  feed: Maybe<
+  currentUser?: Maybe<{ __typename?: 'User'; login: string }>;
+  feed?: Maybe<
     Array<
       Maybe<{
         __typename?: 'Entry';
@@ -240,10 +240,10 @@ export type FeedQuery = {
           __typename?: 'Repository';
           full_name: string;
           html_url: string;
-          description: Maybe<string>;
+          description?: Maybe<string>;
           stargazers_count: number;
-          open_issues_count: Maybe<number>;
-          owner: Maybe<{ __typename?: 'User'; avatar_url: string }>;
+          open_issues_count?: Maybe<number>;
+          owner?: Maybe<{ __typename?: 'User'; avatar_url: string }>;
         };
         vote: { __typename?: 'Vote'; vote_value: number };
         postedBy: { __typename?: 'User'; html_url: string; login: string };
@@ -258,7 +258,7 @@ export type SubmitRepositoryMutationVariables = {
 
 export type SubmitRepositoryMutation = {
   __typename?: 'Mutation';
-  submitRepository: Maybe<{ __typename?: 'Entry'; createdAt: number }>;
+  submitRepository?: Maybe<{ __typename?: 'Entry'; createdAt: number }>;
 };
 
 export type SubmitCommentMutationVariables = {
@@ -268,7 +268,7 @@ export type SubmitCommentMutationVariables = {
 
 export type SubmitCommentMutation = {
   __typename?: 'Mutation';
-  submitComment: Maybe<{
+  submitComment?: Maybe<{
     __typename?: 'Comment';
     id: number;
     createdAt: number;
@@ -284,5 +284,5 @@ export type VoteMutationVariables = {
 
 export type VoteMutation = {
   __typename?: 'Mutation';
-  vote: Maybe<{ __typename?: 'Entry'; score: number; id: number; vote: { __typename?: 'Vote'; vote_value: number } }>;
+  vote?: Maybe<{ __typename?: 'Entry'; score: number; id: number; vote: { __typename?: 'Vote'; vote_value: number } }>;
 };

--- a/dev-test/githunt/types.immutableTypes.ts
+++ b/dev-test/githunt/types.immutableTypes.ts
@@ -167,7 +167,7 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 export type OnCommentAddedSubscription = { readonly __typename?: 'Subscription' } & {
-  readonly commentAdded: Maybe<
+  readonly commentAdded?: Maybe<
     { readonly __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
         readonly postedBy: { readonly __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
       }
@@ -181,8 +181,8 @@ export type CommentQueryVariables = {
 };
 
 export type CommentQuery = { readonly __typename?: 'Query' } & {
-  readonly currentUser: Maybe<{ readonly __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
-  readonly entry: Maybe<
+  readonly currentUser?: Maybe<{ readonly __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  readonly entry?: Maybe<
     { readonly __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
         readonly postedBy: { readonly __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
         readonly comments: ReadonlyArray<Maybe<{ readonly __typename?: 'Comment' } & CommentsPageCommentFragment>>;
@@ -202,12 +202,12 @@ export type CommentsPageCommentFragment = { readonly __typename?: 'Comment' } & 
 export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { readonly __typename?: 'Query' } & {
-  readonly currentUser: Maybe<{ readonly __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+  readonly currentUser?: Maybe<{ readonly __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
 };
 
 export type FeedEntryFragment = { readonly __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
     readonly repository: { readonly __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
-        readonly owner: Maybe<{ readonly __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+        readonly owner?: Maybe<{ readonly __typename?: 'User' } & Pick<User, 'avatar_url'>>;
       };
   } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -219,8 +219,8 @@ export type FeedQueryVariables = {
 };
 
 export type FeedQuery = { readonly __typename?: 'Query' } & {
-  readonly currentUser: Maybe<{ readonly __typename?: 'User' } & Pick<User, 'login'>>;
-  readonly feed: Maybe<ReadonlyArray<Maybe<{ readonly __typename?: 'Entry' } & FeedEntryFragment>>>;
+  readonly currentUser?: Maybe<{ readonly __typename?: 'User' } & Pick<User, 'login'>>;
+  readonly feed?: Maybe<ReadonlyArray<Maybe<{ readonly __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -228,7 +228,7 @@ export type SubmitRepositoryMutationVariables = {
 };
 
 export type SubmitRepositoryMutation = { readonly __typename?: 'Mutation' } & {
-  readonly submitRepository: Maybe<{ readonly __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+  readonly submitRepository?: Maybe<{ readonly __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
 };
 
 export type RepoInfoFragment = { readonly __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
@@ -245,7 +245,7 @@ export type SubmitCommentMutationVariables = {
 };
 
 export type SubmitCommentMutation = { readonly __typename?: 'Mutation' } & {
-  readonly submitComment: Maybe<{ readonly __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  readonly submitComment?: Maybe<{ readonly __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = { readonly __typename?: 'Entry' } & Pick<Entry, 'score'> & {
@@ -258,7 +258,7 @@ export type VoteMutationVariables = {
 };
 
 export type VoteMutation = { readonly __typename?: 'Mutation' } & {
-  readonly vote: Maybe<
+  readonly vote?: Maybe<
     { readonly __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
         readonly vote: { readonly __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
       }

--- a/dev-test/githunt/types.preResolveTypes.compatibility.ts
+++ b/dev-test/githunt/types.preResolveTypes.compatibility.ts
@@ -168,7 +168,7 @@ export type OnCommentAddedSubscriptionVariables = {
 
 export type OnCommentAddedSubscription = {
   __typename?: 'Subscription';
-  commentAdded: Maybe<{
+  commentAdded?: Maybe<{
     __typename?: 'Comment';
     id: number;
     createdAt: number;
@@ -185,8 +185,8 @@ export type CommentQueryVariables = {
 
 export type CommentQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string; html_url: string }>;
-  entry: Maybe<{
+  currentUser?: Maybe<{ __typename?: 'User'; login: string; html_url: string }>;
+  entry?: Maybe<{
     __typename?: 'Entry';
     id: number;
     createdAt: number;
@@ -195,8 +195,8 @@ export type CommentQuery = {
     comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
     repository: {
       __typename?: 'Repository';
-      description: Maybe<string>;
-      open_issues_count: Maybe<number>;
+      description?: Maybe<string>;
+      open_issues_count?: Maybe<number>;
       stargazers_count: number;
       full_name: string;
       html_url: string;
@@ -216,7 +216,7 @@ export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string; avatar_url: string }>;
+  currentUser?: Maybe<{ __typename?: 'User'; login: string; avatar_url: string }>;
 };
 
 export type FeedEntryFragment = {
@@ -227,7 +227,7 @@ export type FeedEntryFragment = {
     __typename?: 'Repository';
     full_name: string;
     html_url: string;
-    owner: Maybe<{ __typename?: 'User'; avatar_url: string }>;
+    owner?: Maybe<{ __typename?: 'User'; avatar_url: string }>;
   };
 } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -240,8 +240,8 @@ export type FeedQueryVariables = {
 
 export type FeedQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string }>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User'; login: string }>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -250,7 +250,7 @@ export type SubmitRepositoryMutationVariables = {
 
 export type SubmitRepositoryMutation = {
   __typename?: 'Mutation';
-  submitRepository: Maybe<{ __typename?: 'Entry'; createdAt: number }>;
+  submitRepository?: Maybe<{ __typename?: 'Entry'; createdAt: number }>;
 };
 
 export type RepoInfoFragment = {
@@ -258,9 +258,9 @@ export type RepoInfoFragment = {
   createdAt: number;
   repository: {
     __typename?: 'Repository';
-    description: Maybe<string>;
+    description?: Maybe<string>;
     stargazers_count: number;
-    open_issues_count: Maybe<number>;
+    open_issues_count?: Maybe<number>;
   };
   postedBy: { __typename?: 'User'; html_url: string; login: string };
 };
@@ -272,7 +272,7 @@ export type SubmitCommentMutationVariables = {
 
 export type SubmitCommentMutation = {
   __typename?: 'Mutation';
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = {
@@ -288,7 +288,7 @@ export type VoteMutationVariables = {
 
 export type VoteMutation = {
   __typename?: 'Mutation';
-  vote: Maybe<{ __typename?: 'Entry'; score: number; id: number; vote: { __typename?: 'Vote'; vote_value: number } }>;
+  vote?: Maybe<{ __typename?: 'Entry'; score: number; id: number; vote: { __typename?: 'Vote'; vote_value: number } }>;
 };
 
 export namespace OnCommentAdded {

--- a/dev-test/githunt/types.preResolveTypes.ts
+++ b/dev-test/githunt/types.preResolveTypes.ts
@@ -168,7 +168,7 @@ export type OnCommentAddedSubscriptionVariables = {
 
 export type OnCommentAddedSubscription = {
   __typename?: 'Subscription';
-  commentAdded: Maybe<{
+  commentAdded?: Maybe<{
     __typename?: 'Comment';
     id: number;
     createdAt: number;
@@ -185,8 +185,8 @@ export type CommentQueryVariables = {
 
 export type CommentQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string; html_url: string }>;
-  entry: Maybe<{
+  currentUser?: Maybe<{ __typename?: 'User'; login: string; html_url: string }>;
+  entry?: Maybe<{
     __typename?: 'Entry';
     id: number;
     createdAt: number;
@@ -195,8 +195,8 @@ export type CommentQuery = {
     comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
     repository: {
       __typename?: 'Repository';
-      description: Maybe<string>;
-      open_issues_count: Maybe<number>;
+      description?: Maybe<string>;
+      open_issues_count?: Maybe<number>;
       stargazers_count: number;
       full_name: string;
       html_url: string;
@@ -216,7 +216,7 @@ export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string; avatar_url: string }>;
+  currentUser?: Maybe<{ __typename?: 'User'; login: string; avatar_url: string }>;
 };
 
 export type FeedEntryFragment = {
@@ -227,7 +227,7 @@ export type FeedEntryFragment = {
     __typename?: 'Repository';
     full_name: string;
     html_url: string;
-    owner: Maybe<{ __typename?: 'User'; avatar_url: string }>;
+    owner?: Maybe<{ __typename?: 'User'; avatar_url: string }>;
   };
 } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -240,8 +240,8 @@ export type FeedQueryVariables = {
 
 export type FeedQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string }>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User'; login: string }>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -250,7 +250,7 @@ export type SubmitRepositoryMutationVariables = {
 
 export type SubmitRepositoryMutation = {
   __typename?: 'Mutation';
-  submitRepository: Maybe<{ __typename?: 'Entry'; createdAt: number }>;
+  submitRepository?: Maybe<{ __typename?: 'Entry'; createdAt: number }>;
 };
 
 export type RepoInfoFragment = {
@@ -258,9 +258,9 @@ export type RepoInfoFragment = {
   createdAt: number;
   repository: {
     __typename?: 'Repository';
-    description: Maybe<string>;
+    description?: Maybe<string>;
     stargazers_count: number;
-    open_issues_count: Maybe<number>;
+    open_issues_count?: Maybe<number>;
   };
   postedBy: { __typename?: 'User'; html_url: string; login: string };
 };
@@ -272,7 +272,7 @@ export type SubmitCommentMutationVariables = {
 
 export type SubmitCommentMutation = {
   __typename?: 'Mutation';
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = {
@@ -288,5 +288,5 @@ export type VoteMutationVariables = {
 
 export type VoteMutation = {
   __typename?: 'Mutation';
-  vote: Maybe<{ __typename?: 'Entry'; score: number; id: number; vote: { __typename?: 'Vote'; vote_value: number } }>;
+  vote?: Maybe<{ __typename?: 'Entry'; score: number; id: number; vote: { __typename?: 'Vote'; vote_value: number } }>;
 };

--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -173,7 +173,7 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 export type OnCommentAddedSubscriptionMyOperation = { __typename?: 'Subscription' } & {
-  commentAdded: Maybe<
+  commentAdded?: Maybe<
     { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
       }
@@ -187,8 +187,8 @@ export type CommentQueryVariables = {
 };
 
 export type CommentQueryMyOperation = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
-  entry: Maybe<
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  entry?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
         comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
@@ -207,12 +207,12 @@ export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Comm
 export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQueryMyOperation = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
 };
 
 export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
     repository: { __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
-        owner: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+        owner?: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
       };
   } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -224,8 +224,8 @@ export type FeedQueryVariables = {
 };
 
 export type FeedQueryMyOperation = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -233,7 +233,7 @@ export type SubmitRepositoryMutationVariables = {
 };
 
 export type SubmitRepositoryMutationMyOperation = { __typename?: 'Mutation' } & {
-  submitRepository: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+  submitRepository?: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
 };
 
 export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
@@ -250,7 +250,7 @@ export type SubmitCommentMutationVariables = {
 };
 
 export type SubmitCommentMutationMyOperation = { __typename?: 'Mutation' } & {
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Entry, 'score'> & {
@@ -263,7 +263,7 @@ export type VoteMutationVariables = {
 };
 
 export type VoteMutationMyOperation = { __typename?: 'Mutation' } & {
-  vote: Maybe<
+  vote?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
         vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
       }

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -174,7 +174,7 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
-  commentAdded: Maybe<
+  commentAdded?: Maybe<
     { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
       }
@@ -188,8 +188,8 @@ export type CommentQueryVariables = {
 };
 
 export type CommentQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
-  entry: Maybe<
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  entry?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
         comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
@@ -208,12 +208,12 @@ export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Comm
 export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
 };
 
 export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
     repository: { __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
-        owner: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+        owner?: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
       };
   } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -225,8 +225,8 @@ export type FeedQueryVariables = {
 };
 
 export type FeedQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -234,7 +234,7 @@ export type SubmitRepositoryMutationVariables = {
 };
 
 export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & {
-  submitRepository: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+  submitRepository?: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
 };
 
 export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
@@ -251,7 +251,7 @@ export type SubmitCommentMutationVariables = {
 };
 
 export type SubmitCommentMutation = { __typename?: 'Mutation' } & {
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Entry, 'score'> & {
@@ -264,7 +264,7 @@ export type VoteMutationVariables = {
 };
 
 export type VoteMutation = { __typename?: 'Mutation' } & {
-  vote: Maybe<
+  vote?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
         vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
       }

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -174,7 +174,7 @@ export type OnCommentAddedSubscriptionVariables = {
 
 export type OnCommentAddedSubscription = {
   __typename?: 'Subscription';
-  commentAdded: Maybe<{
+  commentAdded?: Maybe<{
     __typename?: 'Comment';
     id: number;
     createdAt: number;
@@ -191,8 +191,8 @@ export type CommentQueryVariables = {
 
 export type CommentQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string; html_url: string }>;
-  entry: Maybe<{
+  currentUser?: Maybe<{ __typename?: 'User'; login: string; html_url: string }>;
+  entry?: Maybe<{
     __typename?: 'Entry';
     id: number;
     createdAt: number;
@@ -201,8 +201,8 @@ export type CommentQuery = {
     comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
     repository: {
       __typename?: 'Repository';
-      description: Maybe<string>;
-      open_issues_count: Maybe<number>;
+      description?: Maybe<string>;
+      open_issues_count?: Maybe<number>;
       stargazers_count: number;
       full_name: string;
       html_url: string;
@@ -222,7 +222,7 @@ export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string; avatar_url: string }>;
+  currentUser?: Maybe<{ __typename?: 'User'; login: string; avatar_url: string }>;
 };
 
 export type FeedEntryFragment = {
@@ -233,7 +233,7 @@ export type FeedEntryFragment = {
     __typename?: 'Repository';
     full_name: string;
     html_url: string;
-    owner: Maybe<{ __typename?: 'User'; avatar_url: string }>;
+    owner?: Maybe<{ __typename?: 'User'; avatar_url: string }>;
   };
 } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -246,8 +246,8 @@ export type FeedQueryVariables = {
 
 export type FeedQuery = {
   __typename?: 'Query';
-  currentUser: Maybe<{ __typename?: 'User'; login: string }>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User'; login: string }>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -256,7 +256,7 @@ export type SubmitRepositoryMutationVariables = {
 
 export type SubmitRepositoryMutation = {
   __typename?: 'Mutation';
-  submitRepository: Maybe<{ __typename?: 'Entry'; createdAt: number }>;
+  submitRepository?: Maybe<{ __typename?: 'Entry'; createdAt: number }>;
 };
 
 export type RepoInfoFragment = {
@@ -264,9 +264,9 @@ export type RepoInfoFragment = {
   createdAt: number;
   repository: {
     __typename?: 'Repository';
-    description: Maybe<string>;
+    description?: Maybe<string>;
     stargazers_count: number;
-    open_issues_count: Maybe<number>;
+    open_issues_count?: Maybe<number>;
   };
   postedBy: { __typename?: 'User'; html_url: string; login: string };
 };
@@ -278,7 +278,7 @@ export type SubmitCommentMutationVariables = {
 
 export type SubmitCommentMutation = {
   __typename?: 'Mutation';
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = {
@@ -294,7 +294,7 @@ export type VoteMutationVariables = {
 
 export type VoteMutation = {
   __typename?: 'Mutation';
-  vote: Maybe<{ __typename?: 'Entry'; score: number; id: number; vote: { __typename?: 'Vote'; vote_value: number } }>;
+  vote?: Maybe<{ __typename?: 'Entry'; score: number; id: number; vote: { __typename?: 'Vote'; vote_value: number } }>;
 };
 
 export const CommentsPageCommentFragmentDoc = gql`

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -173,7 +173,7 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
-  commentAdded: Maybe<
+  commentAdded?: Maybe<
     { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
       }
@@ -187,8 +187,8 @@ export type CommentQueryVariables = {
 };
 
 export type CommentQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
-  entry: Maybe<
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  entry?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
         comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
@@ -207,12 +207,12 @@ export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Comm
 export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
 };
 
 export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
     repository: { __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
-        owner: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+        owner?: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
       };
   } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -224,8 +224,8 @@ export type FeedQueryVariables = {
 };
 
 export type FeedQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -233,7 +233,7 @@ export type SubmitRepositoryMutationVariables = {
 };
 
 export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & {
-  submitRepository: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+  submitRepository?: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
 };
 
 export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
@@ -250,7 +250,7 @@ export type SubmitCommentMutationVariables = {
 };
 
 export type SubmitCommentMutation = { __typename?: 'Mutation' } & {
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Entry, 'score'> & {
@@ -263,7 +263,7 @@ export type VoteMutationVariables = {
 };
 
 export type VoteMutation = { __typename?: 'Mutation' } & {
-  vote: Maybe<
+  vote?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
         vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
       }

--- a/dev-test/githunt/types.stencilApollo.tsx
+++ b/dev-test/githunt/types.stencilApollo.tsx
@@ -170,7 +170,7 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
-  commentAdded: Maybe<
+  commentAdded?: Maybe<
     { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
       }
@@ -184,8 +184,8 @@ export type CommentQueryVariables = {
 };
 
 export type CommentQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
-  entry: Maybe<
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  entry?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
         comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
@@ -204,12 +204,12 @@ export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Comm
 export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
 };
 
 export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
     repository: { __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
-        owner: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+        owner?: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
       };
   } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -221,8 +221,8 @@ export type FeedQueryVariables = {
 };
 
 export type FeedQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -230,7 +230,7 @@ export type SubmitRepositoryMutationVariables = {
 };
 
 export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & {
-  submitRepository: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+  submitRepository?: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
 };
 
 export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
@@ -247,7 +247,7 @@ export type SubmitCommentMutationVariables = {
 };
 
 export type SubmitCommentMutation = { __typename?: 'Mutation' } & {
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Entry, 'score'> & {
@@ -260,7 +260,7 @@ export type VoteMutationVariables = {
 };
 
 export type VoteMutation = { __typename?: 'Mutation' } & {
-  vote: Maybe<
+  vote?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
         vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
       }

--- a/dev-test/githunt/types.ts
+++ b/dev-test/githunt/types.ts
@@ -167,7 +167,7 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
-  commentAdded: Maybe<
+  commentAdded?: Maybe<
     { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
       }
@@ -181,8 +181,8 @@ export type CommentQueryVariables = {
 };
 
 export type CommentQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
-  entry: Maybe<
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  entry?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
         comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
@@ -201,12 +201,12 @@ export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Comm
 export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
 };
 
 export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
     repository: { __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
-        owner: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+        owner?: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
       };
   } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -218,8 +218,8 @@ export type FeedQueryVariables = {
 };
 
 export type FeedQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -227,7 +227,7 @@ export type SubmitRepositoryMutationVariables = {
 };
 
 export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & {
-  submitRepository: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+  submitRepository?: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
 };
 
 export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
@@ -244,7 +244,7 @@ export type SubmitCommentMutationVariables = {
 };
 
 export type SubmitCommentMutation = { __typename?: 'Mutation' } & {
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Entry, 'score'> & {
@@ -257,7 +257,7 @@ export type VoteMutationVariables = {
 };
 
 export type VoteMutation = { __typename?: 'Mutation' } & {
-  vote: Maybe<
+  vote?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
         vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
       }

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -171,7 +171,7 @@ export type OnCommentAddedSubscriptionVariables = {
 };
 
 export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
-  commentAdded: Maybe<
+  commentAdded?: Maybe<
     { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
       }
@@ -185,8 +185,8 @@ export type CommentQueryVariables = {
 };
 
 export type CommentQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
-  entry: Maybe<
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  entry?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
         postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
         comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
@@ -205,12 +205,12 @@ export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Comm
 export type CurrentUserForProfileQueryVariables = {};
 
 export type CurrentUserForProfileQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
 };
 
 export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
     repository: { __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
-        owner: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+        owner?: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
       };
   } & VoteButtonsFragment &
   RepoInfoFragment;
@@ -222,8 +222,8 @@ export type FeedQueryVariables = {
 };
 
 export type FeedQuery = { __typename?: 'Query' } & {
-  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
-  feed: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
 };
 
 export type SubmitRepositoryMutationVariables = {
@@ -231,7 +231,7 @@ export type SubmitRepositoryMutationVariables = {
 };
 
 export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & {
-  submitRepository: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+  submitRepository?: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
 };
 
 export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
@@ -248,7 +248,7 @@ export type SubmitCommentMutationVariables = {
 };
 
 export type SubmitCommentMutation = { __typename?: 'Mutation' } & {
-  submitComment: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
 };
 
 export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Entry, 'score'> & {
@@ -261,7 +261,7 @@ export type VoteMutationVariables = {
 };
 
 export type VoteMutation = { __typename?: 'Mutation' } & {
-  vote: Maybe<
+  vote?: Maybe<
     { __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
         vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
       }

--- a/dev-test/star-wars/__generated__/CreateReviewForEpisode.tsx
+++ b/dev-test/star-wars/__generated__/CreateReviewForEpisode.tsx
@@ -13,7 +13,7 @@ export type CreateReviewForEpisodeMutationVariables = {
 };
 
 export type CreateReviewForEpisodeMutation = { __typename?: 'Mutation' } & {
-  createReview: Types.Maybe<{ __typename?: 'Review' } & Pick<Types.Review, 'stars' | 'commentary'>>;
+  createReview?: Types.Maybe<{ __typename?: 'Review' } & Pick<Types.Review, 'stars' | 'commentary'>>;
 };
 
 export const CreateReviewForEpisodeDocument = gql`

--- a/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
+++ b/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
@@ -12,9 +12,9 @@ export type HeroAndFriendsNamesQueryVariables = {
 };
 
 export type HeroAndFriendsNamesQuery = { __typename?: 'Query' } & {
-  hero: Types.Maybe<
+  hero?: Types.Maybe<
     | ({ __typename?: 'Human' } & Pick<Types.Human, 'name'> & {
-          friends: Types.Maybe<
+          friends?: Types.Maybe<
             Array<
               Types.Maybe<
                 | ({ __typename?: 'Human' } & Pick<Types.Human, 'name'>)
@@ -24,7 +24,7 @@ export type HeroAndFriendsNamesQuery = { __typename?: 'Query' } & {
           >;
         })
     | ({ __typename?: 'Droid' } & Pick<Types.Droid, 'name'> & {
-          friends: Types.Maybe<
+          friends?: Types.Maybe<
             Array<
               Types.Maybe<
                 | ({ __typename?: 'Human' } & Pick<Types.Human, 'name'>)

--- a/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
+++ b/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
@@ -10,7 +10,7 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type HeroAppearsInQueryVariables = {};
 
 export type HeroAppearsInQuery = { __typename?: 'Query' } & {
-  hero: Types.Maybe<
+  hero?: Types.Maybe<
     | ({ __typename?: 'Human' } & Pick<Types.Human, 'name' | 'appearsIn'>)
     | ({ __typename?: 'Droid' } & Pick<Types.Droid, 'name' | 'appearsIn'>)
   >;

--- a/dev-test/star-wars/__generated__/HeroDetails.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetails.tsx
@@ -12,7 +12,7 @@ export type HeroDetailsQueryVariables = {
 };
 
 export type HeroDetailsQuery = { __typename?: 'Query' } & {
-  hero: Types.Maybe<
+  hero?: Types.Maybe<
     | ({ __typename?: 'Human' } & Pick<Types.Human, 'height' | 'name'>)
     | ({ __typename?: 'Droid' } & Pick<Types.Droid, 'primaryFunction' | 'name'>)
   >;

--- a/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
@@ -13,7 +13,7 @@ export type HeroDetailsWithFragmentQueryVariables = {
 };
 
 export type HeroDetailsWithFragmentQuery = { __typename?: 'Query' } & {
-  hero: Types.Maybe<
+  hero?: Types.Maybe<
     ({ __typename?: 'Human' } & HeroDetails_Human_Fragment) | ({ __typename?: 'Droid' } & HeroDetails_Droid_Fragment)
   >;
 };

--- a/dev-test/star-wars/__generated__/HeroName.tsx
+++ b/dev-test/star-wars/__generated__/HeroName.tsx
@@ -12,7 +12,7 @@ export type HeroNameQueryVariables = {
 };
 
 export type HeroNameQuery = { __typename?: 'Query' } & {
-  hero: Types.Maybe<
+  hero?: Types.Maybe<
     ({ __typename?: 'Human' } & Pick<Types.Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Types.Droid, 'name'>)
   >;
 };

--- a/dev-test/star-wars/__generated__/HeroNameConditional.tsx
+++ b/dev-test/star-wars/__generated__/HeroNameConditional.tsx
@@ -13,7 +13,7 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 export type HeroNameConditionalInclusionQuery = { __typename?: 'Query' } & {
-  hero: Types.Maybe<
+  hero?: Types.Maybe<
     ({ __typename?: 'Human' } & Pick<Types.Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Types.Droid, 'name'>)
   >;
 };
@@ -24,7 +24,7 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 export type HeroNameConditionalExclusionQuery = { __typename?: 'Query' } & {
-  hero: Types.Maybe<
+  hero?: Types.Maybe<
     ({ __typename?: 'Human' } & Pick<Types.Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Types.Droid, 'name'>)
   >;
 };

--- a/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
+++ b/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
@@ -12,9 +12,9 @@ export type HeroParentTypeDependentFieldQueryVariables = {
 };
 
 export type HeroParentTypeDependentFieldQuery = { __typename?: 'Query' } & {
-  hero: Types.Maybe<
+  hero?: Types.Maybe<
     | ({ __typename?: 'Human' } & Pick<Types.Human, 'name'> & {
-          friends: Types.Maybe<
+          friends?: Types.Maybe<
             Array<
               Types.Maybe<
                 | ({ __typename?: 'Human' } & Pick<Types.Human, 'height' | 'name'>)
@@ -24,7 +24,7 @@ export type HeroParentTypeDependentFieldQuery = { __typename?: 'Query' } & {
           >;
         })
     | ({ __typename?: 'Droid' } & Pick<Types.Droid, 'name'> & {
-          friends: Types.Maybe<
+          friends?: Types.Maybe<
             Array<
               Types.Maybe<
                 | ({ __typename?: 'Human' } & Pick<Types.Human, 'height' | 'name'>)

--- a/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
+++ b/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
@@ -12,7 +12,7 @@ export type HeroTypeDependentAliasedFieldQueryVariables = {
 };
 
 export type HeroTypeDependentAliasedFieldQuery = { __typename?: 'Query' } & {
-  hero: Types.Maybe<
+  hero?: Types.Maybe<
     | ({ __typename?: 'Human' } & { property: Types.Human['homePlanet'] })
     | ({ __typename?: 'Droid' } & { property: Types.Droid['primaryFunction'] })
   >;

--- a/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
+++ b/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
@@ -11,7 +11,7 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type HumanWithNullHeightQueryVariables = {};
 
 export type HumanWithNullHeightQuery = { __typename?: 'Query' } & {
-  human: Types.Maybe<{ __typename?: 'Human' } & HumanFieldsFragment>;
+  human?: Types.Maybe<{ __typename?: 'Human' } & HumanFieldsFragment>;
 };
 
 export const HumanWithNullHeightDocument = gql`

--- a/dev-test/star-wars/__generated__/TwoHeroes.tsx
+++ b/dev-test/star-wars/__generated__/TwoHeroes.tsx
@@ -10,10 +10,10 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type TwoHeroesQueryVariables = {};
 
 export type TwoHeroesQuery = { __typename?: 'Query' } & {
-  r2: Types.Maybe<
+  r2?: Types.Maybe<
     ({ __typename?: 'Human' } & Pick<Types.Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Types.Droid, 'name'>)
   >;
-  luke: Types.Maybe<
+  luke?: Types.Maybe<
     ({ __typename?: 'Human' } & Pick<Types.Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Types.Droid, 'name'>)
   >;
 };

--- a/dev-test/star-wars/types.globallyAvailable.d.ts
+++ b/dev-test/star-wars/types.globallyAvailable.d.ts
@@ -238,7 +238,7 @@ type CreateReviewForEpisodeMutationVariables = {
 };
 
 type CreateReviewForEpisodeMutation = { __typename?: 'Mutation' } & {
-  createReview: Maybe<{ __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>>;
+  createReview?: Maybe<{ __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>>;
 };
 
 type HeroAndFriendsNamesQueryVariables = {
@@ -246,16 +246,16 @@ type HeroAndFriendsNamesQueryVariables = {
 };
 
 type HeroAndFriendsNamesQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>
             >
           >;
         })
     | ({ __typename?: 'Droid' } & Pick<Droid, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>
             >
@@ -267,7 +267,7 @@ type HeroAndFriendsNamesQuery = { __typename?: 'Query' } & {
 type HeroAppearsInQueryVariables = {};
 
 type HeroAppearsInQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'name' | 'appearsIn'>)
     | ({ __typename?: 'Droid' } & Pick<Droid, 'name' | 'appearsIn'>)
   >;
@@ -278,7 +278,7 @@ type HeroDetailsQueryVariables = {
 };
 
 type HeroDetailsQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
     | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction' | 'name'>)
   >;
@@ -295,7 +295,7 @@ type HeroDetailsWithFragmentQueryVariables = {
 };
 
 type HeroDetailsWithFragmentQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     ({ __typename?: 'Human' } & HeroDetails_Human_Fragment) | ({ __typename?: 'Droid' } & HeroDetails_Droid_Fragment)
   >;
 };
@@ -305,7 +305,7 @@ type HeroNameQueryVariables = {
 };
 
 type HeroNameQuery = { __typename?: 'Query' } & {
-  hero: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  hero?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };
 
 type HeroNameConditionalInclusionQueryVariables = {
@@ -314,7 +314,7 @@ type HeroNameConditionalInclusionQueryVariables = {
 };
 
 type HeroNameConditionalInclusionQuery = { __typename?: 'Query' } & {
-  hero: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  hero?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };
 
 type HeroNameConditionalExclusionQueryVariables = {
@@ -323,7 +323,7 @@ type HeroNameConditionalExclusionQueryVariables = {
 };
 
 type HeroNameConditionalExclusionQuery = { __typename?: 'Query' } & {
-  hero: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  hero?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };
 
 type HeroParentTypeDependentFieldQueryVariables = {
@@ -331,9 +331,9 @@ type HeroParentTypeDependentFieldQueryVariables = {
 };
 
 type HeroParentTypeDependentFieldQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<
                 | ({ __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
@@ -343,7 +343,7 @@ type HeroParentTypeDependentFieldQuery = { __typename?: 'Query' } & {
           >;
         })
     | ({ __typename?: 'Droid' } & Pick<Droid, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<
                 | ({ __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
@@ -360,7 +360,7 @@ type HeroTypeDependentAliasedFieldQueryVariables = {
 };
 
 type HeroTypeDependentAliasedFieldQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & { property: Human['homePlanet'] })
     | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })
   >;
@@ -371,12 +371,12 @@ type HumanFieldsFragment = { __typename?: 'Human' } & Pick<Human, 'name' | 'mass
 type HumanWithNullHeightQueryVariables = {};
 
 type HumanWithNullHeightQuery = { __typename?: 'Query' } & {
-  human: Maybe<{ __typename?: 'Human' } & HumanFieldsFragment>;
+  human?: Maybe<{ __typename?: 'Human' } & HumanFieldsFragment>;
 };
 
 type TwoHeroesQueryVariables = {};
 
 type TwoHeroesQuery = { __typename?: 'Query' } & {
-  r2: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
-  luke: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  r2?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  luke?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };

--- a/dev-test/star-wars/types.immutableTypes.ts
+++ b/dev-test/star-wars/types.immutableTypes.ts
@@ -240,7 +240,7 @@ export type CreateReviewForEpisodeMutationVariables = {
 };
 
 export type CreateReviewForEpisodeMutation = { readonly __typename?: 'Mutation' } & {
-  readonly createReview: Maybe<{ readonly __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>>;
+  readonly createReview?: Maybe<{ readonly __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>>;
 };
 
 export type HeroAndFriendsNamesQueryVariables = {
@@ -248,9 +248,9 @@ export type HeroAndFriendsNamesQueryVariables = {
 };
 
 export type HeroAndFriendsNamesQuery = { readonly __typename?: 'Query' } & {
-  readonly hero: Maybe<
+  readonly hero?: Maybe<
     | ({ readonly __typename?: 'Human' } & Pick<Human, 'name'> & {
-          readonly friends: Maybe<
+          readonly friends?: Maybe<
             ReadonlyArray<
               Maybe<
                 | ({ readonly __typename?: 'Human' } & Pick<Human, 'name'>)
@@ -260,7 +260,7 @@ export type HeroAndFriendsNamesQuery = { readonly __typename?: 'Query' } & {
           >;
         })
     | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'name'> & {
-          readonly friends: Maybe<
+          readonly friends?: Maybe<
             ReadonlyArray<
               Maybe<
                 | ({ readonly __typename?: 'Human' } & Pick<Human, 'name'>)
@@ -275,7 +275,7 @@ export type HeroAndFriendsNamesQuery = { readonly __typename?: 'Query' } & {
 export type HeroAppearsInQueryVariables = {};
 
 export type HeroAppearsInQuery = { readonly __typename?: 'Query' } & {
-  readonly hero: Maybe<
+  readonly hero?: Maybe<
     | ({ readonly __typename?: 'Human' } & Pick<Human, 'name' | 'appearsIn'>)
     | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'name' | 'appearsIn'>)
   >;
@@ -286,7 +286,7 @@ export type HeroDetailsQueryVariables = {
 };
 
 export type HeroDetailsQuery = { readonly __typename?: 'Query' } & {
-  readonly hero: Maybe<
+  readonly hero?: Maybe<
     | ({ readonly __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
     | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'primaryFunction' | 'name'>)
   >;
@@ -303,7 +303,7 @@ export type HeroDetailsWithFragmentQueryVariables = {
 };
 
 export type HeroDetailsWithFragmentQuery = { readonly __typename?: 'Query' } & {
-  readonly hero: Maybe<
+  readonly hero?: Maybe<
     | ({ readonly __typename?: 'Human' } & HeroDetails_Human_Fragment)
     | ({ readonly __typename?: 'Droid' } & HeroDetails_Droid_Fragment)
   >;
@@ -314,7 +314,7 @@ export type HeroNameQueryVariables = {
 };
 
 export type HeroNameQuery = { readonly __typename?: 'Query' } & {
-  readonly hero: Maybe<
+  readonly hero?: Maybe<
     | ({ readonly __typename?: 'Human' } & Pick<Human, 'name'>)
     | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'name'>)
   >;
@@ -326,7 +326,7 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 export type HeroNameConditionalInclusionQuery = { readonly __typename?: 'Query' } & {
-  readonly hero: Maybe<
+  readonly hero?: Maybe<
     | ({ readonly __typename?: 'Human' } & Pick<Human, 'name'>)
     | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'name'>)
   >;
@@ -338,7 +338,7 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 export type HeroNameConditionalExclusionQuery = { readonly __typename?: 'Query' } & {
-  readonly hero: Maybe<
+  readonly hero?: Maybe<
     | ({ readonly __typename?: 'Human' } & Pick<Human, 'name'>)
     | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'name'>)
   >;
@@ -349,9 +349,9 @@ export type HeroParentTypeDependentFieldQueryVariables = {
 };
 
 export type HeroParentTypeDependentFieldQuery = { readonly __typename?: 'Query' } & {
-  readonly hero: Maybe<
+  readonly hero?: Maybe<
     | ({ readonly __typename?: 'Human' } & Pick<Human, 'name'> & {
-          readonly friends: Maybe<
+          readonly friends?: Maybe<
             ReadonlyArray<
               Maybe<
                 | ({ readonly __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
@@ -361,7 +361,7 @@ export type HeroParentTypeDependentFieldQuery = { readonly __typename?: 'Query' 
           >;
         })
     | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'name'> & {
-          readonly friends: Maybe<
+          readonly friends?: Maybe<
             ReadonlyArray<
               Maybe<
                 | ({ readonly __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
@@ -378,9 +378,9 @@ export type HeroTypeDependentAliasedFieldQueryVariables = {
 };
 
 export type HeroTypeDependentAliasedFieldQuery = { readonly __typename?: 'Query' } & {
-  readonly hero: Maybe<
-    | ({ readonly __typename?: 'Human' } & { readonly property: Human['homePlanet'] })
-    | ({ readonly __typename?: 'Droid' } & { readonly property: Droid['primaryFunction'] })
+  readonly hero?: Maybe<
+    | ({ readonly __typename?: 'Human' } & { property: Human['homePlanet'] })
+    | ({ readonly __typename?: 'Droid' } & { property: Droid['primaryFunction'] })
   >;
 };
 
@@ -389,17 +389,17 @@ export type HumanFieldsFragment = { readonly __typename?: 'Human' } & Pick<Human
 export type HumanWithNullHeightQueryVariables = {};
 
 export type HumanWithNullHeightQuery = { readonly __typename?: 'Query' } & {
-  readonly human: Maybe<{ readonly __typename?: 'Human' } & HumanFieldsFragment>;
+  readonly human?: Maybe<{ readonly __typename?: 'Human' } & HumanFieldsFragment>;
 };
 
 export type TwoHeroesQueryVariables = {};
 
 export type TwoHeroesQuery = { readonly __typename?: 'Query' } & {
-  readonly r2: Maybe<
+  readonly r2?: Maybe<
     | ({ readonly __typename?: 'Human' } & Pick<Human, 'name'>)
     | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'name'>)
   >;
-  readonly luke: Maybe<
+  readonly luke?: Maybe<
     | ({ readonly __typename?: 'Human' } & Pick<Human, 'name'>)
     | ({ readonly __typename?: 'Droid' } & Pick<Droid, 'name'>)
   >;

--- a/dev-test/star-wars/types.preResolveTypes.ts
+++ b/dev-test/star-wars/types.preResolveTypes.ts
@@ -241,7 +241,7 @@ export type CreateReviewForEpisodeMutationVariables = {
 
 export type CreateReviewForEpisodeMutation = {
   __typename?: 'Mutation';
-  createReview: Maybe<{ __typename?: 'Review'; stars: number; commentary: Maybe<string> }>;
+  createReview?: Maybe<{ __typename?: 'Review'; stars: number; commentary?: Maybe<string> }>;
 };
 
 export type HeroAndFriendsNamesQueryVariables = {
@@ -250,16 +250,16 @@ export type HeroAndFriendsNamesQueryVariables = {
 
 export type HeroAndFriendsNamesQuery = {
   __typename?: 'Query';
-  hero: Maybe<
+  hero?: Maybe<
     | {
         __typename?: 'Human';
         name: string;
-        friends: Maybe<Array<Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>>>;
+        friends?: Maybe<Array<Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>>>;
       }
     | {
         __typename?: 'Droid';
         name: string;
-        friends: Maybe<Array<Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>>>;
+        friends?: Maybe<Array<Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>>>;
       }
   >;
 };
@@ -268,7 +268,7 @@ export type HeroAppearsInQueryVariables = {};
 
 export type HeroAppearsInQuery = {
   __typename?: 'Query';
-  hero: Maybe<
+  hero?: Maybe<
     | { __typename?: 'Human'; name: string; appearsIn: Array<Maybe<Episode>> }
     | { __typename?: 'Droid'; name: string; appearsIn: Array<Maybe<Episode>> }
   >;
@@ -280,15 +280,15 @@ export type HeroDetailsQueryVariables = {
 
 export type HeroDetailsQuery = {
   __typename?: 'Query';
-  hero: Maybe<
-    | { __typename?: 'Human'; height: Maybe<number>; name: string }
-    | { __typename?: 'Droid'; primaryFunction: Maybe<string>; name: string }
+  hero?: Maybe<
+    | { __typename?: 'Human'; height?: Maybe<number>; name: string }
+    | { __typename?: 'Droid'; primaryFunction?: Maybe<string>; name: string }
   >;
 };
 
-type HeroDetails_Human_Fragment = { __typename?: 'Human'; height: Maybe<number>; name: string };
+type HeroDetails_Human_Fragment = { __typename?: 'Human'; height?: Maybe<number>; name: string };
 
-type HeroDetails_Droid_Fragment = { __typename?: 'Droid'; primaryFunction: Maybe<string>; name: string };
+type HeroDetails_Droid_Fragment = { __typename?: 'Droid'; primaryFunction?: Maybe<string>; name: string };
 
 export type HeroDetailsFragment = HeroDetails_Human_Fragment | HeroDetails_Droid_Fragment;
 
@@ -298,7 +298,7 @@ export type HeroDetailsWithFragmentQueryVariables = {
 
 export type HeroDetailsWithFragmentQuery = {
   __typename?: 'Query';
-  hero: Maybe<
+  hero?: Maybe<
     ({ __typename?: 'Human' } & HeroDetails_Human_Fragment) | ({ __typename?: 'Droid' } & HeroDetails_Droid_Fragment)
   >;
 };
@@ -309,7 +309,7 @@ export type HeroNameQueryVariables = {
 
 export type HeroNameQuery = {
   __typename?: 'Query';
-  hero: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
+  hero?: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
 };
 
 export type HeroNameConditionalInclusionQueryVariables = {
@@ -319,7 +319,7 @@ export type HeroNameConditionalInclusionQueryVariables = {
 
 export type HeroNameConditionalInclusionQuery = {
   __typename?: 'Query';
-  hero: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
+  hero?: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
 };
 
 export type HeroNameConditionalExclusionQueryVariables = {
@@ -329,7 +329,7 @@ export type HeroNameConditionalExclusionQueryVariables = {
 
 export type HeroNameConditionalExclusionQuery = {
   __typename?: 'Query';
-  hero: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
+  hero?: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
 };
 
 export type HeroParentTypeDependentFieldQueryVariables = {
@@ -338,14 +338,14 @@ export type HeroParentTypeDependentFieldQueryVariables = {
 
 export type HeroParentTypeDependentFieldQuery = {
   __typename?: 'Query';
-  hero: Maybe<
+  hero?: Maybe<
     | {
         __typename?: 'Human';
         name: string;
-        friends: Maybe<
+        friends?: Maybe<
           Array<
             Maybe<
-              { __typename?: 'Human'; height: Maybe<number>; name: string } | { __typename?: 'Droid'; name: string }
+              { __typename?: 'Human'; height?: Maybe<number>; name: string } | { __typename?: 'Droid'; name: string }
             >
           >
         >;
@@ -353,10 +353,10 @@ export type HeroParentTypeDependentFieldQuery = {
     | {
         __typename?: 'Droid';
         name: string;
-        friends: Maybe<
+        friends?: Maybe<
           Array<
             Maybe<
-              { __typename?: 'Human'; height: Maybe<number>; name: string } | { __typename?: 'Droid'; name: string }
+              { __typename?: 'Human'; height?: Maybe<number>; name: string } | { __typename?: 'Droid'; name: string }
             >
           >
         >;
@@ -370,22 +370,22 @@ export type HeroTypeDependentAliasedFieldQueryVariables = {
 
 export type HeroTypeDependentAliasedFieldQuery = {
   __typename?: 'Query';
-  hero: Maybe<{ __typename?: 'Human'; property: Maybe<string> } | { __typename?: 'Droid'; property: Maybe<string> }>;
+  hero?: Maybe<{ __typename?: 'Human'; property?: Maybe<string> } | { __typename?: 'Droid'; property?: Maybe<string> }>;
 };
 
-export type HumanFieldsFragment = { __typename?: 'Human'; name: string; mass: Maybe<number> };
+export type HumanFieldsFragment = { __typename?: 'Human'; name: string; mass?: Maybe<number> };
 
 export type HumanWithNullHeightQueryVariables = {};
 
 export type HumanWithNullHeightQuery = {
   __typename?: 'Query';
-  human: Maybe<{ __typename?: 'Human' } & HumanFieldsFragment>;
+  human?: Maybe<{ __typename?: 'Human' } & HumanFieldsFragment>;
 };
 
 export type TwoHeroesQueryVariables = {};
 
 export type TwoHeroesQuery = {
   __typename?: 'Query';
-  r2: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
-  luke: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
+  r2?: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
+  luke?: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
 };

--- a/dev-test/star-wars/types.skipSchema.ts
+++ b/dev-test/star-wars/types.skipSchema.ts
@@ -240,7 +240,7 @@ export type CreateReviewForEpisodeMutationVariables = {
 };
 
 export type CreateReviewForEpisodeMutation = { __typename?: 'Mutation' } & {
-  createReview: Maybe<{ __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>>;
+  createReview?: Maybe<{ __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>>;
 };
 
 export type HeroAndFriendsNamesQueryVariables = {
@@ -248,16 +248,16 @@ export type HeroAndFriendsNamesQueryVariables = {
 };
 
 export type HeroAndFriendsNamesQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>
             >
           >;
         })
     | ({ __typename?: 'Droid' } & Pick<Droid, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>
             >
@@ -269,7 +269,7 @@ export type HeroAndFriendsNamesQuery = { __typename?: 'Query' } & {
 export type HeroAppearsInQueryVariables = {};
 
 export type HeroAppearsInQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'name' | 'appearsIn'>)
     | ({ __typename?: 'Droid' } & Pick<Droid, 'name' | 'appearsIn'>)
   >;
@@ -280,7 +280,7 @@ export type HeroDetailsQueryVariables = {
 };
 
 export type HeroDetailsQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
     | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction' | 'name'>)
   >;
@@ -297,7 +297,7 @@ export type HeroDetailsWithFragmentQueryVariables = {
 };
 
 export type HeroDetailsWithFragmentQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     ({ __typename?: 'Human' } & HeroDetails_Human_Fragment) | ({ __typename?: 'Droid' } & HeroDetails_Droid_Fragment)
   >;
 };
@@ -307,7 +307,7 @@ export type HeroNameQueryVariables = {
 };
 
 export type HeroNameQuery = { __typename?: 'Query' } & {
-  hero: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  hero?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };
 
 export type HeroNameConditionalInclusionQueryVariables = {
@@ -316,7 +316,7 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 export type HeroNameConditionalInclusionQuery = { __typename?: 'Query' } & {
-  hero: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  hero?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };
 
 export type HeroNameConditionalExclusionQueryVariables = {
@@ -325,7 +325,7 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 export type HeroNameConditionalExclusionQuery = { __typename?: 'Query' } & {
-  hero: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  hero?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };
 
 export type HeroParentTypeDependentFieldQueryVariables = {
@@ -333,9 +333,9 @@ export type HeroParentTypeDependentFieldQueryVariables = {
 };
 
 export type HeroParentTypeDependentFieldQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<
                 | ({ __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
@@ -345,7 +345,7 @@ export type HeroParentTypeDependentFieldQuery = { __typename?: 'Query' } & {
           >;
         })
     | ({ __typename?: 'Droid' } & Pick<Droid, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<
                 | ({ __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
@@ -362,7 +362,7 @@ export type HeroTypeDependentAliasedFieldQueryVariables = {
 };
 
 export type HeroTypeDependentAliasedFieldQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & { property: Human['homePlanet'] })
     | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })
   >;
@@ -373,12 +373,12 @@ export type HumanFieldsFragment = { __typename?: 'Human' } & Pick<Human, 'name' 
 export type HumanWithNullHeightQueryVariables = {};
 
 export type HumanWithNullHeightQuery = { __typename?: 'Query' } & {
-  human: Maybe<{ __typename?: 'Human' } & HumanFieldsFragment>;
+  human?: Maybe<{ __typename?: 'Human' } & HumanFieldsFragment>;
 };
 
 export type TwoHeroesQueryVariables = {};
 
 export type TwoHeroesQuery = { __typename?: 'Query' } & {
-  r2: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
-  luke: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  r2?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  luke?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };

--- a/dev-test/star-wars/types.ts
+++ b/dev-test/star-wars/types.ts
@@ -240,7 +240,7 @@ export type CreateReviewForEpisodeMutationVariables = {
 };
 
 export type CreateReviewForEpisodeMutation = { __typename?: 'Mutation' } & {
-  createReview: Maybe<{ __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>>;
+  createReview?: Maybe<{ __typename?: 'Review' } & Pick<Review, 'stars' | 'commentary'>>;
 };
 
 export type HeroAndFriendsNamesQueryVariables = {
@@ -248,16 +248,16 @@ export type HeroAndFriendsNamesQueryVariables = {
 };
 
 export type HeroAndFriendsNamesQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>
             >
           >;
         })
     | ({ __typename?: 'Droid' } & Pick<Droid, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>
             >
@@ -269,7 +269,7 @@ export type HeroAndFriendsNamesQuery = { __typename?: 'Query' } & {
 export type HeroAppearsInQueryVariables = {};
 
 export type HeroAppearsInQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'name' | 'appearsIn'>)
     | ({ __typename?: 'Droid' } & Pick<Droid, 'name' | 'appearsIn'>)
   >;
@@ -280,7 +280,7 @@ export type HeroDetailsQueryVariables = {
 };
 
 export type HeroDetailsQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
     | ({ __typename?: 'Droid' } & Pick<Droid, 'primaryFunction' | 'name'>)
   >;
@@ -297,7 +297,7 @@ export type HeroDetailsWithFragmentQueryVariables = {
 };
 
 export type HeroDetailsWithFragmentQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     ({ __typename?: 'Human' } & HeroDetails_Human_Fragment) | ({ __typename?: 'Droid' } & HeroDetails_Droid_Fragment)
   >;
 };
@@ -307,7 +307,7 @@ export type HeroNameQueryVariables = {
 };
 
 export type HeroNameQuery = { __typename?: 'Query' } & {
-  hero: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  hero?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };
 
 export type HeroNameConditionalInclusionQueryVariables = {
@@ -316,7 +316,7 @@ export type HeroNameConditionalInclusionQueryVariables = {
 };
 
 export type HeroNameConditionalInclusionQuery = { __typename?: 'Query' } & {
-  hero: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  hero?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };
 
 export type HeroNameConditionalExclusionQueryVariables = {
@@ -325,7 +325,7 @@ export type HeroNameConditionalExclusionQueryVariables = {
 };
 
 export type HeroNameConditionalExclusionQuery = { __typename?: 'Query' } & {
-  hero: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  hero?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };
 
 export type HeroParentTypeDependentFieldQueryVariables = {
@@ -333,9 +333,9 @@ export type HeroParentTypeDependentFieldQueryVariables = {
 };
 
 export type HeroParentTypeDependentFieldQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & Pick<Human, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<
                 | ({ __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
@@ -345,7 +345,7 @@ export type HeroParentTypeDependentFieldQuery = { __typename?: 'Query' } & {
           >;
         })
     | ({ __typename?: 'Droid' } & Pick<Droid, 'name'> & {
-          friends: Maybe<
+          friends?: Maybe<
             Array<
               Maybe<
                 | ({ __typename?: 'Human' } & Pick<Human, 'height' | 'name'>)
@@ -362,7 +362,7 @@ export type HeroTypeDependentAliasedFieldQueryVariables = {
 };
 
 export type HeroTypeDependentAliasedFieldQuery = { __typename?: 'Query' } & {
-  hero: Maybe<
+  hero?: Maybe<
     | ({ __typename?: 'Human' } & { property: Human['homePlanet'] })
     | ({ __typename?: 'Droid' } & { property: Droid['primaryFunction'] })
   >;
@@ -373,12 +373,12 @@ export type HumanFieldsFragment = { __typename?: 'Human' } & Pick<Human, 'name' 
 export type HumanWithNullHeightQueryVariables = {};
 
 export type HumanWithNullHeightQuery = { __typename?: 'Query' } & {
-  human: Maybe<{ __typename?: 'Human' } & HumanFieldsFragment>;
+  human?: Maybe<{ __typename?: 'Human' } & HumanFieldsFragment>;
 };
 
 export type TwoHeroesQueryVariables = {};
 
 export type TwoHeroesQuery = { __typename?: 'Query' } & {
-  r2: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
-  luke: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  r2?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
+  luke?: Maybe<({ __typename?: 'Human' } & Pick<Human, 'name'>) | ({ __typename?: 'Droid' } & Pick<Droid, 'name'>)>;
 };

--- a/dev-test/test-message/types.tsx
+++ b/dev-test/test-message/types.tsx
@@ -59,7 +59,7 @@ export type GetMessagesQueryVariables = {
 };
 
 export type GetMessagesQuery = { __typename?: 'Query' } & {
-  messages: Maybe<Array<Maybe<{ __typename?: 'Message' } & Pick<Message, 'id'>>>>;
+  messages?: Maybe<Array<Maybe<{ __typename?: 'Message' } & Pick<Message, 'id'>>>>;
 };
 
 export type CreateMessageMutationVariables = {
@@ -67,7 +67,7 @@ export type CreateMessageMutationVariables = {
 };
 
 export type CreateMessageMutation = { __typename?: 'Mutation' } & {
-  createMessage: Maybe<{ __typename?: 'Message' } & Pick<Message, 'id'>>;
+  createMessage?: Maybe<{ __typename?: 'Message' } & Pick<Message, 'id'>>;
 };
 
 export type DeclineMutationVariables = {
@@ -76,7 +76,7 @@ export type DeclineMutationVariables = {
 };
 
 export type DeclineMutation = { __typename?: 'Mutation' } & {
-  decline: Maybe<{ __typename?: 'Message' } & Pick<Message, 'id'>>;
+  decline?: Maybe<{ __typename?: 'Message' } & Pick<Message, 'id'>>;
 };
 
 export type ApproveMutationVariables = {
@@ -84,7 +84,7 @@ export type ApproveMutationVariables = {
 };
 
 export type ApproveMutation = { __typename?: 'Mutation' } & {
-  approve: Maybe<{ __typename?: 'Message' } & Pick<Message, 'id'>>;
+  approve?: Maybe<{ __typename?: 'Message' } & Pick<Message, 'id'>>;
 };
 
 export type EscalateMutationVariables = {
@@ -92,7 +92,7 @@ export type EscalateMutationVariables = {
 };
 
 export type EscalateMutation = { __typename?: 'Mutation' } & {
-  escalate: Maybe<{ __typename?: 'Message' } & Pick<Message, 'id'>>;
+  escalate?: Maybe<{ __typename?: 'Message' } & Pick<Message, 'id'>>;
 };
 
 /**

--- a/dev-test/test-schema/types.preResolveTypes.ts
+++ b/dev-test/test-schema/types.preResolveTypes.ts
@@ -37,7 +37,7 @@ export type TestQueryVariables = {};
 
 export type TestQuery = {
   __typename?: 'Query';
-  testArr1: Maybe<Array<Maybe<string>>>;
+  testArr1?: Maybe<Array<Maybe<string>>>;
   testArr2: Array<Maybe<string>>;
   testArr3: Array<string>;
 };

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/base.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/base.ts
@@ -1,5 +1,5 @@
 import { ScalarsMap, ConvertNameFn } from '../types';
-import { GraphQLObjectType, GraphQLInterfaceType, GraphQLNonNull, GraphQLList } from 'graphql';
+import { GraphQLObjectType, GraphQLInterfaceType, GraphQLOutputType } from 'graphql';
 
 export type PrimitiveField = string;
 export type PrimitiveAliasedFields = { alias: string; fieldName: string };
@@ -12,11 +12,8 @@ export type SelectionSetProcessorConfig = {
   convertName: ConvertNameFn<any>;
   enumPrefix: boolean | null;
   scalars: ScalarsMap;
-  formatNamedField: (name: string) => string;
-  wrapTypeWithModifiers: (
-    baseType: string,
-    type: GraphQLObjectType | GraphQLNonNull<GraphQLObjectType> | GraphQLList<GraphQLObjectType>
-  ) => string;
+  formatNamedField(name: string, type?: GraphQLOutputType | null): string;
+  wrapTypeWithModifiers(baseType: string, type: GraphQLOutputType): string;
 };
 
 export class BaseSelectionSetProcessor<Config extends SelectionSetProcessorConfig> {

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/pre-resolve-types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/pre-resolve-types.ts
@@ -40,10 +40,11 @@ export class PreResolveTypesProcessor extends BaseSelectionSetProcessor<Selectio
         typeToUse = this.config.scalars[baseType.name];
       }
 
-      const wrappedType = this.config.wrapTypeWithModifiers(typeToUse, fieldObj.type as GraphQLObjectType);
+      const name = this.config.formatNamedField(field, fieldObj.type);
+      const wrappedType = this.config.wrapTypeWithModifiers(typeToUse, fieldObj.type);
 
       return {
-        name: this.config.formatNamedField(field),
+        name,
         type: wrappedType,
       };
     });
@@ -58,9 +59,8 @@ export class PreResolveTypesProcessor extends BaseSelectionSetProcessor<Selectio
     }
 
     return fields.map(aliasedField => {
-      const name = this.config.formatNamedField(aliasedField.alias);
-
       if (aliasedField.fieldName === '__typename') {
+        const name = this.config.formatNamedField(aliasedField.alias, null);
         return {
           name,
           type: `'${schemaType.name}'`,
@@ -76,7 +76,8 @@ export class PreResolveTypesProcessor extends BaseSelectionSetProcessor<Selectio
             this.config.convertName(baseType.name, { useTypesPrefix: this.config.enumPrefix });
         }
 
-        const wrappedType = this.config.wrapTypeWithModifiers(typeToUse, fieldObj.type as GraphQLObjectType);
+        const name = this.config.formatNamedField(aliasedField.alias, fieldObj.type);
+        const wrappedType = this.config.wrapTypeWithModifiers(typeToUse, fieldObj.type);
 
         return {
           name,
@@ -92,7 +93,7 @@ export class PreResolveTypesProcessor extends BaseSelectionSetProcessor<Selectio
     }
 
     return fields.map(field => ({
-      name: this.config.formatNamedField(field.alias || field.name),
+      name: field.alias || field.name,
       type: field.selectionSet,
     }));
   }

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -362,15 +362,15 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       const selectionSet = this.createNext(realSelectedFieldType, field.selectionSet);
 
       linkFields.push({
-        alias: field.alias ? field.alias.value : undefined,
-        name: field.name.value,
+        alias: field.alias ? this._processor.config.formatNamedField(field.alias.value, selectedFieldType) : undefined,
+        name: this._processor.config.formatNamedField(field.name.value, selectedFieldType),
         type: realSelectedFieldType.name,
         selectionSet: this._processor.config.wrapTypeWithModifiers(
           selectionSet
             .transformSelectionSet()
             .split(`\n`)
             .join(`\n  `),
-          selectedFieldType as any
+          selectedFieldType
         ),
       });
     }

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -178,12 +178,12 @@ export type FeedQueryVariables = {};
 
 export type FeedQuery = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id' | 'commentCount'>
     & { repository: (
       { __typename?: 'Repository' }
-      & { owner: Maybe<(
+      & { owner?: Maybe<(
         { __typename?: 'User' }
         & Pick<User, 'avatar_url'>
       )> }
@@ -198,7 +198,7 @@ export type Feed2QueryVariables = {
 
 export type Feed2Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -211,7 +211,7 @@ export type Feed3QueryVariables = {
 
 export type Feed3Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -224,7 +224,7 @@ export type Feed4QueryVariables = {
 
 export type Feed4Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -475,12 +475,12 @@ export type FeedQueryVariables = {};
 
 export type FeedQuery = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id' | 'commentCount'>
     & { repository: (
       { __typename?: 'Repository' }
-      & { owner: Maybe<(
+      & { owner?: Maybe<(
         { __typename?: 'User' }
         & Pick<User, 'avatar_url'>
       )> }
@@ -495,7 +495,7 @@ export type Feed2QueryVariables = {
 
 export type Feed2Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -508,7 +508,7 @@ export type Feed3QueryVariables = {
 
 export type Feed3Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -521,7 +521,7 @@ export type Feed4QueryVariables = {
 
 export type Feed4Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -178,12 +178,12 @@ export type FeedQueryVariables = {};
 
 export type FeedQuery = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id' | 'commentCount'>
     & { repository: (
       { __typename?: 'Repository' }
-      & { owner: Maybe<(
+      & { owner?: Maybe<(
         { __typename?: 'User' }
         & Pick<User, 'avatar_url'>
       )> }
@@ -198,7 +198,7 @@ export type Feed2QueryVariables = {
 
 export type Feed2Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -211,7 +211,7 @@ export type Feed3QueryVariables = {
 
 export type Feed3Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -224,7 +224,7 @@ export type Feed4QueryVariables = {
 
 export type Feed4Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -495,12 +495,12 @@ export type FeedQueryVariables = {};
 
 export type FeedQuery = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id' | 'commentCount'>
     & { repository: (
       { __typename?: 'Repository' }
-      & { owner: Maybe<(
+      & { owner?: Maybe<(
         { __typename?: 'User' }
         & Pick<User, 'avatar_url'>
       )> }
@@ -515,7 +515,7 @@ export type Feed2QueryVariables = {
 
 export type Feed2Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -528,7 +528,7 @@ export type Feed3QueryVariables = {
 
 export type Feed3Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -541,7 +541,7 @@ export type Feed4QueryVariables = {
 
 export type Feed4Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -793,12 +793,12 @@ export type FeedQueryVariables = {};
 
 export type FeedQuery = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id' | 'commentCount'>
     & { repository: (
       { __typename?: 'Repository' }
-      & { owner: Maybe<(
+      & { owner?: Maybe<(
         { __typename?: 'User' }
         & Pick<User, 'avatar_url'>
       )> }
@@ -813,7 +813,7 @@ export type Feed2QueryVariables = {
 
 export type Feed2Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -826,7 +826,7 @@ export type Feed3QueryVariables = {
 
 export type Feed3Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }
@@ -839,7 +839,7 @@ export type Feed4QueryVariables = {
 
 export type Feed4Query = (
   { __typename?: 'Query' }
-  & { feed: Maybe<Array<Maybe<(
+  & { feed?: Maybe<Array<Maybe<(
     { __typename?: 'Entry' }
     & Pick<Entry, 'id'>
   )>>> }

--- a/packages/plugins/typescript/operations/src/ts-selection-set-processor.ts
+++ b/packages/plugins/typescript/operations/src/ts-selection-set-processor.ts
@@ -52,7 +52,7 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
               ? `'${schemaType.name}'`
               : `${parentName}['${aliasedField.fieldName}']`;
 
-          return `${this.config.formatNamedField(aliasedField.alias)}: ${value}`;
+          return `${aliasedField.alias}: ${value}`;
         })
         .join(', ')} }`,
     ];
@@ -63,10 +63,6 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
       return [];
     }
 
-    return [
-      `{ ${fields
-        .map(field => `${this.config.formatNamedField(field.alias || field.name)}: ${field.selectionSet}`)
-        .join(', ')} }`,
-    ];
+    return [`{ ${fields.map(field => `${field.alias || field.name}: ${field.selectionSet}`).join(', ')} }`];
   }
 }

--- a/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
+++ b/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
@@ -34,7 +34,7 @@ export type GetEntityBrandDataQuery = (
 
 type EntityBrandData_User_Fragment = (
   { __typename?: 'User' }
-  & { brandData: Maybe<(
+  & { brandData?: Maybe<(
     { __typename?: 'EntityBrandData' }
     & Pick<EntityBrandData, 'active' | 'browsable' | 'title' | 'alternateTitle' | 'description'>
   )> }
@@ -42,7 +42,7 @@ type EntityBrandData_User_Fragment = (
 
 type EntityBrandData_Company_Fragment = (
   { __typename?: 'Company' }
-  & { brandData: Maybe<(
+  & { brandData?: Maybe<(
     { __typename?: 'EntityBrandData' }
     & Pick<EntityBrandData, 'active' | 'browsable' | 'title' | 'alternateTitle' | 'description'>
   )> }
@@ -50,7 +50,7 @@ type EntityBrandData_Company_Fragment = (
 
 type EntityBrandData_Theater_Fragment = (
   { __typename?: 'Theater' }
-  & { brandData: Maybe<(
+  & { brandData?: Maybe<(
     { __typename?: 'EntityBrandData' }
     & Pick<EntityBrandData, 'active' | 'browsable' | 'title' | 'alternateTitle' | 'description'>
   )> }
@@ -58,7 +58,7 @@ type EntityBrandData_Theater_Fragment = (
 
 type EntityBrandData_Movie_Fragment = (
   { __typename?: 'Movie' }
-  & { brandData: Maybe<(
+  & { brandData?: Maybe<(
     { __typename?: 'EntityBrandData' }
     & Pick<EntityBrandData, 'active' | 'browsable' | 'title' | 'alternateTitle' | 'description'>
   )> }
@@ -69,10 +69,10 @@ export type EntityBrandDataFragment = EntityBrandData_User_Fragment | EntityBran
 type ElementMetadata_User_Fragment = (
   { __typename?: 'User' }
   & Pick<User, 'createdAt' | 'updatedAt'>
-  & { createdBy: Maybe<(
+  & { createdBy?: Maybe<(
     { __typename?: 'User' }
     & Pick<User, 'id' | 'name'>
-  )>, updatedBy: Maybe<(
+  )>, updatedBy?: Maybe<(
     { __typename?: 'User' }
     & Pick<User, 'id' | 'name'>
   )> }
@@ -81,10 +81,10 @@ type ElementMetadata_User_Fragment = (
 type ElementMetadata_Company_Fragment = (
   { __typename?: 'Company' }
   & Pick<Company, 'createdAt' | 'updatedAt'>
-  & { createdBy: Maybe<(
+  & { createdBy?: Maybe<(
     { __typename?: 'User' }
     & Pick<User, 'id' | 'name'>
-  )>, updatedBy: Maybe<(
+  )>, updatedBy?: Maybe<(
     { __typename?: 'User' }
     & Pick<User, 'id' | 'name'>
   )> }
@@ -93,10 +93,10 @@ type ElementMetadata_Company_Fragment = (
 type ElementMetadata_Theater_Fragment = (
   { __typename?: 'Theater' }
   & Pick<Theater, 'createdAt' | 'updatedAt'>
-  & { createdBy: Maybe<(
+  & { createdBy?: Maybe<(
     { __typename?: 'User' }
     & Pick<User, 'id' | 'name'>
-  )>, updatedBy: Maybe<(
+  )>, updatedBy?: Maybe<(
     { __typename?: 'User' }
     & Pick<User, 'id' | 'name'>
   )> }
@@ -105,10 +105,10 @@ type ElementMetadata_Theater_Fragment = (
 type ElementMetadata_Movie_Fragment = (
   { __typename?: 'Movie' }
   & Pick<Movie, 'createdAt' | 'updatedAt'>
-  & { createdBy: Maybe<(
+  & { createdBy?: Maybe<(
     { __typename?: 'User' }
     & Pick<User, 'id' | 'name'>
-  )>, updatedBy: Maybe<(
+  )>, updatedBy?: Maybe<(
     { __typename?: 'User' }
     & Pick<User, 'id' | 'name'>
   )> }

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -224,7 +224,7 @@ describe('TypeScript Operations Plugin', () => {
       });
 
       expect(result).toBeSimilarStringTo(
-        `export type TestQuery = { __typename?: 'Query', f: Types.Maybe<Types.E>, user: { __typename?: 'User', id: string, f: Types.Maybe<Types.E>, j: Types.Maybe<any> } };`
+        `export type TestQuery = { __typename?: 'Query', f?: Types.Maybe<Types.E>, user: { __typename?: 'User', id: string, f?: Types.Maybe<Types.E>, j?: Types.Maybe<any> } };`
       );
 
       await validate(result, config);
@@ -795,7 +795,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
       export type TestQuery = (
         { __typename?: 'Query' }
-        & { some: Maybe<(
+        & { some?: Maybe<(
           { __typename?: 'A' }
           & Node_A_Fragment
         ) | (
@@ -836,7 +836,7 @@ describe('TypeScript Operations Plugin', () => {
       const config = { preResolveTypes: true };
       const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
-      export type Unnamed_1_Query = { __typename?: 'Query', dummy: Maybe<string>, type: 'Query' };
+      export type Unnamed_1_Query = { __typename?: 'Query', dummy?: Maybe<string>, type: 'Query' };
       `);
       await validate(result, config);
     });
@@ -931,7 +931,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
         export type UnionTestQuery = (
           { __typename?: 'Query' } 
-          & { unionTest: Maybe<(
+          & { unionTest?: Maybe<(
             { __typename?: 'User' }
             & Pick<User, 'id'>
           ) | (
@@ -1030,7 +1030,7 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
       { __typename?: 'Query' }
-      & { unionTest: Maybe<(
+      & { unionTest?: Maybe<(
         { __typename: 'User' }
         & Pick<User, 'email'>
       ) | (
@@ -1473,7 +1473,7 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
-        export type MeQuery = { me: Maybe<UserFieldsFragment> };
+        export type MeQuery = { me?: Maybe<UserFieldsFragment> };
       `);
       await validate(result, config);
     });
@@ -1498,7 +1498,7 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-      export type MeQuery = { me: Maybe<(
+      export type MeQuery = { me?: Maybe<(
         Pick<User, 'username'>
         & UserFieldsFragment
       )> };
@@ -1532,7 +1532,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
       export type MeQuery = (
         { __typename?: 'Query' }
-        & { me: Maybe<(
+        & { me?: Maybe<(
           { __typename?: 'User' }
           & Pick<User, 'username'>
           & UserFieldsFragment
@@ -1543,7 +1543,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
         export type UserProfileFragment = (
           { __typename?: 'User' }
-          & { profile: Maybe<(
+          & { profile?: Maybe<(
             { __typename?: 'Profile' }
             & Pick<Profile, 'age'>
           )> }
@@ -1603,7 +1603,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
       export type Unnamed_1_Query = (
         { __typename?: 'Query' }
-        & { b: Maybe<(
+        & { b?: Maybe<(
           { __typename?: 'A' }
           & AFragment
         ) | (
@@ -1726,7 +1726,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
       export type Unnamed_1_Query = (
         { __typename?: 'Query' }
-        & { b: Maybe<(
+        & { b?: Maybe<(
           { __typename?: 'A' }
           & AFragment
           & BFragment
@@ -1807,7 +1807,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
         export type UnionTestQuery = (
           { __typename?: 'Query' }
-            & { unionTest: Maybe<(
+            & { unionTest?: Maybe<(
             { __typename?: 'User' }
             & Pick<User, 'id'>
           ) | (
@@ -1915,9 +1915,9 @@ describe('TypeScript Operations Plugin', () => {
       const config = { skipTypename: true };
       const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = { me: Maybe<(
+        export type CurrentUserQuery = { me?: Maybe<(
             Pick<User, 'username' | 'id'>
-            & { profile: Maybe<Pick<Profile, 'age'>> }
+            & { profile?: Maybe<Pick<Profile, 'age'>> }
         )> };
       `);
 
@@ -1952,7 +1952,7 @@ describe('TypeScript Operations Plugin', () => {
         };`
       );
       expect(result).toBeSimilarStringTo(`
-        export type MeQuery = { currentUser: Maybe<Pick<User, 'login' | 'html_url'>>, entry: Maybe<(
+        export type MeQuery = { currentUser?: Maybe<Pick<User, 'login' | 'html_url'>>, entry?: Maybe<(
           Pick<Entry, 'id' | 'createdAt'>
           & { postedBy: Pick<User, 'login' | 'html_url'> }
         )> };
@@ -1983,7 +1983,7 @@ describe('TypeScript Operations Plugin', () => {
       });
 
       expect(result).toBeSimilarStringTo(`
-        export type MeQuery = { __typename?: 'Query', currentUser: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, postedBy: { __typename?: 'User', login: string, html_url: string } }> };
+        export type MeQuery = { __typename?: 'Query', currentUser?: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry?: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, postedBy: { __typename?: 'User', login: string, html_url: string } }> };
       `);
       await validate(result, config, gitHuntSchema);
     });
@@ -2114,7 +2114,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
         export type DummyQuery = (
           { customName: Query['dummy'] }
-          & { customName2: Maybe<Pick<Profile, 'age'>> }
+          & { customName2?: Maybe<Pick<Profile, 'age'>> }
         );
       `);
       await validate(result, config);
@@ -2137,9 +2137,9 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type CurrentUserQuery = { me: Maybe<(
+        export type CurrentUserQuery = { me?: Maybe<(
           Pick<User, 'id' | 'username' | 'role'>
-          & { profile: Maybe<Pick<Profile, 'age'>> }
+          & { profile?: Maybe<Pick<Profile, 'age'>> }
         )> };
       `);
       await validate(result, config);
@@ -2163,7 +2163,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
         export type UserFieldsFragment = (
           Pick<User, 'id' | 'username'>
-          & { profile: Maybe<Pick<Profile, 'age'>> }
+          & { profile?: Maybe<Pick<Profile, 'age'>> }
         );
       `);
       await validate(result, config);
@@ -2187,9 +2187,9 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type LoginMutation = { login: Maybe<(
+        export type LoginMutation = { login?: Maybe<(
           Pick<User, 'id' | 'username'>
-          & { profile: Maybe<Pick<Profile, 'age'>> }
+          & { profile?: Maybe<Pick<Profile, 'age'>> }
         )> };
       `);
       await validate(result, config);
@@ -2222,7 +2222,7 @@ describe('TypeScript Operations Plugin', () => {
       const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`
-        export type TestSubscription = { userCreated: Maybe<Pick<User, 'id'>> };
+        export type TestSubscription = { userCreated?: Maybe<Pick<User, 'id'>> };
       `);
       await validate(result, config);
     });
@@ -2415,7 +2415,7 @@ describe('TypeScript Operations Plugin', () => {
             { __typename?: '__Schema' }
             & { queryType: (
               { __typename?: '__Type' }
-              & { fields: Maybe<Array<(
+              & { fields?: Maybe<Array<(
                 { __typename?: '__Field' }
                 & Pick<__Field, 'name'>
               )>> }
@@ -2460,10 +2460,10 @@ describe('TypeScript Operations Plugin', () => {
       expect(content).toBeSimilarStringTo(`
         export type InfoQuery = (
           { __typename?: 'Query' }
-          & { __type: Maybe<(
+          & { __type?: Maybe<(
             { __typename?: '__Type' }
             & Pick<__Type, 'name'>
-            & { fields: Maybe<Array<(
+            & { fields?: Maybe<Array<(
               { __typename?: '__Field' }
               & Pick<__Field, 'name'>
               & { type: (
@@ -2587,7 +2587,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(content).toBeSimilarStringTo(`
         export type PREFIX_UsersQuery = (
           { __typename?: 'Query' }
-          & { users: Maybe<Array<Maybe<(
+          & { users?: Maybe<Array<Maybe<(
             { __typename?: 'User' }
             & Pick<PREFIX_User, 'access'>
           )>>> }
@@ -2826,7 +2826,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(content).toBeSimilarStringTo(`
         export type SomethingQuery = (
           { __typename?: 'Query' }
-          & { node: Maybe<(
+          & { node?: Maybe<(
             { __typename?: 'A' }
             & Pick<A, 'a'>
           ) | (
@@ -2896,7 +2896,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(content).toBeSimilarStringTo(`
         export type UserQuery = (
           { __typename?: 'Query' }
-          & { user: Maybe<(
+          & { user?: Maybe<(
             { __typename?: 'User' }
             & Pick<User, 'id' | 'login'>
           ) | (
@@ -2905,7 +2905,7 @@ describe('TypeScript Operations Plugin', () => {
           ) | (
             { __typename?: 'Error3' }
             & Pick<Error3, 'message'>
-            & { info: Maybe<(
+            & { info?: Maybe<(
               { __typename?: 'AdditionalInfo' }
               & Pick<AdditionalInfo, 'message'>
             )> }
@@ -2989,7 +2989,7 @@ describe('TypeScript Operations Plugin', () => {
       expect(content).toBeSimilarStringTo(`
         export type UserQuery = (
           { __typename?: 'Query' } 
-          & { user: Maybe<(
+          & { user?: Maybe<(
             { __typename?: 'User' }
             & Pick<User, 'id' | 'login'>
           ) | (
@@ -2998,7 +2998,7 @@ describe('TypeScript Operations Plugin', () => {
           ) | (
             { __typename?: 'Error3' }
             & Pick<Error3, 'message'>
-            & { info: Maybe<(
+            & { info?: Maybe<(
                 { __typename?: 'AdditionalInfo' }
                 & Pick<AdditionalInfo, 'message' | 'message2'>
               )> }
@@ -3231,7 +3231,7 @@ describe('TypeScript Operations Plugin', () => {
         ) | (
           { __typename?: 'Error3' }
           & Pick<Error3, 'message'>
-          & { info: Maybe<(
+          & { info?: Maybe<(
             { __typename?: 'AdditionalInfo' }
             & AdditionalInfoFragment
           )> }
@@ -3255,7 +3255,7 @@ describe('TypeScript Operations Plugin', () => {
   
       type UserResult1_Error3_Fragment = (
         { __typename?: 'Error3' }
-        & { info: Maybe<(
+        & { info?: Maybe<(
           { __typename?: 'AdditionalInfo' }
           & Pick<AdditionalInfo, 'message2'>
         )> }
@@ -3395,7 +3395,7 @@ describe('TypeScript Operations Plugin', () => {
         ) | (
           { __typename?: 'Error3' }
           & Pick<Error3, 'message'>
-          & { info: Maybe<(
+          & { info?: Maybe<(
             { __typename?: 'AdditionalInfo' }
             & Pick<AdditionalInfo, 'message2' | 'message'>
           )> }
@@ -3528,7 +3528,7 @@ describe('TypeScript Operations Plugin', () => {
         ) | (
           { __typename?: 'Error3' }
           & Pick<Error3, 'message'>
-          & { info: Maybe<(
+          & { info?: Maybe<(
             { __typename?: 'AdditionalInfo' }
             & Pick<AdditionalInfo, 'message2' | 'message'>
           )> }
@@ -3976,7 +3976,7 @@ function test(q: GetEntityBrandDataQuery): void {
       expect(content).toBeSimilarStringTo(`
       export type UserQuery = (
         { __typename?: 'Query' }
-        & { user: Maybe<(
+        & { user?: Maybe<(
           { __typename?: 'User' }
           & Pick<User, 'name'>
         )> }

--- a/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
+++ b/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
@@ -169,7 +169,7 @@ export enum VoteType {
 export type GetSomethingQueryVariables = {};
 
 
-export type GetSomethingQuery = { feed: Maybe<Array<Maybe<Pick<Entry, 'id'>>>> };
+export type GetSomethingQuery = { feed?: Maybe<Array<Maybe<Pick<Entry, 'id'>>>> };
 
 export const GetSomethingDocument = gql\`
     query GET_SOMETHING {


### PR DESCRIPTION
Fix for #3638
Related #3463 #3060 #2590

This MR makes all nullable fields be optional (for typescript and flow), if `avoidOptionals` option is not true. 

There is an inconsistency between the top-level types and the query types. Example from `dev-test`: 
https://github.com/dotansimha/graphql-code-generator/blob/master/dev-test/githunt/types.preResolveTypes.ts
```ts
// This is the top-level type and description is optional
export type Repository = {
  __typename?: 'Repository';
  /** Just the name of the repository, e.g. GitHunt-API */
  name: Scalars['String'];
  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
  full_name: Scalars['String'];
  /** The description of the repository */
  description?: Maybe<Scalars['String']>;
  /** The link to the repository on GitHub */
  html_url: Scalars['String'];
  /** The number of people who have starred this repository on GitHub */
  stargazers_count: Scalars['Int'];
  /** The number of open issues on this repository on GitHub */
  open_issues_count?: Maybe<Scalars['Int']>;
  /** The owner of this repository on GitHub, e.g. apollostack */
  owner?: Maybe<User>;
};

// This is query type, and description is mandatory now
export type CommentQuery = {
    repository: {
      __typename?: 'Repository';
      description: Maybe<string>;
      open_issues_count: Maybe<number>;
      stargazers_count: number;
      full_name: string;
      html_url: string;
    };
  }>;
};
```

Same bug for `preresolveTypes: false`
Example from https://github.com/dotansimha/graphql-code-generator/blob/master/dev-test/githunt/types.ts
```ts
// This is top-level type
export type Query = {
  /** Return the currently logged in user, or null if nobody is logged in */
  currentUser?: Maybe<User>;
};

// This is query type, notice currentUser become mandatory
export type CommentQuery = { __typename?: 'Query' } & {
  currentUser: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
}
```

My fix is actually easy. There are two methods: `formatNamedField` and `wrapTypeWithModifiers`, they should be applied always together, and `formatNamedField` should add optional mark when it needed (line [53](https://github.com/dotansimha/graphql-code-generator/pull/3639/commits/ea69ed97042a34ac9c34bb65ad0baf2e63f99258#diff-b05502b152b19c27071a4c3bffb8d02fR54))