### PR TITLE
feat(typescript-generic-sdk): export `Sdk` type

### DIFF
--- a/packages/plugins/typescript/generic-sdk/src/visitor.ts
+++ b/packages/plugins/typescript/generic-sdk/src/visitor.ts
@@ -73,6 +73,7 @@ export function getSdk<C>(requester: Requester<C>) {
   return {
 ${allPossibleActions.join(',\n')}
   };
-}`;
+}
+export type Sdk = ReturnType<typeof getSdk>;`;
   }
 }

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -281,6 +281,7 @@ export function getSdk<C>(requester: Requester<C>) {
     }
   };
 }
+export type Sdk = ReturnType<typeof getSdk>;
 async function test() {
   const requester = <R, V> (doc: DocumentNode, vars: V): Promise<R> => Promise.resolve({} as unknown as R);
   const sdk = getSdk(requester);
@@ -578,6 +579,7 @@ export function getSdk<C>(requester: Requester<C>) {
     }
   };
 }
+export type Sdk = ReturnType<typeof getSdk>;
 async function test() {
   const requester = <R, V> (doc: string, vars: V): Promise<R> => Promise.resolve({} as unknown as R);
   const sdk = getSdk(requester);


### PR DESCRIPTION
Like #3704 but for the generic sdk