### PR TITLE
Fix #3998: Fix nested input suffix reduplication

### DIFF
--- a/packages/plugins/java/java/src/visitor.ts
+++ b/packages/plugins/java/java/src/visitor.ts
@@ -62,7 +62,7 @@ export class JavaResolversVisitor extends BaseVisitor<JavaResolversPluginRawConf
       allImports.push(`java.util.stream.Collectors`);
     }
 
-    return allImports.map((i) => `import ${i};`).join('\n') + '\n';
+    return allImports.map(i => `import ${i};`).join('\n') + '\n';
   }
 
   public wrapWithClass(content: string): string {
@@ -104,7 +104,7 @@ export class JavaResolversVisitor extends BaseVisitor<JavaResolversPluginRawConf
     this._addHashMapImport = true;
     this._addMapImport = true;
     const enumName = this.convertName(node.name);
-    const enumValues = node.values.map((enumValue) => (enumValue as any)(node.name.value)).join(',\n') + ';';
+    const enumValues = node.values.map(enumValue => (enumValue as any)(node.name.value)).join(',\n') + ';';
     const enumCtor = indentMultiline(`
 public final String label;
  
@@ -156,9 +156,11 @@ public static ${enumName} valueOfLabel(String label) {
         result = { isArray, baseType: 'Object', typeName: 'Object', isScalar: true, isEnum: false };
       }
     } else if (isInputObjectType(schemaType)) {
+      const convertedName = this.convertName(schemaType.name);
+      const typeName = convertedName.endsWith('Input') ? convertedName : `${convertedName}Input`;
       result = {
-        baseType: `${this.convertName(schemaType.name)}Input`,
-        typeName: `${this.convertName(schemaType.name)}Input`,
+        baseType: typeName,
+        typeName: typeName,
         isScalar: false,
         isEnum: false,
         isArray,
@@ -186,14 +188,14 @@ public static ${enumName} valueOfLabel(String label) {
     this._addMapImport = true;
 
     const classMembers = inputValueArray
-      .map((arg) => {
+      .map(arg => {
         const typeToUse = this.resolveInputFieldType(arg.type);
 
         return indent(`private ${typeToUse.typeName} _${arg.name.value};`);
       })
       .join('\n');
     const ctorSet = inputValueArray
-      .map((arg) => {
+      .map(arg => {
         const typeToUse = this.resolveInputFieldType(arg.type);
 
         if (typeToUse.isArray && !typeToUse.isScalar) {
@@ -224,7 +226,7 @@ public static ${enumName} valueOfLabel(String label) {
       })
       .join('\n');
     const getters = inputValueArray
-      .map((arg) => {
+      .map(arg => {
         const typeToUse = this.resolveInputFieldType(arg.type);
 
         return indent(
@@ -269,7 +271,7 @@ ${getters}
   }
 
   ObjectTypeDefinition(node: ObjectTypeDefinitionNode): string {
-    const fieldsArguments = node.fields.map((f) => (f as any)(node.name.value)).filter((r) => r);
+    const fieldsArguments = node.fields.map(f => (f as any)(node.name.value)).filter(r => r);
 
     return fieldsArguments.join('\n');
   }

--- a/packages/plugins/java/java/tests/java.spec.ts
+++ b/packages/plugins/java/java/tests/java.spec.ts
@@ -14,6 +14,7 @@ describe('Java', () => {
       me: User!
       user(id: ID!): User!
       searchUser(searchFields: SearchUser!): [User!]!
+      updateUser(input: UpdateUserMetadataInput!): [User!]!
     }
 
     input InputWithArray {
@@ -31,6 +32,16 @@ describe('Java', () => {
     }
 
     input MetadataSearch {
+      something: Int
+    }
+
+    input UpdateUserInput {
+      id: ID!
+      username: String
+      metadata: UpdateUserMetadataInput
+    }
+
+    input UpdateUserMetadataInput {
       something: Int
     }
 
@@ -284,6 +295,40 @@ describe('Java', () => {
         public Object getDateOfBirth() { return this._dateOfBirth; }
         public ResultSort getSort() { return this._sort; }
         public MetadataSearchInput getMetadata() { return this._metadata; }
+      }`);
+    });
+
+    it('Should generate nested inputs with out duplicated `Input` suffix', async () => {
+      const result = await plugin(schema, [], {}, { outputFile: OUTPUT_FILE });
+
+      expect(result).toBeSimilarStringTo(`public static class UpdateUserMetadataInput {
+        private Integer _something;
+      
+        public UpdateUserMetadataInput(Map<String, Object> args) {
+          if (args != null) {
+            this._something = (Integer) args.get("something");
+          }
+        }
+      
+        public Integer getSomething() { return this._something; }
+      }`);
+
+      expect(result).toBeSimilarStringTo(`public static class UpdateUserInput {
+        private Object _id;
+        private String _username;
+        private UpdateUserMetadataInput _metadata;
+      
+        public UpdateUserInput(Map<String, Object> args) {
+          if (args != null) {
+            this._id = (Object) args.get("id");
+            this._username = (String) args.get("username");
+            this._metadata = new UpdateUserMetadataInput((Map<String, Object>) args.get("metadata"));
+          }
+        }
+      
+        public Object getId() { return this._id; }
+        public String getUsername() { return this._username; }
+        public UpdateUserMetadataInput getMetadata() { return this._metadata; }
       }`);
     });
   });

--- a/packages/plugins/java/kotlin/src/visitor.ts
+++ b/packages/plugins/java/kotlin/src/visitor.ts
@@ -27,7 +27,7 @@ import {
 import { wrapTypeWithModifiers } from '@graphql-codegen/java-common';
 
 export const KOTLIN_SCALARS = {
-  ID: 'String',
+  ID: 'Any',
   String: 'String',
   Boolean: 'Boolean',
   Int: 'Int',
@@ -121,9 +121,11 @@ ${enumValues}
         result = { isArray, baseType: 'Any', typeName: 'Any', isScalar: true, nullable: nullable };
       }
     } else if (isInputObjectType(schemaType)) {
+      const convertedName = this.convertName(schemaType.name);
+      const typeName = convertedName.endsWith('Input') ? convertedName : `${convertedName}Input`;
       result = {
-        baseType: `${this.convertName(schemaType.name)}Input`,
-        typeName: `${this.convertName(schemaType.name)}Input`,
+        baseType: typeName,
+        typeName: typeName,
         isScalar: false,
         isArray,
         nullable: nullable,
@@ -208,7 +210,8 @@ ${classMembers}
   }
 
   InputObjectTypeDefinition(node: InputObjectTypeDefinitionNode): string {
-    const name = `${this.convertName(node)}Input`;
+    const convertedName = this.convertName(node);
+    const name = convertedName.endsWith('Input') ? convertedName : `${convertedName}Input`;
 
     return this.buildInputTransfomer(name, node.fields);
   }

--- a/packages/plugins/java/kotlin/tests/kotlin.spec.ts
+++ b/packages/plugins/java/kotlin/tests/kotlin.spec.ts
@@ -11,6 +11,7 @@ describe('Kotlin', () => {
       me: User!
       user(id: ID!): User!
       searchUser(searchFields: SearchUser!): [User!]!
+      updateUser(input: UpdateUserMetadataInput!): [User!]!
     }
 
     input InputWithArray {
@@ -29,7 +30,17 @@ describe('Kotlin', () => {
     input MetadataSearch {
       something: Int
     }
-
+    
+    input UpdateUserInput {
+      id: ID!
+      username: String
+      metadata: UpdateUserMetadataInput
+    }
+    
+    input UpdateUserMetadataInput {
+      something: Int
+    }
+    
     enum ResultSort {
       ASC
       DESC
@@ -158,7 +169,7 @@ describe('Kotlin', () => {
 
       // language=kotlin
       expect(result).toBeSimilarStringTo(`data class QueryUserArgs(
-        val id: String
+        val id: Any
       )`);
 
       // language=kotlin
@@ -182,6 +193,22 @@ describe('Kotlin', () => {
           val name: String? = null,
           val sort: ResultSort? = null,
           val metadata: MetadataSearchInput? = null
+        )`);
+    });
+
+    it('Should generate nested inputs with out duplicated `Input` suffix', async () => {
+      const result = await plugin(schema, [], {}, { outputFile: OUTPUT_FILE });
+
+      // language=kotlin
+      expect(result).toBeSimilarStringTo(`data class UpdateUserMetadataInput(
+          val something: Int? = null
+        )`);
+
+      // language=kotlin
+      expect(result).toBeSimilarStringTo(`data class UpdateUserInput(
+          val id: Any,
+          val username: String? = null,
+          val metadata: UpdateUserMetadataInput? = null
         )`);
     });
   });


### PR DESCRIPTION
Fix for the #3998 

BREAKING: 
- I've changed `ID` default scalar's type for the `Kotlin` language from `String` to `Any` — it was done to achieve consistency with the `Java` language: it uses `Object` type (not `java.lang.String` as it was in `Kotlin`)

Except this breaking change above, I hadn't change previously written tests, so there should not be any regression.