### PR TITLE
feat: add generation of kotlin classes for types

### DIFF
--- a/packages/plugins/java/kotlin/src/config.ts
+++ b/packages/plugins/java/kotlin/src/config.ts
@@ -47,4 +47,21 @@ export interface KotlinResolversPluginRawConfig extends RawConfig {
    * ```
    */
   listType?: string;
+  /**
+   * @name withTypes
+   * @type boolean
+   * @default false
+   * @description Allow you to enable generation for the types
+   *
+   * @example
+   * ```yml
+   * generates:
+   *   src/main/kotlin/my-org/my-app/Types.kt:
+   *     plugins:
+   *       - kotlin
+   *     config:
+   *       withTypes: true
+   * ```
+   */
+  withTypes?: boolean;
 }

--- a/packages/plugins/java/kotlin/src/visitor.ts
+++ b/packages/plugins/java/kotlin/src/visitor.ts
@@ -18,6 +18,7 @@ import {
   InputValueDefinitionNode,
   isEnumType,
   isInputObjectType,
+  isObjectType,
   isScalarType,
   Kind,
   ObjectTypeDefinitionNode,
@@ -38,6 +39,12 @@ export interface KotlinResolverParsedConfig extends ParsedConfig {
   package: string;
   listType: string;
   enumValues: EnumValuesMap;
+  withTypes: boolean;
+}
+
+export interface FieldDefinitionReturnType {
+  inputTransformer?: ((typeName: string) => string) | FieldDefinitionNode;
+  node: FieldDefinitionNode;
 }
 
 export class KotlinResolversVisitor extends BaseVisitor<KotlinResolversPluginRawConfig, KotlinResolverParsedConfig> {
@@ -45,6 +52,7 @@ export class KotlinResolversVisitor extends BaseVisitor<KotlinResolversPluginRaw
     super(rawConfig, {
       enumValues: rawConfig.enumValues || {},
       listType: rawConfig.listType || 'Iterable',
+      withTypes: rawConfig.withTypes || false,
       package: rawConfig.package || defaultPackageName,
       scalars: buildScalars(_schema, rawConfig.scalars, KOTLIN_SCALARS),
     });
@@ -128,7 +136,7 @@ ${enumValues}
         isArray,
         nullable: nullable,
       };
-    } else if (isEnumType(schemaType)) {
+    } else if (isEnumType(schemaType) || isObjectType(schemaType)) {
       result = {
         isArray,
         baseType: this.convertName(schemaType.name),
@@ -155,6 +163,24 @@ ${enumValues}
         const initial = initialValue ? ` = ${initialValue}` : typeToUse.nullable ? ' = null' : '';
 
         return indent(`val ${arg.name.value}: ${typeToUse.typeName}${typeToUse.nullable ? '?' : ''}${initial}`, 2);
+      })
+      .join(',\n');
+
+    // language=kotlin
+    return `data class ${name}(
+${classMembers}
+)`;
+  }
+
+  protected buildTypeTransfomer(name: string, typeValueArray: ReadonlyArray<FieldDefinitionNode>): string {
+    const classMembers = typeValueArray
+      .map(arg => {
+        if (!arg.type) {
+          return '';
+        }
+        const typeToUse = this.resolveInputFieldType(arg.type);
+
+        return indent(`val ${arg.name.value}: ${typeToUse.typeName}${typeToUse.nullable ? '?' : ''}`, 2);
       })
       .join(',\n');
 
@@ -192,19 +218,20 @@ ${classMembers}
     return undefined;
   }
 
-  FieldDefinition(node: FieldDefinitionNode): (typeName: string) => string {
-    return (typeName: string) => {
-      if (node.arguments.length > 0) {
+  FieldDefinition(node: FieldDefinitionNode): FieldDefinitionReturnType {
+    if (node.arguments.length > 0) {
+      const inputTransformer = (typeName: string) => {
         const transformerName = `${this.convertName(typeName, { useTypesPrefix: true })}${this.convertName(
           node.name.value,
           { useTypesPrefix: false }
         )}Args`;
 
         return this.buildInputTransfomer(transformerName, node.arguments);
-      }
+      };
 
-      return null;
-    };
+      return { node, inputTransformer };
+    }
+    return { node };
   }
 
   InputObjectTypeDefinition(node: InputObjectTypeDefinitionNode): string {
@@ -214,8 +241,24 @@ ${classMembers}
   }
 
   ObjectTypeDefinition(node: ObjectTypeDefinitionNode): string {
-    const fieldsArguments = node.fields.map(f => (f as any)(node.name.value)).filter(r => r);
+    const name = this.convertName(node);
+    const fields = (node.fields as unknown) as FieldDefinitionReturnType[];
 
-    return fieldsArguments.join('\n');
+    const fieldNodes = [];
+    const argsTypes = [];
+    fields.forEach(({ node, inputTransformer }) => {
+      if (node) {
+        fieldNodes.push(node);
+      }
+      if (inputTransformer) {
+        argsTypes.push(inputTransformer);
+      }
+    });
+
+    let types = argsTypes.map(f => (f as any)(node.name.value)).filter(r => r);
+    if (this.config.withTypes) {
+      types = types.concat([this.buildTypeTransfomer(name, fieldNodes)]);
+    }
+    return types.join('\n');
   }
 }

--- a/packages/plugins/java/kotlin/tests/kotlin.spec.ts
+++ b/packages/plugins/java/kotlin/tests/kotlin.spec.ts
@@ -185,4 +185,43 @@ describe('Kotlin', () => {
         )`);
     });
   });
+
+  describe('Types', () => {
+    it('Should NOT generate type class per each type if withTypes is not specified', async () => {
+      const result = await plugin(schema, [], {}, { outputFile: OUTPUT_FILE });
+
+      // language=kotlin
+      expect(result).not.toBeSimilarStringTo(`data class User(
+        val skip: Int? = null,
+        val limit: Int? = null
+      )`);
+
+      // language=kotlin
+      expect(result).not.toBeSimilarStringTo(`data class Chat(
+        val skip: Int? = null,
+        val limit: Int? = null
+      )`);
+    });
+
+    it('Should generate type class per each type if withTypes is true', async () => {
+      const result = await plugin(schema, [], { withTypes: true }, { outputFile: OUTPUT_FILE });
+
+      // language=kotlin
+      expect(result).toBeSimilarStringTo(`data class User(
+        val id: String,
+        val username: String,
+        val email: String,
+        val name: String?,
+        val friends: Iterable<User>,
+        val hobbies: Iterable<String>
+      )`);
+
+      // language=kotlin
+      expect(result).toBeSimilarStringTo(`data class Chat(
+        val id: String,
+        val users: Iterable<User>,
+        val title: String?
+      )`);
+    });
+  });
 });

--- a/website/docs/generated-config/kotlin.md
+++ b/website/docs/generated-config/kotlin.md
@@ -44,3 +44,19 @@ generates:
     config:
       listType: Map
 ```
+
+### withTypes (`boolean`, default value: `false`)
+
+Allow you to enable generation for the types
+
+
+#### Usage Example
+
+```yml
+generates:
+  src/main/kotlin/my-org/my-app/Types.kt:
+    plugins:
+      - kotlin
+    config:
+      withTypes: true
+```


### PR DESCRIPTION
Added generation of Kotlin data classes for object types. Probably connected with the https://github.com/dotansimha/graphql-code-generator/issues/3484, but this is only for Kotlin and not Java.