### PR TITLE
Additional type argument to allow custom config.name for react-apollo HOCs

### DIFF
--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -349,7 +349,7 @@ export const OnCommentAddedComponent = (props: OnCommentAddedComponentProps) => 
 );
 
 export type OnCommentAddedProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<
+  [key in TDataName]: ApolloReactHoc.DataValue<
     OnCommentAddedSubscriptionMyOperation,
     OnCommentAddedSubscriptionVariables
   >;
@@ -417,7 +417,7 @@ export const CommentComponent = (props: CommentComponentProps) => (
 );
 
 export type CommentProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<CommentQueryMyOperation, CommentQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<CommentQueryMyOperation, CommentQueryVariables>;
 } &
   TChildProps;
 export function withComment<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -463,7 +463,7 @@ export const CurrentUserForProfileComponent = (props: CurrentUserForProfileCompo
 );
 
 export type CurrentUserForProfileProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<
+  [key in TDataName]: ApolloReactHoc.DataValue<
     CurrentUserForProfileQueryMyOperation,
     CurrentUserForProfileQueryVariables
   >;
@@ -513,7 +513,7 @@ export const FeedComponent = (props: FeedComponentProps) => (
 );
 
 export type FeedProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<FeedQueryMyOperation, FeedQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<FeedQueryMyOperation, FeedQueryVariables>;
 } &
   TChildProps;
 export function withFeed<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -348,24 +348,26 @@ export const OnCommentAddedComponent = (props: OnCommentAddedComponentProps) => 
   />
 );
 
-export type OnCommentAddedProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  OnCommentAddedSubscriptionMyOperation,
-  OnCommentAddedSubscriptionVariables
-> &
+export type OnCommentAddedProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<
+    OnCommentAddedSubscriptionMyOperation,
+    OnCommentAddedSubscriptionVariables
+  >;
+} &
   TChildProps;
-export function withOnCommentAdded<TProps, TChildProps = {}>(
+export function withOnCommentAdded<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     OnCommentAddedSubscriptionMyOperation,
     OnCommentAddedSubscriptionVariables,
-    OnCommentAddedProps<TChildProps>
+    OnCommentAddedProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withSubscription<
     TProps,
     OnCommentAddedSubscriptionMyOperation,
     OnCommentAddedSubscriptionVariables,
-    OnCommentAddedProps<TChildProps>
+    OnCommentAddedProps<TChildProps, TDataName>
   >(OnCommentAddedDocument, {
     alias: 'onCommentAdded',
     ...operationOptions,
@@ -414,23 +416,27 @@ export const CommentComponent = (props: CommentComponentProps) => (
   <ApolloReactComponents.Query<CommentQueryMyOperation, CommentQueryVariables> query={CommentDocument} {...props} />
 );
 
-export type CommentProps<TChildProps = {}> = ApolloReactHoc.DataProps<CommentQueryMyOperation, CommentQueryVariables> &
+export type CommentProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<CommentQueryMyOperation, CommentQueryVariables>;
+} &
   TChildProps;
-export function withComment<TProps, TChildProps = {}>(
+export function withComment<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     CommentQueryMyOperation,
     CommentQueryVariables,
-    CommentProps<TChildProps>
+    CommentProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withQuery<TProps, CommentQueryMyOperation, CommentQueryVariables, CommentProps<TChildProps>>(
-    CommentDocument,
-    {
-      alias: 'comment',
-      ...operationOptions,
-    }
-  );
+  return ApolloReactHoc.withQuery<
+    TProps,
+    CommentQueryMyOperation,
+    CommentQueryVariables,
+    CommentProps<TChildProps, TDataName>
+  >(CommentDocument, {
+    alias: 'comment',
+    ...operationOptions,
+  });
 }
 export type CommentQueryResult = ApolloReactCommon.QueryResult<CommentQueryMyOperation, CommentQueryVariables>;
 export const CurrentUserForProfileDocument = gql`
@@ -456,24 +462,26 @@ export const CurrentUserForProfileComponent = (props: CurrentUserForProfileCompo
   />
 );
 
-export type CurrentUserForProfileProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  CurrentUserForProfileQueryMyOperation,
-  CurrentUserForProfileQueryVariables
-> &
+export type CurrentUserForProfileProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<
+    CurrentUserForProfileQueryMyOperation,
+    CurrentUserForProfileQueryVariables
+  >;
+} &
   TChildProps;
-export function withCurrentUserForProfile<TProps, TChildProps = {}>(
+export function withCurrentUserForProfile<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     CurrentUserForProfileQueryMyOperation,
     CurrentUserForProfileQueryVariables,
-    CurrentUserForProfileProps<TChildProps>
+    CurrentUserForProfileProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     CurrentUserForProfileQueryMyOperation,
     CurrentUserForProfileQueryVariables,
-    CurrentUserForProfileProps<TChildProps>
+    CurrentUserForProfileProps<TChildProps, TDataName>
   >(CurrentUserForProfileDocument, {
     alias: 'currentUserForProfile',
     ...operationOptions,
@@ -504,17 +512,19 @@ export const FeedComponent = (props: FeedComponentProps) => (
   <ApolloReactComponents.Query<FeedQueryMyOperation, FeedQueryVariables> query={FeedDocument} {...props} />
 );
 
-export type FeedProps<TChildProps = {}> = ApolloReactHoc.DataProps<FeedQueryMyOperation, FeedQueryVariables> &
+export type FeedProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<FeedQueryMyOperation, FeedQueryVariables>;
+} &
   TChildProps;
-export function withFeed<TProps, TChildProps = {}>(
+export function withFeed<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     FeedQueryMyOperation,
     FeedQueryVariables,
-    FeedProps<TChildProps>
+    FeedProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withQuery<TProps, FeedQueryMyOperation, FeedQueryVariables, FeedProps<TChildProps>>(
+  return ApolloReactHoc.withQuery<TProps, FeedQueryMyOperation, FeedQueryVariables, FeedProps<TChildProps, TDataName>>(
     FeedDocument,
     {
       alias: 'feed',
@@ -549,24 +559,26 @@ export const SubmitRepositoryComponent = (props: SubmitRepositoryComponentProps)
   />
 );
 
-export type SubmitRepositoryProps<TChildProps = {}> = ApolloReactHoc.MutateProps<
-  SubmitRepositoryMutationMyOperation,
-  SubmitRepositoryMutationVariables
-> &
+export type SubmitRepositoryProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    SubmitRepositoryMutationMyOperation,
+    SubmitRepositoryMutationVariables
+  >;
+} &
   TChildProps;
-export function withSubmitRepository<TProps, TChildProps = {}>(
+export function withSubmitRepository<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     SubmitRepositoryMutationMyOperation,
     SubmitRepositoryMutationVariables,
-    SubmitRepositoryProps<TChildProps>
+    SubmitRepositoryProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withMutation<
     TProps,
     SubmitRepositoryMutationMyOperation,
     SubmitRepositoryMutationVariables,
-    SubmitRepositoryProps<TChildProps>
+    SubmitRepositoryProps<TChildProps, TDataName>
   >(SubmitRepositoryDocument, {
     alias: 'submitRepository',
     ...operationOptions,
@@ -601,24 +613,26 @@ export const SubmitCommentComponent = (props: SubmitCommentComponentProps) => (
   />
 );
 
-export type SubmitCommentProps<TChildProps = {}> = ApolloReactHoc.MutateProps<
-  SubmitCommentMutationMyOperation,
-  SubmitCommentMutationVariables
-> &
+export type SubmitCommentProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    SubmitCommentMutationMyOperation,
+    SubmitCommentMutationVariables
+  >;
+} &
   TChildProps;
-export function withSubmitComment<TProps, TChildProps = {}>(
+export function withSubmitComment<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     SubmitCommentMutationMyOperation,
     SubmitCommentMutationVariables,
-    SubmitCommentProps<TChildProps>
+    SubmitCommentProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withMutation<
     TProps,
     SubmitCommentMutationMyOperation,
     SubmitCommentMutationVariables,
-    SubmitCommentProps<TChildProps>
+    SubmitCommentProps<TChildProps, TDataName>
   >(SubmitCommentDocument, {
     alias: 'submitComment',
     ...operationOptions,
@@ -650,23 +664,27 @@ export const VoteComponent = (props: VoteComponentProps) => (
   <ApolloReactComponents.Mutation<VoteMutationMyOperation, VoteMutationVariables> mutation={VoteDocument} {...props} />
 );
 
-export type VoteProps<TChildProps = {}> = ApolloReactHoc.MutateProps<VoteMutationMyOperation, VoteMutationVariables> &
+export type VoteProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<VoteMutationMyOperation, VoteMutationVariables>;
+} &
   TChildProps;
-export function withVote<TProps, TChildProps = {}>(
+export function withVote<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     VoteMutationMyOperation,
     VoteMutationVariables,
-    VoteProps<TChildProps>
+    VoteProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withMutation<TProps, VoteMutationMyOperation, VoteMutationVariables, VoteProps<TChildProps>>(
-    VoteDocument,
-    {
-      alias: 'vote',
-      ...operationOptions,
-    }
-  );
+  return ApolloReactHoc.withMutation<
+    TProps,
+    VoteMutationMyOperation,
+    VoteMutationVariables,
+    VoteProps<TChildProps, TDataName>
+  >(VoteDocument, {
+    alias: 'vote',
+    ...operationOptions,
+  });
 }
 export type VoteMutationResult = ApolloReactCommon.MutationResult<VoteMutationMyOperation>;
 export type VoteMutationOptions = ApolloReactCommon.BaseMutationOptions<VoteMutationMyOperation, VoteMutationVariables>;

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -346,24 +346,23 @@ export const OnCommentAddedComponent = (props: OnCommentAddedComponentProps) => 
   />
 );
 
-export type OnCommentAddedProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  OnCommentAddedSubscription,
-  OnCommentAddedSubscriptionVariables
-> &
+export type OnCommentAddedProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
+} &
   TChildProps;
-export function withOnCommentAdded<TProps, TChildProps = {}>(
+export function withOnCommentAdded<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables,
-    OnCommentAddedProps<TChildProps>
+    OnCommentAddedProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withSubscription<
     TProps,
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables,
-    OnCommentAddedProps<TChildProps>
+    OnCommentAddedProps<TChildProps, TDataName>
   >(OnCommentAddedDocument, {
     alias: 'onCommentAdded',
     ...operationOptions,
@@ -439,17 +438,19 @@ export const CommentComponent = (props: CommentComponentProps) => (
   <ApolloReactComponents.Query<CommentQuery, CommentQueryVariables> query={CommentDocument} {...props} />
 );
 
-export type CommentProps<TChildProps = {}> = ApolloReactHoc.DataProps<CommentQuery, CommentQueryVariables> &
+export type CommentProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<CommentQuery, CommentQueryVariables>;
+} &
   TChildProps;
-export function withComment<TProps, TChildProps = {}>(
+export function withComment<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     CommentQuery,
     CommentQueryVariables,
-    CommentProps<TChildProps>
+    CommentProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withQuery<TProps, CommentQuery, CommentQueryVariables, CommentProps<TChildProps>>(
+  return ApolloReactHoc.withQuery<TProps, CommentQuery, CommentQueryVariables, CommentProps<TChildProps, TDataName>>(
     CommentDocument,
     {
       alias: 'comment',
@@ -507,24 +508,23 @@ export const CurrentUserForProfileComponent = (props: CurrentUserForProfileCompo
   />
 );
 
-export type CurrentUserForProfileProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  CurrentUserForProfileQuery,
-  CurrentUserForProfileQueryVariables
-> &
+export type CurrentUserForProfileProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
+} &
   TChildProps;
-export function withCurrentUserForProfile<TProps, TChildProps = {}>(
+export function withCurrentUserForProfile<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     CurrentUserForProfileQuery,
     CurrentUserForProfileQueryVariables,
-    CurrentUserForProfileProps<TChildProps>
+    CurrentUserForProfileProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     CurrentUserForProfileQuery,
     CurrentUserForProfileQueryVariables,
-    CurrentUserForProfileProps<TChildProps>
+    CurrentUserForProfileProps<TChildProps, TDataName>
   >(CurrentUserForProfileDocument, {
     alias: 'currentUserForProfile',
     ...operationOptions,
@@ -589,14 +589,25 @@ export const FeedComponent = (props: FeedComponentProps) => (
   <ApolloReactComponents.Query<FeedQuery, FeedQueryVariables> query={FeedDocument} {...props} />
 );
 
-export type FeedProps<TChildProps = {}> = ApolloReactHoc.DataProps<FeedQuery, FeedQueryVariables> & TChildProps;
-export function withFeed<TProps, TChildProps = {}>(
-  operationOptions?: ApolloReactHoc.OperationOption<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps>>
+export type FeedProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<FeedQuery, FeedQueryVariables>;
+} &
+  TChildProps;
+export function withFeed<TProps, TChildProps = {}, TDataName extends string = 'data'>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    FeedQuery,
+    FeedQueryVariables,
+    FeedProps<TChildProps, TDataName>
+  >
 ) {
-  return ApolloReactHoc.withQuery<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps>>(FeedDocument, {
-    alias: 'feed',
-    ...operationOptions,
-  });
+  return ApolloReactHoc.withQuery<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps, TDataName>>(
+    FeedDocument,
+    {
+      alias: 'feed',
+      ...operationOptions,
+    }
+  );
 }
 
 /**
@@ -649,24 +660,23 @@ export const SubmitRepositoryComponent = (props: SubmitRepositoryComponentProps)
   />
 );
 
-export type SubmitRepositoryProps<TChildProps = {}> = ApolloReactHoc.MutateProps<
-  SubmitRepositoryMutation,
-  SubmitRepositoryMutationVariables
-> &
+export type SubmitRepositoryProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
+} &
   TChildProps;
-export function withSubmitRepository<TProps, TChildProps = {}>(
+export function withSubmitRepository<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     SubmitRepositoryMutation,
     SubmitRepositoryMutationVariables,
-    SubmitRepositoryProps<TChildProps>
+    SubmitRepositoryProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withMutation<
     TProps,
     SubmitRepositoryMutation,
     SubmitRepositoryMutationVariables,
-    SubmitRepositoryProps<TChildProps>
+    SubmitRepositoryProps<TChildProps, TDataName>
   >(SubmitRepositoryDocument, {
     alias: 'submitRepository',
     ...operationOptions,
@@ -728,24 +738,23 @@ export const SubmitCommentComponent = (props: SubmitCommentComponentProps) => (
   />
 );
 
-export type SubmitCommentProps<TChildProps = {}> = ApolloReactHoc.MutateProps<
-  SubmitCommentMutation,
-  SubmitCommentMutationVariables
-> &
+export type SubmitCommentProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<SubmitCommentMutation, SubmitCommentMutationVariables>;
+} &
   TChildProps;
-export function withSubmitComment<TProps, TChildProps = {}>(
+export function withSubmitComment<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     SubmitCommentMutation,
     SubmitCommentMutationVariables,
-    SubmitCommentProps<TChildProps>
+    SubmitCommentProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withMutation<
     TProps,
     SubmitCommentMutation,
     SubmitCommentMutationVariables,
-    SubmitCommentProps<TChildProps>
+    SubmitCommentProps<TChildProps, TDataName>
   >(SubmitCommentDocument, {
     alias: 'submitComment',
     ...operationOptions,
@@ -805,11 +814,19 @@ export const VoteComponent = (props: VoteComponentProps) => (
   <ApolloReactComponents.Mutation<VoteMutation, VoteMutationVariables> mutation={VoteDocument} {...props} />
 );
 
-export type VoteProps<TChildProps = {}> = ApolloReactHoc.MutateProps<VoteMutation, VoteMutationVariables> & TChildProps;
-export function withVote<TProps, TChildProps = {}>(
-  operationOptions?: ApolloReactHoc.OperationOption<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps>>
+export type VoteProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<VoteMutation, VoteMutationVariables>;
+} &
+  TChildProps;
+export function withVote<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    VoteMutation,
+    VoteMutationVariables,
+    VoteProps<TChildProps, TDataName>
+  >
 ) {
-  return ApolloReactHoc.withMutation<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps>>(
+  return ApolloReactHoc.withMutation<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps, TDataName>>(
     VoteDocument,
     {
       alias: 'vote',

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -347,7 +347,7 @@ export const OnCommentAddedComponent = (props: OnCommentAddedComponentProps) => 
 );
 
 export type OnCommentAddedProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
 } &
   TChildProps;
 export function withOnCommentAdded<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -439,7 +439,7 @@ export const CommentComponent = (props: CommentComponentProps) => (
 );
 
 export type CommentProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<CommentQuery, CommentQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<CommentQuery, CommentQueryVariables>;
 } &
   TChildProps;
 export function withComment<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -509,7 +509,7 @@ export const CurrentUserForProfileComponent = (props: CurrentUserForProfileCompo
 );
 
 export type CurrentUserForProfileProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
 } &
   TChildProps;
 export function withCurrentUserForProfile<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -590,7 +590,7 @@ export const FeedComponent = (props: FeedComponentProps) => (
 );
 
 export type FeedProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<FeedQuery, FeedQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<FeedQuery, FeedQueryVariables>;
 } &
   TChildProps;
 export function withFeed<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -373,7 +373,7 @@ export const OnCommentAddedComponent = (props: OnCommentAddedComponentProps) => 
 );
 
 export type OnCommentAddedProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
 } &
   TChildProps;
 export function withOnCommentAdded<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -436,7 +436,7 @@ export const CommentComponent = (props: CommentComponentProps) => (
 );
 
 export type CommentProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<CommentQuery, CommentQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<CommentQuery, CommentQueryVariables>;
 } &
   TChildProps;
 export function withComment<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -477,7 +477,7 @@ export const CurrentUserForProfileComponent = (props: CurrentUserForProfileCompo
 );
 
 export type CurrentUserForProfileProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
 } &
   TChildProps;
 export function withCurrentUserForProfile<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -524,7 +524,7 @@ export const FeedComponent = (props: FeedComponentProps) => (
 );
 
 export type FeedProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<FeedQuery, FeedQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<FeedQuery, FeedQueryVariables>;
 } &
   TChildProps;
 export function withFeed<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -372,24 +372,23 @@ export const OnCommentAddedComponent = (props: OnCommentAddedComponentProps) => 
   />
 );
 
-export type OnCommentAddedProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  OnCommentAddedSubscription,
-  OnCommentAddedSubscriptionVariables
-> &
+export type OnCommentAddedProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
+} &
   TChildProps;
-export function withOnCommentAdded<TProps, TChildProps = {}>(
+export function withOnCommentAdded<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables,
-    OnCommentAddedProps<TChildProps>
+    OnCommentAddedProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withSubscription<
     TProps,
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables,
-    OnCommentAddedProps<TChildProps>
+    OnCommentAddedProps<TChildProps, TDataName>
   >(OnCommentAddedDocument, {
     alias: 'onCommentAdded',
     ...operationOptions,
@@ -436,17 +435,19 @@ export const CommentComponent = (props: CommentComponentProps) => (
   <ApolloReactComponents.Query<CommentQuery, CommentQueryVariables> query={CommentDocument} {...props} />
 );
 
-export type CommentProps<TChildProps = {}> = ApolloReactHoc.DataProps<CommentQuery, CommentQueryVariables> &
+export type CommentProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<CommentQuery, CommentQueryVariables>;
+} &
   TChildProps;
-export function withComment<TProps, TChildProps = {}>(
+export function withComment<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     CommentQuery,
     CommentQueryVariables,
-    CommentProps<TChildProps>
+    CommentProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withQuery<TProps, CommentQuery, CommentQueryVariables, CommentProps<TChildProps>>(
+  return ApolloReactHoc.withQuery<TProps, CommentQuery, CommentQueryVariables, CommentProps<TChildProps, TDataName>>(
     CommentDocument,
     {
       alias: 'comment',
@@ -475,24 +476,23 @@ export const CurrentUserForProfileComponent = (props: CurrentUserForProfileCompo
   />
 );
 
-export type CurrentUserForProfileProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  CurrentUserForProfileQuery,
-  CurrentUserForProfileQueryVariables
-> &
+export type CurrentUserForProfileProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
+} &
   TChildProps;
-export function withCurrentUserForProfile<TProps, TChildProps = {}>(
+export function withCurrentUserForProfile<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     CurrentUserForProfileQuery,
     CurrentUserForProfileQueryVariables,
-    CurrentUserForProfileProps<TChildProps>
+    CurrentUserForProfileProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     CurrentUserForProfileQuery,
     CurrentUserForProfileQueryVariables,
-    CurrentUserForProfileProps<TChildProps>
+    CurrentUserForProfileProps<TChildProps, TDataName>
   >(CurrentUserForProfileDocument, {
     alias: 'currentUserForProfile',
     ...operationOptions,
@@ -523,14 +523,25 @@ export const FeedComponent = (props: FeedComponentProps) => (
   <ApolloReactComponents.Query<FeedQuery, FeedQueryVariables> query={FeedDocument} {...props} />
 );
 
-export type FeedProps<TChildProps = {}> = ApolloReactHoc.DataProps<FeedQuery, FeedQueryVariables> & TChildProps;
-export function withFeed<TProps, TChildProps = {}>(
-  operationOptions?: ApolloReactHoc.OperationOption<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps>>
+export type FeedProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<FeedQuery, FeedQueryVariables>;
+} &
+  TChildProps;
+export function withFeed<TProps, TChildProps = {}, TDataName extends string = 'data'>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    FeedQuery,
+    FeedQueryVariables,
+    FeedProps<TChildProps, TDataName>
+  >
 ) {
-  return ApolloReactHoc.withQuery<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps>>(FeedDocument, {
-    alias: 'feed',
-    ...operationOptions,
-  });
+  return ApolloReactHoc.withQuery<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps, TDataName>>(
+    FeedDocument,
+    {
+      alias: 'feed',
+      ...operationOptions,
+    }
+  );
 }
 export type FeedQueryResult = ApolloReactCommon.QueryResult<FeedQuery, FeedQueryVariables>;
 export const SubmitRepositoryDocument = gql`
@@ -556,24 +567,23 @@ export const SubmitRepositoryComponent = (props: SubmitRepositoryComponentProps)
   />
 );
 
-export type SubmitRepositoryProps<TChildProps = {}> = ApolloReactHoc.MutateProps<
-  SubmitRepositoryMutation,
-  SubmitRepositoryMutationVariables
-> &
+export type SubmitRepositoryProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
+} &
   TChildProps;
-export function withSubmitRepository<TProps, TChildProps = {}>(
+export function withSubmitRepository<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     SubmitRepositoryMutation,
     SubmitRepositoryMutationVariables,
-    SubmitRepositoryProps<TChildProps>
+    SubmitRepositoryProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withMutation<
     TProps,
     SubmitRepositoryMutation,
     SubmitRepositoryMutationVariables,
-    SubmitRepositoryProps<TChildProps>
+    SubmitRepositoryProps<TChildProps, TDataName>
   >(SubmitRepositoryDocument, {
     alias: 'submitRepository',
     ...operationOptions,
@@ -608,24 +618,23 @@ export const SubmitCommentComponent = (props: SubmitCommentComponentProps) => (
   />
 );
 
-export type SubmitCommentProps<TChildProps = {}> = ApolloReactHoc.MutateProps<
-  SubmitCommentMutation,
-  SubmitCommentMutationVariables
-> &
+export type SubmitCommentProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<SubmitCommentMutation, SubmitCommentMutationVariables>;
+} &
   TChildProps;
-export function withSubmitComment<TProps, TChildProps = {}>(
+export function withSubmitComment<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     SubmitCommentMutation,
     SubmitCommentMutationVariables,
-    SubmitCommentProps<TChildProps>
+    SubmitCommentProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withMutation<
     TProps,
     SubmitCommentMutation,
     SubmitCommentMutationVariables,
-    SubmitCommentProps<TChildProps>
+    SubmitCommentProps<TChildProps, TDataName>
   >(SubmitCommentDocument, {
     alias: 'submitComment',
     ...operationOptions,
@@ -657,11 +666,19 @@ export const VoteComponent = (props: VoteComponentProps) => (
   <ApolloReactComponents.Mutation<VoteMutation, VoteMutationVariables> mutation={VoteDocument} {...props} />
 );
 
-export type VoteProps<TChildProps = {}> = ApolloReactHoc.MutateProps<VoteMutation, VoteMutationVariables> & TChildProps;
-export function withVote<TProps, TChildProps = {}>(
-  operationOptions?: ApolloReactHoc.OperationOption<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps>>
+export type VoteProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<VoteMutation, VoteMutationVariables>;
+} &
+  TChildProps;
+export function withVote<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    VoteMutation,
+    VoteMutationVariables,
+    VoteProps<TChildProps, TDataName>
+  >
 ) {
-  return ApolloReactHoc.withMutation<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps>>(
+  return ApolloReactHoc.withMutation<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps, TDataName>>(
     VoteDocument,
     {
       alias: 'vote',

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -345,24 +345,23 @@ export const OnCommentAddedComponent = (props: OnCommentAddedComponentProps) => 
   />
 );
 
-export type OnCommentAddedProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  OnCommentAddedSubscription,
-  OnCommentAddedSubscriptionVariables
-> &
+export type OnCommentAddedProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
+} &
   TChildProps;
-export function withOnCommentAdded<TProps, TChildProps = {}>(
+export function withOnCommentAdded<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables,
-    OnCommentAddedProps<TChildProps>
+    OnCommentAddedProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withSubscription<
     TProps,
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables,
-    OnCommentAddedProps<TChildProps>
+    OnCommentAddedProps<TChildProps, TDataName>
   >(OnCommentAddedDocument, {
     alias: 'onCommentAdded',
     ...operationOptions,
@@ -409,17 +408,19 @@ export const CommentComponent = (props: CommentComponentProps) => (
   <ApolloReactComponents.Query<CommentQuery, CommentQueryVariables> query={CommentDocument} {...props} />
 );
 
-export type CommentProps<TChildProps = {}> = ApolloReactHoc.DataProps<CommentQuery, CommentQueryVariables> &
+export type CommentProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<CommentQuery, CommentQueryVariables>;
+} &
   TChildProps;
-export function withComment<TProps, TChildProps = {}>(
+export function withComment<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     CommentQuery,
     CommentQueryVariables,
-    CommentProps<TChildProps>
+    CommentProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withQuery<TProps, CommentQuery, CommentQueryVariables, CommentProps<TChildProps>>(
+  return ApolloReactHoc.withQuery<TProps, CommentQuery, CommentQueryVariables, CommentProps<TChildProps, TDataName>>(
     CommentDocument,
     {
       alias: 'comment',
@@ -448,24 +449,23 @@ export const CurrentUserForProfileComponent = (props: CurrentUserForProfileCompo
   />
 );
 
-export type CurrentUserForProfileProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  CurrentUserForProfileQuery,
-  CurrentUserForProfileQueryVariables
-> &
+export type CurrentUserForProfileProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
+} &
   TChildProps;
-export function withCurrentUserForProfile<TProps, TChildProps = {}>(
+export function withCurrentUserForProfile<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     CurrentUserForProfileQuery,
     CurrentUserForProfileQueryVariables,
-    CurrentUserForProfileProps<TChildProps>
+    CurrentUserForProfileProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     CurrentUserForProfileQuery,
     CurrentUserForProfileQueryVariables,
-    CurrentUserForProfileProps<TChildProps>
+    CurrentUserForProfileProps<TChildProps, TDataName>
   >(CurrentUserForProfileDocument, {
     alias: 'currentUserForProfile',
     ...operationOptions,
@@ -496,14 +496,25 @@ export const FeedComponent = (props: FeedComponentProps) => (
   <ApolloReactComponents.Query<FeedQuery, FeedQueryVariables> query={FeedDocument} {...props} />
 );
 
-export type FeedProps<TChildProps = {}> = ApolloReactHoc.DataProps<FeedQuery, FeedQueryVariables> & TChildProps;
-export function withFeed<TProps, TChildProps = {}>(
-  operationOptions?: ApolloReactHoc.OperationOption<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps>>
+export type FeedProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<FeedQuery, FeedQueryVariables>;
+} &
+  TChildProps;
+export function withFeed<TProps, TChildProps = {}, TDataName extends string = 'data'>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    FeedQuery,
+    FeedQueryVariables,
+    FeedProps<TChildProps, TDataName>
+  >
 ) {
-  return ApolloReactHoc.withQuery<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps>>(FeedDocument, {
-    alias: 'feed',
-    ...operationOptions,
-  });
+  return ApolloReactHoc.withQuery<TProps, FeedQuery, FeedQueryVariables, FeedProps<TChildProps, TDataName>>(
+    FeedDocument,
+    {
+      alias: 'feed',
+      ...operationOptions,
+    }
+  );
 }
 export type FeedQueryResult = ApolloReactCommon.QueryResult<FeedQuery, FeedQueryVariables>;
 export const SubmitRepositoryDocument = gql`
@@ -529,24 +540,23 @@ export const SubmitRepositoryComponent = (props: SubmitRepositoryComponentProps)
   />
 );
 
-export type SubmitRepositoryProps<TChildProps = {}> = ApolloReactHoc.MutateProps<
-  SubmitRepositoryMutation,
-  SubmitRepositoryMutationVariables
-> &
+export type SubmitRepositoryProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
+} &
   TChildProps;
-export function withSubmitRepository<TProps, TChildProps = {}>(
+export function withSubmitRepository<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     SubmitRepositoryMutation,
     SubmitRepositoryMutationVariables,
-    SubmitRepositoryProps<TChildProps>
+    SubmitRepositoryProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withMutation<
     TProps,
     SubmitRepositoryMutation,
     SubmitRepositoryMutationVariables,
-    SubmitRepositoryProps<TChildProps>
+    SubmitRepositoryProps<TChildProps, TDataName>
   >(SubmitRepositoryDocument, {
     alias: 'submitRepository',
     ...operationOptions,
@@ -581,24 +591,23 @@ export const SubmitCommentComponent = (props: SubmitCommentComponentProps) => (
   />
 );
 
-export type SubmitCommentProps<TChildProps = {}> = ApolloReactHoc.MutateProps<
-  SubmitCommentMutation,
-  SubmitCommentMutationVariables
-> &
+export type SubmitCommentProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<SubmitCommentMutation, SubmitCommentMutationVariables>;
+} &
   TChildProps;
-export function withSubmitComment<TProps, TChildProps = {}>(
+export function withSubmitComment<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     SubmitCommentMutation,
     SubmitCommentMutationVariables,
-    SubmitCommentProps<TChildProps>
+    SubmitCommentProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withMutation<
     TProps,
     SubmitCommentMutation,
     SubmitCommentMutationVariables,
-    SubmitCommentProps<TChildProps>
+    SubmitCommentProps<TChildProps, TDataName>
   >(SubmitCommentDocument, {
     alias: 'submitComment',
     ...operationOptions,
@@ -630,11 +639,19 @@ export const VoteComponent = (props: VoteComponentProps) => (
   <ApolloReactComponents.Mutation<VoteMutation, VoteMutationVariables> mutation={VoteDocument} {...props} />
 );
 
-export type VoteProps<TChildProps = {}> = ApolloReactHoc.MutateProps<VoteMutation, VoteMutationVariables> & TChildProps;
-export function withVote<TProps, TChildProps = {}>(
-  operationOptions?: ApolloReactHoc.OperationOption<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps>>
+export type VoteProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<VoteMutation, VoteMutationVariables>;
+} &
+  TChildProps;
+export function withVote<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    VoteMutation,
+    VoteMutationVariables,
+    VoteProps<TChildProps, TDataName>
+  >
 ) {
-  return ApolloReactHoc.withMutation<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps>>(
+  return ApolloReactHoc.withMutation<TProps, VoteMutation, VoteMutationVariables, VoteProps<TChildProps, TDataName>>(
     VoteDocument,
     {
       alias: 'vote',

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -346,7 +346,7 @@ export const OnCommentAddedComponent = (props: OnCommentAddedComponentProps) => 
 );
 
 export type OnCommentAddedProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>;
 } &
   TChildProps;
 export function withOnCommentAdded<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -409,7 +409,7 @@ export const CommentComponent = (props: CommentComponentProps) => (
 );
 
 export type CommentProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<CommentQuery, CommentQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<CommentQuery, CommentQueryVariables>;
 } &
   TChildProps;
 export function withComment<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -450,7 +450,7 @@ export const CurrentUserForProfileComponent = (props: CurrentUserForProfileCompo
 );
 
 export type CurrentUserForProfileProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>;
 } &
   TChildProps;
 export function withCurrentUserForProfile<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -497,7 +497,7 @@ export const FeedComponent = (props: FeedComponentProps) => (
 );
 
 export type FeedProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<FeedQuery, FeedQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<FeedQuery, FeedQueryVariables>;
 } &
   TChildProps;
 export function withFeed<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/star-wars/__generated__/CreateReviewForEpisode.tsx
+++ b/dev-test/star-wars/__generated__/CreateReviewForEpisode.tsx
@@ -43,24 +43,26 @@ export const CreateReviewForEpisodeComponent = (props: CreateReviewForEpisodeCom
   />
 );
 
-export type CreateReviewForEpisodeProps<TChildProps = {}> = ApolloReactHoc.MutateProps<
-  CreateReviewForEpisodeMutation,
-  CreateReviewForEpisodeMutationVariables
-> &
+export type CreateReviewForEpisodeProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    CreateReviewForEpisodeMutation,
+    CreateReviewForEpisodeMutationVariables
+  >;
+} &
   TChildProps;
-export function withCreateReviewForEpisode<TProps, TChildProps = {}>(
+export function withCreateReviewForEpisode<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     CreateReviewForEpisodeMutation,
     CreateReviewForEpisodeMutationVariables,
-    CreateReviewForEpisodeProps<TChildProps>
+    CreateReviewForEpisodeProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withMutation<
     TProps,
     CreateReviewForEpisodeMutation,
     CreateReviewForEpisodeMutationVariables,
-    CreateReviewForEpisodeProps<TChildProps>
+    CreateReviewForEpisodeProps<TChildProps, TDataName>
   >(CreateReviewForEpisodeDocument, {
     alias: 'createReviewForEpisode',
     ...operationOptions,

--- a/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
+++ b/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
@@ -58,24 +58,23 @@ export const HeroAndFriendsNamesComponent = (props: HeroAndFriendsNamesComponent
   />
 );
 
-export type HeroAndFriendsNamesProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroAndFriendsNamesQuery,
-  HeroAndFriendsNamesQueryVariables
-> &
+export type HeroAndFriendsNamesProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HeroAndFriendsNamesQuery, HeroAndFriendsNamesQueryVariables>;
+} &
   TChildProps;
-export function withHeroAndFriendsNames<TProps, TChildProps = {}>(
+export function withHeroAndFriendsNames<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroAndFriendsNamesQuery,
     HeroAndFriendsNamesQueryVariables,
-    HeroAndFriendsNamesProps<TChildProps>
+    HeroAndFriendsNamesProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroAndFriendsNamesQuery,
     HeroAndFriendsNamesQueryVariables,
-    HeroAndFriendsNamesProps<TChildProps>
+    HeroAndFriendsNamesProps<TChildProps, TDataName>
   >(HeroAndFriendsNamesDocument, {
     alias: 'heroAndFriendsNames',
     ...operationOptions,

--- a/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
+++ b/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
@@ -59,7 +59,7 @@ export const HeroAndFriendsNamesComponent = (props: HeroAndFriendsNamesComponent
 );
 
 export type HeroAndFriendsNamesProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HeroAndFriendsNamesQuery, HeroAndFriendsNamesQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HeroAndFriendsNamesQuery, HeroAndFriendsNamesQueryVariables>;
 } &
   TChildProps;
 export function withHeroAndFriendsNames<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
+++ b/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
@@ -36,24 +36,23 @@ export const HeroAppearsInComponent = (props: HeroAppearsInComponentProps) => (
   />
 );
 
-export type HeroAppearsInProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroAppearsInQuery,
-  HeroAppearsInQueryVariables
-> &
+export type HeroAppearsInProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HeroAppearsInQuery, HeroAppearsInQueryVariables>;
+} &
   TChildProps;
-export function withHeroAppearsIn<TProps, TChildProps = {}>(
+export function withHeroAppearsIn<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroAppearsInQuery,
     HeroAppearsInQueryVariables,
-    HeroAppearsInProps<TChildProps>
+    HeroAppearsInProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroAppearsInQuery,
     HeroAppearsInQueryVariables,
-    HeroAppearsInProps<TChildProps>
+    HeroAppearsInProps<TChildProps, TDataName>
   >(HeroAppearsInDocument, {
     alias: 'heroAppearsIn',
     ...operationOptions,

--- a/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
+++ b/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
@@ -37,7 +37,7 @@ export const HeroAppearsInComponent = (props: HeroAppearsInComponentProps) => (
 );
 
 export type HeroAppearsInProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HeroAppearsInQuery, HeroAppearsInQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HeroAppearsInQuery, HeroAppearsInQueryVariables>;
 } &
   TChildProps;
 export function withHeroAppearsIn<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/star-wars/__generated__/HeroDetails.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetails.tsx
@@ -40,22 +40,26 @@ export const HeroDetailsComponent = (props: HeroDetailsComponentProps) => (
   <ApolloReactComponents.Query<HeroDetailsQuery, HeroDetailsQueryVariables> query={HeroDetailsDocument} {...props} />
 );
 
-export type HeroDetailsProps<TChildProps = {}> = ApolloReactHoc.DataProps<HeroDetailsQuery, HeroDetailsQueryVariables> &
+export type HeroDetailsProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HeroDetailsQuery, HeroDetailsQueryVariables>;
+} &
   TChildProps;
-export function withHeroDetails<TProps, TChildProps = {}>(
+export function withHeroDetails<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroDetailsQuery,
     HeroDetailsQueryVariables,
-    HeroDetailsProps<TChildProps>
+    HeroDetailsProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withQuery<TProps, HeroDetailsQuery, HeroDetailsQueryVariables, HeroDetailsProps<TChildProps>>(
-    HeroDetailsDocument,
-    {
-      alias: 'heroDetails',
-      ...operationOptions,
-    }
-  );
+  return ApolloReactHoc.withQuery<
+    TProps,
+    HeroDetailsQuery,
+    HeroDetailsQueryVariables,
+    HeroDetailsProps<TChildProps, TDataName>
+  >(HeroDetailsDocument, {
+    alias: 'heroDetails',
+    ...operationOptions,
+  });
 }
 export type HeroDetailsQueryResult = ApolloReactCommon.QueryResult<HeroDetailsQuery, HeroDetailsQueryVariables>;

--- a/dev-test/star-wars/__generated__/HeroDetails.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetails.tsx
@@ -41,7 +41,7 @@ export const HeroDetailsComponent = (props: HeroDetailsComponentProps) => (
 );
 
 export type HeroDetailsProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HeroDetailsQuery, HeroDetailsQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HeroDetailsQuery, HeroDetailsQueryVariables>;
 } &
   TChildProps;
 export function withHeroDetails<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
@@ -38,24 +38,23 @@ export const HeroDetailsWithFragmentComponent = (props: HeroDetailsWithFragmentC
   />
 );
 
-export type HeroDetailsWithFragmentProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroDetailsWithFragmentQuery,
-  HeroDetailsWithFragmentQueryVariables
-> &
+export type HeroDetailsWithFragmentProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HeroDetailsWithFragmentQuery, HeroDetailsWithFragmentQueryVariables>;
+} &
   TChildProps;
-export function withHeroDetailsWithFragment<TProps, TChildProps = {}>(
+export function withHeroDetailsWithFragment<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroDetailsWithFragmentQuery,
     HeroDetailsWithFragmentQueryVariables,
-    HeroDetailsWithFragmentProps<TChildProps>
+    HeroDetailsWithFragmentProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroDetailsWithFragmentQuery,
     HeroDetailsWithFragmentQueryVariables,
-    HeroDetailsWithFragmentProps<TChildProps>
+    HeroDetailsWithFragmentProps<TChildProps, TDataName>
   >(HeroDetailsWithFragmentDocument, {
     alias: 'heroDetailsWithFragment',
     ...operationOptions,

--- a/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
@@ -39,7 +39,7 @@ export const HeroDetailsWithFragmentComponent = (props: HeroDetailsWithFragmentC
 );
 
 export type HeroDetailsWithFragmentProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HeroDetailsWithFragmentQuery, HeroDetailsWithFragmentQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HeroDetailsWithFragmentQuery, HeroDetailsWithFragmentQueryVariables>;
 } &
   TChildProps;
 export function withHeroDetailsWithFragment<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/star-wars/__generated__/HeroName.tsx
+++ b/dev-test/star-wars/__generated__/HeroName.tsx
@@ -34,7 +34,7 @@ export const HeroNameComponent = (props: HeroNameComponentProps) => (
 );
 
 export type HeroNameProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HeroNameQuery, HeroNameQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HeroNameQuery, HeroNameQueryVariables>;
 } &
   TChildProps;
 export function withHeroName<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/star-wars/__generated__/HeroName.tsx
+++ b/dev-test/star-wars/__generated__/HeroName.tsx
@@ -33,17 +33,19 @@ export const HeroNameComponent = (props: HeroNameComponentProps) => (
   <ApolloReactComponents.Query<HeroNameQuery, HeroNameQueryVariables> query={HeroNameDocument} {...props} />
 );
 
-export type HeroNameProps<TChildProps = {}> = ApolloReactHoc.DataProps<HeroNameQuery, HeroNameQueryVariables> &
+export type HeroNameProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HeroNameQuery, HeroNameQueryVariables>;
+} &
   TChildProps;
-export function withHeroName<TProps, TChildProps = {}>(
+export function withHeroName<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroNameQuery,
     HeroNameQueryVariables,
-    HeroNameProps<TChildProps>
+    HeroNameProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withQuery<TProps, HeroNameQuery, HeroNameQueryVariables, HeroNameProps<TChildProps>>(
+  return ApolloReactHoc.withQuery<TProps, HeroNameQuery, HeroNameQueryVariables, HeroNameProps<TChildProps, TDataName>>(
     HeroNameDocument,
     {
       alias: 'heroName',

--- a/dev-test/star-wars/__generated__/HeroNameConditional.tsx
+++ b/dev-test/star-wars/__generated__/HeroNameConditional.tsx
@@ -53,7 +53,7 @@ export const HeroNameConditionalInclusionComponent = (props: HeroNameConditional
 );
 
 export type HeroNameConditionalInclusionProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<
+  [key in TDataName]: ApolloReactHoc.DataValue<
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables
   >;
@@ -105,7 +105,7 @@ export const HeroNameConditionalExclusionComponent = (props: HeroNameConditional
 );
 
 export type HeroNameConditionalExclusionProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<
+  [key in TDataName]: ApolloReactHoc.DataValue<
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables
   >;

--- a/dev-test/star-wars/__generated__/HeroNameConditional.tsx
+++ b/dev-test/star-wars/__generated__/HeroNameConditional.tsx
@@ -52,24 +52,26 @@ export const HeroNameConditionalInclusionComponent = (props: HeroNameConditional
   />
 );
 
-export type HeroNameConditionalInclusionProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroNameConditionalInclusionQuery,
-  HeroNameConditionalInclusionQueryVariables
-> &
+export type HeroNameConditionalInclusionProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<
+    HeroNameConditionalInclusionQuery,
+    HeroNameConditionalInclusionQueryVariables
+  >;
+} &
   TChildProps;
-export function withHeroNameConditionalInclusion<TProps, TChildProps = {}>(
+export function withHeroNameConditionalInclusion<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables,
-    HeroNameConditionalInclusionProps<TChildProps>
+    HeroNameConditionalInclusionProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables,
-    HeroNameConditionalInclusionProps<TChildProps>
+    HeroNameConditionalInclusionProps<TChildProps, TDataName>
   >(HeroNameConditionalInclusionDocument, {
     alias: 'heroNameConditionalInclusion',
     ...operationOptions,
@@ -102,24 +104,26 @@ export const HeroNameConditionalExclusionComponent = (props: HeroNameConditional
   />
 );
 
-export type HeroNameConditionalExclusionProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroNameConditionalExclusionQuery,
-  HeroNameConditionalExclusionQueryVariables
-> &
+export type HeroNameConditionalExclusionProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<
+    HeroNameConditionalExclusionQuery,
+    HeroNameConditionalExclusionQueryVariables
+  >;
+} &
   TChildProps;
-export function withHeroNameConditionalExclusion<TProps, TChildProps = {}>(
+export function withHeroNameConditionalExclusion<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables,
-    HeroNameConditionalExclusionProps<TChildProps>
+    HeroNameConditionalExclusionProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables,
-    HeroNameConditionalExclusionProps<TChildProps>
+    HeroNameConditionalExclusionProps<TChildProps, TDataName>
   >(HeroNameConditionalExclusionDocument, {
     alias: 'heroNameConditionalExclusion',
     ...operationOptions,

--- a/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
+++ b/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
@@ -75,7 +75,7 @@ export const HeroParentTypeDependentFieldComponent = (props: HeroParentTypeDepen
 );
 
 export type HeroParentTypeDependentFieldProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<
+  [key in TDataName]: ApolloReactHoc.DataValue<
     HeroParentTypeDependentFieldQuery,
     HeroParentTypeDependentFieldQueryVariables
   >;

--- a/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
+++ b/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
@@ -74,24 +74,26 @@ export const HeroParentTypeDependentFieldComponent = (props: HeroParentTypeDepen
   />
 );
 
-export type HeroParentTypeDependentFieldProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroParentTypeDependentFieldQuery,
-  HeroParentTypeDependentFieldQueryVariables
-> &
+export type HeroParentTypeDependentFieldProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<
+    HeroParentTypeDependentFieldQuery,
+    HeroParentTypeDependentFieldQueryVariables
+  >;
+} &
   TChildProps;
-export function withHeroParentTypeDependentField<TProps, TChildProps = {}>(
+export function withHeroParentTypeDependentField<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroParentTypeDependentFieldQuery,
     HeroParentTypeDependentFieldQueryVariables,
-    HeroParentTypeDependentFieldProps<TChildProps>
+    HeroParentTypeDependentFieldProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroParentTypeDependentFieldQuery,
     HeroParentTypeDependentFieldQueryVariables,
-    HeroParentTypeDependentFieldProps<TChildProps>
+    HeroParentTypeDependentFieldProps<TChildProps, TDataName>
   >(HeroParentTypeDependentFieldDocument, {
     alias: 'heroParentTypeDependentField',
     ...operationOptions,

--- a/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
+++ b/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
@@ -46,7 +46,7 @@ export const HeroTypeDependentAliasedFieldComponent = (props: HeroTypeDependentA
 );
 
 export type HeroTypeDependentAliasedFieldProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<
+  [key in TDataName]: ApolloReactHoc.DataValue<
     HeroTypeDependentAliasedFieldQuery,
     HeroTypeDependentAliasedFieldQueryVariables
   >;

--- a/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
+++ b/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
@@ -45,24 +45,26 @@ export const HeroTypeDependentAliasedFieldComponent = (props: HeroTypeDependentA
   />
 );
 
-export type HeroTypeDependentAliasedFieldProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroTypeDependentAliasedFieldQuery,
-  HeroTypeDependentAliasedFieldQueryVariables
-> &
+export type HeroTypeDependentAliasedFieldProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<
+    HeroTypeDependentAliasedFieldQuery,
+    HeroTypeDependentAliasedFieldQueryVariables
+  >;
+} &
   TChildProps;
-export function withHeroTypeDependentAliasedField<TProps, TChildProps = {}>(
+export function withHeroTypeDependentAliasedField<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroTypeDependentAliasedFieldQuery,
     HeroTypeDependentAliasedFieldQueryVariables,
-    HeroTypeDependentAliasedFieldProps<TChildProps>
+    HeroTypeDependentAliasedFieldProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroTypeDependentAliasedFieldQuery,
     HeroTypeDependentAliasedFieldQueryVariables,
-    HeroTypeDependentAliasedFieldProps<TChildProps>
+    HeroTypeDependentAliasedFieldProps<TChildProps, TDataName>
   >(HeroTypeDependentAliasedFieldDocument, {
     alias: 'heroTypeDependentAliasedField',
     ...operationOptions,

--- a/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
+++ b/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
@@ -35,7 +35,7 @@ export const HumanWithNullHeightComponent = (props: HumanWithNullHeightComponent
 );
 
 export type HumanWithNullHeightProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HumanWithNullHeightQuery, HumanWithNullHeightQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HumanWithNullHeightQuery, HumanWithNullHeightQueryVariables>;
 } &
   TChildProps;
 export function withHumanWithNullHeight<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
+++ b/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
@@ -34,24 +34,23 @@ export const HumanWithNullHeightComponent = (props: HumanWithNullHeightComponent
   />
 );
 
-export type HumanWithNullHeightProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HumanWithNullHeightQuery,
-  HumanWithNullHeightQueryVariables
-> &
+export type HumanWithNullHeightProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HumanWithNullHeightQuery, HumanWithNullHeightQueryVariables>;
+} &
   TChildProps;
-export function withHumanWithNullHeight<TProps, TChildProps = {}>(
+export function withHumanWithNullHeight<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HumanWithNullHeightQuery,
     HumanWithNullHeightQueryVariables,
-    HumanWithNullHeightProps<TChildProps>
+    HumanWithNullHeightProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HumanWithNullHeightQuery,
     HumanWithNullHeightQueryVariables,
-    HumanWithNullHeightProps<TChildProps>
+    HumanWithNullHeightProps<TChildProps, TDataName>
   >(HumanWithNullHeightDocument, {
     alias: 'humanWithNullHeight',
     ...operationOptions,

--- a/dev-test/star-wars/__generated__/TwoHeroes.tsx
+++ b/dev-test/star-wars/__generated__/TwoHeroes.tsx
@@ -37,22 +37,26 @@ export const TwoHeroesComponent = (props: TwoHeroesComponentProps) => (
   <ApolloReactComponents.Query<TwoHeroesQuery, TwoHeroesQueryVariables> query={TwoHeroesDocument} {...props} />
 );
 
-export type TwoHeroesProps<TChildProps = {}> = ApolloReactHoc.DataProps<TwoHeroesQuery, TwoHeroesQueryVariables> &
+export type TwoHeroesProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<TwoHeroesQuery, TwoHeroesQueryVariables>;
+} &
   TChildProps;
-export function withTwoHeroes<TProps, TChildProps = {}>(
+export function withTwoHeroes<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     TwoHeroesQuery,
     TwoHeroesQueryVariables,
-    TwoHeroesProps<TChildProps>
+    TwoHeroesProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withQuery<TProps, TwoHeroesQuery, TwoHeroesQueryVariables, TwoHeroesProps<TChildProps>>(
-    TwoHeroesDocument,
-    {
-      alias: 'twoHeroes',
-      ...operationOptions,
-    }
-  );
+  return ApolloReactHoc.withQuery<
+    TProps,
+    TwoHeroesQuery,
+    TwoHeroesQueryVariables,
+    TwoHeroesProps<TChildProps, TDataName>
+  >(TwoHeroesDocument, {
+    alias: 'twoHeroes',
+    ...operationOptions,
+  });
 }
 export type TwoHeroesQueryResult = ApolloReactCommon.QueryResult<TwoHeroesQuery, TwoHeroesQueryVariables>;

--- a/dev-test/star-wars/__generated__/TwoHeroes.tsx
+++ b/dev-test/star-wars/__generated__/TwoHeroes.tsx
@@ -38,7 +38,7 @@ export const TwoHeroesComponent = (props: TwoHeroesComponentProps) => (
 );
 
 export type TwoHeroesProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<TwoHeroesQuery, TwoHeroesQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<TwoHeroesQuery, TwoHeroesQueryVariables>;
 } &
   TChildProps;
 export function withTwoHeroes<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/star-wars/types.refetchFn.tsx
+++ b/dev-test/star-wars/types.refetchFn.tsx
@@ -337,7 +337,7 @@ export const HeroAndFriendsNamesComponent = (props: HeroAndFriendsNamesComponent
 );
 
 export type HeroAndFriendsNamesProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HeroAndFriendsNamesQuery, HeroAndFriendsNamesQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HeroAndFriendsNamesQuery, HeroAndFriendsNamesQueryVariables>;
 } &
   TChildProps;
 export function withHeroAndFriendsNames<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -386,7 +386,7 @@ export const HeroAppearsInComponent = (props: HeroAppearsInComponentProps) => (
 );
 
 export type HeroAppearsInProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HeroAppearsInQuery, HeroAppearsInQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HeroAppearsInQuery, HeroAppearsInQueryVariables>;
 } &
   TChildProps;
 export function withHeroAppearsIn<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -434,7 +434,7 @@ export const HeroDetailsComponent = (props: HeroDetailsComponentProps) => (
 );
 
 export type HeroDetailsProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HeroDetailsQuery, HeroDetailsQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HeroDetailsQuery, HeroDetailsQueryVariables>;
 } &
   TChildProps;
 export function withHeroDetails<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -480,7 +480,7 @@ export const HeroDetailsWithFragmentComponent = (props: HeroDetailsWithFragmentC
 );
 
 export type HeroDetailsWithFragmentProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HeroDetailsWithFragmentQuery, HeroDetailsWithFragmentQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HeroDetailsWithFragmentQuery, HeroDetailsWithFragmentQueryVariables>;
 } &
   TChildProps;
 export function withHeroDetailsWithFragment<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -525,7 +525,7 @@ export const HeroNameComponent = (props: HeroNameComponentProps) => (
 );
 
 export type HeroNameProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HeroNameQuery, HeroNameQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HeroNameQuery, HeroNameQueryVariables>;
 } &
   TChildProps;
 export function withHeroName<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -572,7 +572,7 @@ export const HeroNameConditionalInclusionComponent = (props: HeroNameConditional
 );
 
 export type HeroNameConditionalInclusionProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<
+  [key in TDataName]: ApolloReactHoc.DataValue<
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables
   >;
@@ -627,7 +627,7 @@ export const HeroNameConditionalExclusionComponent = (props: HeroNameConditional
 );
 
 export type HeroNameConditionalExclusionProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<
+  [key in TDataName]: ApolloReactHoc.DataValue<
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables
   >;
@@ -697,7 +697,7 @@ export const HeroParentTypeDependentFieldComponent = (props: HeroParentTypeDepen
 );
 
 export type HeroParentTypeDependentFieldProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<
+  [key in TDataName]: ApolloReactHoc.DataValue<
     HeroParentTypeDependentFieldQuery,
     HeroParentTypeDependentFieldQueryVariables
   >;
@@ -756,7 +756,7 @@ export const HeroTypeDependentAliasedFieldComponent = (props: HeroTypeDependentA
 );
 
 export type HeroTypeDependentAliasedFieldProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<
+  [key in TDataName]: ApolloReactHoc.DataValue<
     HeroTypeDependentAliasedFieldQuery,
     HeroTypeDependentAliasedFieldQueryVariables
   >;
@@ -808,7 +808,7 @@ export const HumanWithNullHeightComponent = (props: HumanWithNullHeightComponent
 );
 
 export type HumanWithNullHeightProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<HumanWithNullHeightQuery, HumanWithNullHeightQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<HumanWithNullHeightQuery, HumanWithNullHeightQueryVariables>;
 } &
   TChildProps;
 export function withHumanWithNullHeight<TProps, TChildProps = {}, TDataName extends string = 'data'>(
@@ -856,7 +856,7 @@ export const TwoHeroesComponent = (props: TwoHeroesComponentProps) => (
 );
 
 export type TwoHeroesProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactCommon.DataValue<TwoHeroesQuery, TwoHeroesQueryVariables>;
+  [key in TDataName]: ApolloReactHoc.DataValue<TwoHeroesQuery, TwoHeroesQueryVariables>;
 } &
   TChildProps;
 export function withTwoHeroes<TProps, TChildProps = {}, TDataName extends string = 'data'>(

--- a/dev-test/star-wars/types.refetchFn.tsx
+++ b/dev-test/star-wars/types.refetchFn.tsx
@@ -284,24 +284,26 @@ export const CreateReviewForEpisodeComponent = (props: CreateReviewForEpisodeCom
   />
 );
 
-export type CreateReviewForEpisodeProps<TChildProps = {}> = ApolloReactHoc.MutateProps<
-  CreateReviewForEpisodeMutation,
-  CreateReviewForEpisodeMutationVariables
-> &
+export type CreateReviewForEpisodeProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    CreateReviewForEpisodeMutation,
+    CreateReviewForEpisodeMutationVariables
+  >;
+} &
   TChildProps;
-export function withCreateReviewForEpisode<TProps, TChildProps = {}>(
+export function withCreateReviewForEpisode<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     CreateReviewForEpisodeMutation,
     CreateReviewForEpisodeMutationVariables,
-    CreateReviewForEpisodeProps<TChildProps>
+    CreateReviewForEpisodeProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withMutation<
     TProps,
     CreateReviewForEpisodeMutation,
     CreateReviewForEpisodeMutationVariables,
-    CreateReviewForEpisodeProps<TChildProps>
+    CreateReviewForEpisodeProps<TChildProps, TDataName>
   >(CreateReviewForEpisodeDocument, {
     alias: 'createReviewForEpisode',
     ...operationOptions,
@@ -334,24 +336,23 @@ export const HeroAndFriendsNamesComponent = (props: HeroAndFriendsNamesComponent
   />
 );
 
-export type HeroAndFriendsNamesProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroAndFriendsNamesQuery,
-  HeroAndFriendsNamesQueryVariables
-> &
+export type HeroAndFriendsNamesProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HeroAndFriendsNamesQuery, HeroAndFriendsNamesQueryVariables>;
+} &
   TChildProps;
-export function withHeroAndFriendsNames<TProps, TChildProps = {}>(
+export function withHeroAndFriendsNames<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroAndFriendsNamesQuery,
     HeroAndFriendsNamesQueryVariables,
-    HeroAndFriendsNamesProps<TChildProps>
+    HeroAndFriendsNamesProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroAndFriendsNamesQuery,
     HeroAndFriendsNamesQueryVariables,
-    HeroAndFriendsNamesProps<TChildProps>
+    HeroAndFriendsNamesProps<TChildProps, TDataName>
   >(HeroAndFriendsNamesDocument, {
     alias: 'heroAndFriendsNames',
     ...operationOptions,
@@ -384,24 +385,23 @@ export const HeroAppearsInComponent = (props: HeroAppearsInComponentProps) => (
   />
 );
 
-export type HeroAppearsInProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroAppearsInQuery,
-  HeroAppearsInQueryVariables
-> &
+export type HeroAppearsInProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HeroAppearsInQuery, HeroAppearsInQueryVariables>;
+} &
   TChildProps;
-export function withHeroAppearsIn<TProps, TChildProps = {}>(
+export function withHeroAppearsIn<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroAppearsInQuery,
     HeroAppearsInQueryVariables,
-    HeroAppearsInProps<TChildProps>
+    HeroAppearsInProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroAppearsInQuery,
     HeroAppearsInQueryVariables,
-    HeroAppearsInProps<TChildProps>
+    HeroAppearsInProps<TChildProps, TDataName>
   >(HeroAppearsInDocument, {
     alias: 'heroAppearsIn',
     ...operationOptions,
@@ -433,23 +433,27 @@ export const HeroDetailsComponent = (props: HeroDetailsComponentProps) => (
   <ApolloReactComponents.Query<HeroDetailsQuery, HeroDetailsQueryVariables> query={HeroDetailsDocument} {...props} />
 );
 
-export type HeroDetailsProps<TChildProps = {}> = ApolloReactHoc.DataProps<HeroDetailsQuery, HeroDetailsQueryVariables> &
+export type HeroDetailsProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HeroDetailsQuery, HeroDetailsQueryVariables>;
+} &
   TChildProps;
-export function withHeroDetails<TProps, TChildProps = {}>(
+export function withHeroDetails<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroDetailsQuery,
     HeroDetailsQueryVariables,
-    HeroDetailsProps<TChildProps>
+    HeroDetailsProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withQuery<TProps, HeroDetailsQuery, HeroDetailsQueryVariables, HeroDetailsProps<TChildProps>>(
-    HeroDetailsDocument,
-    {
-      alias: 'heroDetails',
-      ...operationOptions,
-    }
-  );
+  return ApolloReactHoc.withQuery<
+    TProps,
+    HeroDetailsQuery,
+    HeroDetailsQueryVariables,
+    HeroDetailsProps<TChildProps, TDataName>
+  >(HeroDetailsDocument, {
+    alias: 'heroDetails',
+    ...operationOptions,
+  });
 }
 export type HeroDetailsQueryResult = ApolloReactCommon.QueryResult<HeroDetailsQuery, HeroDetailsQueryVariables>;
 export function refetchHeroDetailsQuery(variables?: HeroDetailsQueryVariables) {
@@ -475,24 +479,23 @@ export const HeroDetailsWithFragmentComponent = (props: HeroDetailsWithFragmentC
   />
 );
 
-export type HeroDetailsWithFragmentProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroDetailsWithFragmentQuery,
-  HeroDetailsWithFragmentQueryVariables
-> &
+export type HeroDetailsWithFragmentProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HeroDetailsWithFragmentQuery, HeroDetailsWithFragmentQueryVariables>;
+} &
   TChildProps;
-export function withHeroDetailsWithFragment<TProps, TChildProps = {}>(
+export function withHeroDetailsWithFragment<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroDetailsWithFragmentQuery,
     HeroDetailsWithFragmentQueryVariables,
-    HeroDetailsWithFragmentProps<TChildProps>
+    HeroDetailsWithFragmentProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroDetailsWithFragmentQuery,
     HeroDetailsWithFragmentQueryVariables,
-    HeroDetailsWithFragmentProps<TChildProps>
+    HeroDetailsWithFragmentProps<TChildProps, TDataName>
   >(HeroDetailsWithFragmentDocument, {
     alias: 'heroDetailsWithFragment',
     ...operationOptions,
@@ -521,17 +524,19 @@ export const HeroNameComponent = (props: HeroNameComponentProps) => (
   <ApolloReactComponents.Query<HeroNameQuery, HeroNameQueryVariables> query={HeroNameDocument} {...props} />
 );
 
-export type HeroNameProps<TChildProps = {}> = ApolloReactHoc.DataProps<HeroNameQuery, HeroNameQueryVariables> &
+export type HeroNameProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HeroNameQuery, HeroNameQueryVariables>;
+} &
   TChildProps;
-export function withHeroName<TProps, TChildProps = {}>(
+export function withHeroName<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroNameQuery,
     HeroNameQueryVariables,
-    HeroNameProps<TChildProps>
+    HeroNameProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withQuery<TProps, HeroNameQuery, HeroNameQueryVariables, HeroNameProps<TChildProps>>(
+  return ApolloReactHoc.withQuery<TProps, HeroNameQuery, HeroNameQueryVariables, HeroNameProps<TChildProps, TDataName>>(
     HeroNameDocument,
     {
       alias: 'heroName',
@@ -566,24 +571,26 @@ export const HeroNameConditionalInclusionComponent = (props: HeroNameConditional
   />
 );
 
-export type HeroNameConditionalInclusionProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroNameConditionalInclusionQuery,
-  HeroNameConditionalInclusionQueryVariables
-> &
+export type HeroNameConditionalInclusionProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<
+    HeroNameConditionalInclusionQuery,
+    HeroNameConditionalInclusionQueryVariables
+  >;
+} &
   TChildProps;
-export function withHeroNameConditionalInclusion<TProps, TChildProps = {}>(
+export function withHeroNameConditionalInclusion<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables,
-    HeroNameConditionalInclusionProps<TChildProps>
+    HeroNameConditionalInclusionProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables,
-    HeroNameConditionalInclusionProps<TChildProps>
+    HeroNameConditionalInclusionProps<TChildProps, TDataName>
   >(HeroNameConditionalInclusionDocument, {
     alias: 'heroNameConditionalInclusion',
     ...operationOptions,
@@ -619,24 +626,26 @@ export const HeroNameConditionalExclusionComponent = (props: HeroNameConditional
   />
 );
 
-export type HeroNameConditionalExclusionProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroNameConditionalExclusionQuery,
-  HeroNameConditionalExclusionQueryVariables
-> &
+export type HeroNameConditionalExclusionProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<
+    HeroNameConditionalExclusionQuery,
+    HeroNameConditionalExclusionQueryVariables
+  >;
+} &
   TChildProps;
-export function withHeroNameConditionalExclusion<TProps, TChildProps = {}>(
+export function withHeroNameConditionalExclusion<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables,
-    HeroNameConditionalExclusionProps<TChildProps>
+    HeroNameConditionalExclusionProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables,
-    HeroNameConditionalExclusionProps<TChildProps>
+    HeroNameConditionalExclusionProps<TChildProps, TDataName>
   >(HeroNameConditionalExclusionDocument, {
     alias: 'heroNameConditionalExclusion',
     ...operationOptions,
@@ -687,24 +696,26 @@ export const HeroParentTypeDependentFieldComponent = (props: HeroParentTypeDepen
   />
 );
 
-export type HeroParentTypeDependentFieldProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroParentTypeDependentFieldQuery,
-  HeroParentTypeDependentFieldQueryVariables
-> &
+export type HeroParentTypeDependentFieldProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<
+    HeroParentTypeDependentFieldQuery,
+    HeroParentTypeDependentFieldQueryVariables
+  >;
+} &
   TChildProps;
-export function withHeroParentTypeDependentField<TProps, TChildProps = {}>(
+export function withHeroParentTypeDependentField<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroParentTypeDependentFieldQuery,
     HeroParentTypeDependentFieldQueryVariables,
-    HeroParentTypeDependentFieldProps<TChildProps>
+    HeroParentTypeDependentFieldProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroParentTypeDependentFieldQuery,
     HeroParentTypeDependentFieldQueryVariables,
-    HeroParentTypeDependentFieldProps<TChildProps>
+    HeroParentTypeDependentFieldProps<TChildProps, TDataName>
   >(HeroParentTypeDependentFieldDocument, {
     alias: 'heroParentTypeDependentField',
     ...operationOptions,
@@ -744,24 +755,26 @@ export const HeroTypeDependentAliasedFieldComponent = (props: HeroTypeDependentA
   />
 );
 
-export type HeroTypeDependentAliasedFieldProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HeroTypeDependentAliasedFieldQuery,
-  HeroTypeDependentAliasedFieldQueryVariables
-> &
+export type HeroTypeDependentAliasedFieldProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<
+    HeroTypeDependentAliasedFieldQuery,
+    HeroTypeDependentAliasedFieldQueryVariables
+  >;
+} &
   TChildProps;
-export function withHeroTypeDependentAliasedField<TProps, TChildProps = {}>(
+export function withHeroTypeDependentAliasedField<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HeroTypeDependentAliasedFieldQuery,
     HeroTypeDependentAliasedFieldQueryVariables,
-    HeroTypeDependentAliasedFieldProps<TChildProps>
+    HeroTypeDependentAliasedFieldProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HeroTypeDependentAliasedFieldQuery,
     HeroTypeDependentAliasedFieldQueryVariables,
-    HeroTypeDependentAliasedFieldProps<TChildProps>
+    HeroTypeDependentAliasedFieldProps<TChildProps, TDataName>
   >(HeroTypeDependentAliasedFieldDocument, {
     alias: 'heroTypeDependentAliasedField',
     ...operationOptions,
@@ -794,24 +807,23 @@ export const HumanWithNullHeightComponent = (props: HumanWithNullHeightComponent
   />
 );
 
-export type HumanWithNullHeightProps<TChildProps = {}> = ApolloReactHoc.DataProps<
-  HumanWithNullHeightQuery,
-  HumanWithNullHeightQueryVariables
-> &
+export type HumanWithNullHeightProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<HumanWithNullHeightQuery, HumanWithNullHeightQueryVariables>;
+} &
   TChildProps;
-export function withHumanWithNullHeight<TProps, TChildProps = {}>(
+export function withHumanWithNullHeight<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     HumanWithNullHeightQuery,
     HumanWithNullHeightQueryVariables,
-    HumanWithNullHeightProps<TChildProps>
+    HumanWithNullHeightProps<TChildProps, TDataName>
   >
 ) {
   return ApolloReactHoc.withQuery<
     TProps,
     HumanWithNullHeightQuery,
     HumanWithNullHeightQueryVariables,
-    HumanWithNullHeightProps<TChildProps>
+    HumanWithNullHeightProps<TChildProps, TDataName>
   >(HumanWithNullHeightDocument, {
     alias: 'humanWithNullHeight',
     ...operationOptions,
@@ -843,23 +855,27 @@ export const TwoHeroesComponent = (props: TwoHeroesComponentProps) => (
   <ApolloReactComponents.Query<TwoHeroesQuery, TwoHeroesQueryVariables> query={TwoHeroesDocument} {...props} />
 );
 
-export type TwoHeroesProps<TChildProps = {}> = ApolloReactHoc.DataProps<TwoHeroesQuery, TwoHeroesQueryVariables> &
+export type TwoHeroesProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactCommon.DataValue<TwoHeroesQuery, TwoHeroesQueryVariables>;
+} &
   TChildProps;
-export function withTwoHeroes<TProps, TChildProps = {}>(
+export function withTwoHeroes<TProps, TChildProps = {}, TDataName extends string = 'data'>(
   operationOptions?: ApolloReactHoc.OperationOption<
     TProps,
     TwoHeroesQuery,
     TwoHeroesQueryVariables,
-    TwoHeroesProps<TChildProps>
+    TwoHeroesProps<TChildProps, TDataName>
   >
 ) {
-  return ApolloReactHoc.withQuery<TProps, TwoHeroesQuery, TwoHeroesQueryVariables, TwoHeroesProps<TChildProps>>(
-    TwoHeroesDocument,
-    {
-      alias: 'twoHeroes',
-      ...operationOptions,
-    }
-  );
+  return ApolloReactHoc.withQuery<
+    TProps,
+    TwoHeroesQuery,
+    TwoHeroesQueryVariables,
+    TwoHeroesProps<TChildProps, TDataName>
+  >(TwoHeroesDocument, {
+    alias: 'twoHeroes',
+    ...operationOptions,
+  });
 }
 export type TwoHeroesQueryResult = ApolloReactCommon.QueryResult<TwoHeroesQuery, TwoHeroesQueryVariables>;
 export function refetchTwoHeroesQuery(variables?: TwoHeroesQueryVariables) {

--- a/packages/plugins/typescript/react-apollo/package.json
+++ b/packages/plugins/typescript/react-apollo/package.json
@@ -25,11 +25,11 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0",
     "graphql-tag": "^2.0.0"
   },
-  "main": "dist/index.cjs.js",	
-  "module": "dist/index.esm.js",	
-  "typings": "dist/index.d.ts",	
-  "typescript": {	
-    "definition": "dist/index.d.ts"	
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
   },
   "buildOptions": {
     "input": "./src/index.ts"

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -120,11 +120,17 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
       this.convertName(operationName + pascalCase(operationType) + this._parsedConfig.operationResultSuffix);
     const variablesVarName =
       this._externalImportPrefix + this.convertName(operationName + pascalCase(operationType) + 'Variables');
-    const argType = operationType === 'mutation' ? 'MutationFunction' : 'DataValue';
+    const typeArgs = `<${typeVariableName}, ${variablesVarName}>`;
 
-    this.imports.add(this.getApolloReactCommonImport());
+    if (operationType === 'mutation') {
+      this.imports.add(this.getApolloReactCommonImport());
 
-    return `ApolloReactCommon.${argType}<${typeVariableName}, ${variablesVarName}>`;
+      return `ApolloReactCommon.MutationFunction${typeArgs}`;
+    } else {
+      this.imports.add(this.getApolloReactHocImport());
+
+      return `ApolloReactHoc.DataValue${typeArgs}`;
+    }
   }
 
   private _buildMutationFn(

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -120,7 +120,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
       this.convertName(operationName + pascalCase(operationType) + this._parsedConfig.operationResultSuffix);
     const variablesVarName =
       this._externalImportPrefix + this.convertName(operationName + pascalCase(operationType) + 'Variables');
-    const argType = operationType === 'mutation' ? 'MutateProps' : 'DataProps';
+    const argType = operationType === 'mutation' ? 'MutationFunction' : 'DataValue';
 
     this.imports.add(this.getApolloReactCommonImport());
     this.imports.add(this.getApolloReactHocImport());
@@ -152,20 +152,20 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     this.imports.add(this.getApolloReactHocImport());
     const operationName: string = this.convertName(node.name.value, { useTypesPrefix: false });
     const propsTypeName: string = this.convertName(node.name.value, { suffix: 'Props' });
+    const defaultDataName = node.operation === 'mutation' ? 'mutate' : 'data';
 
-    const propsVar = `export type ${propsTypeName}<TChildProps = {}> = ${this._buildHocProps(
-      node.name.value,
-      node.operation
-    )} & TChildProps;`;
+    const propsVar = `export type ${propsTypeName}<TChildProps = {}, TDataName extends string = '${defaultDataName}'> = {
+      [key in TDataName]: ${this._buildHocProps(node.name.value, node.operation)}
+    } & TChildProps;`;
 
-    const hocString = `export function with${operationName}<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+    const hocString = `export function with${operationName}<TProps, TChildProps = {}, TDataName extends string = '${defaultDataName}'>(operationOptions?: ApolloReactHoc.OperationOption<
   TProps,
   ${operationResultType},
   ${operationVariablesTypes},
-  ${propsTypeName}<TChildProps>>) {
+  ${propsTypeName}<TChildProps, TDataName>>) {
     return ApolloReactHoc.with${pascalCase(
       node.operation
-    )}<TProps, ${operationResultType}, ${operationVariablesTypes}, ${propsTypeName}<TChildProps>>(${this.getDocumentNodeVariable(
+    )}<TProps, ${operationResultType}, ${operationVariablesTypes}, ${propsTypeName}<TChildProps, TDataName>>(${this.getDocumentNodeVariable(
       node,
       documentVariableName
     )}, {
@@ -229,7 +229,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
 
     const queryDescription = `
  * To run a query within a React component, call \`use${operationName}\` and pass it any options that fit your needs.
- * When your component renders, \`use${operationName}\` returns an object from Apollo Client that contains loading, error, and data properties 
+ * When your component renders, \`use${operationName}\` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.`;
 
     const queryExample = `

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -151,8 +151,8 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     this.imports.add(this.getApolloReactHocImport());
     const operationName: string = this.convertName(node.name.value, { useTypesPrefix: false });
     const propsTypeName: string = this.convertName(node.name.value, { suffix: 'Props' });
-    const defaultDataName = node.operation === 'mutation' ? 'mutate' : 'data';
 
+    const defaultDataName = node.operation === 'mutation' ? 'mutate' : 'data';
     const propsVar = `export type ${propsTypeName}<TChildProps = {}, TDataName extends string = '${defaultDataName}'> = {
       [key in TDataName]: ${this._buildHocProps(node.name.value, node.operation)}
     } & TChildProps;`;

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -123,9 +123,8 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     const argType = operationType === 'mutation' ? 'MutationFunction' : 'DataValue';
 
     this.imports.add(this.getApolloReactCommonImport());
-    this.imports.add(this.getApolloReactHocImport());
 
-    return `ApolloReactHoc.${argType}<${typeVariableName}, ${variablesVarName}>`;
+    return `ApolloReactCommon.${argType}<${typeVariableName}, ${variablesVarName}>`;
   }
 
   private _buildMutationFn(

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -922,20 +922,22 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(
-        `export type TestProps<TChildProps = {}> = ApolloReactHoc.DataProps<TestQuery, TestQueryVariables> & TChildProps;`
+        `export type TestProps<TChildProps = {}, TDataName extends string = 'data'> = {
+          [key in TDataName]: ApolloReactHoc.DataValue<TestQuery, TestQueryVariables>
+        } & TChildProps;`
       );
 
       expect(content.content)
-        .toBeSimilarStringTo(`export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
-  TestQuery,
-  TestQueryVariables,
-  TestProps<TChildProps>>) {
-    return ApolloReactHoc.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps>>(TestDocument, {
-      alias: 'test',
-      ...operationOptions
-    });
-}`);
+        .toBeSimilarStringTo(`export function withTest<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+      TProps,
+      TestQuery,
+      TestQueryVariables,
+      TestProps<TChildProps, TDataName>>) {
+        return ApolloReactHoc.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps, TDataName>>(TestDocument, {
+          alias: 'test',
+          ...operationOptions
+        });
+    }`);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -951,7 +953,9 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(
-        `export type TestProps<TChildProps = {}> = ApolloReactHoc.DataProps<TestQueryResponse, TestQueryVariables> & TChildProps;`
+        `export type TestProps<TChildProps = {}, TDataName extends string = 'data'> = {
+          [key in TDataName]: ApolloReactHoc.DataValue<TestQueryResponse, TestQueryVariables>
+        } & TChildProps;`
       );
 
       await validateTypeScript(content, schema, docs, {});
@@ -1218,7 +1222,7 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
  * __useFeedQuery__
  *
  * To run a query within a React component, call \`useFeedQuery\` and pass it any options that fit your needs.
- * When your component renders, \`useFeedQuery\` returns an object from Apollo Client that contains loading, error, and data properties 
+ * When your component renders, \`useFeedQuery\` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
@@ -1933,16 +1937,16 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTest<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestQuery,
         TestQueryVariables,
-        TestProps<TChildProps>>) {
-          return ApolloReactHoc.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps>>(Operations.test, {
+        TestProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps, TDataName>>(Operations.test, {
             alias: 'test',
             ...operationOptions
           });
-      }
+      };
       `);
       await validateTypeScript(content, schema, docs, {});
     });
@@ -2011,12 +2015,12 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTest<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestMutation,
         TestMutationVariables,
-        TestProps<TChildProps>>) {
-          return ApolloReactHoc.withMutation<TProps, TestMutation, TestMutationVariables, TestProps<TChildProps>>(Operations.test, {
+        TestProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withMutation<TProps, TestMutation, TestMutationVariables, TestProps<TChildProps, TDataName>>(Operations.test, {
             alias: 'test',
             ...operationOptions
           });
@@ -2089,12 +2093,12 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTest<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestSubscription,
         TestSubscriptionVariables,
-        TestProps<TChildProps>>) {
-          return ApolloReactHoc.withSubscription<TProps, TestSubscription, TestSubscriptionVariables, TestProps<TChildProps>>(Operations.test, {
+        TestProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withSubscription<TProps, TestSubscription, TestSubscriptionVariables, TestProps<TChildProps, TDataName>>(Operations.test, {
             alias: 'test',
             ...operationOptions
           });
@@ -2192,36 +2196,36 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTestOne<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTestOne<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestOneQuery,
         TestOneQueryVariables,
-        TestOneProps<TChildProps>>) {
-          return ApolloReactHoc.withQuery<TProps, TestOneQuery, TestOneQueryVariables, TestOneProps<TChildProps>>(Operations.testOne, {
+        TestOneProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withQuery<TProps, TestOneQuery, TestOneQueryVariables, TestOneProps<TChildProps, TDataName>>(Operations.testOne, {
             alias: 'testOne',
             ...operationOptions
           });
       }
       `);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTestTwo<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTestTwo<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestTwoMutation,
         TestTwoMutationVariables,
-        TestTwoProps<TChildProps>>) {
-          return ApolloReactHoc.withMutation<TProps, TestTwoMutation, TestTwoMutationVariables, TestTwoProps<TChildProps>>(Operations.testTwo, {
+        TestTwoProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withMutation<TProps, TestTwoMutation, TestTwoMutationVariables, TestTwoProps<TChildProps, TDataName>>(Operations.testTwo, {
             alias: 'testTwo',
             ...operationOptions
           });
       }
       `);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTestThree<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTestThree<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestThreeSubscription,
         TestThreeSubscriptionVariables,
-        TestThreeProps<TChildProps>>) {
-          return ApolloReactHoc.withSubscription<TProps, TestThreeSubscription, TestThreeSubscriptionVariables, TestThreeProps<TChildProps>>(Operations.testThree, {
+        TestThreeProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withSubscription<TProps, TestThreeSubscription, TestThreeSubscriptionVariables, TestThreeProps<TChildProps, TDataName>>(Operations.testThree, {
             alias: 'testThree',
             ...operationOptions
           });
@@ -2299,12 +2303,12 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTest<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestQuery,
         TestQueryVariables,
-        TestProps<TChildProps>>) {
-          return ApolloReactHoc.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps>>(Operations.test, {
+        TestProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withQuery<TProps, TestQuery, TestQueryVariables, TestProps<TChildProps, TDataName>>(Operations.test, {
             alias: 'test',
             ...operationOptions
           });
@@ -2376,12 +2380,12 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTest<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestMutation,
         TestMutationVariables,
-        TestProps<TChildProps>>) {
-          return ApolloReactHoc.withMutation<TProps, TestMutation, TestMutationVariables, TestProps<TChildProps>>(Operations.test, {
+        TestProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withMutation<TProps, TestMutation, TestMutationVariables, TestProps<TChildProps, TDataName>>(Operations.test, {
             alias: 'test',
             ...operationOptions
           });
@@ -2453,16 +2457,17 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTest<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTest<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestSubscription,
         TestSubscriptionVariables,
-        TestProps<TChildProps>>) {
-          return ApolloReactHoc.withSubscription<TProps, TestSubscription, TestSubscriptionVariables, TestProps<TChildProps>>(Operations.test, {
+        TestProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withSubscription<TProps, TestSubscription, TestSubscriptionVariables, TestProps<TChildProps, TDataName>>(Operations.test, {
             alias: 'test',
             ...operationOptions
           });
-      }`);
+      }
+      `);
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -2554,36 +2559,36 @@ export function useListenToCommentsSubscription(baseOptions?: ApolloReactHooks.S
 
       expect(content.prepend).toContain(`import * as Operations from './document.graphql';`);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTestOne<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTestOne<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestOneQuery,
         TestOneQueryVariables,
-        TestOneProps<TChildProps>>) {
-          return ApolloReactHoc.withQuery<TProps, TestOneQuery, TestOneQueryVariables, TestOneProps<TChildProps>>(Operations.testOne, {
+        TestOneProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withQuery<TProps, TestOneQuery, TestOneQueryVariables, TestOneProps<TChildProps, TDataName>>(Operations.testOne, {
             alias: 'testOne',
             ...operationOptions
           });
       }
       `);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTestTwo<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTestTwo<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestTwoMutation,
         TestTwoMutationVariables,
-        TestTwoProps<TChildProps>>) {
-          return ApolloReactHoc.withMutation<TProps, TestTwoMutation, TestTwoMutationVariables, TestTwoProps<TChildProps>>(Operations.testTwo, {
+        TestTwoProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withMutation<TProps, TestTwoMutation, TestTwoMutationVariables, TestTwoProps<TChildProps, TDataName>>(Operations.testTwo, {
             alias: 'testTwo',
             ...operationOptions
           });
       }
       `);
       expect(content.content).toBeSimilarStringTo(`
-      export function withTestThree<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+      export function withTestThree<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
         TProps,
         TestThreeSubscription,
         TestThreeSubscriptionVariables,
-        TestThreeProps<TChildProps>>) {
-          return ApolloReactHoc.withSubscription<TProps, TestThreeSubscription, TestThreeSubscriptionVariables, TestThreeProps<TChildProps>>(Operations.testThree, {
+        TestThreeProps<TChildProps, TDataName>>) {
+          return ApolloReactHoc.withSubscription<TProps, TestThreeSubscription, TestThreeSubscriptionVariables, TestThreeProps<TChildProps, TDataName>>(Operations.testThree, {
             alias: 'testThree',
             ...operationOptions
           });

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -923,7 +923,7 @@ query MyFeed {
 
       expect(content.content).toBeSimilarStringTo(
         `export type TestProps<TChildProps = {}, TDataName extends string = 'data'> = {
-          [key in TDataName]: ApolloReactHoc.DataValue<TestQuery, TestQueryVariables>
+          [key in TDataName]: ApolloReactCommon.DataValue<TestQuery, TestQueryVariables>
         } & TChildProps;`
       );
 
@@ -954,7 +954,7 @@ query MyFeed {
 
       expect(content.content).toBeSimilarStringTo(
         `export type TestProps<TChildProps = {}, TDataName extends string = 'data'> = {
-          [key in TDataName]: ApolloReactHoc.DataValue<TestQueryResponse, TestQueryVariables>
+          [key in TDataName]: ApolloReactCommon.DataValue<TestQueryResponse, TestQueryVariables>
         } & TChildProps;`
       );
 

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -923,7 +923,7 @@ query MyFeed {
 
       expect(content.content).toBeSimilarStringTo(
         `export type TestProps<TChildProps = {}, TDataName extends string = 'data'> = {
-          [key in TDataName]: ApolloReactCommon.DataValue<TestQuery, TestQueryVariables>
+          [key in TDataName]: ApolloReactHoc.DataValue<TestQuery, TestQueryVariables>
         } & TChildProps;`
       );
 
@@ -954,7 +954,7 @@ query MyFeed {
 
       expect(content.content).toBeSimilarStringTo(
         `export type TestProps<TChildProps = {}, TDataName extends string = 'data'> = {
-          [key in TDataName]: ApolloReactCommon.DataValue<TestQueryResponse, TestQueryVariables>
+          [key in TDataName]: ApolloReactHoc.DataValue<TestQueryResponse, TestQueryVariables>
         } & TChildProps;`
       );
 


### PR DESCRIPTION
Fixes issue described in https://github.com/dotansimha/graphql-code-generator/issues/2192