### PR TITLE
PR for #3899 providing a TypeScript TypeDefs plugin

### DIFF
--- a/packages/plugins/typescript/typedefs/jest.config.js
+++ b/packages/plugins/typescript/typedefs/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../../jest.project')({	dirname: __dirname });

--- a/packages/plugins/typescript/typedefs/package.json
+++ b/packages/plugins/typescript/typedefs/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@graphql-codegen/typescript-typedefs",
+  "version": "1.13.3",
+  "description": "GraphQL Code Generator plugin for generating the gql typeDefs constant",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dotansimha/graphql-code-generator.git",
+    "directory": "packages/plugins/typescript/urql"
+  },
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint **/*.ts",
+    "test": "jest --no-watchman --config ../../../../jest.config.js",
+    "prepack": "bob prepack"
+  },
+  "dependencies": {
+    "@graphql-codegen/plugin-helpers": "1.13.3",
+    "@graphql-codegen/visitor-plugin-common": "1.13.3",
+    "auto-bind": "~4.0.0",
+    "pascal-case": "3.1.1",
+    "tslib": "~1.11.1"
+  },
+  "peerDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0",
+    "graphql-tag": "^2.0.0"
+  },
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "buildOptions": {
+    "input": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/typescript/typedefs/src/index.ts
+++ b/packages/plugins/typescript/typedefs/src/index.ts
@@ -1,0 +1,23 @@
+import { PluginFunction, Types } from "@graphql-codegen/plugin-helpers";
+import { GraphQLSchema, printSchema } from "graphql";
+
+export const plugin: PluginFunction<{}, Types.ComplexPluginOutput> = (
+    schema: GraphQLSchema,
+    documents: Types.DocumentFile[],
+    config: {}
+) => {
+
+  const prepend: string[] = [];
+  prepend.push(`import gql from 'graphql-tag';`);
+
+  const content: string = [
+    'export const typeDefs = gql`',
+    printSchema(schema),
+    '`;',
+  ].join('\n')
+
+  return {
+    prepend,
+    content
+  };
+};

--- a/packages/plugins/typescript/typedefs/tests/typedefs.spec.ts
+++ b/packages/plugins/typescript/typedefs/tests/typedefs.spec.ts
@@ -1,0 +1,33 @@
+import { buildSchema } from 'graphql';
+import { plugin } from '../src/index';
+
+describe('TypeScript Typedefs Plugin', () => {
+  describe('Output', () => {
+    const typeDefs = /* GraphQL */ `
+      type Query {
+        helloWorld(name: String): String!
+      }
+
+      schema {
+        query: Query
+      }
+    `;
+    const schema = buildSchema(typeDefs);
+
+    it('Should output the schema inside gql template literal tag', async () => {
+      const content = await plugin(schema, [], {});
+
+      expect(content).toBeSimilarStringTo(`
+        import gql from 'graphql-tag';
+      
+        type Query {
+          helloWorld(name: String): String!
+        }
+
+        schema {
+          query: Query
+        }
+      `);
+    });
+  });
+});

--- a/website/docs/plugins/typescript-typedefs.md
+++ b/website/docs/plugins/typescript-typedefs.md
@@ -1,0 +1,23 @@
+---
+id: typescript-typedefs
+title: TypeScript Typedefs
+---
+
+This plugin generates the gql typeDefs constant from the schema. 
+
+## Installation
+
+    $ yarn add -D @graphql-codegen/typescript-typedefs
+
+## Usage
+
+Run `graphql-codegen` as usual:
+
+```yaml
+schema: schema.json
+generates:
+  ./src/generated-types.ts:
+    plugins:
+      - typescript
+      - typescript-typedefs
+```


### PR DESCRIPTION
Hi @dotansimha,

Here is a PR for the Typedefs plugin.
I created it as a draft for now as the test is failing and I'm stuck.

The test is created from https://graphql-code-generator.com/docs/custom-codegen/contributing/ and looks similar as other tests. 
But for some reason `expect(result.content).toBeSimilarStringTo(..);` in the test is complaining `TypeError: expect(...).toBeSimilarStringTo is not a function`. I just don't see what I'm doing wrong unfortunately.