### PR TITLE
Improved near-operation-file fragment imports

### DIFF
--- a/dev-test/githunt/__generated__/comment.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/comment.query.stencil-component.tsx
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { CommentsPageCommentFragmentDoc } from './comments-page-comment.fragment.stencil-component';
 import 'stencil-apollo';
 import { Component, Prop, h } from '@stencil/core';
 

--- a/dev-test/githunt/__generated__/feed-entry.fragment.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/feed-entry.fragment.stencil-component.tsx
@@ -1,4 +1,6 @@
 import gql from 'graphql-tag';
+import { VoteButtonsFragmentDoc } from './vote-buttons.fragment.stencil-component';
+import { RepoInfoFragmentDoc } from './repo-info.fragment.stencil-component';
 
 declare global {
   export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Types.Entry, 'id' | 'commentCount'> & {

--- a/dev-test/githunt/__generated__/feed.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/feed.query.stencil-component.tsx
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { FeedEntryFragmentDoc } from './feed-entry.fragment.stencil-component';
 import 'stencil-apollo';
 import { Component, Prop, h } from '@stencil/core';
 

--- a/dev-test/githunt/__generated__/submit-comment.mutation.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/submit-comment.mutation.stencil-component.tsx
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { CommentsPageCommentFragmentDoc } from './comments-page-comment.fragment.stencil-component';
 import 'stencil-apollo';
 import { Component, Prop, h } from '@stencil/core';
 

--- a/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
@@ -1,7 +1,8 @@
 import * as Types from '../types.d';
 
-import { HeroDetailsFragmentDoc, HeroDetails_Human_Fragment, HeroDetails_Droid_Fragment } from './HeroDetailsFragment';
+import { HeroDetails_Human_Fragment, HeroDetails_Droid_Fragment } from './HeroDetailsFragment';
 import gql from 'graphql-tag';
+import { HeroDetailsFragmentDoc } from './HeroDetailsFragment';
 import * as React from 'react';
 import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactComponents from '@apollo/react-components';

--- a/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
+++ b/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
@@ -1,7 +1,8 @@
 import * as Types from '../types.d';
 
-import { HumanFieldsFragmentDoc, HumanFieldsFragment } from './HumanFields';
+import { HumanFieldsFragment } from './HumanFields';
 import gql from 'graphql-tag';
+import { HumanFieldsFragmentDoc } from './HumanFields';
 import * as React from 'react';
 import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactComponents from '@apollo/react-components';

--- a/packages/plugins/flow/flow/src/index.ts
+++ b/packages/plugins/flow/flow/src/index.ts
@@ -6,7 +6,7 @@ import { FlowPluginConfig } from './config';
 export * from './visitor';
 export * from './flow-variables-to-object';
 
-export const plugin: PluginFunction<FlowPluginConfig> = (
+export const plugin: PluginFunction<FlowPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: FlowPluginConfig

--- a/packages/plugins/flow/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/flow/tests/flow.spec.ts
@@ -58,7 +58,7 @@ describe('Flow Plugin', () => {
           captcha: String
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       expect(result.content).toBeSimilarStringTo(`
@@ -90,7 +90,7 @@ describe('Flow Plugin', () => {
         "My custom scalar"
         scalar A
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       expect(result.content).toBeSimilarStringTo(`
@@ -114,7 +114,7 @@ describe('Flow Plugin', () => {
           f: String
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         /** MyInput */
@@ -131,7 +131,7 @@ describe('Flow Plugin', () => {
           f: String!
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         /** MyInput */
@@ -153,7 +153,7 @@ describe('Flow Plugin', () => {
           f: String!
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         /** 
@@ -177,7 +177,7 @@ describe('Flow Plugin', () => {
           id: ID
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         /** my union */
@@ -197,7 +197,7 @@ describe('Flow Plugin', () => {
           id: ID
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         /** this is b */
@@ -217,7 +217,7 @@ describe('Flow Plugin', () => {
           id: ID
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export type B = {|
@@ -236,7 +236,7 @@ describe('Flow Plugin', () => {
           id: ID!
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export type Node = {|
@@ -258,7 +258,7 @@ describe('Flow Plugin', () => {
           B
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export const MyEnumValues = Object.freeze({
@@ -383,7 +383,7 @@ describe('Flow Plugin', () => {
           _MyOtherValue
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       expect(result.content).toBeSimilarStringTo(`
@@ -481,7 +481,7 @@ describe('Flow Plugin', () => {
     });
 
     it('Should generate correct values when using links between types - pascalCase (default)', async () => {
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       expect(result.content).toBeSimilarStringTo(`
@@ -546,7 +546,7 @@ describe('Flow Plugin', () => {
     });
 
     it('Should generate correct values when using links between types - pascalCase (default) with custom prefix', async () => {
-      const result = (await plugin(schema, [], { typesPrefix: 'I' }, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], { typesPrefix: 'I' }, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
 
@@ -614,7 +614,7 @@ describe('Flow Plugin', () => {
   describe('Arguments', () => {
     it('Should generate correctly types for field arguments - with basic fields', async () => {
       const schema = buildSchema(`type MyType { foo(a: String!, b: String, c: [String], d: [Int!]!): String }`);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       validateFlow(result);
@@ -624,7 +624,7 @@ describe('Flow Plugin', () => {
       const schema = buildSchema(
         `type MyType { foo(a: String = "default", b: String! = "default", c: String): String }`
       );
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       validateFlow(result);
@@ -634,7 +634,7 @@ describe('Flow Plugin', () => {
       const schema = buildSchema(
         `input MyInput { f: String } type MyType { foo(a: MyInput, b: MyInput!, c: [MyInput], d: [MyInput]!, e: [MyInput!]!): String }`
       );
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       validateFlow(result);
@@ -644,7 +644,7 @@ describe('Flow Plugin', () => {
       const schema = buildSchema(
         `input Input { name: String } type Mutation { foo(id: String, input: Input): String }`
       );
-      const result = (await plugin(schema, [], { typesPrefix: 'T' }, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], { typesPrefix: 'T' }, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       validateFlow(result);
@@ -654,7 +654,7 @@ describe('Flow Plugin', () => {
   describe('Enum', () => {
     it('Should build basic enum correctly', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export const MyEnumValues = Object.freeze({
@@ -725,7 +725,7 @@ describe('Flow Plugin', () => {
   describe('Scalars', () => {
     it('Should build basic scalar correctly as any', async () => {
       const schema = buildSchema(`scalar A`);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       expect(result).not.toContain('export type A = any;');
@@ -769,7 +769,7 @@ describe('Flow Plugin', () => {
           k: [[String]]!
           l: [[String!]!]!
         }`);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
 
@@ -784,7 +784,7 @@ describe('Flow Plugin', () => {
           foo: String
           bar: String!
         }`);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       validateFlow(result);
@@ -800,7 +800,7 @@ describe('Flow Plugin', () => {
           foo: String!
         }
         `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       validateFlow(result);
@@ -821,7 +821,7 @@ describe('Flow Plugin', () => {
           bar: String!
         }
         `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       validateFlow(result);
@@ -837,7 +837,7 @@ describe('Flow Plugin', () => {
           bar: String!
         }
         `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       validateFlow(result);
@@ -857,7 +857,7 @@ describe('Flow Plugin', () => {
       
       union MyUnion = MyType | MyOtherType
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       expect(result.content).toBeSimilarStringTo(`
@@ -875,7 +875,7 @@ describe('Flow Plugin', () => {
           foo: String
           bar: String!
         }`);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       validateFlow(result);
@@ -891,7 +891,7 @@ describe('Flow Plugin', () => {
         directive @universal on OBJECT | FIELD_DEFINITION | ENUM_VALUE
       `);
 
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       validateFlow(result);
     });
@@ -920,7 +920,7 @@ describe('Flow Plugin', () => {
         }
       `);
 
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toMatchSnapshot();
       validateFlow(result);
@@ -949,7 +949,7 @@ describe('Flow Plugin', () => {
       }
     `);
 
-    const content = (await plugin(schema, [], { skipTypename: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const content = await plugin(schema, [], { skipTypename: true }, { outputFile: '' });
     expect(content).not.toContain('__typename');
 
     validateFlow(content);

--- a/packages/plugins/flow/resolvers/src/index.ts
+++ b/packages/plugins/flow/resolvers/src/index.ts
@@ -4,7 +4,7 @@ import { Types, PluginFunction, addFederationReferencesToSchema } from '@graphql
 import { parse, printSchema, visit, GraphQLSchema } from 'graphql';
 import { FlowResolversVisitor } from './visitor';
 
-export const plugin: PluginFunction<RawResolversConfig> = (
+export const plugin: PluginFunction<RawResolversConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: RawResolversConfig

--- a/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
@@ -19,7 +19,7 @@ describe('Flow Resolvers Plugin', () => {
     `);
 
     const config: any = { noSchemaStitching: true };
-    const result = (await plugin(testSchema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(testSchema, [], config, { outputFile: '' });
 
     expect(result.prepend).toContain(
       `export type $RequireFields<Origin, Keys> = $Diff<Origin, Keys> & $ObjMapi<Keys, <Key>(k: Key) => $NonMaybeType<$ElementType<Origin, Key>>>;`
@@ -88,7 +88,7 @@ describe('Flow Resolvers Plugin', () => {
       skipTypename: true,
       addUnderscoreToArgsType: true,
     };
-    const result = (await plugin(testSchema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(testSchema, [], config, { outputFile: '' });
     const o = mergeOutputs([result]);
     expect(o).toContain(`$RequireFields<Mutation_RandomArgs, { byteLength: * }>>,`);
     expect(o).toContain(

--- a/packages/plugins/flow/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/mapping.spec.ts
@@ -7,7 +7,7 @@ import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 
 describe('ResolversTypes', () => {
   it('Should build ResolversTypes object when there are no mappers', async () => {
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {

--- a/packages/plugins/java/apollo-android/src/plugin.ts
+++ b/packages/plugins/java/apollo-android/src/plugin.ts
@@ -64,11 +64,11 @@ export interface JavaApolloAndroidPluginConfig extends RawConfig {
   fileType: FileType;
 }
 
-export const plugin: PluginFunction<JavaApolloAndroidPluginConfig> = (
+export const plugin: PluginFunction<JavaApolloAndroidPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: JavaApolloAndroidPluginConfig
-): Types.PluginOutput => {
+) => {
   const allAst = concatAST(documents.map(v => v.document));
   const allFragments: LoadedFragment[] = [
     ...(allAst.definitions.filter(d => d.kind === Kind.FRAGMENT_DEFINITION) as FragmentDefinitionNode[]).map(
@@ -100,7 +100,7 @@ export const plugin: PluginFunction<JavaApolloAndroidPluginConfig> = (
   }
 
   if (!visitor) {
-    return '';
+    return { content: '' };
   }
 
   const visitResult = visit(allAst, visitor as any);

--- a/packages/plugins/java/apollo-android/tests/input.spec.ts
+++ b/packages/plugins/java/apollo-android/tests/input.spec.ts
@@ -35,13 +35,13 @@ describe('java-apollo-android', () => {
     ];
 
     it('Should produce valid Java code', async () => {
-      const result = (await plugin(schema, files, config)) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, files, config);
       const output = mergeOutputs([result]);
       await validateJava(output);
     });
 
     it('Should create a basic input type signature correctly', async () => {
-      const result = (await plugin(schema, files, config)) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, files, config);
       const output = mergeOutputs([result]);
 
       expect(result.prepend).toContain('import com.apollographql.apollo.api.InputType;');
@@ -52,7 +52,7 @@ describe('java-apollo-android', () => {
     });
 
     it('Should create private fields correctly', async () => {
-      const result = (await plugin(schema, files, config)) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, files, config);
       const output = mergeOutputs([result]);
 
       expect(result.prepend).toContain('import com.apollographql.apollo.api.Input;');
@@ -70,7 +70,7 @@ describe('java-apollo-android', () => {
     });
 
     it('Should create ctor correctly', async () => {
-      const result = (await plugin(schema, files, config)) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, files, config);
       const output = mergeOutputs([result]);
 
       expect(output)
@@ -85,7 +85,7 @@ describe('java-apollo-android', () => {
     });
 
     it('Should create getters correctly', async () => {
-      const result = (await plugin(schema, files, config)) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, files, config);
       const output = mergeOutputs([result]);
 
       expect(result.prepend).toContain('import javax.annotation.Nullable;');
@@ -98,14 +98,14 @@ describe('java-apollo-android', () => {
     });
 
     it('Should have Builder static getter', async () => {
-      const result = (await plugin(schema, files, config)) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, files, config);
       const output = mergeOutputs([result]);
 
       expect(output).toBeSimilarStringTo(`public static Builder builder() { return new Builder(); }`);
     });
 
     it('Should have Builder nested class ', async () => {
-      const result = (await plugin(schema, files, config)) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, files, config);
       const output = mergeOutputs([result]);
 
       expect(output).toBeSimilarStringTo(`public static final class Builder {`);
@@ -145,7 +145,7 @@ describe('java-apollo-android', () => {
     });
 
     it('Should have marshaller built for the fields', async () => {
-      const result = (await plugin(schema, files, config)) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, files, config);
       const output = mergeOutputs([result]);
 
       // Simple, non-null

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -12,6 +12,7 @@ import { DeclarationBlockConfig } from './utils';
 import autoBind from 'auto-bind';
 import { convertFactory } from './naming';
 import { ASTNode, FragmentDefinitionNode, OperationDefinitionNode } from 'graphql';
+import { ImportDecleration, FragmentImport } from './imports';
 
 export interface BaseVisitorConvertOptions {
   useTypesPrefix?: boolean;
@@ -24,6 +25,7 @@ export interface ParsedConfig {
   addTypename: boolean;
   nonOptionalTypename: boolean;
   externalFragments: LoadedFragment[];
+  fragmentImports: ImportDecleration<FragmentImport>[];
   immutableTypes: boolean;
 }
 
@@ -123,6 +125,7 @@ export interface RawConfig {
 
   /* The following configuration are for preset configuration and should not be set manually (for most use cases...) */
   externalFragments?: LoadedFragment[];
+  fragmentImports?: ImportDecleration<FragmentImport>[];
   globalNamespace?: boolean;
 }
 
@@ -136,6 +139,7 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
       convert: convertFactory(rawConfig),
       typesPrefix: rawConfig.typesPrefix || '',
       externalFragments: rawConfig.externalFragments || [],
+      fragmentImports: rawConfig.fragmentImports || [],
       addTypename: !rawConfig.skipTypename,
       nonOptionalTypename: !!rawConfig.nonOptionalTypename,
       ...((additionalConfig || {}) as any),

--- a/packages/plugins/other/visitor-plugin-common/src/imports.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/imports.ts
@@ -1,0 +1,87 @@
+import { dirname, isAbsolute, join, parse, relative, resolve } from 'path';
+
+export type ImportDecleration<T = string> = {
+  outputPath: string;
+  importSource: ImportSource<T>;
+  baseOutputDir: string;
+  baseDir: string;
+};
+
+export type ImportSource<T = string> = {
+  /**
+   * Source path, relative to the `baseOutputDir`
+   */
+  path: string;
+  /**
+   * Namespace to import source as
+   */
+  namespace?: string;
+  /**
+   * Entity names to import
+   */
+  identifiers?: T[];
+};
+
+export type FragmentImport = {
+  name: string;
+  kind: 'type' | 'document';
+};
+
+export function generateFragmentImportStatement(
+  statement: ImportDecleration<FragmentImport>,
+  kind: 'type' | 'document' | 'both'
+): string {
+  const { importSource: fragmentImportSource, ...rest } = statement;
+  const { identifiers, path, namespace } = fragmentImportSource;
+  const importSource: ImportSource<string> = {
+    identifiers: identifiers
+      .filter(fragmentImport => kind === 'both' || kind === fragmentImport.kind)
+      .map(({ name }) => name),
+    path,
+    namespace,
+  };
+  return generateImportStatement({ importSource, ...rest });
+}
+
+export function generateImportStatement(statement: ImportDecleration): string {
+  const { baseDir, importSource, outputPath } = statement;
+  const importPath = resolveImportPath(baseDir, outputPath, importSource.path);
+  const importNames =
+    importSource.identifiers && importSource.identifiers.length ? `{ ${importSource.identifiers.join(', ')} }` : '*';
+  const importAlias = importSource.namespace ? ` as ${importSource.namespace}` : '';
+  return `import ${importNames}${importAlias} from '${importPath}';${importAlias ? '\n' : ''}`;
+}
+
+function resolveImportPath(baseDir: string, outputPath: string, sourcePath: string) {
+  const shouldAbsolute = !sourcePath.startsWith('~');
+  if (shouldAbsolute) {
+    const absGeneratedFilePath = resolve(baseDir, outputPath);
+    const absImportFilePath = resolve(baseDir, sourcePath);
+    return resolveRelativeImport(absGeneratedFilePath, absImportFilePath);
+  } else {
+    return sourcePath.replace(`~`, '');
+  }
+}
+
+export function resolveRelativeImport(from: string, to: string): string {
+  if (!isAbsolute(from)) {
+    throw new Error(`Argument 'from' must be an absolute path, '${from}' given.`);
+  }
+  if (!isAbsolute(to)) {
+    throw new Error(`Argument 'to' must be an absolute path, '${to}' given.`);
+  }
+  return fixLocalFilePath(clearExtension(relative(dirname(from), to)));
+}
+
+export function resolveImportSource<T>(source: string | ImportSource<T>): ImportSource<T> {
+  return typeof source === 'string' ? { path: source } : source;
+}
+
+export function clearExtension(path: string): string {
+  const parsedPath = parse(path);
+  return join(parsedPath.dir, parsedPath.name).replace(/\\/g, '/');
+}
+
+export function fixLocalFilePath(path: string): string {
+  return !path.startsWith('..') ? `./${path}` : path;
+}

--- a/packages/plugins/other/visitor-plugin-common/src/index.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/index.ts
@@ -6,6 +6,7 @@ export * from './scalars';
 export * from './enum-values';
 export * from './declaration-kinds';
 export * from './avoid-optionals';
+export * from './imports';
 
 export * from './base-visitor';
 export * from './base-types-visitor';

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -18,7 +18,7 @@ export type ParsedEnumValuesMap = {
   };
 };
 export type ConvertNameFn<T = {}> = ConvertFn<T>;
-export type GetFragmentSuffixFn = (node: FragmentDefinitionNode | string, suffix?: string) => string;
+export type GetFragmentSuffixFn = (node: FragmentDefinitionNode | string) => string;
 
 export interface ConvertOptions {
   prefix?: string;

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -1,22 +1,22 @@
-import { GraphQLSchema, GraphQLOutputType, isEnumType, isNonNullType } from 'graphql';
 import {
-  wrapTypeWithModifiers,
-  PreResolveTypesProcessor,
-  ParsedDocumentsConfig,
+  AvoidOptionalsConfig,
   BaseDocumentsVisitor,
-  LoadedFragment,
+  DeclarationKind,
+  generateFragmentImportStatement,
   getConfigValue,
+  LoadedFragment,
+  normalizeAvoidOptionals,
+  ParsedDocumentsConfig,
+  PreResolveTypesProcessor,
   SelectionSetProcessorConfig,
   SelectionSetToObject,
-  DeclarationKind,
-  normalizeAvoidOptionals,
-  AvoidOptionalsConfig,
+  wrapTypeWithModifiers,
 } from '@graphql-codegen/visitor-plugin-common';
-import { TypeScriptOperationVariablesToObject } from './ts-operation-variables-to-object';
-import { TypeScriptDocumentsPluginConfig } from './config';
-
-import { TypeScriptSelectionSetProcessor } from './ts-selection-set-processor';
 import autoBind from 'auto-bind';
+import { GraphQLOutputType, GraphQLSchema, isEnumType, isNonNullType } from 'graphql';
+import { TypeScriptDocumentsPluginConfig } from './config';
+import { TypeScriptOperationVariablesToObject } from './ts-operation-variables-to-object';
+import { TypeScriptSelectionSetProcessor } from './ts-selection-set-processor';
 
 export interface TypeScriptDocumentsParsedConfig extends ParsedDocumentsConfig {
   avoidOptionals: AvoidOptionalsConfig;
@@ -96,6 +96,12 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
     this._declarationBlockConfig = {
       ignoreExport: this.config.noExport,
     };
+  }
+
+  public getImports(): Array<string> {
+    return !this.config.globalNamespace
+      ? this.config.fragmentImports.map(fragmentImport => generateFragmentImportStatement(fragmentImport, 'type'))
+      : [];
   }
 
   protected getPunctuation(declarationKind: DeclarationKind): string {

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -119,10 +119,12 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { noExport: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).not.toContain('export');
-      await validate(result, config);
+      expect(content).not.toContain('export');
+      await validate(content, config);
     });
 
     it('Should handle "namespacedImportName" and add it when specified', async () => {
@@ -150,9 +152,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { namespacedImportName: 'Types' };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type NotificationsQuery = (
           { __typename?: 'Query' }
           & { notifications: Array<(
@@ -169,7 +173,7 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should handle "namespacedImportName" and "preResolveTypes" together', async () => {
@@ -203,15 +207,15 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { namespacedImportName: 'Types', preResolveTypes: true };
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
 
-      expect(result).toBeSimilarStringTo(
+      expect(content).toBeSimilarStringTo(
         `export type TestQuery = { __typename?: 'Query', f?: Types.Maybe<Types.E>, user: { __typename?: 'User', id: string, f?: Types.Maybe<Types.E>, j?: Types.Maybe<any> } };`
       );
 
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should generate the correct output when using immutableTypes config', async () => {
@@ -234,9 +238,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { namingConvention: 'lower-case#lowerCase', immutableTypes: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type notificationsquery = (
           { readonly __typename?: 'Query' }
           & { readonly notifications: ReadonlyArray<(
@@ -252,7 +258,7 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
   });
 
@@ -278,11 +284,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: doc }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: doc }], config, {
         outputFile: '',
       });
-      expect(result).toContain(`Pick<User, 'id' | 'joinDate'>`);
-      await validate(result, config, testSchema);
+      expect(content).toContain(`Pick<User, 'id' | 'joinDate'>`);
+      await validate(content, config, testSchema);
     });
   });
 
@@ -307,10 +313,12 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { operationResultSuffix: 'Result' };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`export type NotificationsQueryVariables = {};`);
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`export type NotificationsQueryVariables = {};`);
+      expect(content).toBeSimilarStringTo(`
         export type NotificationsQueryResult = (
           { __typename?: 'Query' }
           & { notifications: Array<(
@@ -327,7 +335,7 @@ describe('TypeScript Operations Plugin', () => {
         );
       `);
 
-      await validate(result, config);
+      await validate(content, config);
     });
   });
 
@@ -352,9 +360,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { namingConvention: 'lower-case#lowerCase' };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type notificationsquery = (
           { __typename?: 'Query' }
           & { notifications: Array<(
@@ -370,7 +380,7 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should allow custom naming and point to the correct type - with custom prefix', async () => {
@@ -394,10 +404,12 @@ describe('TypeScript Operations Plugin', () => {
       `);
 
       const config = { typesPrefix: 'i', namingConvention: 'lower-case#lowerCase' };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`export type inotificationsqueryvariables = {};`);
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`export type inotificationsqueryvariables = {};`);
+      expect(content).toBeSimilarStringTo(`
         export type inotificationsquery = (
           { __typename?: 'Query' }
           & { notifications: Array<(
@@ -413,7 +425,7 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Test for dedupeOperationSuffix', async () => {
@@ -455,67 +467,81 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      expect(await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })).toContain(
-        'export type NotificationsQueryQuery ='
-      );
-      expect(await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })).toContain(
-        'export type MyFragmentFragment ='
-      );
       expect(
-        await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast }],
-          { dedupeOperationSuffix: false },
-          { outputFile: '' }
-        )
+        (await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })).content
       ).toContain('export type NotificationsQueryQuery =');
       expect(
-        await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast }],
-          { dedupeOperationSuffix: true },
-          { outputFile: '' }
-        )
+        (await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })).content
+      ).toContain('export type MyFragmentFragment =');
+      expect(
+        (
+          await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast }],
+            { dedupeOperationSuffix: false },
+            { outputFile: '' }
+          )
+        ).content
+      ).toContain('export type NotificationsQueryQuery =');
+      expect(
+        (
+          await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast }],
+            { dedupeOperationSuffix: true },
+            { outputFile: '' }
+          )
+        ).content
       ).toContain('export type NotificationsQuery =');
       expect(
-        await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast }],
-          { dedupeOperationSuffix: true },
-          { outputFile: '' }
-        )
+        (
+          await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast }],
+            { dedupeOperationSuffix: true },
+            { outputFile: '' }
+          )
+        ).content
       ).toContain('export type MyFragment =');
       expect(
-        await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast2 }],
-          { dedupeOperationSuffix: true },
-          { outputFile: '' }
-        )
+        (
+          await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast2 }],
+            { dedupeOperationSuffix: true },
+            { outputFile: '' }
+          )
+        ).content
       ).toContain('export type NotificationsQuery =');
       expect(
-        await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast2 }],
-          { dedupeOperationSuffix: false },
-          { outputFile: '' }
-        )
+        (
+          await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast2 }],
+            { dedupeOperationSuffix: false },
+            { outputFile: '' }
+          )
+        ).content
       ).toContain('export type NotificationsQuery =');
       expect(
-        await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast2 }],
-          { dedupeOperationSuffix: false },
-          { outputFile: '' }
-        )
+        (
+          await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast2 }],
+            { dedupeOperationSuffix: false },
+            { outputFile: '' }
+          )
+        ).content
       ).toContain('export type MyFragment =');
 
-      const withUsage = await plugin(
-        schema,
-        [{ location: 'test-file.ts', document: ast3 }],
-        { dedupeOperationSuffix: true },
-        { outputFile: '' }
-      );
+      const withUsage = (
+        await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast3 }],
+          { dedupeOperationSuffix: true },
+          { outputFile: '' }
+        )
+      ).content;
       expect(withUsage).toBeSimilarStringTo(`
         export type MyFragment = (
           { __typename?: 'Query' }
@@ -576,67 +602,81 @@ describe('TypeScript Operations Plugin', () => {
       }
     `);
 
-    expect(await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })).toContain(
-      'export type NotificationsQueryQuery ='
-    );
-    expect(await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })).toContain(
-      'export type MyFragmentFragment ='
-    );
     expect(
-      await plugin(
-        schema,
-        [{ location: 'test-file.ts', document: ast }],
-        { omitOperationSuffix: true },
-        { outputFile: '' }
-      )
+      (await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })).content
+    ).toContain('export type NotificationsQueryQuery =');
+    expect(
+      (await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })).content
+    ).toContain('export type MyFragmentFragment =');
+    expect(
+      (
+        await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { omitOperationSuffix: true },
+          { outputFile: '' }
+        )
+      ).content
     ).toContain('export type NotificationsQuery =');
     expect(
-      await plugin(
-        schema,
-        [{ location: 'test-file.ts', document: ast }],
-        { omitOperationSuffix: true },
-        { outputFile: '' }
-      )
+      (
+        await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { omitOperationSuffix: true },
+          { outputFile: '' }
+        )
+      ).content
     ).toContain('export type MyFragment =');
     expect(
-      await plugin(
-        schema,
-        [{ location: 'test-file.ts', document: ast2 }],
-        { omitOperationSuffix: true },
-        { outputFile: '' }
-      )
+      (
+        await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { omitOperationSuffix: true },
+          { outputFile: '' }
+        )
+      ).content
     ).toContain('export type Notifications =');
     expect(
+      (
+        await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { omitOperationSuffix: true },
+          { outputFile: '' }
+        )
+      ).content
+    ).toContain('export type My =');
+    expect(
+      (
+        await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { omitOperationSuffix: false },
+          { outputFile: '' }
+        )
+      ).content
+    ).toContain('export type NotificationsQuery =');
+    expect(
+      (
+        await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { omitOperationSuffix: false },
+          { outputFile: '' }
+        )
+      ).content
+    ).toContain('export type MyFragment =');
+
+    const withUsage = (
       await plugin(
         schema,
-        [{ location: 'test-file.ts', document: ast2 }],
+        [{ location: 'test-file.ts', document: ast3 }],
         { omitOperationSuffix: true },
         { outputFile: '' }
       )
-    ).toContain('export type My =');
-    expect(
-      await plugin(
-        schema,
-        [{ location: 'test-file.ts', document: ast2 }],
-        { omitOperationSuffix: false },
-        { outputFile: '' }
-      )
-    ).toContain('export type NotificationsQuery =');
-    expect(
-      await plugin(
-        schema,
-        [{ location: 'test-file.ts', document: ast2 }],
-        { omitOperationSuffix: false },
-        { outputFile: '' }
-      )
-    ).toContain('export type MyFragment =');
-
-    const withUsage = await plugin(
-      schema,
-      [{ location: 'test-file.ts', document: ast3 }],
-      { omitOperationSuffix: true },
-      { outputFile: '' }
-    );
+    ).content;
     expect(withUsage).toBeSimilarStringTo(`
       export type My = (
         { __typename?: 'Query' }
@@ -714,17 +754,17 @@ describe('TypeScript Operations Plugin', () => {
         skipTypename: true,
         preResolveTypes: true,
       };
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
 
-      expect(result).toContain(
+      expect(content).toContain(
         `export type Q1Query = { search: Array<{ __typename: 'Movie', id: string, title: string } | { __typename: 'Person', id: string, name: string }> };`
       );
-      expect(result).toContain(
+      expect(content).toContain(
         `export type Q2Query = { search: Array<{ __typename: 'Movie', id: string, title: string } | { __typename: 'Person', id: string, name: string }> };`
       );
-      await validate(result, config, testSchema);
+      await validate(content, config, testSchema);
     });
 
     it('Should skip __typename when skipTypename is set to true', async () => {
@@ -734,10 +774,12 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).not.toContain(`__typename`);
-      await validate(result, config);
+      expect(content).not.toContain(`__typename`);
+      await validate(content, config);
     });
 
     it('Should add __typename when dealing with fragments', async () => {
@@ -773,10 +815,10 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
       export type TestQuery = (
         { __typename?: 'Query' }
         & { some?: Maybe<(
@@ -788,7 +830,7 @@ describe('TypeScript Operations Plugin', () => {
         )> }
       );
       `);
-      await validate(result, config, testSchema);
+      await validate(content, config, testSchema);
     });
 
     it('Should add aliased __typename correctly', async () => {
@@ -799,15 +841,17 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
       export type Unnamed_1_Query = (
         { __typename?: 'Query' }
         & Pick<Query, 'dummy'>
         & { type: 'Query' }
       );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should add aliased __typename correctly with preResovleTypes', async () => {
@@ -818,11 +862,13 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { preResolveTypes: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
       export type Unnamed_1_Query = { __typename?: 'Query', dummy?: Maybe<string>, type: 'Query' };
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should add __typename as non-optional when explicitly specified', async () => {
@@ -833,14 +879,16 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
         export type Unnamed_1_Query = (
           { __typename: 'Query' }
           & Pick<Query, 'dummy'>
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should add __typename as non-optional when forced', async () => {
@@ -850,14 +898,16 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { nonOptionalTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
         export type Unnamed_1_Query = (
           { __typename: 'Query' }
           & Pick<Query, 'dummy'>
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should add __typename as optional when its not specified', async () => {
@@ -867,14 +917,16 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
         export type Unnamed_1_Query = (
           { __typename?: 'Query' }
           & Pick<Query, 'dummy'>
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should add __typename as non-optional when its explictly specified, even if skipTypename is true', async () => {
@@ -885,15 +937,17 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type Unnamed_1_Query = (
           { __typename: 'Query' }
           & Pick<Query, 'dummy'>
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should add __typename correctly when unions are in use', async () => {
@@ -911,8 +965,10 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
         export type UnionTestQuery = (
           { __typename?: 'Query' } 
           & { unionTest?: Maybe<(
@@ -924,7 +980,7 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should add __typename correctly when interfaces are in use', async () => {
@@ -947,8 +1003,10 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
         export type NotificationsQuery = (
           { __typename?: 'Query' }
           & { notifications: Array<(
@@ -964,7 +1022,7 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
     it('should mark __typename as non optional in case it is included in the selection set of an interface field', async () => {
       const ast = parse(/* GraphQL */ `
@@ -981,8 +1039,10 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
         export type NotificationsQuery = (
           { __typename?: 'Query' }
           & { notifications: Array<(
@@ -994,7 +1054,7 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
     it('should mark __typename as non optional in case it is included in the selection set of an union field', async () => {
       const ast = parse(/* GraphQL */ `
@@ -1011,8 +1071,10 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
       { __typename?: 'Query' }
       & { unionTest?: Maybe<(
         { __typename: 'User' }
@@ -1023,7 +1085,7 @@ describe('TypeScript Operations Plugin', () => {
       )> }
     );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
   });
 
@@ -1035,14 +1097,16 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
         export type Unnamed_1_Query = Pick<Query, 'dummy'>;
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type Unnamed_1_QueryVariables = {};
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should handle unnamed documents correctly with multiple documents', async () => {
@@ -1056,21 +1120,23 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type Unnamed_1_Query = Pick<Query, 'dummy'>;
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type Unnamed_1_QueryVariables = {};
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type Unnamed_2_Query = Pick<Query, 'dummy'>;
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type Unnamed_2_QueryVariables = {};
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
   });
 
@@ -1141,7 +1207,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
 
@@ -1157,8 +1223,8 @@ describe('TypeScript Operations Plugin', () => {
       }
       `;
 
-      await validate(result, config, testSchema, usage);
-      expect(mergeOutputs([result])).toMatchSnapshot();
+      await validate(content, config, testSchema, usage);
+      expect(mergeOutputs([content])).toMatchSnapshot();
     });
 
     it('Should generate the correct __typename when using fragment over type', async () => {
@@ -1183,11 +1249,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
-      await validate(result, config, testSchema);
-      expect(mergeOutputs([result])).toMatchSnapshot();
+      await validate(content, config, testSchema);
+      expect(mergeOutputs([content])).toMatchSnapshot();
     });
 
     it('Should generate the correct __typename when using both inline fragment and spread over type', async () => {
@@ -1216,11 +1282,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
-      await validate(result, config, testSchema);
-      expect(mergeOutputs([result])).toMatchSnapshot();
+      await validate(content, config, testSchema);
+      expect(mergeOutputs([content])).toMatchSnapshot();
     });
 
     it('Should generate the correct __typename when using fragment spread over type', async () => {
@@ -1247,11 +1313,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
-      await validate(result, config, testSchema);
-      expect(mergeOutputs([result])).toMatchSnapshot();
+      await validate(content, config, testSchema);
+      expect(mergeOutputs([content])).toMatchSnapshot();
     });
 
     it('Should generate the correct __typename when using fragment spread over union', async () => {
@@ -1281,11 +1347,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
       await validate(
-        result,
+        content,
         config,
         testSchema,
         `function test(q: AaaQuery) {
@@ -1293,7 +1359,7 @@ describe('TypeScript Operations Plugin', () => {
         console.log(q.user.__typename === 'Error' ? q.user.__typename : null);
       }`
       );
-      expect(mergeOutputs([result])).toMatchSnapshot();
+      expect(mergeOutputs([content])).toMatchSnapshot();
     });
 
     it('Should have valid fragments intersection on different types (with usage) #2498', async () => {
@@ -1339,12 +1405,12 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
 
       await validate(
-        result,
+        content,
         config,
         testSchema,
         `
@@ -1356,7 +1422,7 @@ describe('TypeScript Operations Plugin', () => {
               }
           }`
       );
-      expect(mergeOutputs([result])).toMatchSnapshot();
+      expect(mergeOutputs([content])).toMatchSnapshot();
     });
 
     it('Should have valid __typename usage and split types according to that (with usage)', async () => {
@@ -1402,7 +1468,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
 
@@ -1418,8 +1484,8 @@ describe('TypeScript Operations Plugin', () => {
       }
       `;
 
-      await validate(result, config, testSchema, usage);
-      expect(mergeOutputs([result])).toMatchSnapshot();
+      await validate(content, config, testSchema, usage);
+      expect(mergeOutputs([content])).toMatchSnapshot();
     });
 
     it('Should support fragment spread correctly with simple type with no other fields', async () => {
@@ -1440,11 +1506,13 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
         export type MeQuery = { me?: Maybe<UserFieldsFragment> };
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should support fragment spread correctly with simple type with other fields', async () => {
@@ -1464,15 +1532,17 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
       export type MeQuery = { me?: Maybe<(
         Pick<User, 'username'>
         & UserFieldsFragment
       )> };
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should support fragment spread correctly with multiple fragment spread', async () => {
@@ -1496,9 +1566,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: false };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
       export type MeQuery = (
         { __typename?: 'Query' }
         & { me?: Maybe<(
@@ -1509,7 +1581,7 @@ describe('TypeScript Operations Plugin', () => {
         )> }
       );
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type UserProfileFragment = (
           { __typename?: 'User' }
           & { profile?: Maybe<(
@@ -1518,13 +1590,13 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type UserFieldsFragment = (
           { __typename?: 'User' }
           & Pick<User, 'id'>
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should generate the correct intersection for fragments when using with interfaces with different type', async () => {
@@ -1567,9 +1639,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
       export type Unnamed_1_Query = (
         { __typename?: 'Query' }
         & { b?: Maybe<(
@@ -1591,7 +1665,7 @@ describe('TypeScript Operations Plugin', () => {
           & Pick<B, 'id' | 'y'>
         );
       `);
-      await validate(result, config, schema);
+      await validate(content, config, schema);
     });
 
     it('Should generate the correct intersection for fragments when type implements 2 interfaces', async () => {
@@ -1637,8 +1711,10 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
       export type Unnamed_1_Query = (
         { __typename?: 'Query' }
         & { myType: (
@@ -1649,7 +1725,7 @@ describe('TypeScript Operations Plugin', () => {
         ) }
       );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should generate the correct intersection for fragments when using with interfaces with same type', async () => {
@@ -1690,9 +1766,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
       export type Unnamed_1_Query = (
         { __typename?: 'Query' }
         & { b?: Maybe<(
@@ -1712,8 +1790,8 @@ describe('TypeScript Operations Plugin', () => {
           & Pick<A, 'x'>
         );
       `);
-      validateTs(mergeOutputs([result]), config);
-      expect(mergeOutputs([result])).toMatchSnapshot();
+      validateTs(mergeOutputs([content]), config);
+      expect(mergeOutputs([content])).toMatchSnapshot();
     });
 
     it('Should support interfaces correctly when used with inline fragments', async () => {
@@ -1737,8 +1815,10 @@ describe('TypeScript Operations Plugin', () => {
       `);
 
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
         export type NotificationsQuery = (
           { __typename?: 'Query' }
           & { notifications: Array<(
@@ -1754,7 +1834,7 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should support union correctly when used with inline fragments', async () => {
@@ -1772,9 +1852,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type UnionTestQuery = (
           { __typename?: 'Query' }
             & { unionTest?: Maybe<(
@@ -1786,7 +1868,7 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should support union correctly when used with inline fragments on types implementing common interface', async () => {
@@ -1808,9 +1890,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type UnionTestQuery = (
           { __typename?: 'Query' }
           & { mixedNotifications: Array<(
@@ -1822,7 +1906,7 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should support union correctly when used with inline fragments on types implementing common interface and also other types', async () => {
@@ -1848,9 +1932,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = {};
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type UnionTestQuery = (
           { __typename?: 'Query' }
           & { search: Array<(
@@ -1865,7 +1951,7 @@ describe('TypeScript Operations Plugin', () => {
           )> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should support inline fragments', async () => {
@@ -1883,15 +1969,17 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
-      expect(result).toBeSimilarStringTo(`
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+      expect(content).toBeSimilarStringTo(`
         export type CurrentUserQuery = { me?: Maybe<(
             Pick<User, 'username' | 'id'>
             & { profile?: Maybe<Pick<Profile, 'age'>> }
         )> };
       `);
 
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should build a basic selection set based on basic query on GitHub schema', async () => {
@@ -1912,22 +2000,22 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(gitHuntSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(gitHuntSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
 
-      expect(result).toBeSimilarStringTo(
+      expect(content).toBeSimilarStringTo(
         `export type MeQueryVariables = {
           repoFullName: Scalars['String'];
         };`
       );
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type MeQuery = { currentUser?: Maybe<Pick<User, 'login' | 'html_url'>>, entry?: Maybe<(
           Pick<Entry, 'id' | 'createdAt'>
           & { postedBy: Pick<User, 'login' | 'html_url'> }
         )> };
       `);
-      await validate(result, config, gitHuntSchema);
+      await validate(content, config, gitHuntSchema);
     });
 
     it('Should build a basic selection set based on basic query on GitHub schema with preResolveTypes=true', async () => {
@@ -1948,14 +2036,14 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { preResolveTypes: true };
-      const result = await plugin(gitHuntSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(gitHuntSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type MeQuery = { __typename?: 'Query', currentUser?: Maybe<{ __typename?: 'User', login: string, html_url: string }>, entry?: Maybe<{ __typename?: 'Entry', id: number, createdAt: number, postedBy: { __typename?: 'User', login: string, html_url: string } }> };
       `);
-      await validate(result, config, gitHuntSchema);
+      await validate(content, config, gitHuntSchema);
     });
 
     it('Should produce valid output with preResolveTypes=true and enums', async () => {
@@ -1993,11 +2081,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { preResolveTypes: true };
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
 
-      const o = await validate(result, config, testSchema);
+      const o = await validate(content, config, testSchema);
       expect(o).toContain(`export enum Information_EntryType {`);
       expect(o).toContain(`__typename?: 'Information_Entry', id: Information_EntryType,`);
     });
@@ -2041,11 +2129,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { preResolveTypes: true, typesPrefix: 'I', enumPrefix: false };
-      const result = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
+      const { content } = await plugin(testSchema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
 
-      const o = await validate(result, config, testSchema);
+      const o = await validate(content, config, testSchema);
       expect(o).toBeSimilarStringTo(` export type ITestQueryVariables = {
         e: Information_EntryType;
       };`);
@@ -2061,12 +2149,14 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type DummyQuery = Pick<Query, 'dummy'>;
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should build a basic selection set based on basic query with field aliasing for basic scalar', async () => {
@@ -2079,15 +2169,17 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type DummyQuery = (
           { customName: Query['dummy'] }
           & { customName2?: Maybe<Pick<Profile, 'age'>> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should build a basic selection set based on a query with inner fields', async () => {
@@ -2104,15 +2196,17 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type CurrentUserQuery = { me?: Maybe<(
           Pick<User, 'id' | 'username' | 'role'>
           & { profile?: Maybe<Pick<Profile, 'age'>> }
         )> };
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
   });
 
@@ -2128,15 +2222,17 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type UserFieldsFragment = (
           Pick<User, 'id' | 'username'>
           & { profile?: Maybe<Pick<Profile, 'age'>> }
         );
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
   });
 
@@ -2154,15 +2250,17 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type LoginMutation = { login?: Maybe<(
           Pick<User, 'id' | 'username'>
           & { profile?: Maybe<Pick<Profile, 'age'>> }
         )> };
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should detect Query correctly', async () => {
@@ -2172,12 +2270,14 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type TestQuery = Pick<Query, 'dummy'>;
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should detect Subscription correctly', async () => {
@@ -2189,12 +2289,14 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`
+      expect(content).toBeSimilarStringTo(`
         export type TestSubscription = { userCreated?: Maybe<Pick<User, 'id'>> };
       `);
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should handle operation variables correctly', async () => {
@@ -2213,9 +2315,11 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(
+      expect(content).toBeSimilarStringTo(
         `export type TestQueryQueryVariables = {
           username?: Maybe<Scalars['String']>;
           email?: Maybe<Scalars['String']>;
@@ -2227,7 +2331,7 @@ describe('TypeScript Operations Plugin', () => {
           innerRequired: Array<Scalars['String']>;
         };`
       );
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should handle operation variables correctly when they use custom scalars', async () => {
@@ -2237,14 +2341,16 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(
+      expect(content).toBeSimilarStringTo(
         `export type TestQueryQueryVariables = {
           test?: Maybe<Scalars['DateTime']>;
         };`
       );
-      await validate(result, config);
+      await validate(content, config);
     });
 
     it('Should create empty variables when there are no operation variables', async () => {
@@ -2254,10 +2360,12 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
       const config = { skipTypename: true };
-      const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, { outputFile: '' });
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
 
-      expect(result).toBeSimilarStringTo(`export type TestQueryQueryVariables = {};`);
-      await validate(result, config);
+      expect(content).toBeSimilarStringTo(`export type TestQueryQueryVariables = {};`);
+      await validate(content, config);
     });
 
     it('avoid duplicates - each type name should be unique', async () => {
@@ -2289,7 +2397,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -2331,7 +2439,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -2369,7 +2477,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -2418,7 +2526,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -2540,7 +2648,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         { typesPrefix: 'PREFIX_' },
@@ -2582,7 +2690,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -2647,7 +2755,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         schema,
         [{ location: '', document: query }],
         {},
@@ -2722,7 +2830,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         schema,
         [{ location: '', document: query }],
         {},
@@ -2784,7 +2892,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -2854,7 +2962,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -2947,7 +3055,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -3003,7 +3111,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -3053,7 +3161,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -3153,7 +3261,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -3326,7 +3434,7 @@ describe('TypeScript Operations Plugin', () => {
         flattenGeneratedTypes: true,
       };
 
-      const content = await plugin(testSchema, [{ location: '', document: query }], config, {
+      const { content } = await plugin(testSchema, [{ location: '', document: query }], config, {
         outputFile: 'graphql.ts',
       });
 
@@ -3460,7 +3568,7 @@ describe('TypeScript Operations Plugin', () => {
         flattenGeneratedTypes: true,
       };
 
-      const content = await plugin(testSchema, [{ location: '', document: query }], config, {
+      const { content } = await plugin(testSchema, [{ location: '', document: query }], config, {
         outputFile: 'graphql.ts',
       });
 
@@ -3569,7 +3677,7 @@ describe('TypeScript Operations Plugin', () => {
 
       const config = {};
 
-      const content = await plugin(testSchema, [{ location: '', document: query }], config, {
+      const { content } = await plugin(testSchema, [{ location: '', document: query }], config, {
         outputFile: 'graphql.ts',
       });
 
@@ -3628,7 +3736,7 @@ describe('TypeScript Operations Plugin', () => {
         namespacedImportName: 'Types',
       };
 
-      const content = await plugin(testSchema, [{ location: '', document: query }], config, {
+      const { content } = await plugin(testSchema, [{ location: '', document: query }], config, {
         outputFile: 'graphql.ts',
       });
 
@@ -3754,7 +3862,7 @@ describe('TypeScript Operations Plugin', () => {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -3822,7 +3930,7 @@ function test(q: GetEntityBrandDataQuery): void {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         testSchema,
         [{ location: '', document: query }],
         {},
@@ -3888,7 +3996,7 @@ function test(q: GetEntityBrandDataQuery): void {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         schema,
         [
           { location: '', document: productFragmentDocument },
@@ -3938,7 +4046,7 @@ function test(q: GetEntityBrandDataQuery): void {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         schema,
         [{ location: '', document: fragment }],
         {},
@@ -4005,7 +4113,7 @@ function test(q: GetEntityBrandDataQuery): void {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         schema,
         [{ location: '', document: fragment }],
         {},
@@ -4083,7 +4191,7 @@ function test(q: GetEntityBrandDataQuery): void {
         }
       `);
 
-      const content = await plugin(
+      const { content } = await plugin(
         schema,
         [{ location: '', document: fragment }],
         {},
@@ -4143,7 +4251,7 @@ function test(q: GetEntityBrandDataQuery): void {
           }
         }
       `);
-      const content = await plugin(
+      const { content } = await plugin(
         schema,
         [{ location: '', document: query }],
         {

--- a/packages/plugins/typescript/react-apollo-offix/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo-offix/src/visitor.ts
@@ -39,7 +39,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<RawClientSideBaseP
   }
 
   public getImports(): string[] {
-    const baseImports = super.getImports();
+    const baseImports = super.getImports({ excludeFragments: true });
     const hasOperations = this._collectedOperations.length > 0;
 
     if (!hasOperations) {

--- a/packages/plugins/typescript/react-apollo/src/index.ts
+++ b/packages/plugins/typescript/react-apollo/src/index.ts
@@ -5,7 +5,7 @@ import { ReactApolloVisitor } from './visitor';
 import { extname } from 'path';
 import { ReactApolloRawPluginConfig } from './config';
 
-export const plugin: PluginFunction<ReactApolloRawPluginConfig> = (
+export const plugin: PluginFunction<ReactApolloRawPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: ReactApolloRawPluginConfig

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -502,7 +502,7 @@ describe('React Apollo', () => {
           `),
         },
       ];
-      const result = (await plugin(schema, docs, {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, docs, {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export const MyFragmentFragmentDoc = gql\`

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -5,7 +5,7 @@ import { parse, visit, GraphQLSchema, printSchema } from 'graphql';
 import { TypeScriptResolversVisitor } from './visitor';
 import { TypeScriptResolversPluginConfig } from './config';
 
-export const plugin: PluginFunction<TypeScriptResolversPluginConfig> = (
+export const plugin: PluginFunction<TypeScriptResolversPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: TypeScriptResolversPluginConfig

--- a/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
@@ -6,7 +6,7 @@ import { buildSchema } from 'graphql';
 
 describe('ResolversTypes', () => {
   it('Should build ResolversTypes object when there are no mappers', async () => {
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
@@ -370,7 +370,7 @@ describe('ResolversTypes', () => {
         me: User
       }
     `);
-    const result = (await plugin(testSchema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(testSchema, [], config, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
@@ -1085,7 +1085,7 @@ describe('ResolversTypes', () => {
   });
 
   it('Should build ResolversTypes object when there are no mappers', async () => {
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -8,7 +8,7 @@ import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 describe('TypeScript Resolvers Plugin', () => {
   describe('Backward Compatability', () => {
     it('Should generate IDirectiveResolvers by default', async () => {
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
       expect(result.content).toBeSimilarStringTo(`
       /**
        * @deprecated
@@ -20,7 +20,7 @@ describe('TypeScript Resolvers Plugin', () => {
 
     it('Should not generate IDirectiveResolvers when prefix is overwritten', async () => {
       const config = { typesPrefix: 'PREFIX_' };
-      const result = (await plugin(schema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], config, { outputFile: '' });
       expect(result.content).not.toContain(`export type IDirectiveResolvers`);
       expect(result.content).not.toContain(`export type DirectiveResolvers`);
       expect(result.content).toContain(`export type PREFIX_DirectiveResolvers`);
@@ -28,7 +28,7 @@ describe('TypeScript Resolvers Plugin', () => {
     });
 
     it('Should generate IResolvers by default', async () => {
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
       expect(result.content).toBeSimilarStringTo(`
       /**
        * @deprecated
@@ -40,7 +40,7 @@ describe('TypeScript Resolvers Plugin', () => {
 
     it('Should not generate IResolvers when prefix is overwritten', async () => {
       const config = { typesPrefix: 'PREFIX_' };
-      const result = (await plugin(schema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], config, { outputFile: '' });
       expect(result.content).not.toContain(`export type IResolvers`);
       expect(result.content).not.toContain(`export type Resolvers`);
       expect(result.content).toContain(`export type PREFIX_Resolvers`);
@@ -48,7 +48,7 @@ describe('TypeScript Resolvers Plugin', () => {
     });
 
     it('Should generate IResolvers by default with deprecated warning', async () => {
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
       expect(result.content).toBeSimilarStringTo(`
       /**
        * @deprecated
@@ -122,7 +122,7 @@ describe('TypeScript Resolvers Plugin', () => {
   });
 
   it('Should use StitchingResolver by default', async () => {
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
       export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
@@ -187,7 +187,7 @@ describe('TypeScript Resolvers Plugin', () => {
 
   it('Should not warn when noSchemaStitching is not defined', async () => {
     const spy = jest.spyOn(console, 'warn').mockImplementation();
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(spy).not.toHaveBeenCalled();
 
@@ -234,7 +234,7 @@ describe('TypeScript Resolvers Plugin', () => {
     `);
 
     const config: any = { noSchemaStitching: true };
-    const result = (await plugin(testSchema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(testSchema, [], config, { outputFile: '' });
     const mergedOutputs = mergeOutputs([
       result,
       {
@@ -282,7 +282,7 @@ describe('TypeScript Resolvers Plugin', () => {
       },
       typesPrefix: 'GQL_',
     };
-    const result = (await plugin(testSchema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(testSchema, [], config, { outputFile: '' });
     const tsContent = (await tsPlugin(testSchema, [], config, {
       outputFile: 'graphql.ts',
     })) as Types.ComplexPluginOutput;
@@ -318,7 +318,7 @@ describe('TypeScript Resolvers Plugin', () => {
   });
 
   it('Should generate basic type resolvers', async () => {
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
@@ -721,7 +721,7 @@ describe('TypeScript Resolvers Plugin', () => {
 
   it('Should generate the correct imports when schema has scalars', async () => {
     const testSchema = buildSchema(`scalar MyScalar`);
-    const result = (await plugin(testSchema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(testSchema, [], {}, { outputFile: '' });
 
     expect(result.prepend).toContain(
       `import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';`
@@ -731,7 +731,7 @@ describe('TypeScript Resolvers Plugin', () => {
 
   it('Should generate the correct imports when schema has no scalars', async () => {
     const testSchema = buildSchema(`type MyType { f: String }`);
-    const result = (await plugin(testSchema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(testSchema, [], {}, { outputFile: '' });
 
     expect(result.prepend).not.toContain(`import { GraphQLResolveInfo, GraphQLScalarTypeConfig } from 'graphql';`);
     await validate(result, {}, testSchema);
@@ -817,7 +817,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   context: TContext,
   info: GraphQLResolveInfo
 ) => Promise<TResult> | TResult;`;
-      const result = (await plugin(testSchema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(testSchema, [], {}, { outputFile: '' });
 
       expect(result.content).toContain(defaultResolverFn);
       await validate(result, {}, testSchema);
@@ -842,7 +842,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     `);
 
     const tsContent = (await tsPlugin(testSchema, [], {}, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
-    const content = (await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
+    const content = await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
 
     expect(content.content).toBeSimilarStringTo(`CCCUnion: ResolversTypes['CCCFoo'] | ResolversTypes['CCCBar']`); // In ResolversTypes
     expect(content.content).toBeSimilarStringTo(`
@@ -857,7 +857,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   it('Should generate the correct resolver args type names when typesPrefix is specified', async () => {
     const testSchema = buildSchema(`type MyType { f(a: String): String }`);
     const config = { typesPrefix: 'T' };
-    const result = (await plugin(testSchema, [], config, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(testSchema, [], config, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(
       `f?: Resolver<Maybe<TResolversTypes['String']>, ParentType, ContextType, RequireFields<TMyTypeFArgs, never>>,`
@@ -868,7 +868,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   // dotansimha/graphql-code-generator#3322
   it('should make list of all-optional arguments include undefined types', async () => {
     const testSchema = buildSchema(`type MyType { f(a: String, b: Int): String }`);
-    const result = (await plugin(testSchema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(testSchema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(
       `f?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeFArgs, never>>,`
@@ -879,7 +879,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   // dotansimha/graphql-code-generator#3322
   it('should include generic wrapper type only when necessary', async () => {
     const testSchema = buildSchema(`type MyType { f: String }`);
-    const result = (await plugin(testSchema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(testSchema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(
       `f?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,`
@@ -1088,7 +1088,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         comment: String
       }
     `);
-    const content = (await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
+    const content = await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
 
     expect(content.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
@@ -1121,7 +1121,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         comment: String
       }
     `);
-    const content = (await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
+    const content = await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
 
     expect(content.content).toBeSimilarStringTo(`
       export type ResolversParentTypes = {
@@ -1301,7 +1301,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
       }
     `);
 
-    const result = (await plugin(schemaWithNoImplementors, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schemaWithNoImplementors, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
@@ -1624,7 +1624,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         namingConvention: 'keep',
         constEnums: true,
       };
-      const output = (await plugin(testSchema, [], config, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
+      const output = await plugin(testSchema, [], config, { outputFile: 'graphql.ts' });
       const o = await validate(output, config, testSchema);
 
       expect(o).toBeSimilarStringTo(`
@@ -1722,7 +1722,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
       const tsContent = (await tsPlugin(testSchema, [], config, {
         outputFile: 'graphql.ts',
       })) as Types.ComplexPluginOutput;
-      const output = (await plugin(testSchema, [], config, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
+      const output = await plugin(testSchema, [], config, { outputFile: 'graphql.ts' });
 
       expect(output.prepend.length).toBe(2);
       expect(output.prepend.filter(t => t.includes('ProjectRole')).length).toBe(0);

--- a/packages/plugins/typescript/type-graphql/src/index.ts
+++ b/packages/plugins/typescript/type-graphql/src/index.ts
@@ -10,7 +10,7 @@ const TYPE_GRAPHQL_IMPORT = `import * as TypeGraphQL from 'type-graphql';`;
 const DECORATOR_FIX = `type FixDecorator<T> = T;`;
 const isDefinitionInterface = (definition: string) => definition.includes('@TypeGraphQL.InterfaceType()');
 
-export const plugin: PluginFunction<TypeGraphQLPluginConfig> = (
+export const plugin: PluginFunction<TypeGraphQLPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: TypeGraphQLPluginConfig

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -8,7 +8,7 @@ describe('type-graphql', () => {
     const schema = buildSchema(/* GraphQL */ `
       scalar A
     `);
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.prepend).toContainEqual(`import * as TypeGraphQL from 'type-graphql';`);
   });
@@ -23,7 +23,7 @@ describe('type-graphql', () => {
         B
       }
     `);
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
       /** custom enum */
@@ -59,7 +59,7 @@ describe('type-graphql', () => {
       }
     `);
 
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.ObjectType()
@@ -108,7 +108,7 @@ describe('type-graphql', () => {
       }
     `);
 
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.ObjectType({ implements: ITest })
@@ -154,7 +154,7 @@ describe('type-graphql', () => {
       }
     `);
 
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.InputType()
@@ -231,7 +231,7 @@ describe('type-graphql', () => {
       }
     `);
 
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.ArgsType()

--- a/packages/plugins/typescript/typescript/src/index.ts
+++ b/packages/plugins/typescript/typescript/src/index.ts
@@ -22,7 +22,7 @@ export * from './visitor';
 export * from './config';
 export * from './introspection-visitor';
 
-export const plugin: PluginFunction<TypeScriptPluginConfig> = (
+export const plugin: PluginFunction<TypeScriptPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: TypeScriptPluginConfig

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -8,7 +8,7 @@ describe('TypeScript', () => {
     const schema = buildSchema(/* GraphQL */ `
       scalar A
     `);
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
     expect(result.prepend).toBeSimilarStringTo('export type Maybe<T> =');
   });
 
@@ -18,7 +18,7 @@ describe('TypeScript', () => {
         "My custom scalar"
         scalar A
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       /** All built-in and custom scalars, mapped to their actual values */
@@ -41,7 +41,7 @@ describe('TypeScript', () => {
           f: String
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         /** MyInput */
@@ -56,7 +56,7 @@ describe('TypeScript', () => {
           f: String!
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         /** MyInput */
@@ -76,7 +76,7 @@ describe('TypeScript', () => {
           f: String!
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         /** 
@@ -98,7 +98,7 @@ describe('TypeScript', () => {
           id: ID
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         /** my union */
@@ -116,7 +116,7 @@ describe('TypeScript', () => {
           id: ID
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         /** this is b */
@@ -134,7 +134,7 @@ describe('TypeScript', () => {
           id: ID
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export type B = {
@@ -151,7 +151,7 @@ describe('TypeScript', () => {
           id: ID!
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export type Node = {
@@ -170,7 +170,7 @@ describe('TypeScript', () => {
           B
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       /** custom enum */
@@ -191,7 +191,7 @@ describe('TypeScript', () => {
           My_Value
         }
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export enum MyEnum {
@@ -465,7 +465,7 @@ describe('TypeScript', () => {
         firstName: String! @deprecated(reason: "Field \`fullName\` has been superseded by \`firstName\`.")
       }`);
 
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
       expect(result.content).toBeSimilarStringTo(`
       export type User = {
         __typename?: 'User';
@@ -488,7 +488,7 @@ describe('TypeScript', () => {
         count: Int! @default(value: 1)
       }`);
 
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
       expect(result.content).toBeSimilarStringTo(
         `export type Any = Scalars['String'] | Scalars['Int'] | Scalars['Float'] | Scalars['ID'];`
       );
@@ -656,7 +656,7 @@ describe('TypeScript', () => {
       enum MyEnum {
         A
       }`);
-      const result = (await plugin(schema, [], { constEnums: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], { constEnums: true }, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export const enum MyEnum {
@@ -1201,7 +1201,7 @@ describe('TypeScript', () => {
         foo: String
         bar: String!
       }`);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export type Scalars = {
@@ -1318,7 +1318,7 @@ describe('TypeScript', () => {
         foo: String
         bar: MyScalar!
       }`);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export type Scalars = {
@@ -1411,7 +1411,7 @@ describe('TypeScript', () => {
           foo: String
           bar: String!
         }`);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
@@ -1433,7 +1433,7 @@ describe('TypeScript', () => {
           foo: String!
         }
         `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
@@ -1464,7 +1464,7 @@ describe('TypeScript', () => {
           bar: String!
         }
         `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
@@ -1494,7 +1494,7 @@ describe('TypeScript', () => {
 
         type MyType implements MyInterface
         `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
@@ -1519,7 +1519,7 @@ describe('TypeScript', () => {
           bar: String!
         }
         `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyType = {
@@ -1602,7 +1602,7 @@ describe('TypeScript', () => {
 
       union MyUnion = MyType | MyOtherType
       `);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export type MyUnion = MyType | MyOtherType;
@@ -1618,7 +1618,7 @@ describe('TypeScript', () => {
           foo: String
           bar: String!
         }`);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyInterface = {
@@ -1639,7 +1639,7 @@ describe('TypeScript', () => {
         directive @universal on OBJECT | FIELD_DEFINITION | ENUM_VALUE
       `);
 
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).not.toContain('simple');
       expect(result.content).not.toContain('withArguments');
@@ -1722,7 +1722,7 @@ describe('TypeScript', () => {
 
     it('Should enable typesPrefix for enums by default', async () => {
       const schema = buildSchema(`type T { f: String, e: E } enum E { A }`);
-      const result = (await plugin(schema, [], { typesPrefix: 'I' }, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], { typesPrefix: 'I' }, { outputFile: '' });
 
       expect(result.content).toContain(`export enum IE {`);
       expect(result.content).toContain(`e?: Maybe<IE>;`);
@@ -1840,7 +1840,7 @@ describe('TypeScript', () => {
     });
 
     it('Should generate correct values when using links between types - pascalCase (default)', async () => {
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export enum MyEnum {
@@ -1902,7 +1902,7 @@ describe('TypeScript', () => {
     });
 
     it('Should generate correct values when using links between types - pascalCase (default) with custom prefix', async () => {
-      const result = (await plugin(schema, [], { typesPrefix: 'I' }, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], { typesPrefix: 'I' }, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export enum IMyEnum {
@@ -1965,7 +1965,7 @@ describe('TypeScript', () => {
     it('Should generate correctly types for field arguments - with basic fields', async () => {
       const schema = buildSchema(`type MyType { foo(a: String!, b: String, c: [String], d: [Int!]!): String }`);
 
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
@@ -1983,7 +1983,7 @@ describe('TypeScript', () => {
       const schema = buildSchema(
         `type MyType { foo(a: String = "default", b: String! = "default", c: String, d: String!): String }`
       );
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
@@ -2024,7 +2024,7 @@ describe('TypeScript', () => {
       const schema = buildSchema(
         `input MyInput { f: String } type MyType { foo(a: MyInput, b: MyInput!, c: [MyInput], d: [MyInput]!, e: [MyInput!]!): String }`
       );
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
@@ -2041,7 +2041,7 @@ describe('TypeScript', () => {
 
     it('Should add custom prefix for mutation arguments', async () => {
       const schema = buildSchema(`input Input { name: String } type Mutation { foo(id: ID, input: Input): String }`);
-      const result = (await plugin(schema, [], { typesPrefix: 'T' }, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], { typesPrefix: 'T' }, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type TInput = {
@@ -2079,7 +2079,7 @@ describe('TypeScript', () => {
           books: [Book!]!
         }
       `);
-      const result = (await plugin(testSchema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(testSchema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type NodeTextArgs = {
@@ -2094,7 +2094,7 @@ describe('TypeScript', () => {
   describe('Enum', () => {
     it('Should build basic enum correctly', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
-      const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, [], {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export enum MyEnum {
@@ -2268,7 +2268,7 @@ describe('TypeScript', () => {
       }
     `);
 
-    const content = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const content = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(content).not.toContainEqual('[object Object]');
 
@@ -2297,7 +2297,7 @@ describe('TypeScript', () => {
       }
     `);
 
-    const result = (await plugin(schema, [], {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], {}, { outputFile: '' });
     expect(result.content).toContain('__typename');
 
     validateTs(result);
@@ -2325,7 +2325,7 @@ describe('TypeScript', () => {
       }
     `);
 
-    const result = (await plugin(schema, [], { skipTypename: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], { skipTypename: true }, { outputFile: '' });
     expect(result.content).not.toContain('__typename');
 
     validateTs(result);
@@ -2353,7 +2353,7 @@ describe('TypeScript', () => {
       }
     `);
 
-    const result = (await plugin(schema, [], { noExport: true }, { outputFile: '' })) as Types.ComplexPluginOutput;
+    const result = await plugin(schema, [], { noExport: true }, { outputFile: '' });
     expect(result.content).not.toContain('export');
 
     validateTs(result);
@@ -2428,7 +2428,7 @@ describe('TypeScript', () => {
         },
       }),
     });
-    const output = (await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
+    const output = await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
 
     expect(output.content).toBeSimilarStringTo(`
       export enum Foo {

--- a/packages/plugins/typescript/urql/src/index.ts
+++ b/packages/plugins/typescript/urql/src/index.ts
@@ -5,7 +5,7 @@ import { UrqlVisitor } from './visitor';
 import { extname } from 'path';
 import { UrqlRawPluginConfig } from './config';
 
-export const plugin: PluginFunction<UrqlRawPluginConfig> = (
+export const plugin: PluginFunction<UrqlRawPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: UrqlRawPluginConfig

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -131,7 +131,7 @@ describe('urql', () => {
           `),
         },
       ];
-      const result = (await plugin(schema, docs, {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, docs, {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export const MyFragmentFragmentDoc = gql\`

--- a/packages/plugins/typescript/vue-apollo/src/index.ts
+++ b/packages/plugins/typescript/vue-apollo/src/index.ts
@@ -5,7 +5,7 @@ import { VueApolloVisitor } from './visitor';
 import { extname } from 'path';
 import { VueApolloRawPluginConfig } from './config';
 
-export const plugin: PluginFunction<VueApolloRawPluginConfig> = (
+export const plugin: PluginFunction<VueApolloRawPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: VueApolloRawPluginConfig

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -258,7 +258,7 @@ describe('Vue Apollo', () => {
           `),
         },
       ];
-      const result = (await plugin(schema, docs, {}, { outputFile: '' })) as Types.ComplexPluginOutput;
+      const result = await plugin(schema, docs, {}, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
       export const MyFragmentFragmentDoc = gql\`

--- a/packages/presets/near-operation-file/src/resolve-document-imports.ts
+++ b/packages/presets/near-operation-file/src/resolve-document-imports.ts
@@ -1,4 +1,5 @@
 import { isUsingTypes, Types } from '@graphql-codegen/plugin-helpers';
+import { generateImportStatement, ImportSource, resolveImportSource } from '@graphql-codegen/visitor-plugin-common';
 import { FragmentDefinitionNode, GraphQLSchema } from 'graphql';
 import buildFragmentResolver from './fragment-resolver';
 
@@ -6,44 +7,16 @@ export type FragmentRegistry = {
   [fragmentName: string]: { location: string; importNames: string[]; onType: string; node: FragmentDefinitionNode };
 };
 
-export type ImportSourceDefinition = {
-  /**
-   * Source path, relative to the `baseOutputDir`
-   */
-  path: string;
-  /**
-   * Namespace to import source as
-   */
-  namespace?: string;
-  /**
-   * Entity names to import
-   */
-  names?: string[];
-};
-
-function resolveImportSource(source: string | ImportSourceDefinition): ImportSourceDefinition {
-  return typeof source === 'string' ? { path: source } : source;
-}
-
-type GenerateImportStatement = (paths: {
-  relativeOutputPath: string;
-  importSource: ImportSourceDefinition;
-  baseOutputDir: string;
-}) => string;
-
 export type DocumentImportResolverOptions = {
+  baseDir: string;
   /**
    * Generates a target file path from the source `document.location`
    */
   generateFilePath: (location: string) => string;
   /**
-   *
-   */
-  generateImportStatement: GenerateImportStatement;
-  /**
    *  Schema base types source
    */
-  schemaTypesSource: string | ImportSourceDefinition;
+  schemaTypesSource: string | ImportSource;
 };
 
 /**
@@ -52,21 +25,19 @@ export type DocumentImportResolverOptions = {
  * Resolves user provided imports and fragment imports using the `DocumentImportResolverOptions`.
  * Does not define specific plugins, but rather returns a string[] of `importStatements` for the calling plugin to make use of
  */
-export default function resolveDocumentImportStatements<T>(
+export function resolveDocumentImports<T>(
   presetOptions: Types.PresetFnArgs<T>,
   schemaObject: GraphQLSchema,
   importResolverOptions: DocumentImportResolverOptions
 ) {
   const resolveFragments = buildFragmentResolver(importResolverOptions, presetOptions, schemaObject);
   const { baseOutputDir, documents } = presetOptions;
-  const { generateFilePath, generateImportStatement, schemaTypesSource } = importResolverOptions;
+  const { generateFilePath, schemaTypesSource, baseDir } = importResolverOptions;
 
   return documents.map(documentFile => {
     const generatedFilePath = generateFilePath(documentFile.location);
-    const { externalFragments, fragmentImportStatements: importStatements } = resolveFragments(
-      generatedFilePath,
-      documentFile.document
-    );
+    const importStatements = [];
+    const { externalFragments, fragmentImports } = resolveFragments(generatedFilePath, documentFile.document);
 
     if (
       isUsingTypes(
@@ -76,9 +47,10 @@ export default function resolveDocumentImportStatements<T>(
       )
     ) {
       const schemaTypesImportStatement = generateImportStatement({
+        baseDir,
         importSource: resolveImportSource(schemaTypesSource),
         baseOutputDir,
-        relativeOutputPath: generatedFilePath,
+        outputPath: generatedFilePath,
       });
       importStatements.unshift(schemaTypesImportStatement);
     }
@@ -87,6 +59,7 @@ export default function resolveDocumentImportStatements<T>(
       filename: generatedFilePath,
       documents: [documentFile],
       importStatements,
+      fragmentImports,
       externalFragments,
     };
   });

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -1,4 +1,4 @@
-import { parse, dirname, relative, join, isAbsolute } from 'path';
+import { parse, join } from 'path';
 import { DocumentNode, visit, FragmentSpreadNode, FragmentDefinitionNode } from 'graphql';
 import { FragmentRegistry } from './fragment-resolver';
 
@@ -11,12 +11,6 @@ export function appendExtensionToFilePath(baseFilePath: string, extension: strin
   const parsedPath = parse(baseFilePath);
 
   return join(parsedPath.dir, parsedPath.name + extension).replace(/\\/g, '/');
-}
-
-export function clearExtension(path: string): string {
-  const parsedPath = parse(path);
-
-  return join(parsedPath.dir, parsedPath.name).replace(/\\/g, '/');
 }
 
 export function extractExternalFragmentsInUse(
@@ -62,22 +56,4 @@ export function extractExternalFragmentsInUse(
   });
 
   return result;
-}
-
-export function fixLocalFile(path: string): string {
-  if (!path.startsWith('..')) {
-    return `./${path}`;
-  }
-
-  return path;
-}
-
-export function resolveRelativeImport(from: string, to: string): string {
-  if (!isAbsolute(from)) {
-    throw new Error(`Argument 'from' must be an absolute path, '${from}' given.`);
-  }
-  if (!isAbsolute(to)) {
-    throw new Error(`Argument 'to' must be an absolute path, '${to}' given.`);
-  }
-  return fixLocalFile(clearExtension(relative(dirname(from), to)));
 }

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -136,7 +136,7 @@ export function isComplexPluginOutput(obj: Types.PluginOutput): obj is Types.Com
   return typeof obj === 'object' && obj.hasOwnProperty('content');
 }
 
-export type PluginFunction<T = any> = (
+export type PluginFunction<T = any, TReturn extends Types.PluginOutput = Types.PluginOutput> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: T,
@@ -145,7 +145,7 @@ export type PluginFunction<T = any> = (
     allPlugins?: Types.ConfiguredPlugin[];
     [key: string]: any;
   }
-) => Types.Promisable<Types.PluginOutput>;
+) => Types.Promisable<TReturn>;
 
 export type PluginValidateFn<T = any> = (
   schema: GraphQLSchema,

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -136,7 +136,7 @@ export function isComplexPluginOutput(obj: Types.PluginOutput): obj is Types.Com
   return typeof obj === 'object' && obj.hasOwnProperty('content');
 }
 
-export type PluginFunction<T = any, TReturn extends Types.PluginOutput = Types.PluginOutput> = (
+export type PluginFunction<T = any, TOutput extends Types.PluginOutput = Types.PluginOutput> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: T,
@@ -145,7 +145,7 @@ export type PluginFunction<T = any, TReturn extends Types.PluginOutput = Types.P
     allPlugins?: Types.ConfiguredPlugin[];
     [key: string]: any;
   }
-) => Types.Promisable<TReturn>;
+) => Types.Promisable<TOutput>;
 
 export type PluginValidateFn<T = any> = (
   schema: GraphQLSchema,


### PR DESCRIPTION
The current implementation for `near-operation-file` fragment imports was only intended as a workaround to solve issues with unused imports in `typescript-operations` plugin.

This PR is the improved implementation which makes it possible for 3rd party plugins to generate fragment imports correctly.