### PR TITLE
Add apollo-typed-documents to plugin docs

### DIFF
--- a/website/docs/plugins/index.md
+++ b/website/docs/plugins/index.md
@@ -39,6 +39,7 @@ Below is a table that lists all available plugins which can be installed via NPM
 | `java-resolvers`                   | generates Java backend resolvers signature                                                             | [`@graphql-codegen/java-resolvers`](./java-resolvers.md)                                                                                     |
 | `java-apollo-android`              | generates Apollo Android parsers and mappers                                                           | [`@graphql-codegen/java-apollo-android`](./java-apollo-android.md)                                                                           |
 | Scala Plugins                      | generates types for schema and operations, maintained by [`aappddeevv`](https://github.com/aappddeevv) | [`@aappddeevvv/graphql-code-scala-operations`,`@aappddeevvv/graphql-code-scala-schema`](https://github.com/aappddeevv/graphql-codegen-scala) |
+| `apollo-typed-documents`           | Generates `declare module` for `.graphql` files with generic `TypedDocumentNode<TVariables, TData>`. Also generates helper function to create mocks for Apollo Client `MockedProvider`. Maintained by [`rubengrill`](https://github.com/rubengrill/apollo-typed-documents) | [`apollo-typed-documents/lib/codegenTypedDocuments`,`apollo-typed-documents/lib/codegenApolloMock`](https://github.com/rubengrill/apollo-typed-documents) |
 
 In addition, you can build your own code generating plugins based on your specific needs. For more information, check [this doc page](../custom-codegen/index).
 


### PR DESCRIPTION
Couldn't check if working in website, as `yarn start` gives me some errors `Module not found: Can't resolve '@graphql-codegen/add' in '/.../graphql-code-generator/website/src/components/live-demo'`, not sure how to fix this.

Just took last plugin docs as example.