### PR TITLE
Simplify generate examples script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           CI: true
       - name: Test dev-tests
         run: |
-          dev-test/generate-all.sh
+          yarn run generate:examples
           git diff --exit-code -- dev-test/
 
   publish-canary:

--- a/dev-test/generate-all.sh
+++ b/dev-test/generate-all.sh
@@ -1,3 +1,0 @@
-#/bin/sh
-
-DOTENV_CONFIG_PATH=$PWD/dev-test/.env node packages/graphql-codegen-cli/dist/bin.js --require dotenv/config --config ./dev-test/codegen.yml

--- a/dev-test/generate-watch.sh
+++ b/dev-test/generate-watch.sh
@@ -1,3 +1,0 @@
-#/bin/sh
-
-DOTENV_CONFIG_PATH=$PWD/dev-test/.env node packages/graphql-codegen-cli/dist/bin.js --require dotenv/config --config ./dev-test/codegen.yml -w

--- a/dev-test/init.sh
+++ b/dev-test/init.sh
@@ -1,3 +1,0 @@
-#/bin/sh
-
-node packages/graphql-codegen-cli/dist/commonjs/bin.js init

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release": "lerna publish --contents dist --exact --force-publish=\"*\" --ignore @graphql-codegen/live-demo --ignore @graphql-codegen/website",
     "release:canary": "lerna publish --contents dist --force-publish=\"*\" --canary --exact --ignore @graphql-codegen/live-demo --ignore @graphql-codegen/website ",
     "ci:release:canary": "lerna publish --contents dist --ignore @graphql-codegen/live-demo --ignore @graphql-codegen/website --force-publish=\"*\" --preid \"alpha-`git rev-parse --short HEAD`\" --canary --exact --yes",
-    "generate:examples": "./dev-test/generate-all.sh",
+    "generate:examples": "node packages/graphql-codegen-cli/dist/bin.js --require dotenv/config dotenv_config_path=dev-test/.env --config ./dev-test/codegen.yml",
     "build-website": "lerna run build"
   },
   "husky": {


### PR DESCRIPTION
This PR moves script for generating examples from shell to npm scripts. 
It's not so easy to run a shell script on windows, but since it is a one-liner, can be safely moved into `package.json`

This will help people with no shell to contribute to the project