### PR TITLE
feat: futureProofEnums option

### DIFF
--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -69,6 +69,25 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    */
   enumsAsTypes?: boolean;
   /**
+   * @name futureProofEnums
+   * @type boolean
+   * @description This option controls whether or not a catch-all entry is added to enum type definitions for values that may be added in the future. You also have to set `enumsAsTypes` to true if you wish to use this option.
+   * This is useful if you are using `relay`.
+   * @default false
+   *
+   * @example
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    enumsAsTypes: true
+   *    futureProofEnums: true
+   * ```
+   */
+  futureProofEnums?: boolean;
+  /**
    * @name enumsAsConst
    * @type boolean
    * @description Generates enum as TypeScript `const assertions` instead of `enum`. This can even be used to enable enum-like patterns in plain JavaScript code if you choose not to use TypeScript’s enum construct.

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -29,6 +29,7 @@ export interface TypeScriptPluginParsedConfig extends ParsedTypesConfig {
   avoidOptionals: AvoidOptionalsConfig;
   constEnums: boolean;
   enumsAsTypes: boolean;
+  futureProofEnums: boolean;
   enumsAsConst: boolean;
   fieldWrapperValue: string;
   immutableTypes: boolean;
@@ -49,6 +50,7 @@ export class TsVisitor<
       fieldWrapperValue: getConfigValue(pluginConfig.fieldWrapperValue, 'T'),
       constEnums: getConfigValue(pluginConfig.constEnums, false),
       enumsAsTypes: getConfigValue(pluginConfig.enumsAsTypes, false),
+      futureProofEnums: getConfigValue(pluginConfig.futureProofEnums, false),
       enumsAsConst: getConfigValue(pluginConfig.enumsAsConst, false),
       immutableTypes: getConfigValue(pluginConfig.immutableTypes, false),
       wrapFieldDefinitions: getConfigValue(pluginConfig.wrapFieldDefinitions, false),
@@ -185,6 +187,7 @@ export class TsVisitor<
 
                 return comment + indent(wrapWithSingleQuotes(enumValue));
               })
+              .concat(...[this.config.futureProofEnums ? [indent(wrapWithSingleQuotes('%future added value'))] : []])
               .join(' |\n')
         ).string;
     }

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -21,7 +21,7 @@ import {
   Kind,
   InputValueDefinitionNode,
   GraphQLSchema,
-  GraphQLEnumType,
+  isEnumType,
 } from 'graphql';
 import { TypeScriptOperationVariablesToObject } from './typescript-variables-to-object';
 
@@ -59,8 +59,8 @@ export class TsVisitor<
 
     autoBind(this);
     const enumNames = Object.values(schema.getTypeMap())
-      .map(type => (type instanceof GraphQLEnumType ? type.name : undefined))
-      .filter(t => t);
+      .filter(isEnumType)
+      .map(type => type.name);
     this.setArgumentsTransformer(
       new TypeScriptOperationVariablesToObject(
         this.scalars,

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -185,10 +185,12 @@ export class TsVisitor<
                   enumValue = this.config.enumValues[enumName].mappedValues[enumValue];
                 }
 
-                return comment + indent(wrapWithSingleQuotes(enumValue));
+                return comment + indent('| ' + wrapWithSingleQuotes(enumValue));
               })
-              .concat(...[this.config.futureProofEnums ? [indent(wrapWithSingleQuotes('%future added value'))] : []])
-              .join(' |\n')
+              .concat(
+                ...[this.config.futureProofEnums ? [indent('| ' + wrapWithSingleQuotes('%future added value'))] : []]
+              )
+              .join('\n')
         ).string;
     }
 

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -704,6 +704,47 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
+    it('Should add `%future added value` to enum when futureProofEnums is set and also enumAsTypes', async () => {
+      const schema = buildSchema(`
+      enum MyEnum {
+        A
+        B
+      }`);
+      const result = (await plugin(
+        schema,
+        [],
+        { enumsAsTypes: true, futureProofEnums: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect(result.content).toBeSimilarStringTo(`
+      export type MyEnum = 'A' | 'B' | '%future added value';
+    `);
+      validateTs(result);
+    });
+
+    it('Should not add `%future added value` to enum when futureProofEnums is set, but not enumAsTypes', async () => {
+      const schema = buildSchema(`
+      enum MyEnum {
+        A
+        B
+      }`);
+      const result = (await plugin(
+        schema,
+        [],
+        { futureProofEnums: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect(result.content).toBeSimilarStringTo(`
+      export enum MyEnum {
+        A = 'A',
+        B = 'B'
+      }
+    `);
+      validateTs(result);
+    });
+
     it('Should use custom namingConvention for enums (keep)', async () => {
       const schema = buildSchema(/* GraphQL */ `
         enum Foo {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -249,9 +249,9 @@ describe('TypeScript', () => {
       /** custom enum */
       export type MyEnum =
         /** this is a */
-        'A' |
+        | 'A' 
         /** this is b */
-        'B';`);
+        | 'B';`);
     });
   });
 
@@ -680,8 +680,10 @@ describe('TypeScript', () => {
       )) as Types.ComplexPluginOutput;
 
       expect(result.content).toBeSimilarStringTo(`
-      export type MyEnum = 'A' | 'B';
-    `);
+        export type MyEnum = 
+          | 'A' 
+          | 'B';
+      `);
       validateTs(result);
     });
 
@@ -699,8 +701,10 @@ describe('TypeScript', () => {
       )) as Types.ComplexPluginOutput;
 
       expect(result.content).toBeSimilarStringTo(`
-      export type MyEnum = 'BOOP' | 'B';
-    `);
+        export type MyEnum = 
+          | 'BOOP' 
+          | 'B';
+      `);
       validateTs(result);
     });
 
@@ -718,7 +722,10 @@ describe('TypeScript', () => {
       )) as Types.ComplexPluginOutput;
 
       expect(result.content).toBeSimilarStringTo(`
-      export type MyEnum = 'A' | 'B' | '%future added value';
+      export type MyEnum = 
+        | 'A' 
+        | 'B' 
+        | '%future added value'
     `);
       validateTs(result);
     });


### PR DESCRIPTION
`relay` users usually use [noFutureProofEnums option](https://github.com/facebook/relay/blob/da7ed10312e6f10743e646ce2e3027059fd40d73/packages/relay-compiler/bin/RelayCompilerBin.js#L101) in their projects. Although It's clear that this is not something hard to accomplish without this pull request, with a utility type like this:
`type FutureProofEnums<T> = T | '%future added value'`

I thought it would be cool to have an option to support it. For now, `futureProofEnums` works only when `enumsAsTypes` is `true`. Because it looks weird if you add `%future added value` to an `enum`.


Also:
- Moved the  `|` sign from the end of the lines, to the first to be more like prettier format.
- Refactor 2 lines of code