### PR TITLE
docs(README): fix init command

### DIFF
--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -85,7 +85,7 @@ The we can install GraphQL Code Generator using `yarn` (or `npm`):
 
 GraphQL Code Generator lets you setup everything by simply running the following command:
 
-    $ graphql-codegen init
+    $ npx graphql-codegen init
 
 Question by question, it will guide you through the whole process of setting up a schema, selecting and installing plugins, picking a destination of a generated file and a lot more.
 


### PR DESCRIPTION
The CLI is installed with `yarn add -D @graphql-codegen/cli`. Since it's not global, `graphql-codegen init` will fail with a "command not found" error. A few lines down, it's suggested to not install it globally, so we need a different solution.

I added [npx](https://www.npmjs.com/package/npx) in front since that will execute the CLI in `node_modules/.bin`. 