### PR TITLE
feat(typescript-graphql-request): export Sdk type

### DIFF
--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -103,6 +103,7 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
   return {
 ${allPossibleActions.join(',\n')}
   };
-}`;
+}
+export type Sdk = ReturnType<typeof getSdk>;`;
   }
 }

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -284,6 +284,7 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     }
   };
 }
+export type Sdk = ReturnType<typeof getSdk>;
 async function test() {
   const client = new GraphQLClient('');
   const functionWrapper: SdkFunctionWrapper = async <T>(action: () => Promise<T>): Promise<T> => {
@@ -595,6 +596,7 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     }
   };
 }
+export type Sdk = ReturnType<typeof getSdk>;
 async function test() {
   const client = new GraphQLClient('');
   const sdk = getSdk(client);
@@ -897,6 +899,7 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     }
   };
 }
+export type Sdk = ReturnType<typeof getSdk>;
 async function test() {
   const client = new GraphQLClient('');
   const sdk = getSdk(client);


### PR DESCRIPTION
Useful when passing an sdk instance around