### PR TITLE
feat: support type imports

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -705,7 +705,19 @@ export class BaseResolversVisitor<
     }
 
     const defaultType = types.find(t => t.asDefault === true);
-    const namedTypes = types.filter(t => !t.asDefault);
+    let namedTypes = types.filter(t => !t.asDefault);
+
+    if (this.config.useTypeImports) {
+      if (defaultType) {
+        // default as Baz
+        namedTypes = [{ identifier: `default as ${defaultType.identifier}` }, ...namedTypes];
+      }
+      // { Foo, Bar as BarModel }
+      const namedImports = namedTypes.length ? `{ ${namedTypes.map(t => t.identifier).join(', ')} }` : '';
+
+      // { default as Baz, Foo, Bar as BarModel }
+      return `import type ${[namedImports].filter(Boolean).join(', ')} from '${source}';`;
+    }
 
     // { Foo, Bar as BarModel }
     const namedImports = namedTypes.length ? `{ ${namedTypes.map(t => t.identifier).join(', ')} }` : '';

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -341,10 +341,14 @@ export class BaseTypesVisitor<
   }
 
   protected _buildTypeImport(identifier: string, source: string, asDefault = false): string {
+    const { useTypeImports } = this.config;
     if (asDefault) {
+      if (useTypeImports) {
+        return `import type { default as ${identifier} } from '${source}';`;
+      }
       return `import ${identifier} from '${source}';`;
     }
-    return `import { ${identifier} } from '${source}';`;
+    return `import${useTypeImports ? ' type' : ''} { ${identifier} } from '${source}';`;
   }
 
   protected handleEnumValueMapper(

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -25,6 +25,7 @@ export interface ParsedConfig {
   nonOptionalTypename: boolean;
   externalFragments: LoadedFragment[];
   immutableTypes: boolean;
+  useTypeImports: boolean;
 }
 
 export interface RawConfig {
@@ -120,6 +121,20 @@ export interface RawConfig {
    * ```
    */
   nonOptionalTypename?: boolean;
+  /**
+   * @name useTypeImports
+   * @type boolean
+   * @default false
+   * @description Will use `import type {}` rather than `import {}` when importing only types. This gives
+   * compatibility with TypeScript's "importsNotUsedAsValues": "error" option
+   *
+   * @example
+   * ```yml
+   * config:
+   *   useTypeImports: true
+   * ```
+   */
+  useTypeImports?: boolean;
 
   /* The following configuration are for preset configuration and should not be set manually (for most use cases...) */
   externalFragments?: LoadedFragment[];
@@ -138,6 +153,7 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
       externalFragments: rawConfig.externalFragments || [],
       addTypename: !rawConfig.skipTypename,
       nonOptionalTypename: !!rawConfig.nonOptionalTypename,
+      useTypeImports: !!rawConfig.useTypeImports,
       ...((additionalConfig || {}) as any),
     };
 

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -343,10 +343,12 @@ export class ClientSideBaseVisitor<
   public getImports(): string[] {
     const imports = [...this._additionalImports];
 
+    const typeImport = this.config.useTypeImports ? 'import type' : 'import';
+
     switch (this.config.documentMode) {
       case DocumentMode.documentNode:
       case DocumentMode.documentNodeImportFragments: {
-        imports.push(`import { DocumentNode } from 'graphql';`);
+        imports.push(`${typeImport} { DocumentNode } from 'graphql';`);
         break;
       }
       case DocumentMode.graphQLTag: {

--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -38,14 +38,16 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
 
     autoBind(this);
 
-    this._additionalImports.push(`import { GraphQLClient } from 'graphql-request';`);
+    const typeImport = this.config.useTypeImports ? 'import type' : 'import';
+
+    this._additionalImports.push(`${typeImport} { GraphQLClient } from 'graphql-request';`);
 
     if (this.config.documentMode !== DocumentMode.string) {
       this._additionalImports.push(`import { print } from 'graphql';`);
     }
 
     if (this.config.rawRequest) {
-      this._additionalImports.push(`import { GraphQLError } from 'graphql-request/dist/src/types';`);
+      this._additionalImports.push(`${typeImport} { GraphQLError } from 'graphql-request/dist/src/types';`);
     }
   }
 

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -917,3 +917,308 @@ async function test() {
   }
 }"
 `;
+
+exports[`graphql-request sdk Should support useTypeImports 1`] = `
+"export type Maybe<T> = T | null;
+import type { GraphQLClient } from 'graphql-request';
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+/** A comment about an entry, submitted by a user */
+export type Comment = {
+   __typename?: 'Comment';
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** The GitHub user who posted the comment */
+  postedBy: User;
+  /** A timestamp of when the comment was posted */
+  createdAt: Scalars['Float'];
+  /** The text of the comment */
+  content: Scalars['String'];
+  /** The repository which this comment is about */
+  repoName: Scalars['String'];
+};
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type Entry = {
+   __typename?: 'Entry';
+  /** Information about the repository from GitHub */
+  repository: Repository;
+  /** The GitHub user who submitted this entry */
+  postedBy: User;
+  /** A timestamp of when the entry was submitted */
+  createdAt: Scalars['Float'];
+  /** The score of this repository, upvotes - downvotes */
+  score: Scalars['Int'];
+  /** The hot score of this repository */
+  hotScore: Scalars['Float'];
+  /** Comments posted about this repository */
+  comments: Array<Maybe<Comment>>;
+  /** The number of comments posted about this repository */
+  commentCount: Scalars['Int'];
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** XXX to be changed */
+  vote: Vote;
+};
+
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type EntryCommentsArgs = {
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  /** Sort by a combination of freshness and score, using Reddit's algorithm */
+  Hot = 'HOT',
+  /** Newest entries first */
+  New = 'NEW',
+  /** Highest score entries first */
+  Top = 'TOP'
+}
+
+export type Mutation = {
+   __typename?: 'Mutation';
+  /** Submit a new repository, returns the new submission */
+  submitRepository?: Maybe<Entry>;
+  /** Vote on a repository submission, returns the submission that was voted on */
+  vote?: Maybe<Entry>;
+  /** Comment on a repository, returns the new comment */
+  submitComment?: Maybe<Comment>;
+};
+
+
+export type MutationSubmitRepositoryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+
+export type MutationVoteArgs = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+
+export type MutationSubmitCommentArgs = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+export type Query = {
+   __typename?: 'Query';
+  /** A feed of repository submissions */
+  feed?: Maybe<Array<Maybe<Entry>>>;
+  /** A single entry */
+  entry?: Maybe<Entry>;
+  /** Return the currently logged in user, or null if nobody is logged in */
+  currentUser?: Maybe<User>;
+};
+
+
+export type QueryFeedArgs = {
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryEntryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/**
+ * A repository object from the GitHub API. This uses the exact field names returned by the
+ * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
+ */
+export type Repository = {
+   __typename?: 'Repository';
+  /** Just the name of the repository, e.g. GitHunt-API */
+  name: Scalars['String'];
+  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
+  full_name: Scalars['String'];
+  /** The description of the repository */
+  description?: Maybe<Scalars['String']>;
+  /** The link to the repository on GitHub */
+  html_url: Scalars['String'];
+  /** The number of people who have starred this repository on GitHub */
+  stargazers_count: Scalars['Int'];
+  /** The number of open issues on this repository on GitHub */
+  open_issues_count?: Maybe<Scalars['Int']>;
+  /** The owner of this repository on GitHub, e.g. apollostack */
+  owner?: Maybe<User>;
+};
+
+export type Subscription = {
+   __typename?: 'Subscription';
+  /** Subscription fires on every comment added */
+  commentAdded?: Maybe<Comment>;
+};
+
+
+export type SubscriptionCommentAddedArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export type User = {
+   __typename?: 'User';
+  /** The name of the user, e.g. apollostack */
+  login: Scalars['String'];
+  /** The URL to a directly embeddable image for this user's avatar */
+  avatar_url: Scalars['String'];
+  /** The URL of this user's GitHub page */
+  html_url: Scalars['String'];
+};
+
+/** XXX to be removed */
+export type Vote = {
+   __typename?: 'Vote';
+  vote_value: Scalars['Int'];
+};
+
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  Up = 'UP',
+  Down = 'DOWN',
+  Cancel = 'CANCEL'
+}
+export type FeedQueryVariables = {};
+
+
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { feed?: Maybe<Array<Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id' | 'commentCount'>
+    & { repository: (
+      { __typename?: 'Repository' }
+      & { owner?: Maybe<(
+        { __typename?: 'User' }
+        & Pick<User, 'avatar_url'>
+      )> }
+    ) }
+  )>>> }
+);
+
+export type Feed2QueryVariables = {
+  v: Scalars['String'];
+};
+
+
+export type Feed2Query = (
+  { __typename?: 'Query' }
+  & { feed?: Maybe<Array<Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id'>
+  )>>> }
+);
+
+export type Feed3QueryVariables = {
+  v?: Maybe<Scalars['String']>;
+};
+
+
+export type Feed3Query = (
+  { __typename?: 'Query' }
+  & { feed?: Maybe<Array<Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id'>
+  )>>> }
+);
+
+export type Feed4QueryVariables = {
+  v?: Scalars['String'];
+};
+
+
+export type Feed4Query = (
+  { __typename?: 'Query' }
+  & { feed?: Maybe<Array<Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id'>
+  )>>> }
+);
+
+export const FeedDocument = gql\`
+    query feed {
+  feed {
+    id
+    commentCount
+    repository {
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+export const Feed2Document = gql\`
+    query feed2($v: String!) {
+  feed {
+    id
+  }
+}
+    \`;
+export const Feed3Document = gql\`
+    query feed3($v: String) {
+  feed {
+    id
+  }
+}
+    \`;
+export const Feed4Document = gql\`
+    query feed4($v: String! = \\"TEST\\") {
+  feed {
+    id
+  }
+}
+    \`;
+
+export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
+
+
+const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
+  return {
+    feed(variables?: FeedQueryVariables): Promise<FeedQuery> {
+      return withWrapper(() => client.request<FeedQuery>(print(FeedDocument), variables));
+    },
+    feed2(variables: Feed2QueryVariables): Promise<Feed2Query> {
+      return withWrapper(() => client.request<Feed2Query>(print(Feed2Document), variables));
+    },
+    feed3(variables?: Feed3QueryVariables): Promise<Feed3Query> {
+      return withWrapper(() => client.request<Feed3Query>(print(Feed3Document), variables));
+    },
+    feed4(variables?: Feed4QueryVariables): Promise<Feed4Query> {
+      return withWrapper(() => client.request<Feed4Query>(print(Feed4Document), variables));
+    }
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;
+async function test() {
+  const client = new GraphQLClient('');
+  const sdk = getSdk(client);
+  
+  await sdk.feed();
+  await sdk.feed3();
+  await sdk.feed4();
+
+  const result = await sdk.feed2({ v: \\"1\\" });
+
+  if (result.feed) {
+    if (result.feed[0]) {
+      const id = result.feed[0].id
+    }
+  }
+}"
+`;

--- a/packages/plugins/typescript/graphql-request/tests/graphql-request.spec.ts
+++ b/packages/plugins/typescript/graphql-request/tests/graphql-request.spec.ts
@@ -160,5 +160,34 @@ async function test() {
 
       expect(output).toMatchSnapshot();
     });
+
+    it('Should support useTypeImports', async () => {
+      const config = { useTypeImports: true };
+      const docs = [{ location: '', document: basicDoc }];
+      const result = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      const usage = `
+async function test() {
+  const client = new GraphQLClient('');
+  const sdk = getSdk(client);
+  
+  await sdk.feed();
+  await sdk.feed3();
+  await sdk.feed4();
+
+  const result = await sdk.feed2({ v: "1" });
+
+  if (result.feed) {
+    if (result.feed[0]) {
+      const id = result.feed[0].id
+    }
+  }
+}`;
+      const output = await validate(result, config, docs, schema, usage);
+
+      expect(output).toMatchSnapshot();
+    });
   });
 });

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -84,16 +84,17 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
   if (config.customResolverFn) {
     const parsedMapper = parseMapper(config.customResolverFn);
     if (parsedMapper.isExternal) {
+      const importType = config.useTypeImports ? 'import type' : 'import';
       if (parsedMapper.default) {
-        prepend.push(`import ResolverFn from '${parsedMapper.source}';`);
+        prepend.push(`${importType} ResolverFn from '${parsedMapper.source}';`);
       } else {
         prepend.push(
-          `import { ${parsedMapper.import} ${parsedMapper.import !== 'ResolverFn' ? 'as ResolverFn ' : ''}} from '${
-            parsedMapper.source
-          }';`
+          `${importType} { ${parsedMapper.import} ${
+            parsedMapper.import !== 'ResolverFn' ? 'as ResolverFn ' : ''
+          }} from '${parsedMapper.source}';`
         );
       }
-      prepend.push(`export { ResolverFn };`);
+      prepend.push(`export${config.useTypeImports ? ' type' : ''} { ResolverFn };`);
     } else {
       prepend.push(`export type ResolverFn<TResult, TParent, TContext, TArgs> = ${parsedMapper.type}`);
     }

--- a/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
@@ -478,6 +478,41 @@ describe('ResolversTypes', () => {
     };`);
   });
 
+  it('Should build ResolversTypes with mapper set for concrete type using renamed external identifier (with default) and type import', async () => {
+    const result = (await plugin(
+      schema,
+      [],
+      {
+        noSchemaStitching: true,
+        mappers: {
+          MyOtherType: './my-type#default as DatabaseMyOtherType',
+          MyType: './my-type#MyType as DatabaseMyType',
+        },
+        useTypeImports: true,
+      },
+      { outputFile: '' }
+    )) as Types.ComplexPluginOutput;
+
+    expect(result.prepend).toContain(
+      `import type { default as DatabaseMyOtherType, MyType as DatabaseMyType } from './my-type';`
+    );
+    expect(result.content).toBeSimilarStringTo(`
+    export type ResolversTypes = {
+      Query: ResolverTypeWrapper<{}>,
+      MyType: ResolverTypeWrapper<DatabaseMyType>,
+      String: ResolverTypeWrapper<Scalars['String']>,
+      MyOtherType: ResolverTypeWrapper<DatabaseMyOtherType>,
+      Subscription: ResolverTypeWrapper<{}>,
+      Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
+      Node: ResolversTypes['SomeNode'],
+      ID: ResolverTypeWrapper<Scalars['ID']>,
+      SomeNode: ResolverTypeWrapper<SomeNode>,
+      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
+      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
+      Int: ResolverTypeWrapper<Scalars['Int']>,
+    };`);
+  });
+
   it('Should build ResolversTypes with defaultMapper set', async () => {
     const result = (await plugin(
       schema,

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -686,6 +686,78 @@ describe('TypeScript Resolvers Plugin', () => {
 
     await validate(result);
   });
+  it('Should allow to override context with mapped context type as default export with type import', async () => {
+    const result = (await plugin(
+      schema,
+      [],
+      {
+        contextType: './my-file#default',
+        useTypeImports: true,
+      },
+      { outputFile: '' }
+    )) as Types.ComplexPluginOutput;
+
+    expect(result.prepend).toContain(`import type { default as ContextType } from './my-file';`);
+
+    expect(result.content).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+    arg2: Scalars['String'];
+    arg3: Scalars['Boolean']; };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+    export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = ContextType, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MyOtherTypeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = {
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MyTypeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
+        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MyUnionResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type NodeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type QueryResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type SomeNodeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type SubscriptionResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>,
+      };
+    `);
+
+    await validate(result);
+  });
 
   it('should generate named custom field level context type', async () => {
     const result = (await plugin(
@@ -1175,6 +1247,49 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     `);
 
     expect(content.prepend).toContain(`import RootValueType from 'my-file';`);
+  });
+
+  it('should use correct value when rootValueType mapped as default with type import', async () => {
+    const testSchema = buildSchema(/* GraphQL */ `
+      type Subscription {
+        postAdded: Post
+      }
+
+      type Query {
+        posts: [Post]
+      }
+
+      type Mutation {
+        addPost(author: String, comment: String): Post
+      }
+
+      type Post {
+        author: String
+        comment: String
+      }
+    `);
+    const content = (await plugin(
+      testSchema,
+      [],
+      {
+        rootValueType: 'my-file#default',
+        useTypeImports: true,
+      },
+      { outputFile: 'graphql.ts' }
+    )) as Types.ComplexPluginOutput;
+
+    expect(content.content).toBeSimilarStringTo(`
+      export type ResolversTypes = {
+        Query: ResolverTypeWrapper<RootValueType>,
+        Post: ResolverTypeWrapper<Post>,
+        String: ResolverTypeWrapper<Scalars['String']>,
+        Mutation: ResolverTypeWrapper<RootValueType>,
+        Subscription: ResolverTypeWrapper<RootValueType>,
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
+      };
+    `);
+
+    expect(content.prepend).toContain(`import type { default as RootValueType } from 'my-file';`);
   });
 
   it('should use rootValueType in Query, Mutation and Subscription', async () => {


### PR DESCRIPTION
Very rough start on #3695. Not sure how you want to handle this. I'll probably just do the ones we need at work (which means Apollo TS), but it should be fine to expand as we go?

(is there some watch mode I can run that builds as we go? right now I do a full `yarn build` every time I change something, which seems suboptimal)