### PR TITLE
Add field wrapper for list type item [plugins/typescript]

### DIFF
--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -120,8 +120,22 @@ export class TsVisitor<
   }
 
   FieldDefinition(node: FieldDefinitionNode, key?: number | string, parent?: any): string {
-    const typeString = this.config.wrapFieldDefinitions ? `FieldWrapper<${node.type}>` : ((node.type as any) as string);
-    const originalFieldNode = parent[key] as FieldDefinitionNode;
+    let typeString;
+    const originalFieldNode = parent[key];
+
+    if (!this.config.wrapFieldDefinitions) {
+      typeString = node.type;
+    } else {
+      // if field is a list - we should add field resolver in list item
+      if (node.type.toString().startsWith('Array')) {
+        typeString = node.type.toString().replace('Array', 'Array<FieldWrapper') + '>';
+      } else if (node.type.toString().startsWith('Maybe<Array')) {
+        typeString = node.type.toString().replace('Maybe<Array', 'Maybe<Array<FieldWrapper') + '>';
+      } else {
+        typeString = `FieldWrapper<${node.type}>`;
+      }
+    }
+
     const addOptionalSign = !this.config.avoidOptionals.field && originalFieldNode.type.kind !== Kind.NON_NULL_TYPE;
     const comment = this.getFieldComment(node);
     const { type } = this.config.declarationKind;

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1567,6 +1567,40 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
+    it('Should build list type correctly when wrapping field definitions', async () => {
+      const schema = buildSchema(`
+        type ListOfStrings {
+          foo: [String!]!
+        }
+
+        type ListOfMaybeStrings {
+          foo: [String]!
+        }
+      `);
+      const result = (await plugin(
+        schema,
+        [],
+        { wrapFieldDefinitions: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type ListOfStrings = {
+          __typename?: 'ListOfStrings';
+          foo: Array<FieldWrapper<Scalars['String']>>;
+        };
+      `);
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type ListOfMaybeStrings = {
+          __typename?: 'ListOfMaybeStrings';
+          foo: Array<FieldWrapper<Maybe<Scalars['String']>>>;
+        };
+      `);
+
+      validateTs(result);
+    });
+
     it('Should not wrap input type fields', async () => {
       const schema = buildSchema(`
         input MyInput {


### PR DESCRIPTION
Related to issue:  https://github.com/dotansimha/graphql-code-generator/issues/3882

Add wrapping in field wrapper in list item element