### PR TITLE
fix #3665 by moving addition exports into generated sdk...

### DIFF
--- a/packages/plugins/typescript/graphql-request/src/index.ts
+++ b/packages/plugins/typescript/graphql-request/src/index.ts
@@ -5,9 +5,6 @@ import { GraphQLRequestVisitor } from './visitor';
 import { extname } from 'path';
 import { RawGraphQLRequestPluginConfig } from './config';
 
-export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
-export const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
-
 export const plugin: PluginFunction<RawGraphQLRequestPluginConfig> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],

--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -15,6 +15,11 @@ export interface GraphQLRequestPluginConfig extends ClientSideBasePluginConfig {
   rawRequest: boolean;
 }
 
+const additionalSdkExports = `
+export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
+export const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
+`;
+
 export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
   RawGraphQLRequestPluginConfig,
   GraphQLRequestPluginConfig
@@ -43,10 +48,6 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
     if (this.config.rawRequest) {
       this._additionalImports.push(`import { GraphQLError } from 'graphql-request/dist/src/types';`);
     }
-
-    this._additionalImports.push(
-      `import { SdkFunctionWrapper, defaultWrapper } from '@graphql-codegen/typescript-graphql-request';`
-    );
   }
 
   protected buildOperation(
@@ -96,7 +97,8 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
       })
       .map(s => indentMultiline(s, 2));
 
-    return `export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
+    return `${additionalSdkExports}
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
 ${allPossibleActions.join(',\n')}
   };

--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -15,9 +15,8 @@ export interface GraphQLRequestPluginConfig extends ClientSideBasePluginConfig {
   rawRequest: boolean;
 }
 
-const additionalSdkExports = `
+const additionalExportedTypes = `
 export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
-export const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 `;
 
 export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
@@ -97,7 +96,9 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
       })
       .map(s => indentMultiline(s, 2));
 
-    return `${additionalSdkExports}
+    return `${additionalExportedTypes}
+
+const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
 ${allPossibleActions.join(',\n')}

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -3,7 +3,6 @@
 exports[`graphql-request sdk Should allow passing wrapper arg to generated getSdk 1`] = `
 "export type Maybe<T> = T | null;
 import { GraphQLClient } from 'graphql-request';
-import { SdkFunctionWrapper, defaultWrapper } from '@graphql-codegen/typescript-graphql-request';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -264,6 +263,10 @@ export const Feed4Document = \`
   }
 }
     \`;
+
+export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
+export const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
+
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     feed(variables?: FeedQueryVariables): Promise<FeedQuery> {
@@ -319,7 +322,6 @@ exports[`graphql-request sdk Should generate a correct wrap method 1`] = `
 "export type Maybe<T> = T | null;
 import { GraphQLClient } from 'graphql-request';
 import { print } from 'graphql';
-import { SdkFunctionWrapper, defaultWrapper } from '@graphql-codegen/typescript-graphql-request';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -581,6 +583,10 @@ export const Feed4Document = gql\`
   }
 }
     \`;
+
+export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
+export const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
+
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     feed(variables?: FeedQueryVariables): Promise<FeedQuery> {
@@ -618,7 +624,6 @@ async function test() {
 exports[`graphql-request sdk Should generate a correct wrap method with documentMode=string 1`] = `
 "export type Maybe<T> = T | null;
 import { GraphQLClient } from 'graphql-request';
-import { SdkFunctionWrapper, defaultWrapper } from '@graphql-codegen/typescript-graphql-request';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -879,6 +884,10 @@ export const Feed4Document = \`
   }
 }
     \`;
+
+export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
+export const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
+
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     feed(variables?: FeedQueryVariables): Promise<FeedQuery> {

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -265,8 +265,9 @@ export const Feed4Document = \`
     \`;
 
 export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
-export const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 
+
+const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     feed(variables?: FeedQueryVariables): Promise<FeedQuery> {
@@ -585,8 +586,9 @@ export const Feed4Document = gql\`
     \`;
 
 export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
-export const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 
+
+const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     feed(variables?: FeedQueryVariables): Promise<FeedQuery> {
@@ -886,8 +888,9 @@ export const Feed4Document = \`
     \`;
 
 export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
-export const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 
+
+const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     feed(variables?: FeedQueryVariables): Promise<FeedQuery> {

--- a/packages/plugins/typescript/graphql-request/tests/graphql-request.spec.ts
+++ b/packages/plugins/typescript/graphql-request/tests/graphql-request.spec.ts
@@ -1,6 +1,6 @@
 import { DocumentMode } from '@graphql-codegen/visitor-plugin-common';
 import { compileTs } from '@graphql-codegen/testing';
-import { plugin, defaultWrapper, SdkFunctionWrapper } from '../src/index';
+import { plugin } from '../src/index';
 import { parse, buildClientSchema } from 'graphql';
 import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 import { plugin as tsPlugin } from '@graphql-codegen/typescript';
@@ -9,6 +9,8 @@ import { readFileSync } from 'fs';
 import * as ts from 'typescript';
 import { GraphQLClient } from 'graphql-request';
 import nock from 'nock';
+
+type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
 
 describe('graphql-request', () => {
   beforeAll(() => nock.disableNetConnect());


### PR DESCRIPTION
...instead of importing them from the generator package

this fixes #3665. 

pretty simple fix. 
make the additional exported types a constant and add just before the sdk return statement.
default wrapper no longer needs to be exported.

updated test snapshot.