### PR TITLE
[onlyOperationTypes] missing input types

### DIFF
--- a/dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts
+++ b/dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts
@@ -26,6 +26,23 @@ export enum LengthUnit {
   Foot = 'FOOT',
 }
 
+/** The input object sent when someone is creating a new review */
+export type ReviewInput = {
+  /** 0-5 stars */
+  stars: Scalars['Int'];
+  /** Comment about the movie, optional */
+  commentary?: Maybe<Scalars['String']>;
+  /** Favorite color, optional */
+  favoriteColor?: Maybe<ColorInput>;
+};
+
+/** The input object sent when passing a color */
+export type ColorInput = {
+  red: Scalars['Int'];
+  green: Scalars['Int'];
+  blue: Scalars['Int'];
+};
+
 export type CreateReviewForEpisodeMutationVariables = {
   episode: Episode;
   review: ReviewInput;

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -164,7 +164,7 @@ export interface RawTypesConfig extends RawConfig {
    * ```
    */
   wrapFieldDefinitions?: boolean;
-    /**
+  /**
    * @name onlyOperationTypes
    * @type boolean
    * @description This will cause the generator to emit types for operations only (basically only enums and scalars)
@@ -279,7 +279,6 @@ export class BaseTypesVisitor<
   }
 
   InputObjectTypeDefinition(node: InputObjectTypeDefinitionNode): string {
-    if (this.config.onlyOperationTypes) return '';
     return this.getInputObjectDeclarationBlock(node).string;
   }
 


### PR DESCRIPTION
This is a quick fix for https://github.com/dotansimha/graphql-code-generator/pull/3760 
Some input types are missing and this is critical

This is a hotfix and should be reverted after that issue goes https://github.com/dotansimha/graphql-code-generator/issues/3958