### PR TITLE
Fix optional types in queries [flow]

### DIFF
--- a/dev-test/githunt/flow.flow.js
+++ b/dev-test/githunt/flow.flow.js
@@ -176,7 +176,7 @@ export type OnCommentAddedSubscriptionVariables = {
 export type OnCommentAddedSubscription = {
   ...{ __typename?: 'Subscription' },
   ...{|
-    commentAdded: ?{
+    commentAdded?: ?{
       ...{ __typename?: 'Comment' },
       ...$Pick<Comment, {| id: *, createdAt: *, content: * |}>,
       ...{|
@@ -198,11 +198,11 @@ export type CommentQueryVariables = {
 export type CommentQuery = {
   ...{ __typename?: 'Query' },
   ...{|
-    currentUser: ?{
+    currentUser?: ?{
       ...{ __typename?: 'User' },
       ...$Pick<User, {| login: *, html_url: * |}>,
     },
-    entry: ?{
+    entry?: ?{
       ...{ __typename?: 'Entry' },
       ...$Pick<Entry, {| id: *, createdAt: *, commentCount: * |}>,
       ...{|
@@ -218,7 +218,7 @@ export type CommentQuery = {
           ...{ __typename?: 'Repository' },
           ...$Pick<
             Repository,
-            {| description: *, open_issues_count: *, stargazers_count: *, full_name: *, html_url: * |}
+            {| description?: *, open_issues_count?: *, stargazers_count: *, full_name: *, html_url: * |}
           >,
         },
       |},
@@ -242,7 +242,7 @@ export type CurrentUserForProfileQueryVariables = {};
 export type CurrentUserForProfileQuery = {
   ...{ __typename?: 'Query' },
   ...{|
-    currentUser: ?{
+    currentUser?: ?{
       ...{ __typename?: 'User' },
       ...$Pick<User, {| login: *, avatar_url: * |}>,
     },
@@ -257,7 +257,7 @@ export type FeedEntryFragment = {
       ...{ __typename?: 'Repository' },
       ...$Pick<Repository, {| full_name: *, html_url: * |}>,
       ...{|
-        owner: ?{
+        owner?: ?{
           ...{ __typename?: 'User' },
           ...$Pick<User, {| avatar_url: * |}>,
         },
@@ -277,11 +277,11 @@ export type FeedQueryVariables = {
 export type FeedQuery = {
   ...{ __typename?: 'Query' },
   ...{|
-    currentUser: ?{
+    currentUser?: ?{
       ...{ __typename?: 'User' },
       ...$Pick<User, {| login: * |}>,
     },
-    feed: ?Array<?{
+    feed?: ?Array<?{
       ...{ __typename?: 'Entry' },
       ...FeedEntryFragment,
     }>,
@@ -295,7 +295,7 @@ export type SubmitRepositoryMutationVariables = {
 export type SubmitRepositoryMutation = {
   ...{ __typename?: 'Mutation' },
   ...{|
-    submitRepository: ?{
+    submitRepository?: ?{
       ...{ __typename?: 'Entry' },
       ...$Pick<Entry, {| createdAt: * |}>,
     },
@@ -308,7 +308,7 @@ export type RepoInfoFragment = {
   ...{|
     repository: {
       ...{ __typename?: 'Repository' },
-      ...$Pick<Repository, {| description: *, stargazers_count: *, open_issues_count: * |}>,
+      ...$Pick<Repository, {| description?: *, stargazers_count: *, open_issues_count?: * |}>,
     },
     postedBy: {
       ...{ __typename?: 'User' },
@@ -325,7 +325,7 @@ export type SubmitCommentMutationVariables = {
 export type SubmitCommentMutation = {
   ...{ __typename?: 'Mutation' },
   ...{|
-    submitComment: ?{
+    submitComment?: ?{
       ...{ __typename?: 'Comment' },
       ...CommentsPageCommentFragment,
     },
@@ -351,7 +351,7 @@ export type VoteMutationVariables = {
 export type VoteMutation = {
   ...{ __typename?: 'Mutation' },
   ...{|
-    vote: ?{
+    vote?: ?{
       ...{ __typename?: 'Entry' },
       ...$Pick<Entry, {| score: *, id: * |}>,
       ...{|

--- a/packages/plugins/flow/operations/src/flow-selection-set-processor.ts
+++ b/packages/plugins/flow/operations/src/flow-selection-set-processor.ts
@@ -82,15 +82,16 @@ export class FlowWithPickSelectionSetProcessor extends BaseSelectionSetProcessor
 
     const useFlowExactObject = this.config.useFlowExactObjects;
     const useFlowReadOnlyTypes = this.config.useFlowReadOnlyTypes;
+    const formatNamedField = this.config.formatNamedField;
     const parentName =
       (this.config.namespacedImportName ? `${this.config.namespacedImportName}.` : '') +
       this.config.convertName(schemaType.name, {
         useTypesPrefix: true,
       });
-
+    const fieldObj = schemaType.getFields();
     return [
       `$Pick<${parentName}, {${useFlowExactObject ? '|' : ''} ${fields
-        .map(fieldName => `${useFlowReadOnlyTypes ? '+' : ''}${fieldName}: *`)
+        .map(fieldName => `${useFlowReadOnlyTypes ? '+' : ''}${formatNamedField(fieldName, fieldObj[fieldName].type)}: *`)
         .join(', ')} ${useFlowExactObject ? '|' : ''}}>`,
     ];
   }

--- a/packages/plugins/flow/operations/src/visitor.ts
+++ b/packages/plugins/flow/operations/src/visitor.ts
@@ -1,5 +1,5 @@
 import { FlowWithPickSelectionSetProcessor } from './flow-selection-set-processor';
-import { GraphQLSchema, isEnumType } from 'graphql';
+import { GraphQLSchema, isEnumType, isNonNullType, GraphQLOutputType } from 'graphql';
 import { FlowDocumentsPluginConfig } from './config';
 import { FlowOperationVariablesToObject } from '@graphql-codegen/flow';
 import {
@@ -37,12 +37,17 @@ export class FlowDocumentsVisitor extends BaseDocumentsVisitor<FlowDocumentsPlug
     const wrapArray = (type: string) => `Array<${type}>`;
     const wrapOptional = (type: string) => `?${type}`;
 
+    const formatNamedField = (name: string, type: GraphQLOutputType | null): string => {
+      const optional = !!type && !isNonNullType(type);
+      return `${name}${optional ? '?' : ''}`;
+    };
+
     const processorConfig: SelectionSetProcessorConfig = {
       namespacedImportName: this.config.namespacedImportName,
       convertName: this.convertName.bind(this),
       enumPrefix: this.config.enumPrefix,
       scalars: this.scalars,
-      formatNamedField: (name: string): string => name,
+      formatNamedField,
       wrapTypeWithModifiers(baseType, type) {
         return wrapTypeWithModifiers(baseType, type, { wrapOptional, wrapArray });
       },

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -266,7 +266,7 @@ describe('Flow Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
       export type Unnamed_1_Query = ({
         ...{ __typename: 'Query' },
-      ...$Pick<Query, {| dummy: * |}>
+      ...$Pick<Query, {| dummy?: * |}>
     });
       `);
       validateFlow(result);
@@ -292,7 +292,7 @@ describe('Flow Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
       export type Unnamed_1_Query = ({
         ...{ __typename?: 'Query' },
-      ...$Pick<Query, {| dummy: * |}>
+      ...$Pick<Query, {| dummy?: * |}>
     });
       `);
       validateFlow(result);
@@ -319,7 +319,7 @@ describe('Flow Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
       export type Unnamed_1_Query = ({
         ...{ __typename: 'Query' },
-      ...$Pick<Query, {| dummy: * |}>
+      ...$Pick<Query, {| dummy?: * |}>
     });
       `);
       validateFlow(result);
@@ -354,12 +354,12 @@ describe('Flow Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
       export type UnionTestQuery = ({
         ...{ __typename?: 'Query' },
-      ...{| unionTest: ?({
+      ...{| unionTest?: ?({
           ...{ __typename?: 'User' },
         ...$Pick<User, {| id: * |}>
       }) | ({
           ...{ __typename?: 'Profile' },
-        ...$Pick<Profile, {| age: * |}>
+        ...$Pick<Profile, {| age?: * |}>
       }) |}
     });
       `);
@@ -395,12 +395,12 @@ describe('Flow Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
       export type UnionTestQuery = ({
         ...{ __typename: 'Query' },
-      ...{| unionTest: ?({
+      ...{| unionTest?: ?({
           ...{ __typename: 'User' },
         ...$Pick<User, {| id: * |}>
       }) | ({
           ...{ __typename: 'Profile' },
-        ...$Pick<Profile, {| age: * |}>
+        ...$Pick<Profile, {| age?: * |}>
       }) |}
     });
       `);
@@ -476,7 +476,7 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = $Pick<Query, {| dummy: * |}>;`);
+      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = $Pick<Query, {| dummy?: * |}>;`);
       expect(result).toBeSimilarStringTo(`export type Unnamed_1_QueryVariables = {};`);
       validateFlow(result);
     });
@@ -502,9 +502,9 @@ describe('Flow Operations Plugin', () => {
         { skipTypename: true },
         { outputFile: '' }
       );
-      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = $Pick<Query, {| dummy: * |}>;`);
+      expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = $Pick<Query, {| dummy?: * |}>;`);
       expect(result).toBeSimilarStringTo(`export type Unnamed_1_QueryVariables = {};`);
-      expect(result).toBeSimilarStringTo(`export type Unnamed_2_Query = $Pick<Query, {| dummy: * |}>;`);
+      expect(result).toBeSimilarStringTo(`export type Unnamed_2_Query = $Pick<Query, {| dummy?: * |}>;`);
       expect(result).toBeSimilarStringTo(`export type Unnamed_2_QueryVariables = {};`);
       validateFlow(result);
     });
@@ -541,7 +541,7 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-      export type MeQuery = {| me: ?UserFieldsFragment |};
+      export type MeQuery = {| me?: ?UserFieldsFragment |};
       `);
       validateFlow(result);
     });
@@ -575,7 +575,7 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-      export type MeQuery = {| me: ?({
+      export type MeQuery = {| me?: ?({
         ...$Pick<User, {| username: * |}>,
       ...UserFieldsFragment
     }) |};
@@ -617,7 +617,7 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-      export type MeQuery = {| me: ?({
+      export type MeQuery = {| me?: ?({
         ...$Pick<User, {| username: * |}>,
       ...UserFieldsFragment,
       ...UserProfileFragment
@@ -693,7 +693,7 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-      export type UnionTestQuery = {| unionTest: ?$Pick<User, {| id: * |}> | $Pick<Profile, {| age: * |}> |};
+      export type UnionTestQuery = {| unionTest?: ?$Pick<User, {| id: * |}> | $Pick<Profile, {| age?: * |}> |};
       `);
       validateFlow(result);
     });
@@ -725,9 +725,9 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-      export type CurrentUserQuery = {| me: ?({
+      export type CurrentUserQuery = {| me?: ?({
         ...$Pick<User, {| username: *, id: * |}>,
-      ...{| profile: ?$Pick<Profile, {| age: * |}> |}
+      ...{| profile?: ?$Pick<Profile, {| age?: * |}> |}
     }) |};
       `);
       validateFlow(result);
@@ -767,7 +767,7 @@ describe('Flow Operations Plugin', () => {
         };`
       );
       expect(result).toBeSimilarStringTo(`
-      export type MeQuery = {| currentUser: ?$Pick<User, {| login: *, html_url: * |}>, entry: ?({
+      export type MeQuery = {| currentUser?: ?$Pick<User, {| login: *, html_url: * |}>, entry?: ?({
         ...$Pick<Entry, {| id: *, createdAt: * |}>,
       ...{| postedBy: $Pick<User, {| login: *, html_url: * |}> |}
     }) |};
@@ -792,7 +792,7 @@ describe('Flow Operations Plugin', () => {
         { skipTypename: true },
         { outputFile: '' }
       );
-      expect(result).toBeSimilarStringTo(`export type DummyQuery = $Pick<Query, {| dummy: * |}>;`);
+      expect(result).toBeSimilarStringTo(`export type DummyQuery = $Pick<Query, {| dummy?: * |}>;`);
       validateFlow(result);
     });
 
@@ -820,7 +820,7 @@ describe('Flow Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
       export type DummyQuery = ({
         ...{| customName: $ElementType<Query, 'dummy'> |},
-      ...{| customName2: ?$Pick<Profile, {| age: * |}> |}
+      ...{| customName2?: ?$Pick<Profile, {| age?: * |}> |}
     });
       `);
       validateFlow(result);
@@ -852,9 +852,9 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-      export type CurrentUserQuery = {| me: ?({
-        ...$Pick<User, {| id: *, username: *, role: * |}>,
-      ...{| profile: ?$Pick<Profile, {| age: * |}> |}
+      export type CurrentUserQuery = {| me?: ?({
+        ...$Pick<User, {| id: *, username: *, role?: * |}>,
+      ...{| profile?: ?$Pick<Profile, {| age?: * |}> |}
     }) |};
       `);
 
@@ -888,7 +888,7 @@ describe('Flow Operations Plugin', () => {
       expect(result).toBeSimilarStringTo(`
       export type UserFieldsFragment = ({
         ...$Pick<User, {| id: *, username: * |}>,
-      ...{| profile: ?$Pick<Profile, {| age: * |}> |}
+      ...{| profile?: ?$Pick<Profile, {| age?: * |}> |}
     });
       `);
       validateFlow(result);
@@ -921,9 +921,9 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-      export type LoginMutation = {| login: ?({
+      export type LoginMutation = {| login?: ?({
         ...$Pick<User, {| id: *, username: * |}>,
-      ...{| profile: ?$Pick<Profile, {| age: * |}> |}
+      ...{| profile?: ?$Pick<Profile, {| age?: * |}> |}
     }) |};
       `);
       validateFlow(result);
@@ -947,7 +947,7 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
 
-      expect(result).toBeSimilarStringTo(`export type TestQuery = $Pick<Query, {| dummy: * |}>;`);
+      expect(result).toBeSimilarStringTo(`export type TestQuery = $Pick<Query, {| dummy?: * |}>;`);
       validateFlow(result);
     });
 
@@ -971,7 +971,7 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       );
       expect(result).toBeSimilarStringTo(
-        `export type TestSubscription = {| userCreated: ?$Pick<User, {| id: * |}> |};`
+        `export type TestSubscription = {| userCreated?: ?$Pick<User, {| id: * |}> |};`
       );
       validateFlow(result);
     });
@@ -1059,9 +1059,9 @@ describe('Flow Operations Plugin', () => {
       );
 
       expect(result).toBeSimilarStringTo(`
-      export type CurrentUserQuery = { me: ?({
-        ...$Pick<User, { id: *, username: *, role: * }>,
-      ...{ profile: ?$Pick<Profile, { age: * }> }
+      export type CurrentUserQuery = { me?: ?({
+        ...$Pick<User, { id: *, username: *, role?: * }>,
+      ...{ profile?: ?$Pick<Profile, { age?: * }> }
     }) };
       `);
 
@@ -1094,9 +1094,9 @@ describe('Flow Operations Plugin', () => {
       )) as Types.ComplexPluginOutput;
       expect(result.content).toMatchSnapshot();
       expect(result).toBeSimilarStringTo(`
-      export type CurrentUserQuery = {| +me: ?({
-        ...$Pick<User, {| +id: *, +username: *, +role: * |}>,
-      ...{| +profile: ?$Pick<Profile, {| +age: * |}> |}
+      export type CurrentUserQuery = {| +me?: ?({
+        ...$Pick<User, {| +id: *, +username: *, +role?: * |}>,
+      ...{| +profile?: ?$Pick<Profile, {| +age?: * |}> |}
     }) |};
       `);
 


### PR DESCRIPTION
Related https://github.com/dotansimha/graphql-code-generator/pull/3639
Fix for https://github.com/dotansimha/graphql-code-generator/pull/3639#issuecomment-619090429

This PR makes all nullable fields to be optional in flow.
Currently there is an inconsistency between the top-level types and the query types.

example: https://github.com/dotansimha/graphql-code-generator/blob/master/dev-test/githunt/flow.flow.js

```js
// top-level types
export type Repository = {|
  __typename?: 'Repository',
  name: $ElementType<Scalars, 'String'>,
  full_name: $ElementType<Scalars, 'String'>,
  // description is optional field
  description?: ?$ElementType<Scalars, 'String'>,
  html_url: $ElementType<Scalars, 'String'>,
  stargazers_count: $ElementType<Scalars, 'Int'>,
  open_issues_count?: ?$ElementType<Scalars, 'Int'>,
  owner?: ?User,
|};
// query types
export type CommentQuery = {
        repository: {
          ...{ __typename?: 'Repository' },
          ...$Pick<
            Repository,
           // description is mandatory field now
            {| description: *, open_issues_count: *, stargazers_count: *, full_name: *, html_url: * |}
          >,
        },
      |},
    },
  |},
};
```
