### PR TITLE
New option `onlyOperationTypes` for typescript and flow

### DIFF
--- a/dev-test/codegen.yml
+++ b/dev-test/codegen.yml
@@ -85,6 +85,15 @@ generates:
     plugins:
       - typescript
       - typescript-operations
+  ./dev-test/githunt/types.preResolveTypes.onlyOperationTypes.ts:
+    schema: ./dev-test/githunt/schema.json
+    documents: ./dev-test/githunt/**/*.graphql
+    config:
+      preResolveTypes: true
+      onlyOperationTypes: true
+    plugins:
+      - typescript
+      - typescript-operations
   ./dev-test/githunt/types.flatten.preResolveTypes.ts:
     schema: ./dev-test/githunt/schema.json
     documents: ./dev-test/githunt/**/*.graphql
@@ -234,12 +243,31 @@ generates:
     plugins:
       - typescript
       - typescript-operations
+  ./dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts:
+    schema: ./dev-test/star-wars/schema.json
+    documents: ./dev-test/star-wars/**/*.graphql
+    config:
+      preResolveTypes: true
+      onlyOperationTypes: true
+    plugins:
+      - typescript
+      - typescript-operations
   ./dev-test/test-schema/types.preResolveTypes.ts:
     schema: ./dev-test/test-schema/schema.graphql
     documents:
       - 'query test { testArr1 testArr2 testArr3 }'
     config:
       preResolveTypes: true
+    plugins:
+      - typescript
+      - typescript-operations
+  ./dev-test/test-schema/types.preResolveTypes.onlyOperationTypes.ts:
+    schema: ./dev-test/test-schema/schema.graphql
+    documents:
+      - 'query test { testArr1 testArr2 testArr3 }'
+    config:
+      preResolveTypes: true
+      onlyOperationTypes: true
     plugins:
       - typescript
       - typescript-operations

--- a/dev-test/githunt/types.preResolveTypes.onlyOperationTypes.ts
+++ b/dev-test/githunt/types.preResolveTypes.onlyOperationTypes.ts
@@ -1,0 +1,155 @@
+export type Maybe<T> = T | null;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  /** Sort by a combination of freshness and score, using Reddit's algorithm */
+  Hot = 'HOT',
+  /** Newest entries first */
+  New = 'NEW',
+  /** Highest score entries first */
+  Top = 'TOP',
+}
+
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  Up = 'UP',
+  Down = 'DOWN',
+  Cancel = 'CANCEL',
+}
+
+export type OnCommentAddedSubscriptionVariables = {
+  repoFullName: Scalars['String'];
+};
+
+export type OnCommentAddedSubscription = {
+  __typename?: 'Subscription';
+  commentAdded?: Maybe<{
+    __typename?: 'Comment';
+    id: number;
+    createdAt: number;
+    content: string;
+    postedBy: { __typename?: 'User'; login: string; html_url: string };
+  }>;
+};
+
+export type CommentQueryVariables = {
+  repoFullName: Scalars['String'];
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+export type CommentQuery = {
+  __typename?: 'Query';
+  currentUser?: Maybe<{ __typename?: 'User'; login: string; html_url: string }>;
+  entry?: Maybe<{
+    __typename?: 'Entry';
+    id: number;
+    createdAt: number;
+    commentCount: number;
+    postedBy: { __typename?: 'User'; login: string; html_url: string };
+    comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
+    repository: {
+      __typename?: 'Repository';
+      description?: Maybe<string>;
+      open_issues_count?: Maybe<number>;
+      stargazers_count: number;
+      full_name: string;
+      html_url: string;
+    };
+  }>;
+};
+
+export type CommentsPageCommentFragment = {
+  __typename?: 'Comment';
+  id: number;
+  createdAt: number;
+  content: string;
+  postedBy: { __typename?: 'User'; login: string; html_url: string };
+};
+
+export type CurrentUserForProfileQueryVariables = {};
+
+export type CurrentUserForProfileQuery = {
+  __typename?: 'Query';
+  currentUser?: Maybe<{ __typename?: 'User'; login: string; avatar_url: string }>;
+};
+
+export type FeedEntryFragment = {
+  __typename?: 'Entry';
+  id: number;
+  commentCount: number;
+  repository: {
+    __typename?: 'Repository';
+    full_name: string;
+    html_url: string;
+    owner?: Maybe<{ __typename?: 'User'; avatar_url: string }>;
+  };
+} & VoteButtonsFragment &
+  RepoInfoFragment;
+
+export type FeedQueryVariables = {
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+export type FeedQuery = {
+  __typename?: 'Query';
+  currentUser?: Maybe<{ __typename?: 'User'; login: string }>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+};
+
+export type SubmitRepositoryMutationVariables = {
+  repoFullName: Scalars['String'];
+};
+
+export type SubmitRepositoryMutation = {
+  __typename?: 'Mutation';
+  submitRepository?: Maybe<{ __typename?: 'Entry'; createdAt: number }>;
+};
+
+export type RepoInfoFragment = {
+  __typename?: 'Entry';
+  createdAt: number;
+  repository: {
+    __typename?: 'Repository';
+    description?: Maybe<string>;
+    stargazers_count: number;
+    open_issues_count?: Maybe<number>;
+  };
+  postedBy: { __typename?: 'User'; html_url: string; login: string };
+};
+
+export type SubmitCommentMutationVariables = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+export type SubmitCommentMutation = {
+  __typename?: 'Mutation';
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+};
+
+export type VoteButtonsFragment = {
+  __typename?: 'Entry';
+  score: number;
+  vote: { __typename?: 'Vote'; vote_value: number };
+};
+
+export type VoteMutationVariables = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+export type VoteMutation = {
+  __typename?: 'Mutation';
+  vote?: Maybe<{ __typename?: 'Entry'; score: number; id: number; vote: { __typename?: 'Vote'; vote_value: number } }>;
+};

--- a/dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts
+++ b/dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts
@@ -1,0 +1,183 @@
+export type Maybe<T> = T | null;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+/** The episodes in the Star Wars trilogy */
+export enum Episode {
+  /** Star Wars Episode IV: A New Hope, released in 1977. */
+  Newhope = 'NEWHOPE',
+  /** Star Wars Episode V: The Empire Strikes Back, released in 1980. */
+  Empire = 'EMPIRE',
+  /** Star Wars Episode VI: Return of the Jedi, released in 1983. */
+  Jedi = 'JEDI',
+}
+
+/** Units of height */
+export enum LengthUnit {
+  /** The standard unit around the world */
+  Meter = 'METER',
+  /** Primarily used in the United States */
+  Foot = 'FOOT',
+}
+
+export type CreateReviewForEpisodeMutationVariables = {
+  episode: Episode;
+  review: ReviewInput;
+};
+
+export type CreateReviewForEpisodeMutation = {
+  __typename?: 'Mutation';
+  createReview?: Maybe<{ __typename?: 'Review'; stars: number; commentary?: Maybe<string> }>;
+};
+
+export type HeroAndFriendsNamesQueryVariables = {
+  episode?: Maybe<Episode>;
+};
+
+export type HeroAndFriendsNamesQuery = {
+  __typename?: 'Query';
+  hero?: Maybe<
+    | {
+        __typename?: 'Human';
+        name: string;
+        friends?: Maybe<Array<Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>>>;
+      }
+    | {
+        __typename?: 'Droid';
+        name: string;
+        friends?: Maybe<Array<Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>>>;
+      }
+  >;
+};
+
+export type HeroAppearsInQueryVariables = {};
+
+export type HeroAppearsInQuery = {
+  __typename?: 'Query';
+  hero?: Maybe<
+    | { __typename?: 'Human'; name: string; appearsIn: Array<Maybe<Episode>> }
+    | { __typename?: 'Droid'; name: string; appearsIn: Array<Maybe<Episode>> }
+  >;
+};
+
+export type HeroDetailsQueryVariables = {
+  episode?: Maybe<Episode>;
+};
+
+export type HeroDetailsQuery = {
+  __typename?: 'Query';
+  hero?: Maybe<
+    | { __typename?: 'Human'; height?: Maybe<number>; name: string }
+    | { __typename?: 'Droid'; primaryFunction?: Maybe<string>; name: string }
+  >;
+};
+
+type HeroDetails_Human_Fragment = { __typename?: 'Human'; height?: Maybe<number>; name: string };
+
+type HeroDetails_Droid_Fragment = { __typename?: 'Droid'; primaryFunction?: Maybe<string>; name: string };
+
+export type HeroDetailsFragment = HeroDetails_Human_Fragment | HeroDetails_Droid_Fragment;
+
+export type HeroDetailsWithFragmentQueryVariables = {
+  episode?: Maybe<Episode>;
+};
+
+export type HeroDetailsWithFragmentQuery = {
+  __typename?: 'Query';
+  hero?: Maybe<
+    ({ __typename?: 'Human' } & HeroDetails_Human_Fragment) | ({ __typename?: 'Droid' } & HeroDetails_Droid_Fragment)
+  >;
+};
+
+export type HeroNameQueryVariables = {
+  episode?: Maybe<Episode>;
+};
+
+export type HeroNameQuery = {
+  __typename?: 'Query';
+  hero?: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
+};
+
+export type HeroNameConditionalInclusionQueryVariables = {
+  episode?: Maybe<Episode>;
+  includeName: Scalars['Boolean'];
+};
+
+export type HeroNameConditionalInclusionQuery = {
+  __typename?: 'Query';
+  hero?: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
+};
+
+export type HeroNameConditionalExclusionQueryVariables = {
+  episode?: Maybe<Episode>;
+  skipName: Scalars['Boolean'];
+};
+
+export type HeroNameConditionalExclusionQuery = {
+  __typename?: 'Query';
+  hero?: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
+};
+
+export type HeroParentTypeDependentFieldQueryVariables = {
+  episode?: Maybe<Episode>;
+};
+
+export type HeroParentTypeDependentFieldQuery = {
+  __typename?: 'Query';
+  hero?: Maybe<
+    | {
+        __typename?: 'Human';
+        name: string;
+        friends?: Maybe<
+          Array<
+            Maybe<
+              { __typename?: 'Human'; height?: Maybe<number>; name: string } | { __typename?: 'Droid'; name: string }
+            >
+          >
+        >;
+      }
+    | {
+        __typename?: 'Droid';
+        name: string;
+        friends?: Maybe<
+          Array<
+            Maybe<
+              { __typename?: 'Human'; height?: Maybe<number>; name: string } | { __typename?: 'Droid'; name: string }
+            >
+          >
+        >;
+      }
+  >;
+};
+
+export type HeroTypeDependentAliasedFieldQueryVariables = {
+  episode?: Maybe<Episode>;
+};
+
+export type HeroTypeDependentAliasedFieldQuery = {
+  __typename?: 'Query';
+  hero?: Maybe<{ __typename?: 'Human'; property?: Maybe<string> } | { __typename?: 'Droid'; property?: Maybe<string> }>;
+};
+
+export type HumanFieldsFragment = { __typename?: 'Human'; name: string; mass?: Maybe<number> };
+
+export type HumanWithNullHeightQueryVariables = {};
+
+export type HumanWithNullHeightQuery = {
+  __typename?: 'Query';
+  human?: Maybe<{ __typename?: 'Human' } & HumanFieldsFragment>;
+};
+
+export type TwoHeroesQueryVariables = {};
+
+export type TwoHeroesQuery = {
+  __typename?: 'Query';
+  r2?: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
+  luke?: Maybe<{ __typename?: 'Human'; name: string } | { __typename?: 'Droid'; name: string }>;
+};

--- a/dev-test/test-schema/types.preResolveTypes.onlyOperationTypes.ts
+++ b/dev-test/test-schema/types.preResolveTypes.onlyOperationTypes.ts
@@ -1,0 +1,18 @@
+export type Maybe<T> = T | null;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type TestQueryVariables = {};
+
+export type TestQuery = {
+  __typename?: 'Query';
+  testArr1?: Maybe<Array<Maybe<string>>>;
+  testArr2: Array<Maybe<string>>;
+  testArr3: Array<string>;
+};

--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -86,6 +86,24 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    */
   enumsAsConst?: boolean;
   /**
+   * @name onlyOperationTypes
+   * @type boolean
+   * @description This will cause the generator to emit types for operations only (basically only enums and scalars).
+   * Interacts well with `preResolveTypes: true`
+   * @default false
+   *
+   * @example Override all definition types
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    onlyOperationTypes: true
+   * ```
+   */
+  onlyOperationTypes?: boolean;
+  /**
    * @name immutableTypes
    * @type boolean
    * @description Generates immutable types by adding `readonly` to properties and uses `ReadonlyArray`.

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -30,6 +30,7 @@ export interface TypeScriptPluginParsedConfig extends ParsedTypesConfig {
   constEnums: boolean;
   enumsAsTypes: boolean;
   enumsAsConst: boolean;
+  onlyOperationTypes: boolean;
   immutableTypes: boolean;
   maybeValue: string;
   noExport: boolean;
@@ -47,6 +48,7 @@ export class TsVisitor<
       constEnums: getConfigValue(pluginConfig.constEnums, false),
       enumsAsTypes: getConfigValue(pluginConfig.enumsAsTypes, false),
       enumsAsConst: getConfigValue(pluginConfig.enumsAsConst, false),
+      onlyOperationTypes: getConfigValue(pluginConfig.onlyOperationTypes, false),
       immutableTypes: getConfigValue(pluginConfig.immutableTypes, false),
       ...(additionalConfig || {}),
     } as TParsedConfig);


### PR DESCRIPTION
This is a new config option `onlyOperationTypes` intended to generate only types for operations (enums, scalars, etc..., https://github.com/dotansimha/graphql-code-generator/issues/3475#issuecomment-597020849 may be related)

Non-operation types are incorrect to use for the client-side. You can't get a value of the type if you don't have an operation for that. But since non-operation types are not marked, my coworkers accidentally using them all the time. That option will get rid of that

When using `preResolveTypes` you probably don't need all base types, so now you can skip them and significantly reduce the size of types file. For example, in `dev-test/star-wars` 384 lines dropped to 183 with `preResolveTypes` + `onlyOperationTypes`
[dev-test/star-wars/types.ts](https://github.com/dotansimha/graphql-code-generator/blob/167fad8fe27b3e24fbad526ef85a5f0b37a57bca/dev-test/star-wars/types.ts)
[dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts](https://github.com/dotansimha/graphql-code-generator/blob/167fad8fe27b3e24fbad526ef85a5f0b37a57bca/dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts)



I think probably `onlyOperationTypes` + `preResolveTypes` should be default for client-side types on the next major release. It makes types smaller and avoids incorrect usage.

