### PR TITLE
Fix/vue apollo composable alpha 8 compatibility

### DIFF
--- a/dev-test/codegen.yml
+++ b/dev-test/codegen.yml
@@ -213,6 +213,13 @@ generates:
     config:
       componentType: class
       globalNamespace: true
+  ./dev-test/githunt/types.vueApollo.ts:
+    schema: ./dev-test/githunt/schema.json
+    documents: ./dev-test/githunt/**/*.graphql
+    plugins:
+      - typescript
+      - typescript-operations
+      - typescript-vue-apollo
   ./dev-test/star-wars/types.ts:
     schema: ./dev-test/star-wars/schema.json
     documents: ./dev-test/star-wars/**/*.graphql

--- a/dev-test/githunt/types.vueApollo.ts
+++ b/dev-test/githunt/types.vueApollo.ts
@@ -353,14 +353,14 @@ export function useOnCommentAddedSubscription(
     | OnCommentAddedSubscriptionVariables
     | VueCompositionApi.Ref<OnCommentAddedSubscriptionVariables>
     | ReactiveFunction<OnCommentAddedSubscriptionVariables>,
-  options?:
+  options:
     | VueApolloComposable.UseSubscriptionOptions<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>
     | VueCompositionApi.Ref<
         VueApolloComposable.UseSubscriptionOptions<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>
       >
     | ReactiveFunction<
         VueApolloComposable.UseSubscriptionOptions<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>
-      >
+      > = {}
 ) {
   return VueApolloComposable.useSubscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>(
     OnCommentAddedDocument,
@@ -426,10 +426,10 @@ export function useCommentQuery(
     | CommentQueryVariables
     | VueCompositionApi.Ref<CommentQueryVariables>
     | ReactiveFunction<CommentQueryVariables>,
-  options?:
+  options:
     | VueApolloComposable.UseQueryOptions<CommentQuery, CommentQueryVariables>
     | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<CommentQuery, CommentQueryVariables>>
-    | ReactiveFunction<VueApolloComposable.UseQueryOptions<CommentQuery, CommentQueryVariables>>
+    | ReactiveFunction<VueApolloComposable.UseQueryOptions<CommentQuery, CommentQueryVariables>> = {}
 ) {
   return VueApolloComposable.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, variables, options);
 }
@@ -462,14 +462,14 @@ export const CurrentUserForProfileDocument = gql`
  * );
  */
 export function useCurrentUserForProfileQuery(
-  options?:
+  options:
     | VueApolloComposable.UseQueryOptions<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>
     | VueCompositionApi.Ref<
         VueApolloComposable.UseQueryOptions<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>
       >
     | ReactiveFunction<
         VueApolloComposable.UseQueryOptions<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>
-      >
+      > = {}
 ) {
   return VueApolloComposable.useQuery<CurrentUserForProfileQuery, undefined>(
     CurrentUserForProfileDocument,
@@ -513,10 +513,10 @@ export const FeedDocument = gql`
  */
 export function useFeedQuery(
   variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunction<FeedQueryVariables>,
-  options?:
+  options:
     | VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>
     | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>
-    | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>
+    | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> = {}
 ) {
   return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options);
 }
@@ -547,7 +547,10 @@ export const SubmitRepositoryDocument = gql`
  * });
  */
 export function useSubmitRepositoryMutation(
-  options?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
+  options: VueApolloComposable.UseMutationOptionsWithVariables<
+    SubmitRepositoryMutation,
+    SubmitRepositoryMutationVariables
+  >
 ) {
   return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(
     SubmitRepositoryDocument,
@@ -586,7 +589,7 @@ export const SubmitCommentDocument = gql`
  * });
  */
 export function useSubmitCommentMutation(
-  options?: VueApolloComposable.UseMutationOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
+  options: VueApolloComposable.UseMutationOptionsWithVariables<SubmitCommentMutation, SubmitCommentMutationVariables>
 ) {
   return VueApolloComposable.useMutation<SubmitCommentMutation, SubmitCommentMutationVariables>(
     SubmitCommentDocument,
@@ -627,7 +630,9 @@ export const VoteDocument = gql`
  *   },
  * });
  */
-export function useVoteMutation(options?: VueApolloComposable.UseMutationOptions<VoteMutation, VoteMutationVariables>) {
+export function useVoteMutation(
+  options: VueApolloComposable.UseMutationOptionsWithVariables<VoteMutation, VoteMutationVariables>
+) {
   return VueApolloComposable.useMutation<VoteMutation, VoteMutationVariables>(VoteDocument, options);
 }
 export type VoteMutationCompositionFunctionResult = VueApolloComposable.UseMutationReturn<

--- a/dev-test/githunt/types.vueApollo.ts
+++ b/dev-test/githunt/types.vueApollo.ts
@@ -1,0 +1,618 @@
+import gql from 'graphql-tag';
+import * as VueApolloComposable from '@vue/apollo-composable';
+import * as VueCompositionApi from '@vue/composition-api';
+export type Maybe<T> = T | null;
+export type ReactiveFunction<TParam> = () => TParam;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  /** A feed of repository submissions */
+  feed?: Maybe<Array<Maybe<Entry>>>;
+  /** A single entry */
+  entry?: Maybe<Entry>;
+  /** Return the currently logged in user, or null if nobody is logged in */
+  currentUser?: Maybe<User>;
+};
+
+export type QueryFeedArgs = {
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+export type QueryEntryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  /** Sort by a combination of freshness and score, using Reddit's algorithm */
+  Hot = 'HOT',
+  /** Newest entries first */
+  New = 'NEW',
+  /** Highest score entries first */
+  Top = 'TOP',
+}
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type Entry = {
+  __typename?: 'Entry';
+  /** Information about the repository from GitHub */
+  repository: Repository;
+  /** The GitHub user who submitted this entry */
+  postedBy: User;
+  /** A timestamp of when the entry was submitted */
+  createdAt: Scalars['Float'];
+  /** The score of this repository, upvotes - downvotes */
+  score: Scalars['Int'];
+  /** The hot score of this repository */
+  hotScore: Scalars['Float'];
+  /** Comments posted about this repository */
+  comments: Array<Maybe<Comment>>;
+  /** The number of comments posted about this repository */
+  commentCount: Scalars['Int'];
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** XXX to be changed */
+  vote: Vote;
+};
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type EntryCommentsArgs = {
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+/**
+ * A repository object from the GitHub API. This uses the exact field names returned by the
+ * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
+ */
+export type Repository = {
+  __typename?: 'Repository';
+  /** Just the name of the repository, e.g. GitHunt-API */
+  name: Scalars['String'];
+  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
+  full_name: Scalars['String'];
+  /** The description of the repository */
+  description?: Maybe<Scalars['String']>;
+  /** The link to the repository on GitHub */
+  html_url: Scalars['String'];
+  /** The number of people who have starred this repository on GitHub */
+  stargazers_count: Scalars['Int'];
+  /** The number of open issues on this repository on GitHub */
+  open_issues_count?: Maybe<Scalars['Int']>;
+  /** The owner of this repository on GitHub, e.g. apollostack */
+  owner?: Maybe<User>;
+};
+
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export type User = {
+  __typename?: 'User';
+  /** The name of the user, e.g. apollostack */
+  login: Scalars['String'];
+  /** The URL to a directly embeddable image for this user's avatar */
+  avatar_url: Scalars['String'];
+  /** The URL of this user's GitHub page */
+  html_url: Scalars['String'];
+};
+
+/** A comment about an entry, submitted by a user */
+export type Comment = {
+  __typename?: 'Comment';
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** The GitHub user who posted the comment */
+  postedBy: User;
+  /** A timestamp of when the comment was posted */
+  createdAt: Scalars['Float'];
+  /** The text of the comment */
+  content: Scalars['String'];
+  /** The repository which this comment is about */
+  repoName: Scalars['String'];
+};
+
+/** XXX to be removed */
+export type Vote = {
+  __typename?: 'Vote';
+  vote_value: Scalars['Int'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** Submit a new repository, returns the new submission */
+  submitRepository?: Maybe<Entry>;
+  /** Vote on a repository submission, returns the submission that was voted on */
+  vote?: Maybe<Entry>;
+  /** Comment on a repository, returns the new comment */
+  submitComment?: Maybe<Comment>;
+};
+
+export type MutationSubmitRepositoryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+export type MutationVoteArgs = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+export type MutationSubmitCommentArgs = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  Up = 'UP',
+  Down = 'DOWN',
+  Cancel = 'CANCEL',
+}
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** Subscription fires on every comment added */
+  commentAdded?: Maybe<Comment>;
+};
+
+export type SubscriptionCommentAddedArgs = {
+  repoFullName: Scalars['String'];
+};
+
+export type OnCommentAddedSubscriptionVariables = {
+  repoFullName: Scalars['String'];
+};
+
+export type OnCommentAddedSubscription = { __typename?: 'Subscription' } & {
+  commentAdded?: Maybe<
+    { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
+        postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
+      }
+  >;
+};
+
+export type CommentQueryVariables = {
+  repoFullName: Scalars['String'];
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+export type CommentQuery = { __typename?: 'Query' } & {
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'html_url'>>;
+  entry?: Maybe<
+    { __typename?: 'Entry' } & Pick<Entry, 'id' | 'createdAt' | 'commentCount'> & {
+        postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
+        comments: Array<Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>>;
+        repository: { __typename?: 'Repository' } & Pick<
+          Repository,
+          'description' | 'open_issues_count' | 'stargazers_count' | 'full_name' | 'html_url'
+        >;
+      }
+  >;
+};
+
+export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<Comment, 'id' | 'createdAt' | 'content'> & {
+    postedBy: { __typename?: 'User' } & Pick<User, 'login' | 'html_url'>;
+  };
+
+export type CurrentUserForProfileQueryVariables = {};
+
+export type CurrentUserForProfileQuery = { __typename?: 'Query' } & {
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login' | 'avatar_url'>>;
+};
+
+export type FeedEntryFragment = { __typename?: 'Entry' } & Pick<Entry, 'id' | 'commentCount'> & {
+    repository: { __typename?: 'Repository' } & Pick<Repository, 'full_name' | 'html_url'> & {
+        owner?: Maybe<{ __typename?: 'User' } & Pick<User, 'avatar_url'>>;
+      };
+  } & VoteButtonsFragment &
+  RepoInfoFragment;
+
+export type FeedQueryVariables = {
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+export type FeedQuery = { __typename?: 'Query' } & {
+  currentUser?: Maybe<{ __typename?: 'User' } & Pick<User, 'login'>>;
+  feed?: Maybe<Array<Maybe<{ __typename?: 'Entry' } & FeedEntryFragment>>>;
+};
+
+export type SubmitRepositoryMutationVariables = {
+  repoFullName: Scalars['String'];
+};
+
+export type SubmitRepositoryMutation = { __typename?: 'Mutation' } & {
+  submitRepository?: Maybe<{ __typename?: 'Entry' } & Pick<Entry, 'createdAt'>>;
+};
+
+export type RepoInfoFragment = { __typename?: 'Entry' } & Pick<Entry, 'createdAt'> & {
+    repository: { __typename?: 'Repository' } & Pick<
+      Repository,
+      'description' | 'stargazers_count' | 'open_issues_count'
+    >;
+    postedBy: { __typename?: 'User' } & Pick<User, 'html_url' | 'login'>;
+  };
+
+export type SubmitCommentMutationVariables = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+export type SubmitCommentMutation = { __typename?: 'Mutation' } & {
+  submitComment?: Maybe<{ __typename?: 'Comment' } & CommentsPageCommentFragment>;
+};
+
+export type VoteButtonsFragment = { __typename?: 'Entry' } & Pick<Entry, 'score'> & {
+    vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
+  };
+
+export type VoteMutationVariables = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+export type VoteMutation = { __typename?: 'Mutation' } & {
+  vote?: Maybe<
+    { __typename?: 'Entry' } & Pick<Entry, 'score' | 'id'> & {
+        vote: { __typename?: 'Vote' } & Pick<Vote, 'vote_value'>;
+      }
+  >;
+};
+
+export const CommentsPageCommentFragmentDoc = gql`
+  fragment CommentsPageComment on Comment {
+    id
+    postedBy {
+      login
+      html_url
+    }
+    createdAt
+    content
+  }
+`;
+export const VoteButtonsFragmentDoc = gql`
+  fragment VoteButtons on Entry {
+    score
+    vote {
+      vote_value
+    }
+  }
+`;
+export const RepoInfoFragmentDoc = gql`
+  fragment RepoInfo on Entry {
+    createdAt
+    repository {
+      description
+      stargazers_count
+      open_issues_count
+    }
+    postedBy {
+      html_url
+      login
+    }
+  }
+`;
+export const FeedEntryFragmentDoc = gql`
+  fragment FeedEntry on Entry {
+    id
+    commentCount
+    repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+    ...VoteButtons
+    ...RepoInfo
+  }
+  ${VoteButtonsFragmentDoc}
+  ${RepoInfoFragmentDoc}
+`;
+export const OnCommentAddedDocument = gql`
+  subscription onCommentAdded($repoFullName: String!) {
+    commentAdded(repoFullName: $repoFullName) {
+      id
+      postedBy {
+        login
+        html_url
+      }
+      createdAt
+      content
+    }
+  }
+`;
+
+/**
+ * __useOnCommentAddedSubscription__
+ *
+ * To run a query within a Vue component, call `useOnCommentAddedSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useOnCommentAddedSubscription` returns an object from Apollo Client that contains result, loading and error properties
+ * you can use to render your UI.
+ *
+ * @param options that will be passed into the subscription, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
+ *
+ * @example
+ * const { result, loading, error } = useOnCommentAddedSubscription(
+ *   {
+ *      repoFullName: // value for 'repoFullName'
+ *   }
+ * );
+ */
+export function useOnCommentAddedSubscription(
+  variables:
+    | OnCommentAddedSubscriptionVariables
+    | VueCompositionApi.Ref<OnCommentAddedSubscriptionVariables>
+    | ReactiveFunction<OnCommentAddedSubscriptionVariables>,
+  options?:
+    | VueApolloComposable.UseSubscriptionOptions<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>
+    | VueCompositionApi.Ref<
+        VueApolloComposable.UseSubscriptionOptions<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>
+      >
+    | ReactiveFunction<
+        VueApolloComposable.UseSubscriptionOptions<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>
+      >
+) {
+  return VueApolloComposable.useSubscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>(
+    OnCommentAddedDocument,
+    variables,
+    options
+  );
+}
+export type OnCommentAddedSubscriptionCompositionFunctionResult = ReturnType<typeof useOnCommentAddedSubscription>;
+export const CommentDocument = gql`
+  query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
+    currentUser {
+      login
+      html_url
+    }
+    entry(repoFullName: $repoFullName) {
+      id
+      postedBy {
+        login
+        html_url
+      }
+      createdAt
+      comments(limit: $limit, offset: $offset) {
+        ...CommentsPageComment
+      }
+      commentCount
+      repository {
+        full_name
+        html_url
+        ... on Repository {
+          description
+          open_issues_count
+          stargazers_count
+        }
+      }
+    }
+  }
+  ${CommentsPageCommentFragmentDoc}
+`;
+
+/**
+ * __useCommentQuery__
+ *
+ * To run a query within a Vue component, call `useCommentQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCommentQuery` returns an object from Apollo Client that contains result, loading and error properties
+ * you can use to render your UI.
+ *
+ * @param options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
+ *
+ * @example
+ * const { result, loading, error } = useCommentQuery(
+ *   {
+ *      repoFullName: // value for 'repoFullName'
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *   }
+ * );
+ */
+export function useCommentQuery(
+  variables:
+    | CommentQueryVariables
+    | VueCompositionApi.Ref<CommentQueryVariables>
+    | ReactiveFunction<CommentQueryVariables>,
+  options?:
+    | VueApolloComposable.UseQueryOptions<CommentQuery, CommentQueryVariables>
+    | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<CommentQuery, CommentQueryVariables>>
+    | ReactiveFunction<VueApolloComposable.UseQueryOptions<CommentQuery, CommentQueryVariables>>
+) {
+  return VueApolloComposable.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, variables, options);
+}
+export type CommentQueryCompositionFunctionResult = ReturnType<typeof useCommentQuery>;
+export const CurrentUserForProfileDocument = gql`
+  query CurrentUserForProfile {
+    currentUser {
+      login
+      avatar_url
+    }
+  }
+`;
+
+/**
+ * __useCurrentUserForProfileQuery__
+ *
+ * To run a query within a Vue component, call `useCurrentUserForProfileQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCurrentUserForProfileQuery` returns an object from Apollo Client that contains result, loading and error properties
+ * you can use to render your UI.
+ *
+ * @param options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
+ *
+ * @example
+ * const { result, loading, error } = useCurrentUserForProfileQuery(
+ *   {
+ *   }
+ * );
+ */
+export function useCurrentUserForProfileQuery(
+  options?:
+    | VueApolloComposable.UseQueryOptions<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>
+    | VueCompositionApi.Ref<
+        VueApolloComposable.UseQueryOptions<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>
+      >
+    | ReactiveFunction<
+        VueApolloComposable.UseQueryOptions<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>
+      >
+) {
+  return VueApolloComposable.useQuery<CurrentUserForProfileQuery, undefined>(
+    CurrentUserForProfileDocument,
+    undefined,
+    options
+  );
+}
+export type CurrentUserForProfileQueryCompositionFunctionResult = ReturnType<typeof useCurrentUserForProfileQuery>;
+export const FeedDocument = gql`
+  query Feed($type: FeedType!, $offset: Int, $limit: Int) {
+    currentUser {
+      login
+    }
+    feed(type: $type, offset: $offset, limit: $limit) {
+      ...FeedEntry
+    }
+  }
+  ${FeedEntryFragmentDoc}
+`;
+
+/**
+ * __useFeedQuery__
+ *
+ * To run a query within a Vue component, call `useFeedQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFeedQuery` returns an object from Apollo Client that contains result, loading and error properties
+ * you can use to render your UI.
+ *
+ * @param options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
+ *
+ * @example
+ * const { result, loading, error } = useFeedQuery(
+ *   {
+ *      type: // value for 'type'
+ *      offset: // value for 'offset'
+ *      limit: // value for 'limit'
+ *   }
+ * );
+ */
+export function useFeedQuery(
+  variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunction<FeedQueryVariables>,
+  options?:
+    | VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>
+    | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>
+    | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>
+) {
+  return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options);
+}
+export type FeedQueryCompositionFunctionResult = ReturnType<typeof useFeedQuery>;
+export const SubmitRepositoryDocument = gql`
+  mutation submitRepository($repoFullName: String!) {
+    submitRepository(repoFullName: $repoFullName) {
+      createdAt
+    }
+  }
+`;
+
+/**
+ * __useSubmitRepositoryMutation__
+ *
+ * To run a mutation, you first call `useSubmitRepositoryMutation` within a Vue component and pass it any options that fit your needs.
+ * When your component renders, `useSubmitRepositoryMutation` returns an object that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - Several other properties: https://v4.apollo.vuejs.org/api/use-mutation.html#return
+ *
+ * @param options that will be passed into the mutation, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/mutation.html#options;
+ *
+ * @example
+ * const { mutate, loading, error, onDone } = useSubmitRepositoryMutation({
+ *   variables: {
+ *      repoFullName: // value for 'repoFullName'
+ *   },
+ * });
+ */
+export function useSubmitRepositoryMutation(
+  options?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
+) {
+  return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(
+    SubmitRepositoryDocument,
+    options
+  );
+}
+export type SubmitRepositoryMutationCompositionFunctionResult = ReturnType<typeof useSubmitRepositoryMutation>;
+export const SubmitCommentDocument = gql`
+  mutation submitComment($repoFullName: String!, $commentContent: String!) {
+    submitComment(repoFullName: $repoFullName, commentContent: $commentContent) {
+      ...CommentsPageComment
+    }
+  }
+  ${CommentsPageCommentFragmentDoc}
+`;
+
+/**
+ * __useSubmitCommentMutation__
+ *
+ * To run a mutation, you first call `useSubmitCommentMutation` within a Vue component and pass it any options that fit your needs.
+ * When your component renders, `useSubmitCommentMutation` returns an object that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - Several other properties: https://v4.apollo.vuejs.org/api/use-mutation.html#return
+ *
+ * @param options that will be passed into the mutation, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/mutation.html#options;
+ *
+ * @example
+ * const { mutate, loading, error, onDone } = useSubmitCommentMutation({
+ *   variables: {
+ *      repoFullName: // value for 'repoFullName'
+ *      commentContent: // value for 'commentContent'
+ *   },
+ * });
+ */
+export function useSubmitCommentMutation(
+  options?: VueApolloComposable.UseMutationOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
+) {
+  return VueApolloComposable.useMutation<SubmitCommentMutation, SubmitCommentMutationVariables>(
+    SubmitCommentDocument,
+    options
+  );
+}
+export type SubmitCommentMutationCompositionFunctionResult = ReturnType<typeof useSubmitCommentMutation>;
+export const VoteDocument = gql`
+  mutation vote($repoFullName: String!, $type: VoteType!) {
+    vote(repoFullName: $repoFullName, type: $type) {
+      score
+      id
+      vote {
+        vote_value
+      }
+    }
+  }
+`;
+
+/**
+ * __useVoteMutation__
+ *
+ * To run a mutation, you first call `useVoteMutation` within a Vue component and pass it any options that fit your needs.
+ * When your component renders, `useVoteMutation` returns an object that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - Several other properties: https://v4.apollo.vuejs.org/api/use-mutation.html#return
+ *
+ * @param options that will be passed into the mutation, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/mutation.html#options;
+ *
+ * @example
+ * const { mutate, loading, error, onDone } = useVoteMutation({
+ *   variables: {
+ *      repoFullName: // value for 'repoFullName'
+ *      type: // value for 'type'
+ *   },
+ * });
+ */
+export function useVoteMutation(options?: VueApolloComposable.UseMutationOptions<VoteMutation, VoteMutationVariables>) {
+  return VueApolloComposable.useMutation<VoteMutation, VoteMutationVariables>(VoteDocument, options);
+}
+export type VoteMutationCompositionFunctionResult = ReturnType<typeof useVoteMutation>;

--- a/dev-test/githunt/types.vueApollo.ts
+++ b/dev-test/githunt/types.vueApollo.ts
@@ -368,7 +368,10 @@ export function useOnCommentAddedSubscription(
     options
   );
 }
-export type OnCommentAddedSubscriptionCompositionFunctionResult = ReturnType<typeof useOnCommentAddedSubscription>;
+export type OnCommentAddedSubscriptionCompositionFunctionResult = VueApolloComposable.UseSubscriptionReturn<
+  OnCommentAddedSubscription,
+  OnCommentAddedSubscriptionVariables
+>;
 export const CommentDocument = gql`
   query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
     currentUser {
@@ -430,7 +433,10 @@ export function useCommentQuery(
 ) {
   return VueApolloComposable.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, variables, options);
 }
-export type CommentQueryCompositionFunctionResult = ReturnType<typeof useCommentQuery>;
+export type CommentQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<
+  CommentQuery,
+  CommentQueryVariables
+>;
 export const CurrentUserForProfileDocument = gql`
   query CurrentUserForProfile {
     currentUser {
@@ -471,7 +477,10 @@ export function useCurrentUserForProfileQuery(
     options
   );
 }
-export type CurrentUserForProfileQueryCompositionFunctionResult = ReturnType<typeof useCurrentUserForProfileQuery>;
+export type CurrentUserForProfileQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<
+  CurrentUserForProfileQuery,
+  CurrentUserForProfileQueryVariables
+>;
 export const FeedDocument = gql`
   query Feed($type: FeedType!, $offset: Int, $limit: Int) {
     currentUser {
@@ -511,7 +520,7 @@ export function useFeedQuery(
 ) {
   return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options);
 }
-export type FeedQueryCompositionFunctionResult = ReturnType<typeof useFeedQuery>;
+export type FeedQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<FeedQuery, FeedQueryVariables>;
 export const SubmitRepositoryDocument = gql`
   mutation submitRepository($repoFullName: String!) {
     submitRepository(repoFullName: $repoFullName) {
@@ -545,7 +554,10 @@ export function useSubmitRepositoryMutation(
     options
   );
 }
-export type SubmitRepositoryMutationCompositionFunctionResult = ReturnType<typeof useSubmitRepositoryMutation>;
+export type SubmitRepositoryMutationCompositionFunctionResult = VueApolloComposable.UseMutationReturn<
+  SubmitRepositoryMutation,
+  SubmitRepositoryMutationVariables
+>;
 export const SubmitCommentDocument = gql`
   mutation submitComment($repoFullName: String!, $commentContent: String!) {
     submitComment(repoFullName: $repoFullName, commentContent: $commentContent) {
@@ -581,7 +593,10 @@ export function useSubmitCommentMutation(
     options
   );
 }
-export type SubmitCommentMutationCompositionFunctionResult = ReturnType<typeof useSubmitCommentMutation>;
+export type SubmitCommentMutationCompositionFunctionResult = VueApolloComposable.UseMutationReturn<
+  SubmitCommentMutation,
+  SubmitCommentMutationVariables
+>;
 export const VoteDocument = gql`
   mutation vote($repoFullName: String!, $type: VoteType!) {
     vote(repoFullName: $repoFullName, type: $type) {
@@ -615,4 +630,7 @@ export const VoteDocument = gql`
 export function useVoteMutation(options?: VueApolloComposable.UseMutationOptions<VoteMutation, VoteMutationVariables>) {
   return VueApolloComposable.useMutation<VoteMutation, VoteMutationVariables>(VoteDocument, options);
 }
-export type VoteMutationCompositionFunctionResult = ReturnType<typeof useVoteMutation>;
+export type VoteMutationCompositionFunctionResult = VueApolloComposable.UseMutationReturn<
+  VoteMutation,
+  VoteMutationVariables
+>;

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "@types/node": "10.17.20",
     "@types/react": "16.9.34",
     "@types/request": "2.48.4",
+    "@vue/apollo-composable": "^4.0.0-alpha.8",
+    "@vue/composition-api": "^0.5.0",
     "bob-the-bundler": "1.0.0-rc.14",
     "react": "16.13.1",
     "react-dom": "16.13.1",
@@ -99,7 +101,8 @@
     "ts-jest": "25.4.0",
     "stencil-apollo": "0.1.5",
     "typescript": "3.8.3",
-    "urql": "1.9.6"
+    "urql": "1.9.6",
+    "vue": "^2.6.11"
   },
   "lint-staged": {
     "packages/**/src/**/*.{ts,tsx}": [

--- a/packages/plugins/typescript/vue-apollo/jest.config.js
+++ b/packages/plugins/typescript/vue-apollo/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require('../../../../jest.project')({	dirname: __dirname });
+module.exports = require('../../../../jest.project')({ dirname: __dirname });

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -214,14 +214,16 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
                 operationHasNonNullableVariable ? '' : '?'
               }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>, `
             : ''
-        }options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
+        }options: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> = {}) {
             return VueApolloComposable.use${operationType}<${operationResultType}, ${
           operationHasVariables ? operationVariablesTypes : 'undefined'
         }>(${documentNodeVariable}, ${operationHasVariables ? 'variables' : 'undefined'}, options);
           }`;
       }
       case 'Mutation': {
-        return `export function use${operationName}(options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
+        return `export function use${operationName}(options: VueApolloComposable.Use${operationType}Options${
+          operationHasVariables ? (operationHasNonNullableVariable ? 'WithVariables' : '') : 'NoVariables'
+        }<${operationResultType}, ${operationVariablesTypes}>${operationHasNonNullableVariable ? '' : ' = {}'}) {
             return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, options);
           }`;
       }
@@ -232,7 +234,7 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
                 operationHasNonNullableVariable ? '' : '?'
               }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>, `
             : ''
-        }options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
+        }options: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> = {}) {
           return VueApolloComposable.use${operationType}<${operationResultType}, ${
           operationHasVariables ? operationVariablesTypes : 'undefined'
         }>(${documentNodeVariable}, ${operationHasVariables ? 'variables' : 'undefined'}, options);

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -208,16 +208,17 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
   }: BuildCompositionFunctions): string {
     switch (operationType) {
       case 'Query': {
-        if (operationHasVariables) {
-          return `export function use${operationName}(variables${
-            operationHasNonNullableVariable ? '' : '?'
-          }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>, options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
-            return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, variables, options);
+        return `export function use${operationName}(${
+          operationHasVariables
+            ? `variables${
+                operationHasNonNullableVariable ? '' : '?'
+              }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>, `
+            : ''
+        }options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
+            return VueApolloComposable.use${operationType}<${operationResultType}, ${
+          operationHasVariables ? operationVariablesTypes : 'undefined'
+        }>(${documentNodeVariable}, ${operationHasVariables ? 'variables' : 'undefined'}, options);
           }`;
-        }
-        return `export function use${operationName}(options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
-          return VueApolloComposable.use${operationType}<${operationResultType}, undefined>(${documentNodeVariable}, undefined, options);
-        }`;
       }
       case 'Mutation': {
         return `export function use${operationName}(options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
@@ -225,15 +226,16 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
           }`;
       }
       case 'Subscription': {
-        if (operationHasVariables) {
-          return `export function use${operationName}(variables${
-            operationHasNonNullableVariable ? '' : '?'
-          }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>, options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
-          return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, variables, options);
-        }`;
-        }
-        return `export function use${operationName}(options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
-          return VueApolloComposable.use${operationType}<${operationResultType}, undefined>(${documentNodeVariable}, undefined, options);
+        return `export function use${operationName}(${
+          operationHasVariables
+            ? `variables${
+                operationHasNonNullableVariable ? '' : '?'
+              }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>, `
+            : ''
+        }options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
+          return VueApolloComposable.use${operationType}<${operationResultType}, ${
+          operationHasVariables ? operationVariablesTypes : 'undefined'
+        }>(${documentNodeVariable}, ${operationHasVariables ? 'variables' : 'undefined'}, options);
         }`;
       }
     }

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -23,6 +23,7 @@ interface BuildCompositionFunctions {
   operationResultType: string;
   operationVariablesTypes: string;
   operationHasNonNullableVariable: boolean;
+  operationHasVariables: boolean;
   documentNodeVariable: string;
 }
 
@@ -58,6 +59,10 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
 
   private get vueCompositionApiImport(): string {
     return `import * as VueCompositionApi from '@vue/composition-api';`;
+  }
+
+  private get reactiveFunctionType(): string {
+    return 'export type ReactiveFunction<TParam> = () => TParam;';
   }
 
   private getDocumentNodeVariable(node: OperationDefinitionNode, documentVariableName: string): string {
@@ -113,7 +118,7 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
  * __use${operationName}__
  *${operationType === 'Mutation' ? mutationDescription : queryDescription}
  *
- * @param baseOptions options that will be passed into the ${operationType.toLowerCase()}, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/${
+ * @param options that will be passed into the ${operationType.toLowerCase()}, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/${
       operationType === 'Mutation' ? 'mutation' : 'query'
     }.html#options;
  *
@@ -122,9 +127,6 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
   }
 
   private getCompositionFunctionSuffix(name: string, operationType: string) {
-    if (this.config.omitOperationSuffix) {
-      return '';
-    }
     if (!this.config.dedupeOperationSuffix) {
       return pascalCase(operationType);
     }
@@ -160,14 +162,24 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
       useTypesPrefix: false,
     });
 
+    const operationHasVariables = node.variableDefinitions?.length > 0;
+
     const operationHasNonNullableVariable = !!node.variableDefinitions?.some(({ type }) => type.kind === 'NonNullType');
 
     this.imports.add(this.vueApolloComposableImport);
     this.imports.add(this.vueCompositionApiImport);
 
+    // hacky: technically not an import, but a typescript type that is required in the generated code
+    this.imports.add(this.reactiveFunctionType);
+
     const documentNodeVariable = this.getDocumentNodeVariable(node, documentVariableName); // i.e. TestDocument
 
-    const compositionFunctionResultType = this.buildCompositionFunctionReturnType(operationName);
+    const compositionFunctionResultType = this.buildCompositionFunctionReturnType({
+      operationName,
+      operationType,
+      operationResultType,
+      operationVariablesTypes,
+    });
 
     const compositionFunction = this.buildCompositionFunction({
       operationName,
@@ -175,6 +187,7 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
       operationResultType,
       operationVariablesTypes,
       operationHasNonNullableVariable,
+      operationHasVariables,
       documentNodeVariable,
     });
     return [
@@ -187,36 +200,51 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
   private buildCompositionFunction({
     operationName,
     operationType,
-    operationHasNonNullableVariable,
     operationResultType,
     operationVariablesTypes,
+    operationHasNonNullableVariable,
+    operationHasVariables,
     documentNodeVariable,
   }: BuildCompositionFunctions): string {
     switch (operationType) {
       case 'Query': {
-        const reactiveFunctionTypeName = `ReactiveFunction${operationName}`;
-        return `type ${reactiveFunctionTypeName} = () => ${operationVariablesTypes}\nexport function use${operationName}(variables${
-          operationHasNonNullableVariable ? '' : '?'
-        }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ${reactiveFunctionTypeName}, baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
-          return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, variables, baseOptions);
+        if (operationHasVariables) {
+          return `export function use${operationName}(variables${
+            operationHasNonNullableVariable ? '' : '?'
+          }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>, options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
+            return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, variables, options);
+          }`;
+        }
+        return `export function use${operationName}(options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
+          return VueApolloComposable.use${operationType}<${operationResultType}, undefined>(${documentNodeVariable}, undefined, options);
         }`;
       }
       case 'Mutation': {
-        return `export function use${operationName}(baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
-            return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, baseOptions);
+        return `export function use${operationName}(options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
+            return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, options);
           }`;
       }
       case 'Subscription': {
-        return `export function use${operationName}(variables${
-          operationHasNonNullableVariable ? '' : '?'
-        }: ${operationVariablesTypes}, baseOptions?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>) {
-          return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, variables, baseOptions);
+        if (operationHasVariables) {
+          return `export function use${operationName}(variables${
+            operationHasNonNullableVariable ? '' : '?'
+          }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>, options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
+          return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, variables, options);
+        }`;
+        }
+        return `export function use${operationName}(options?: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>) {
+          return VueApolloComposable.use${operationType}<${operationResultType}, undefined>(${documentNodeVariable}, undefined, options);
         }`;
       }
     }
   }
 
-  private buildCompositionFunctionReturnType(operationName: string) {
-    return `export type ${operationName}CompositionFunctionResult = ReturnType<typeof use${operationName}>;`;
+  private buildCompositionFunctionReturnType({
+    operationName,
+    operationType,
+    operationResultType,
+    operationVariablesTypes,
+  }: Partial<BuildCompositionFunctions>) {
+    return `export type ${operationName}CompositionFunctionResult = VueApolloComposable.Use${operationType}Return<${operationResultType}, ${operationVariablesTypes}>;`;
   }
 }

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -136,7 +136,7 @@ describe('Vue Apollo', () => {
 
       expect(
         ((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })) as any).content
-      ).toContain('ReturnType<typeof useNotificationsQueryQuery>;');
+      ).toContain('VueApolloComposable.UseQueryReturn<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
       expect(
         ((await plugin(
           schema,
@@ -144,7 +144,7 @@ describe('Vue Apollo', () => {
           { dedupeOperationSuffix: false },
           { outputFile: '' }
         )) as any).content
-      ).toContain('ReturnType<typeof useNotificationsQueryQuery>;');
+      ).toContain('VueApolloComposable.UseQueryReturn<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
       expect(
         ((await plugin(
           schema,
@@ -152,7 +152,7 @@ describe('Vue Apollo', () => {
           { dedupeOperationSuffix: true },
           { outputFile: '' }
         )) as any).content
-      ).toContain('ReturnType<typeof useNotificationsQuery>;');
+      ).toContain('VueApolloComposable.UseQueryReturn<NotificationsQuery, NotificationsQueryVariables>');
       expect(
         ((await plugin(
           schema,
@@ -160,7 +160,7 @@ describe('Vue Apollo', () => {
           { dedupeOperationSuffix: true },
           { outputFile: '' }
         )) as any).content
-      ).toContain('ReturnType<typeof useNotificationsQuery>;');
+      ).toContain('VueApolloComposable.UseQueryReturn<NotificationsQuery, NotificationsQueryVariables>');
       expect(
         ((await plugin(
           schema,
@@ -168,7 +168,7 @@ describe('Vue Apollo', () => {
           { dedupeOperationSuffix: false },
           { outputFile: '' }
         )) as any).content
-      ).toContain('ReturnType<typeof useNotificationsQuery>;');
+      ).toContain('VueApolloComposable.UseQueryReturn<NotificationsQuery, NotificationsQueryVariables>');
     });
 
     it('should import VueApolloComposable from VueApolloComposableImportFrom config option', async () => {
@@ -543,6 +543,12 @@ query MyFeed {
             id
           }
         }
+
+        subscription test($name: String!) {
+          commentAdded(repoFullName: $name) {
+            id
+          }
+        }
       `);
       const docs = [{ location: '', document: documents }];
 
@@ -556,11 +562,14 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-      export type FeedQueryCompositionFunctionResult = ReturnType<typeof useFeedQuery>;
+      export type FeedQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<FeedQuery, FeedQueryVariables>;
       `);
 
       expect(content.content).toBeSimilarStringTo(`
-      export type SubmitRepositoryMutationCompositionFunctionResult = ReturnType<typeof useSubmitRepositoryMutation>;
+      export type SubmitRepositoryMutationCompositionFunctionResult = VueApolloComposable.UseMutationReturn<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>;
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+      export type TestSubscriptionCompositionFunctionResult = VueApolloComposable.UseSubscriptionReturn<TestSubscription, TestSubscriptionVariables>;
       `);
       await validateTypeScript(content, schema, docs, {});
     });

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -171,59 +171,6 @@ describe('Vue Apollo', () => {
       ).toContain('ReturnType<typeof useNotificationsQuery>;');
     });
 
-    it(`tests for omitOperationSuffix`, async () => {
-      const ast = parse(/* GraphQL */ `
-        query notificationsQuery {
-          notifications {
-            id
-          }
-        }
-      `);
-      const ast2 = parse(/* GraphQL */ `
-        query notifications {
-          notifications {
-            id
-          }
-        }
-      `);
-
-      expect(
-        ((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })) as any).content
-      ).toContain('ReturnType<typeof useNotificationsQueryQuery>;');
-      expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast }],
-          { omitOperationSuffix: false },
-          { outputFile: '' }
-        )) as any).content
-      ).toContain('ReturnType<typeof useNotificationsQueryQuery>;');
-      expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast }],
-          { omitOperationSuffix: true },
-          { outputFile: '' }
-        )) as any).content
-      ).toContain('ReturnType<typeof useNotificationsQuery>;');
-      expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast2 }],
-          { omitOperationSuffix: true },
-          { outputFile: '' }
-        )) as any).content
-      ).toContain('ReturnType<typeof useNotifications>;');
-      expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast2 }],
-          { omitOperationSuffix: false },
-          { outputFile: '' }
-        )) as any).content
-      ).toContain('ReturnType<typeof useNotificationsQuery>;');
-    });
-
     it('should import VueApolloComposable from VueApolloComposableImportFrom config option', async () => {
       const docs = [{ location: '', document: basicDoc }];
       const content = (await plugin(

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -404,15 +404,17 @@ query MyFeed {
           outputFile: 'graphql.ts',
         }
       )) as Types.ComplexPluginOutput;
-      expect(content.content).toBeSimilarStringTo(`type ReactiveFunctionFeedQuery = () => FeedQueryVariables \n
-export function useFeedQuery(variables?: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunctionFeedQuery, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
-  return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, baseOptions);
-}`);
+      expect(content.content).toBeSimilarStringTo(
+        `export function useFeedQuery(options?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>) {
+             return VueApolloComposable.useQuery<FeedQuery, undefined>(FeedDocument, undefined, options);
+           }`
+      );
 
-      expect(content.content).toBeSimilarStringTo(`
-export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
-  return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, baseOptions);
-}`);
+      expect(content.content).toBeSimilarStringTo(
+        `export function useSubmitRepositoryMutation(options?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
+           return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, options);
+         }`
+      );
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -449,15 +451,17 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
         }
       )) as Types.ComplexPluginOutput;
 
-      expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(variables?: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunctionFeedQuery, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
-  return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedQueryDocument, variables, baseOptions);
-}`);
+      expect(content.content).toBeSimilarStringTo(
+        `export function useFeedQuery(options?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>) {
+          return VueApolloComposable.useQuery<FeedQuery, undefined>(FeedQueryDocument, undefined, options);
+        }`
+      );
 
-      expect(content.content).toBeSimilarStringTo(`
-export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
-  return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryMutationDocument, baseOptions);
-}`);
+      expect(content.content).toBeSimilarStringTo(
+        `export function useSubmitRepositoryMutation(options?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
+           return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryMutationDocument, options);
+        }`
+      );
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -496,10 +500,11 @@ export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.Us
         }
       )) as Types.ComplexPluginOutput;
 
-      expect(content.content).toBeSimilarStringTo(`
-export function useListenToCommentsSubscription(variables?: ListenToCommentsSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>) {
-  return VueApolloComposable.useSubscription<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>(ListenToCommentsDocument, variables, baseOptions);
-}`);
+      expect(content.content).toBeSimilarStringTo(
+        `export function useListenToCommentsSubscription(variables?: ListenToCommentsSubscriptionVariables | VueCompositionApi.Ref<ListenToCommentsSubscriptionVariables> | ReactiveFunction<ListenToCommentsSubscriptionVariables>, options?: VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables> | VueCompositionApi.Ref<VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>> | ReactiveFunction<VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>>) {
+          return VueApolloComposable.useSubscription<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>(ListenToCommentsDocument, variables, options);
+        }`
+      );
       await validateTypeScript(content, schema, docs, {});
     });
 
@@ -591,22 +596,25 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
       )) as Types.ComplexPluginOutput;
 
       // query with required variables
-      expect(content.content).toBeSimilarStringTo(`
-      export function useFeedQuery(variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunctionFeedQuery, baseOptions?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>) {
-        return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, baseOptions);
-      }`);
+      expect(content.content).toBeSimilarStringTo(
+        `export function useFeedQuery(variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunction<FeedQueryVariables>, options?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>) {
+           return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options);
+        }`
+      );
 
       // mutation with required variables
-      expect(content.content).toBeSimilarStringTo(`
-      export function useSubmitRepositoryMutation(baseOptions?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
-        return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, baseOptions);
-      }`);
+      expect(content.content).toBeSimilarStringTo(
+        `export function useSubmitRepositoryMutation(options?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
+           return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, options);
+        }`
+      );
 
       // subscription with required variables
-      expect(content.content).toBeSimilarStringTo(`
-      export function useTestSubscription(variables: TestSubscriptionVariables, baseOptions?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>) {
-        return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(TestDocument, variables, baseOptions);
-      }`);
+      expect(content.content).toBeSimilarStringTo(
+        `export function useTestSubscription(variables: TestSubscriptionVariables | VueCompositionApi.Ref<TestSubscriptionVariables> | ReactiveFunction<TestSubscriptionVariables>, options?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables> | VueCompositionApi.Ref<VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>> | ReactiveFunction<VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>>) {
+           return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(TestDocument, variables, options);
+        }`
+      );
 
       await validateTypeScript(content, schema, docs, {});
     });
@@ -618,7 +626,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
  * When your component renders, \`useFeedQuery\` returns an object from Apollo Client that contains result, loading and error properties
  * you can use to render your UI.
  *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
+ * @param options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
  *
  * @example
  * const { result, loading, error } = useFeedQuery(
@@ -636,7 +644,7 @@ export function useListenToCommentsSubscription(variables?: ListenToCommentsSubs
  * - A mutate function that you can call at any time to execute the mutation
  * - Several other properties: https://v4.apollo.vuejs.org/api/use-mutation.html#return
  *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/mutation.html#options;
+ * @param options that will be passed into the mutation, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/mutation.html#options;
  *
  * @example
  * const { mutate, loading, error, onDone } = useSubmitRepositoryMutation({

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -405,13 +405,13 @@ query MyFeed {
         }
       )) as Types.ComplexPluginOutput;
       expect(content.content).toBeSimilarStringTo(
-        `export function useFeedQuery(options?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>) {
+        `export function useFeedQuery(options: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> = {}) {
              return VueApolloComposable.useQuery<FeedQuery, undefined>(FeedDocument, undefined, options);
            }`
       );
 
       expect(content.content).toBeSimilarStringTo(
-        `export function useSubmitRepositoryMutation(options?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
+        `export function useSubmitRepositoryMutation(options: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> = {}) {
            return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, options);
          }`
       );
@@ -452,13 +452,13 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(
-        `export function useFeedQuery(options?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>) {
+        `export function useFeedQuery(options: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> = {}) {
           return VueApolloComposable.useQuery<FeedQuery, undefined>(FeedQueryDocument, undefined, options);
         }`
       );
 
       expect(content.content).toBeSimilarStringTo(
-        `export function useSubmitRepositoryMutation(options?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
+        `export function useSubmitRepositoryMutation(options: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> = {}) {
            return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryMutationDocument, options);
         }`
       );
@@ -501,7 +501,7 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(
-        `export function useListenToCommentsSubscription(variables?: ListenToCommentsSubscriptionVariables | VueCompositionApi.Ref<ListenToCommentsSubscriptionVariables> | ReactiveFunction<ListenToCommentsSubscriptionVariables>, options?: VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables> | VueCompositionApi.Ref<VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>> | ReactiveFunction<VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>>) {
+        `export function useListenToCommentsSubscription(variables?: ListenToCommentsSubscriptionVariables | VueCompositionApi.Ref<ListenToCommentsSubscriptionVariables> | ReactiveFunction<ListenToCommentsSubscriptionVariables>, options: VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables> | VueCompositionApi.Ref<VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>> | ReactiveFunction<VueApolloComposable.UseSubscriptionOptions<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>> = {}) {
           return VueApolloComposable.useSubscription<ListenToCommentsSubscription, ListenToCommentsSubscriptionVariables>(ListenToCommentsDocument, variables, options);
         }`
       );
@@ -574,15 +574,94 @@ query MyFeed {
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('Should generate a mutation composition function with required variables if required in graphql document', async () => {
+      const documents = parse(/* GraphQL */ `
+        mutation submitRepository($name: String!) {
+          submitRepository(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+      const docs = [{ location: '', document: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(
+        `export function useSubmitRepositoryMutation(options: VueApolloComposable.UseMutationOptionsWithVariables<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
+           return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, options);
+        }`
+      );
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should generate a mutation composition function with no variables if not specified in graphql document', async () => {
+      const documents = parse(/* GraphQL */ `
+        mutation submitRepository {
+          submitRepository {
+            id
+          }
+        }
+      `);
+      const docs = [{ location: '', document: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(
+        `export function useSubmitRepositoryMutation(options: VueApolloComposable.UseMutationOptionsNoVariables<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> = {}) {
+           return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, options);
+        }`
+      );
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('Should generate a mutation composition function with optional variables if optional in graphql document', async () => {
+      const documents = parse(/* GraphQL */ `
+        mutation submitRepository($name: String) {
+          submitRepository(repoFullName: $name) {
+            id
+          }
+        }
+      `);
+      const docs = [{ location: '', document: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(
+        `export function useSubmitRepositoryMutation(options: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> = {}) {
+           return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, options);
+        }`
+      );
+
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('Should generate required variables if required in graphql document', async () => {
       const documents = parse(/* GraphQL */ `
         query feed($id: ID!, $name: String, $people: [String]!) {
           feed(id: $id) {
-            id
-          }
-        }
-        mutation submitRepository($name: String!) {
-          submitRepository(repoFullName: $name) {
             id
           }
         }
@@ -606,21 +685,14 @@ query MyFeed {
 
       // query with required variables
       expect(content.content).toBeSimilarStringTo(
-        `export function useFeedQuery(variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunction<FeedQueryVariables>, options?: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>) {
+        `export function useFeedQuery(variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunction<FeedQueryVariables>, options: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> = {}) {
            return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options);
-        }`
-      );
-
-      // mutation with required variables
-      expect(content.content).toBeSimilarStringTo(
-        `export function useSubmitRepositoryMutation(options?: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>) {
-           return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, options);
         }`
       );
 
       // subscription with required variables
       expect(content.content).toBeSimilarStringTo(
-        `export function useTestSubscription(variables: TestSubscriptionVariables | VueCompositionApi.Ref<TestSubscriptionVariables> | ReactiveFunction<TestSubscriptionVariables>, options?: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables> | VueCompositionApi.Ref<VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>> | ReactiveFunction<VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>>) {
+        `export function useTestSubscription(variables: TestSubscriptionVariables | VueCompositionApi.Ref<TestSubscriptionVariables> | ReactiveFunction<TestSubscriptionVariables>, options: VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables> | VueCompositionApi.Ref<VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>> | ReactiveFunction<VueApolloComposable.UseSubscriptionOptions<TestSubscription, TestSubscriptionVariables>> = {}) {
            return VueApolloComposable.useSubscription<TestSubscription, TestSubscriptionVariables>(TestDocument, variables, options);
         }`
       );

--- a/website/docs/plugins/typescript-vue-apollo.md
+++ b/website/docs/plugins/typescript-vue-apollo.md
@@ -11,8 +11,7 @@ This plugin generates @vue/apollo-composable composition functions with TypeScri
 ## Installation
 
 ```bash
-$ yarn add @graphql-codegen/typescript-vue-apollo
-$ yarn add @vue/apollo-composable@4.0.0-alpha.4
+$ yarn add @graphql-codegen/typescript-vue-apollo @vue/apollo-composable@4.0.0-alpha.8 @vue/composition-api
 ```
 
 ## Usage

--- a/yarn.lock
+++ b/yarn.lock
@@ -3375,6 +3375,20 @@
   dependencies:
     wonka "^4.0.9"
 
+"@vue/apollo-composable@^4.0.0-alpha.8":
+  version "4.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@vue/apollo-composable/-/apollo-composable-4.0.0-alpha.8.tgz#6e82a64b1f9637941579aa560defbca3765401ba"
+  integrity sha512-d+9Uigio43C13ex/FfvJ6oaB3YjNUvIc91jSix4PfJERcCPtCeLlVHYinX2MMv40va6gY9sC6GN6QzL5o/80uQ==
+  dependencies:
+    throttle-debounce "^2.1.0"
+
+"@vue/composition-api@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.5.0.tgz#2dbaa02a5d1f5d0d407d53d5529fe444aa8362f3"
+  integrity sha512-9QDFWq7q839G1CTTaxeruPOTrrVOPSaVipJ2TxxK9QAruePNTHOGbOOFRpc8WLl4YPsu1/c29yBhMVmrXz8BZw==
+  dependencies:
+    tslib "^1.9.3"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -8207,7 +8221,7 @@ graphql-language-service-utils@^2.4.0-alpha.6:
 
 graphql-request@^1.5.0:
   version "1.8.2"
-  resolved "https://registry.npmjs.org/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
   integrity sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==
   dependencies:
     cross-fetch "2.2.2"
@@ -15173,6 +15187,11 @@ throat@^5.0.0:
   resolved "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
+throttle-debounce@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
+  integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
+
 through2@^2.0.0, through2@^2.0.2:
   version "2.0.5"
   resolved "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
@@ -15930,6 +15949,11 @@ vue-template-compiler@^2.6.11:
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
+
+vue@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
+  integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Updates the vue plugin to work with `@vue/apollo-composable@4.0.0-alpha.8`
- fixes https://github.com/dotansimha/graphql-code-generator/issues/3679
- fixes the jsdoc bug https://github.com/dotansimha/graphql-code-generator/pull/3715 because of refactored code in this PR