### PR TITLE
feat: support @export directive

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
@@ -194,7 +194,8 @@ export class BaseDocumentsVisitor<
 
     const selectionSet = this._selectionSetToObject.createNext(operationRootType, node.selectionSet);
     const visitedOperationVariables = this._variablesTransfomer.transform<VariableDefinitionNode>(
-      node.variableDefinitions
+      node.variableDefinitions,
+      node.selectionSet
     );
     const operationType: string = pascalCase(node.operation);
     const operationTypeSuffix = this.getOperationSuffix(name, operationType);

--- a/packages/plugins/other/visitor-plugin-common/src/variables-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/variables-to-object.ts
@@ -65,13 +65,12 @@ export class OperationVariablesToObject {
       visitSelections(selectionSet.selections);
     }
 
-    const ret =
-      variablesNode
-        .filter(variable => !exportedArgs.has(variable?.variable?.name?.value))
-        .map(variable => indent(this.transformVariable(variable)))
-        .join(`${this.getPunctuation()}\n`) + this.getPunctuation();
+    const variableDefinitions = variablesNode
+      .filter(variable => !exportedArgs.has(variable?.variable?.name?.value))
+      .map(variable => indent(this.transformVariable(variable)))
+      .join(`${this.getPunctuation()}\n`);
 
-    return ret;
+    return variableDefinitions ? variableDefinitions + this.getPunctuation() : '';
   }
 
   protected getScalar(name: string): string {

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -2339,6 +2339,16 @@ describe('TypeScript Operations Plugin', () => {
             text
           }
         }
+
+        query getCurrentUserPosts3($userId: ID!) {
+          currentUserId @client @export(as: "userId")
+
+          getPostsByUser2(id: $userId, topic: "hello") {
+            id
+            title
+            text
+          }
+        }
       `);
       const config = { skipTypename: true };
       const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
@@ -2349,16 +2359,18 @@ describe('TypeScript Operations Plugin', () => {
         `export type GetCurrentUserPostsQueryVariables = {
           topic: Scalars['String'];
         };
-        
-        
         export type GetCurrentUserPostsQuery = { getPostsByUser?: Maybe<Pick<Post, 'id' | 'title' | 'text'>> };
         
         export type GetCurrentUserPosts2QueryVariables = {
           topic: Scalars['String'];
         };
-        
-        
         export type GetCurrentUserPosts2Query = (
+          Pick<Query, 'currentUserId'>
+          & { getPostsByUser2?: Maybe<Pick<Post, 'id' | 'title' | 'text'>> }
+        );
+        
+        export type GetCurrentUserPosts3QueryVariables = {};
+        export type GetCurrentUserPosts3Query = (
           Pick<Query, 'currentUserId'>
           & { getPostsByUser2?: Maybe<Pick<Post, 'id' | 'title' | 'text'>> }
         );`


### PR DESCRIPTION
Ensures that variables exported via the `@export` directive are not part of the generated typescript variables types.

Closes #2771
