### PR TITLE
Update Java plugin: Omit extra 'Input' suffix from an input's class name if the input type's name ends in Input

### DIFF
--- a/packages/plugins/java/java/src/visitor.ts
+++ b/packages/plugins/java/java/src/visitor.ts
@@ -62,7 +62,7 @@ export class JavaResolversVisitor extends BaseVisitor<JavaResolversPluginRawConf
       allImports.push(`java.util.stream.Collectors`);
     }
 
-    return allImports.map(i => `import ${i};`).join('\n') + '\n';
+    return allImports.map((i) => `import ${i};`).join('\n') + '\n';
   }
 
   public wrapWithClass(content: string): string {
@@ -104,7 +104,7 @@ export class JavaResolversVisitor extends BaseVisitor<JavaResolversPluginRawConf
     this._addHashMapImport = true;
     this._addMapImport = true;
     const enumName = this.convertName(node.name);
-    const enumValues = node.values.map(enumValue => (enumValue as any)(node.name.value)).join(',\n') + ';';
+    const enumValues = node.values.map((enumValue) => (enumValue as any)(node.name.value)).join(',\n') + ';';
     const enumCtor = indentMultiline(`
 public final String label;
  
@@ -186,14 +186,14 @@ public static ${enumName} valueOfLabel(String label) {
     this._addMapImport = true;
 
     const classMembers = inputValueArray
-      .map(arg => {
+      .map((arg) => {
         const typeToUse = this.resolveInputFieldType(arg.type);
 
         return indent(`private ${typeToUse.typeName} _${arg.name.value};`);
       })
       .join('\n');
     const ctorSet = inputValueArray
-      .map(arg => {
+      .map((arg) => {
         const typeToUse = this.resolveInputFieldType(arg.type);
 
         if (typeToUse.isArray && !typeToUse.isScalar) {
@@ -224,7 +224,7 @@ public static ${enumName} valueOfLabel(String label) {
       })
       .join('\n');
     const getters = inputValueArray
-      .map(arg => {
+      .map((arg) => {
         const typeToUse = this.resolveInputFieldType(arg.type);
 
         return indent(
@@ -262,13 +262,14 @@ ${getters}
   }
 
   InputObjectTypeDefinition(node: InputObjectTypeDefinitionNode): string {
-    const name = `${this.convertName(node)}Input`;
+    const convertedName = this.convertName(node);
+    const name = convertedName.endsWith('Input') ? convertedName : `${convertedName}Input`;
 
     return this.buildInputTransfomer(name, node.fields);
   }
 
   ObjectTypeDefinition(node: ObjectTypeDefinitionNode): string {
-    const fieldsArguments = node.fields.map(f => (f as any)(node.name.value)).filter(r => r);
+    const fieldsArguments = node.fields.map((f) => (f as any)(node.name.value)).filter((r) => r);
 
     return fieldsArguments.join('\n');
   }

--- a/packages/plugins/java/java/tests/java.spec.ts
+++ b/packages/plugins/java/java/tests/java.spec.ts
@@ -31,6 +31,10 @@ describe('Java', () => {
       something: Int
     }
 
+    input CustomInput {
+      id: ID!
+    }
+
     enum ResultSort {
       ASC
       DESC
@@ -176,6 +180,22 @@ describe('Java', () => {
       
         public Integer getSkip() { return this._skip; }
         public Integer getLimit() { return this._limit; }
+      }`);
+    });
+
+    it('Should omit extra Input suffix from input class name if schema name already includes the "Input" suffix', async () => {
+      const result = await plugin(schema, [], {}, { outputFile: OUTPUT_FILE });
+
+      expect(result).toBeSimilarStringTo(`public static class CustomInput {
+        private Object _id;
+      
+        public CustomInput(Map<String, Object> args) {
+          if (args != null) {
+            this._id = (Object) args.get("id");
+          }
+        }
+      
+        public Object getId() { return this._id; }
       }`);
     });
 


### PR DESCRIPTION
The crux of the problem I'm trying to solve is the following: consider a schema that includes a type like 

```
input MyEntityInput {
```

In this case, the current codegen will generate a Java class called MyEntityInputInput.java. I'd like to update this to simply generate MyEntityInput.java. I've updated the code to check whether the input type from the schema ends with "Input" and omit adding the "Input" suffix if it does.

The big use case here is when we're using graphql for CRUD operations. If that's the case, then it's very likely that the read operations will necessitate a schema that includes

```
type MyEntity {
```

but that means that we'd want to include the following for writes:

```
input MyEntityInput {
```


The one thing I'm hesitant about with my change is backwards compatibility. For anyone that's been using this tool and has `FooInputInput.java` classes in their codebase, this would start generating different class names. Depending on the philosophy of this open source project, this change could either be considered a breaking change for that use case, or there could be something introduced to the config file to maintain backwards compatibility, such as allowing users to specify a suffix or omit the default suffix. Let me know what your thoughts are!
