### PR TITLE
Pass documents to document node visitor

### DIFF
--- a/packages/plugins/typescript/document-nodes/src/index.ts
+++ b/packages/plugins/typescript/document-nodes/src/index.ts
@@ -105,7 +105,7 @@ export const plugin: PluginFunction<TypeScriptDocumentNodesRawPluginConfig> = (
     ...(config.externalFragments || []),
   ];
 
-  const visitor = new TypeScriptDocumentNodesVisitor(schema, allFragments, config);
+  const visitor = new TypeScriptDocumentNodesVisitor(schema, allFragments, config, documents);
   const visitorResult = visit(allAst, { leave: visitor });
 
   return {

--- a/packages/plugins/typescript/document-nodes/src/visitor.ts
+++ b/packages/plugins/typescript/document-nodes/src/visitor.ts
@@ -1,5 +1,6 @@
 import { TypeScriptDocumentNodesRawPluginConfig } from '.';
 import autoBind from 'auto-bind';
+import { Types } from '@graphql-codegen/plugin-helpers';
 import {
   getConfigValue,
   LoadedFragment,
@@ -18,14 +19,19 @@ export class TypeScriptDocumentNodesVisitor extends ClientSideBaseVisitor<
   TypeScriptDocumentNodesRawPluginConfig,
   TypeScriptDocumentNodesPluginConfig
 > {
-  constructor(schema: GraphQLSchema, fragments: LoadedFragment[], rawConfig: TypeScriptDocumentNodesRawPluginConfig) {
-    super(schema, fragments, rawConfig, {
+  constructor(
+    schema: GraphQLSchema,
+    fragments: LoadedFragment[],
+    rawConfig: TypeScriptDocumentNodesRawPluginConfig,
+    documents: Types.DocumentFile[]
+  ) {
+    const additionalConfig = {
       documentVariablePrefix: getConfigValue(rawConfig.namePrefix, ''),
       documentVariableSuffix: getConfigValue(rawConfig.nameSuffix, ''),
       fragmentVariablePrefix: getConfigValue(rawConfig.fragmentPrefix, ''),
       fragmentVariableSuffix: getConfigValue(rawConfig.fragmentSuffix, ''),
-    });
-
+    };
+    super(schema, fragments, rawConfig, additionalConfig, documents);
     autoBind(this);
   }
 }


### PR DESCRIPTION
Fixes `TypeError: Cannot read property 'length' of undefined` when using `importDocumentNodeExternallyFrom: near-operation-file`.