### PR TITLE
WIP: Fix JS Doc comments in Vue Apollo queries

### DIFF
--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -113,6 +113,7 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
  * __use${operationName}__
  *${operationType === 'Mutation' ? mutationDescription : queryDescription}
  *
+ * ${['Query', 'Subscription'].includes(operationType) ? '@param variables Query variables' : ''}
  * @param baseOptions options that will be passed into the ${operationType.toLowerCase()}, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/${
       operationType === 'Mutation' ? 'mutation' : 'query'
     }.html#options;
@@ -195,11 +196,12 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
     switch (operationType) {
       case 'Query': {
         const reactiveFunctionTypeName = `ReactiveFunction${operationName}`;
-        return `type ${reactiveFunctionTypeName} = () => ${operationVariablesTypes}\nexport function use${operationName}(variables${
+        return `export function use${operationName}(variables${
           operationHasNonNullableVariable ? '' : '?'
         }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ${reactiveFunctionTypeName}, baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
           return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, variables, baseOptions);
-        }`;
+        }
+        type ${reactiveFunctionTypeName} = () => ${operationVariablesTypes}`;
       }
       case 'Mutation': {
         return `export function use${operationName}(baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {


### PR DESCRIPTION
Currently, because of the `type` declaration placed before the exported function in queries, it does not pick up the JSDoc docstring:

![image](https://user-images.githubusercontent.com/26604994/77476753-8ab6c080-6df1-11ea-9cd5-a2a9a3aae95b.png)

![image](https://user-images.githubusercontent.com/26604994/77476764-90140b00-6df1-11ea-900b-a5d0db6137e0.png)

![image](https://user-images.githubusercontent.com/26604994/77476771-94402880-6df1-11ea-809a-b97bba444329.png)

Adding `@param variables` and moving the `type` below the function makes it work properly:

![image](https://user-images.githubusercontent.com/26604994/77476810-a7eb8f00-6df1-11ea-94d4-5d2ee56eb5e5.png)

![image](https://user-images.githubusercontent.com/26604994/77476815-ad48d980-6df1-11ea-9dc9-ca2d381b4fed.png)

I am unable to test these changes properly because I wasn't able to find documentation on the development workflow for modifying existing plugins.

I tried running the `build` script from the main repo and using the `index.cjs.js`, but during the codegen process it errors due to there being "duplicate copies of graphql library":
```
ensure there is only one instance of graphql
```