### PR TITLE
Added 'field' flag to avoidOptionals

### DIFF
--- a/docs/generated-config/typescript-operations.md
+++ b/docs/generated-config/typescript-operations.md
@@ -25,6 +25,7 @@ path/to/file.ts:
    - typescript
  config:
    avoidOptionals:
+     field: true
      inputValue: true
      object: true
 ```

--- a/docs/generated-config/typescript.md
+++ b/docs/generated-config/typescript.md
@@ -24,6 +24,7 @@ path/to/file.ts:
    - typescript
  config:
    avoidOptionals:
+     field: true
      inputValue: true
      object: true
 ```

--- a/packages/plugins/other/visitor-plugin-common/src/avoid-optionals.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/avoid-optionals.ts
@@ -1,8 +1,9 @@
 import { AvoidOptionalsConfig } from './types';
 
-export const DEFAULT_AVIOD_OPTIONALS: AvoidOptionalsConfig = {
+export const DEFAULT_AVOID_OPTIONALS: AvoidOptionalsConfig = {
   object: false,
   inputValue: false,
+  field: false,
 };
 
 export function normalizeAvoidOptionals(avoidOptionals?: boolean | AvoidOptionalsConfig): AvoidOptionalsConfig {
@@ -10,11 +11,12 @@ export function normalizeAvoidOptionals(avoidOptionals?: boolean | AvoidOptional
     return {
       object: avoidOptionals,
       inputValue: avoidOptionals,
+      field: avoidOptionals,
     };
   }
 
   return {
-    ...DEFAULT_AVIOD_OPTIONALS,
+    ...DEFAULT_AVOID_OPTIONALS,
     ...avoidOptionals,
   };
 }

--- a/packages/plugins/other/visitor-plugin-common/src/index.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/index.ts
@@ -5,6 +5,7 @@ export * from './naming';
 export * from './scalars';
 export * from './enum-values';
 export * from './declaration-kinds';
+export * from './avoid-optionals';
 
 export * from './base-visitor';
 export * from './base-types-visitor';

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -53,3 +53,9 @@ export interface DeclarationKindConfig {
   interface?: DeclarationKind;
   arguments?: DeclarationKind;
 }
+
+export interface AvoidOptionalsConfig {
+  field?: boolean;
+  object?: boolean;
+  inputValue?: boolean;
+}

--- a/packages/plugins/typescript/operations/src/config.ts
+++ b/packages/plugins/typescript/operations/src/config.ts
@@ -1,5 +1,4 @@
-import { RawDocumentsConfig } from '@graphql-codegen/visitor-plugin-common';
-import { AvoidOptionalsConfig } from '@graphql-codegen/typescript';
+import { RawDocumentsConfig, AvoidOptionalsConfig } from '@graphql-codegen/visitor-plugin-common';
 
 export interface TypeScriptDocumentsPluginConfig extends RawDocumentsConfig {
   /**
@@ -29,6 +28,7 @@ export interface TypeScriptDocumentsPluginConfig extends RawDocumentsConfig {
    *    - typescript
    *  config:
    *    avoidOptionals:
+   *      field: true
    *      inputValue: true
    *      object: true
    * ```

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -9,6 +9,8 @@ import {
   SelectionSetProcessorConfig,
   SelectionSetToObject,
   DeclarationKind,
+  normalizeAvoidOptionals,
+  AvoidOptionalsConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptOperationVariablesToObject } from './ts-operation-variables-to-object';
 import { TypeScriptDocumentsPluginConfig } from './config';
@@ -17,7 +19,7 @@ import { TypeScriptSelectionSetProcessor } from './ts-selection-set-processor';
 import autoBind from 'auto-bind';
 
 export interface TypeScriptDocumentsParsedConfig extends ParsedDocumentsConfig {
-  avoidOptionals: boolean;
+  avoidOptionals: AvoidOptionalsConfig;
   immutableTypes: boolean;
   noExport: boolean;
 }
@@ -31,8 +33,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
       config,
       {
         noExport: getConfigValue(config.noExport, false),
-        avoidOptionals:
-          typeof config.avoidOptionals === 'boolean' ? getConfigValue(config.avoidOptionals, false) : false,
+        avoidOptionals: normalizeAvoidOptionals(getConfigValue(config.avoidOptionals, false)),
         immutableTypes: getConfigValue(config.immutableTypes, false),
         nonOptionalTypename: getConfigValue(config.nonOptionalTypename, false),
       } as TypeScriptDocumentsParsedConfig,
@@ -51,7 +52,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
     };
 
     const formatNamedField = (name: string, type: GraphQLOutputType | null): string => {
-      const optional = !this.config.avoidOptionals && !!type && !isNonNullType(type);
+      const optional = !this.config.avoidOptionals.field && !!type && !isNonNullType(type);
       return (this.config.immutableTypes ? `readonly ${name}` : name) + (optional ? '?' : '');
     };
 
@@ -84,7 +85,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
       new TypeScriptOperationVariablesToObject(
         this.scalars,
         this.convertName.bind(this),
-        this.config.avoidOptionals,
+        this.config.avoidOptionals.object,
         this.config.immutableTypes,
         this.config.namespacedImportName,
         enumsNames,

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -1,4 +1,9 @@
-import { transformComment, indent, DeclarationBlock } from '@graphql-codegen/visitor-plugin-common';
+import {
+  transformComment,
+  indent,
+  DeclarationBlock,
+  AvoidOptionalsConfig,
+} from '@graphql-codegen/visitor-plugin-common';
 import { TypeGraphQLPluginConfig } from './config';
 import autoBind from 'auto-bind';
 import {
@@ -16,7 +21,6 @@ import {
   TypeScriptOperationVariablesToObject,
   TypeScriptPluginParsedConfig,
   TsVisitor,
-  AvoidOptionalsConfig,
 } from '@graphql-codegen/typescript';
 
 export type DecoratorConfig = {

--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -1,5 +1,4 @@
-import { RawTypesConfig } from '@graphql-codegen/visitor-plugin-common';
-import { AvoidOptionalsConfig } from './types';
+import { RawTypesConfig, AvoidOptionalsConfig } from '@graphql-codegen/visitor-plugin-common';
 
 export interface TypeScriptPluginConfig extends RawTypesConfig {
   /**
@@ -28,6 +27,7 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    *    - typescript
    *  config:
    *    avoidOptionals:
+   *      field: true
    *      inputValue: true
    *      object: true
    * ```

--- a/packages/plugins/typescript/typescript/src/index.ts
+++ b/packages/plugins/typescript/typescript/src/index.ts
@@ -19,7 +19,6 @@ import { TypeScriptPluginConfig } from './config';
 
 export * from './typescript-variables-to-object';
 export * from './visitor';
-export * from './types';
 export * from './config';
 export * from './introspection-visitor';
 

--- a/packages/plugins/typescript/typescript/src/types.ts
+++ b/packages/plugins/typescript/typescript/src/types.ts
@@ -1,4 +1,0 @@
-export interface AvoidOptionalsConfig {
-  object?: boolean;
-  inputValue?: boolean;
-}

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -7,9 +7,10 @@ import {
   ParsedTypesConfig,
   getConfigValue,
   DeclarationKind,
+  normalizeAvoidOptionals,
+  AvoidOptionalsConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptPluginConfig } from './config';
-import { AvoidOptionalsConfig } from './types';
 import autoBind from 'auto-bind';
 import {
   FieldDefinitionNode,
@@ -23,7 +24,6 @@ import {
   GraphQLEnumType,
 } from 'graphql';
 import { TypeScriptOperationVariablesToObject } from './typescript-variables-to-object';
-import { normalizeAvoidOptionals } from './avoid-optionals';
 
 export interface TypeScriptPluginParsedConfig extends ParsedTypesConfig {
   avoidOptionals: AvoidOptionalsConfig;
@@ -122,7 +122,7 @@ export class TsVisitor<
   FieldDefinition(node: FieldDefinitionNode, key?: number | string, parent?: any): string {
     const typeString = this.config.wrapFieldDefinitions ? `FieldWrapper<${node.type}>` : ((node.type as any) as string);
     const originalFieldNode = parent[key] as FieldDefinitionNode;
-    const addOptionalSign = !this.config.avoidOptionals.object && originalFieldNode.type.kind !== Kind.NON_NULL_TYPE;
+    const addOptionalSign = !this.config.avoidOptionals.field && originalFieldNode.type.kind !== Kind.NON_NULL_TYPE;
     const comment = this.getFieldComment(node);
     const { type } = this.config.declarationKind;
 


### PR DESCRIPTION
v1.13.1 changed the behaviour of optional fields.
All nullable fields are now optional `?` including fields inside queries and fragments.
I found that a bit confusing knowing that if a field is requested as part of a query or fragment, then the GraphQL engine will always return the field, and if it's a nullable field, then its value could be null but still present.

Adding `avoidOptionals: true` to `typescript-operations` plugin doesn't work because that also makes all the nullable properties of query and mutation variables non-optional, which is not the desired behaviour.

I've managed to fix it by introducing a new `field` flag to `avoidOptionals` config which specifically makes field values (those returned by queries and fragments) non-optional.

This works because `config.avoidOptionals.field` is being read by both `typescript` and `typescript-operations` plugins which keeps the type definitions consistent.

This also ensures that when `preResolveTypes` is `false` then the fragment definition still matches the original type that it's applying `Pick` on.