### PR TITLE
feat: add generateOnlyEnums option to typescript

### DIFF
--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -182,4 +182,23 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    * ```
    */
   wrapFieldDefinitions?: boolean;
+
+  /**
+   * @name generateOnlyEnums
+   * @type boolean
+   * @description Set the to `true` in order to generate only `enum` definitions
+   * @default false
+   *
+   * @example Generate only enums
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    generateOnlyEnums: true
+   * ```
+   *
+   */
+  generateOnlyEnums?: boolean;
 }

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2436,4 +2436,62 @@ describe('TypeScript', () => {
       }
     `);
   });
+
+  it.only('should print only enums', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type User {
+        id: Int!
+        name: String!
+        email: String!
+      }
+      type QueryRoot {
+        allUsers: [User]!
+        userById(id: Int!): User
+        # Generates a new answer for the guessing game
+        answer: [Int!]!
+      }
+      type SubscriptionRoot {
+        newUser: User
+      }
+      enum Evaluation {
+        NEEDS_IMPROVEMENT
+        MEETS_EXPECTATIONS
+        EXCEEDS_EXPECTATIONS
+        SUPERB
+      }
+      schema {
+        query: QueryRoot
+        subscription: SubscriptionRoot
+      }
+      enum Status {
+        Todo
+        Doing
+        Done
+      }
+    `);
+
+    const result = (await plugin(
+      schema,
+      [],
+      { generateOnlyEnums: true },
+      { outputFile: '' }
+    )) as Types.ComplexPluginOutput;
+
+    expect(result.content).toBeSimilarStringTo(`
+      export enum Evaluation {
+        NeedsImprovement = 'NEEDS_IMPROVEMENT',
+        MeetsExpectations = 'MEETS_EXPECTATIONS',
+        ExceedsExpectations = 'EXCEEDS_EXPECTATIONS',
+        Superb = 'SUPERB'
+      }
+
+      export enum Status {
+        Todo = 'Todo',
+        Doing = 'Doing',
+        Done = 'Done'
+      }
+    `);
+
+    validateTs(result);
+  });
 });


### PR DESCRIPTION
`generateOnlyEnums` was added to `typescript` plugin `options`.  
This allows `typescript` plugin to generate only enums.

Our team use `relay` package.  `relay-compiler` generates `Query`, `Mutation` and `fragment` types based on `schema.graphql` file. So other types this library generates are not useful to us, except enums.  

The problem is whenever we have a type that uses an `enum` it generates that type again, I mean there could be definition of an `enum` in 20 different files. We always liked to have a single source of truth for enums. We even wrote a small package [`relay-enum-generator`](https://github.com/c0m1t/relay-enum-generator).  So we would really appreciate it if there were an option in your package to make this possible. I suppose other teams using `relay` probably have this issue.