### PR TITLE
Fix: set java default class for scalar to Object

### DIFF
--- a/packages/plugins/java/java/src/visitor.ts
+++ b/packages/plugins/java/java/src/visitor.ts
@@ -42,7 +42,7 @@ export class JavaResolversVisitor extends BaseVisitor<JavaResolversPluginRawConf
       listType: rawConfig.listType || 'Iterable',
       className: rawConfig.className || 'Types',
       package: rawConfig.package || defaultPackageName,
-      scalars: buildScalars(_schema, rawConfig.scalars, JAVA_SCALARS),
+      scalars: buildScalars(_schema, rawConfig.scalars, JAVA_SCALARS, 'Object'),
     });
   }
 

--- a/packages/plugins/java/java/tests/java.spec.ts
+++ b/packages/plugins/java/java/tests/java.spec.ts
@@ -8,6 +8,8 @@ const OUTPUT_FILE = 'com/java/generated/resolvers.java';
 
 describe('Java', () => {
   const schema = buildSchema(/* GraphQL */ `
+    scalar DateTime
+
     type Query {
       me: User!
       user(id: ID!): User!
@@ -23,6 +25,7 @@ describe('Java', () => {
       username: String
       email: String
       name: String
+      dateOfBirth: DateTime
       sort: ResultSort
       metadata: MetadataSearch
     }
@@ -45,6 +48,7 @@ describe('Java', () => {
       username: String!
       email: String!
       name: String
+      dateOfBirth: DateTime
       friends(skip: Int, limit: Int): [User!]!
     }
 
@@ -235,6 +239,7 @@ describe('Java', () => {
         private String _username;
         private String _email;
         private String _name;
+        private Object _dateOfBirth;
         private ResultSort _sort;
         private MetadataSearchInput _metadata;
       
@@ -243,6 +248,7 @@ describe('Java', () => {
             this._username = (String) args.get("username");
             this._email = (String) args.get("email");
             this._name = (String) args.get("name");
+            this._dateOfBirth = (Object) args.get("dateOfBirth");
             if (args.get("sort") instanceof ResultSort) {
               this._sort = (ResultSort) args.get("sort");
             } else {
@@ -255,6 +261,7 @@ describe('Java', () => {
         public String getUsername() { return this._username; }
         public String getEmail() { return this._email; }
         public String getName() { return this._name; }
+        public Object getDateOfBirth() { return this._dateOfBirth; }
         public ResultSort getSort() { return this._sort; }
         public MetadataSearchInput getMetadata() { return this._metadata; }
       }`);

--- a/packages/plugins/java/resolvers/src/visitor.ts
+++ b/packages/plugins/java/resolvers/src/visitor.ts
@@ -39,7 +39,7 @@ export class JavaResolversVisitor extends BaseVisitor<JavaResolversPluginRawConf
       defaultMapper: parseMapper(rawConfig.defaultMapper || 'Object'),
       className: rawConfig.className || 'Resolvers',
       listType: rawConfig.listType || 'Iterable',
-      scalars: buildScalars(_schema, rawConfig.scalars, JAVA_SCALARS),
+      scalars: buildScalars(_schema, rawConfig.scalars, JAVA_SCALARS, 'Object'),
     });
   }
 

--- a/packages/plugins/java/resolvers/tests/java-resolvers.spec.ts
+++ b/packages/plugins/java/resolvers/tests/java-resolvers.spec.ts
@@ -7,6 +7,8 @@ const OUTPUT_FILE = 'com/java/generated/resolvers.java';
 
 describe('Java Resolvers', () => {
   const schema = buildSchema(/* GraphQL */ `
+    scalar DateTime
+
     type Query {
       me: User!
     }
@@ -20,6 +22,7 @@ describe('Java Resolvers', () => {
       username: String!
       email: String!
       name: String
+      dateOfBirth: DateTime
     }
 
     type Chat implements Node {
@@ -44,6 +47,7 @@ describe('Java Resolvers', () => {
       public DataFetcher<String> username();
       public DataFetcher<String> email();
       public DataFetcher<String> name();
+      public DataFetcher<Object> dateOfBirth();
     }`);
 
     validateJava(result as any);
@@ -109,6 +113,7 @@ describe('Java Resolvers', () => {
       public DataFetcher<String> username();
       public DataFetcher<String> email();
       public DataFetcher<String> name();
+      public DataFetcher<Object> dateOfBirth();
     }`);
   });
 });

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -253,7 +253,8 @@ export function convertNameParts(str: string, func: (str: string) => string, rem
 export function buildScalars(
   schema: GraphQLSchema | undefined,
   scalarsMapping: ScalarsMap,
-  defaultScalarsMapping: NormalizedScalarsMap = DEFAULT_SCALARS
+  defaultScalarsMapping: NormalizedScalarsMap = DEFAULT_SCALARS,
+  defaultScalarType = 'any'
 ): ParsedScalarsMap {
   const result: ParsedScalarsMap = {};
 
@@ -283,7 +284,7 @@ export function buildScalars(
         } else if (!defaultScalarsMapping[name]) {
           result[name] = {
             isExternal: false,
-            type: 'any',
+            type: defaultScalarType,
           };
         }
       });


### PR DESCRIPTION
related #3929 
For scalars that have not been configured with class mapping, the default behavior is to set it to `any` which works for typescript but in java default type should be `Object`.

I have updated the function `buildScalars` to accept another parameter : defaultScalarType. It's set to `any` by default, but for java, it's set to `Object`. It's likely that other package also need to be updated.
