### PR TITLE
Fix __typename indentation if immutableTypes is false

### DIFF
--- a/packages/plugins/flow/flow/tests/__snapshots__/flow.spec.ts.snap
+++ b/packages/plugins/flow/flow/tests/__snapshots__/flow.spec.ts.snap
@@ -15,7 +15,7 @@ export type TInput = {|
 |};
 
 export type TMutation = {|
-   __typename?: 'Mutation',
+  __typename?: 'Mutation',
   foo?: ?$ElementType<Scalars, 'String'>,
 |};
 
@@ -38,7 +38,7 @@ export type Scalars = {|
 |};
 
 export type MyType = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   foo?: ?$ElementType<Scalars, 'String'>,
 |};
 
@@ -63,7 +63,7 @@ export type Scalars = {|
 |};
 
 export type MyType = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   foo?: ?$ElementType<Scalars, 'String'>,
 |};
 
@@ -91,7 +91,7 @@ export type MyInput = {|
 |};
 
 export type MyType = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   foo?: ?$ElementType<Scalars, 'String'>,
 |};
 
@@ -117,7 +117,7 @@ export type Scalars = {|
 |};
 
 export type MyType = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   foo?: ?$ElementType<Scalars, 'String'>,
 |};
 
@@ -166,7 +166,7 @@ export type Scalars = {|
 |};
 
 export type Mutation = {|
-   __typename?: 'Mutation',
+  __typename?: 'Mutation',
   updateUser: User,
 |};
 
@@ -177,7 +177,7 @@ export type MutationUpdateUserArgs = {|
 |};
 
 export type User = {|
-   __typename?: 'User',
+  __typename?: 'User',
   id: $ElementType<Scalars, 'ID'>,
   username: $ElementType<Scalars, 'String'>,
   email: $ElementType<Scalars, 'String'>,
@@ -210,7 +210,7 @@ export const myenumvalues = Object.freeze({
 export type myenum = $Values<typeof myenumvalues>;
 
 export type mytype = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   f?: ?$ElementType<Scalars, 'String'>,
   bar?: ?myenum,
   b_a_r?: ?$ElementType<Scalars, 'String'>,
@@ -218,7 +218,7 @@ export type mytype = {|
 |};
 
 export type my_type = {|
-   __typename?: 'My_Type',
+  __typename?: 'My_Type',
   linkTest?: ?mytype,
 |};
 
@@ -231,7 +231,7 @@ export type some_interface = {|
 export type impl1 = {|
   ...some_interface,
   ...{|
-     __typename?: 'Impl1',
+    __typename?: 'Impl1',
     id: $ElementType<Scalars, 'ID'>,
   |}
 |};
@@ -239,7 +239,7 @@ export type impl1 = {|
 export type impl_2 = {|
   ...some_interface,
   ...{|
-     __typename?: 'Impl_2',
+    __typename?: 'Impl_2',
     id: $ElementType<Scalars, 'ID'>,
   |}
 |};
@@ -247,13 +247,13 @@ export type impl_2 = {|
 export type impl_3 = {|
   ...some_interface,
   ...{|
-     __typename?: 'impl_3',
+    __typename?: 'impl_3',
     id: $ElementType<Scalars, 'ID'>,
   |}
 |};
 
 export type query = {|
-   __typename?: 'Query',
+  __typename?: 'Query',
   something?: ?myunion,
   use_interface?: ?some_interface,
 |};
@@ -280,7 +280,7 @@ export const MyEnumValues = Object.freeze({
 export type MyEnum = $Values<typeof MyEnumValues>;
 
 export type MyType = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   f?: ?$ElementType<Scalars, 'String'>,
   bar?: ?MyEnum,
   b_a_r?: ?$ElementType<Scalars, 'String'>,
@@ -288,7 +288,7 @@ export type MyType = {|
 |};
 
 export type My_Type = {|
-   __typename?: 'My_Type',
+  __typename?: 'My_Type',
   linkTest?: ?MyType,
 |};
 
@@ -301,7 +301,7 @@ export type Some_Interface = {|
 export type Impl1 = {|
   ...Some_Interface,
   ...{|
-     __typename?: 'Impl1',
+    __typename?: 'Impl1',
     id: $ElementType<Scalars, 'ID'>,
   |}
 |};
@@ -309,7 +309,7 @@ export type Impl1 = {|
 export type Impl_2 = {|
   ...Some_Interface,
   ...{|
-     __typename?: 'Impl_2',
+    __typename?: 'Impl_2',
     id: $ElementType<Scalars, 'ID'>,
   |}
 |};
@@ -317,13 +317,13 @@ export type Impl_2 = {|
 export type Impl_3 = {|
   ...Some_Interface,
   ...{|
-     __typename?: 'impl_3',
+    __typename?: 'impl_3',
     id: $ElementType<Scalars, 'ID'>,
   |}
 |};
 
 export type Query = {|
-   __typename?: 'Query',
+  __typename?: 'Query',
   something?: ?MyUnion,
   use_interface?: ?Some_Interface,
 |};
@@ -350,7 +350,7 @@ export const IMyEnumValues = Object.freeze({
 export type IMyEnum = $Values<typeof IMyEnumValues>;
 
 export type IMyType = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   f?: ?$ElementType<Scalars, 'String'>,
   bar?: ?IMyEnum,
   b_a_r?: ?$ElementType<Scalars, 'String'>,
@@ -358,7 +358,7 @@ export type IMyType = {|
 |};
 
 export type IMy_Type = {|
-   __typename?: 'My_Type',
+  __typename?: 'My_Type',
   linkTest?: ?IMyType,
 |};
 
@@ -371,7 +371,7 @@ export type ISome_Interface = {|
 export type IImpl1 = {|
   ...ISome_Interface,
   ...{|
-     __typename?: 'Impl1',
+    __typename?: 'Impl1',
     id: $ElementType<Scalars, 'ID'>,
   |}
 |};
@@ -379,7 +379,7 @@ export type IImpl1 = {|
 export type IImpl_2 = {|
   ...ISome_Interface,
   ...{|
-     __typename?: 'Impl_2',
+    __typename?: 'Impl_2',
     id: $ElementType<Scalars, 'ID'>,
   |}
 |};
@@ -387,13 +387,13 @@ export type IImpl_2 = {|
 export type IImpl_3 = {|
   ...ISome_Interface,
   ...{|
-     __typename?: 'impl_3',
+    __typename?: 'impl_3',
     id: $ElementType<Scalars, 'ID'>,
   |}
 |};
 
 export type IQuery = {|
-   __typename?: 'Query',
+  __typename?: 'Query',
   something?: ?IMyUnion,
   use_interface?: ?ISome_Interface,
 |};
@@ -431,7 +431,7 @@ export type Scalars = {|
 |};
 
 export type Imytype = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   foo?: ?$ElementType<Scalars, 'String'>,
 |};
 
@@ -456,7 +456,7 @@ export type Scalars = {|
 |};
 
 export type mytype = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   foo?: ?$ElementType<Scalars, 'String'>,
 |};
 
@@ -481,7 +481,7 @@ export type Scalars = {|
 |};
 
 export type MyType = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   foo?: ?$ElementType<Scalars, 'String'>,
   bar: $ElementType<Scalars, 'String'>,
 |};
@@ -505,7 +505,7 @@ export type MyInterface = {|
 export type MyType = {|
   ...MyInterface,
   ...{|
-     __typename?: 'MyType',
+    __typename?: 'MyType',
     foo: $ElementType<Scalars, 'String'>,
   |}
 |};
@@ -534,7 +534,7 @@ export type MyType = {|
   ...MyInterface,
   ...MyOtherInterface,
   ...{|
-     __typename?: 'MyType',
+    __typename?: 'MyType',
     foo: $ElementType<Scalars, 'String'>,
     bar: $ElementType<Scalars, 'String'>,
   |}
@@ -553,12 +553,12 @@ export type Scalars = {|
 |};
 
 export type MyType = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   foo: MyOtherType,
 |};
 
 export type MyOtherType = {|
-   __typename?: 'MyOtherType',
+  __typename?: 'MyOtherType',
   bar: $ElementType<Scalars, 'String'>,
 |};
 "
@@ -629,12 +629,12 @@ export type Scalars = {|
 |};
 
 export type MyType = {|
-   __typename?: 'MyType',
+  __typename?: 'MyType',
   foo: $ElementType<Scalars, 'String'>,
 |};
 
 export type MyOtherType = {|
-   __typename?: 'MyOtherType',
+  __typename?: 'MyOtherType',
   bar: $ElementType<Scalars, 'String'>,
 |};
 

--- a/packages/plugins/flow/flow/tests/flow.spec.ts
+++ b/packages/plugins/flow/flow/tests/flow.spec.ts
@@ -515,7 +515,7 @@ describe('Flow Plugin', () => {
       expect(result.content).toBeSimilarStringTo(`export type Impl1 = {|
         ...Some_Interface,
         ...{|
-           __typename?: 'Impl1',
+          __typename?: 'Impl1',
           id: $ElementType<Scalars, 'ID'>,
         |}
       |};`);
@@ -523,7 +523,7 @@ describe('Flow Plugin', () => {
       expect(result.content).toBeSimilarStringTo(`export type Impl_2 = {|
         ...Some_Interface,
         ...{|
-           __typename?: 'Impl_2',
+          __typename?: 'Impl_2',
           id: $ElementType<Scalars, 'ID'>,
         |}
       |};`);
@@ -531,13 +531,13 @@ describe('Flow Plugin', () => {
       expect(result.content).toBeSimilarStringTo(`export type Impl_3 = {|
         ...Some_Interface,
         ...{|
-           __typename?: 'impl_3',
+          __typename?: 'impl_3',
           id: $ElementType<Scalars, 'ID'>,
         |}
       |};`);
 
       expect(result.content).toBeSimilarStringTo(`export type Query = {|
-        __typename?: 'Query',
+       __typename?: 'Query',
        something?: ?MyUnion,
        use_interface?: ?Some_Interface,
      |};`);
@@ -580,7 +580,7 @@ describe('Flow Plugin', () => {
       expect(result.content).toBeSimilarStringTo(`export type IImpl1 = {|
         ...ISome_Interface,
         ...{|
-           __typename?: 'Impl1',
+          __typename?: 'Impl1',
           id: $ElementType<Scalars, 'ID'>,
         |}
       |};`);
@@ -588,7 +588,7 @@ describe('Flow Plugin', () => {
       expect(result.content).toBeSimilarStringTo(`export type IImpl_2 = {|
         ...ISome_Interface,
         ...{|
-           __typename?: 'Impl_2',
+          __typename?: 'Impl_2',
           id: $ElementType<Scalars, 'ID'>,
         |}
       |};`);
@@ -596,13 +596,13 @@ describe('Flow Plugin', () => {
       expect(result.content).toBeSimilarStringTo(`export type IImpl_3 = {|
         ...ISome_Interface,
         ...{|
-           __typename?: 'impl_3',
+          __typename?: 'impl_3',
           id: $ElementType<Scalars, 'ID'>,
         |}
       |};`);
 
       expect(result.content).toBeSimilarStringTo(`export type IQuery = {|
-        __typename?: 'Query',
+       __typename?: 'Query',
        something?: ?IMyUnion,
        use_interface?: ?ISome_Interface,
      |};`);

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -335,7 +335,7 @@ export class BaseTypesVisitor<
       ...(this.config.addTypename
         ? [
             indent(
-              `${this.config.immutableTypes ? 'readonly' : ''} ${optionalTypename}: '${node.name}'${this.getPunctuation(
+              `${this.config.immutableTypes ? 'readonly ' : ''}${optionalTypename}: '${node.name}'${this.getPunctuation(
                 type
               )}`
             ),

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -14,7 +14,7 @@ export type Scalars = {
 };
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>;
   /** A single entry */
@@ -47,7 +47,7 @@ export enum FeedType {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
-   __typename?: 'Entry';
+  __typename?: 'Entry';
   /** Information about the repository from GitHub */
   repository: Repository;
   /** The GitHub user who submitted this entry */
@@ -80,7 +80,7 @@ export type EntryCommentsArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
-   __typename?: 'Repository';
+  __typename?: 'Repository';
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'];
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -99,7 +99,7 @@ export type Repository = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
-   __typename?: 'User';
+  __typename?: 'User';
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'];
   /** The URL to a directly embeddable image for this user's avatar */
@@ -110,7 +110,7 @@ export type User = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
-   __typename?: 'Comment';
+  __typename?: 'Comment';
   /** The SQL ID of this entry */
   id: Scalars['Int'];
   /** The GitHub user who posted the comment */
@@ -125,12 +125,12 @@ export type Comment = {
 
 /** XXX to be removed */
 export type Vote = {
-   __typename?: 'Vote';
+  __typename?: 'Vote';
   vote_value: Scalars['Int'];
 };
 
 export type Mutation = {
-   __typename?: 'Mutation';
+  __typename?: 'Mutation';
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>;
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -164,7 +164,7 @@ export enum VoteType {
 }
 
 export type Subscription = {
-   __typename?: 'Subscription';
+  __typename?: 'Subscription';
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>;
 };
@@ -312,7 +312,7 @@ export type Scalars = {
 };
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>;
   /** A single entry */
@@ -345,7 +345,7 @@ export enum FeedType {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
-   __typename?: 'Entry';
+  __typename?: 'Entry';
   /** Information about the repository from GitHub */
   repository: Repository;
   /** The GitHub user who submitted this entry */
@@ -378,7 +378,7 @@ export type EntryCommentsArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
-   __typename?: 'Repository';
+  __typename?: 'Repository';
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'];
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -397,7 +397,7 @@ export type Repository = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
-   __typename?: 'User';
+  __typename?: 'User';
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'];
   /** The URL to a directly embeddable image for this user's avatar */
@@ -408,7 +408,7 @@ export type User = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
-   __typename?: 'Comment';
+  __typename?: 'Comment';
   /** The SQL ID of this entry */
   id: Scalars['Int'];
   /** The GitHub user who posted the comment */
@@ -423,12 +423,12 @@ export type Comment = {
 
 /** XXX to be removed */
 export type Vote = {
-   __typename?: 'Vote';
+  __typename?: 'Vote';
   vote_value: Scalars['Int'];
 };
 
 export type Mutation = {
-   __typename?: 'Mutation';
+  __typename?: 'Mutation';
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>;
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -462,7 +462,7 @@ export enum VoteType {
 }
 
 export type Subscription = {
-   __typename?: 'Subscription';
+  __typename?: 'Subscription';
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>;
 };

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -13,7 +13,7 @@ export type Scalars = {
 };
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>;
   /** A single entry */
@@ -46,7 +46,7 @@ export enum FeedType {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
-   __typename?: 'Entry';
+  __typename?: 'Entry';
   /** Information about the repository from GitHub */
   repository: Repository;
   /** The GitHub user who submitted this entry */
@@ -79,7 +79,7 @@ export type EntryCommentsArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
-   __typename?: 'Repository';
+  __typename?: 'Repository';
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'];
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -98,7 +98,7 @@ export type Repository = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
-   __typename?: 'User';
+  __typename?: 'User';
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'];
   /** The URL to a directly embeddable image for this user's avatar */
@@ -109,7 +109,7 @@ export type User = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
-   __typename?: 'Comment';
+  __typename?: 'Comment';
   /** The SQL ID of this entry */
   id: Scalars['Int'];
   /** The GitHub user who posted the comment */
@@ -124,12 +124,12 @@ export type Comment = {
 
 /** XXX to be removed */
 export type Vote = {
-   __typename?: 'Vote';
+  __typename?: 'Vote';
   vote_value: Scalars['Int'];
 };
 
 export type Mutation = {
-   __typename?: 'Mutation';
+  __typename?: 'Mutation';
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>;
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -163,7 +163,7 @@ export enum VoteType {
 }
 
 export type Subscription = {
-   __typename?: 'Subscription';
+  __typename?: 'Subscription';
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>;
 };
@@ -325,7 +325,7 @@ export type Scalars = {
 };
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>;
   /** A single entry */
@@ -358,7 +358,7 @@ export enum FeedType {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
-   __typename?: 'Entry';
+  __typename?: 'Entry';
   /** Information about the repository from GitHub */
   repository: Repository;
   /** The GitHub user who submitted this entry */
@@ -391,7 +391,7 @@ export type EntryCommentsArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
-   __typename?: 'Repository';
+  __typename?: 'Repository';
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'];
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -410,7 +410,7 @@ export type Repository = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
-   __typename?: 'User';
+  __typename?: 'User';
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'];
   /** The URL to a directly embeddable image for this user's avatar */
@@ -421,7 +421,7 @@ export type User = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
-   __typename?: 'Comment';
+  __typename?: 'Comment';
   /** The SQL ID of this entry */
   id: Scalars['Int'];
   /** The GitHub user who posted the comment */
@@ -436,12 +436,12 @@ export type Comment = {
 
 /** XXX to be removed */
 export type Vote = {
-   __typename?: 'Vote';
+  __typename?: 'Vote';
   vote_value: Scalars['Int'];
 };
 
 export type Mutation = {
-   __typename?: 'Mutation';
+  __typename?: 'Mutation';
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>;
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -475,7 +475,7 @@ export enum VoteType {
 }
 
 export type Subscription = {
-   __typename?: 'Subscription';
+  __typename?: 'Subscription';
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>;
 };
@@ -628,7 +628,7 @@ export type Scalars = {
 };
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>;
   /** A single entry */
@@ -661,7 +661,7 @@ export enum FeedType {
 
 /** Information about a GitHub repository submitted to GitHunt */
 export type Entry = {
-   __typename?: 'Entry';
+  __typename?: 'Entry';
   /** Information about the repository from GitHub */
   repository: Repository;
   /** The GitHub user who submitted this entry */
@@ -694,7 +694,7 @@ export type EntryCommentsArgs = {
  * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
  */
 export type Repository = {
-   __typename?: 'Repository';
+  __typename?: 'Repository';
   /** Just the name of the repository, e.g. GitHunt-API */
   name: Scalars['String'];
   /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
@@ -713,7 +713,7 @@ export type Repository = {
 
 /** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
 export type User = {
-   __typename?: 'User';
+  __typename?: 'User';
   /** The name of the user, e.g. apollostack */
   login: Scalars['String'];
   /** The URL to a directly embeddable image for this user's avatar */
@@ -724,7 +724,7 @@ export type User = {
 
 /** A comment about an entry, submitted by a user */
 export type Comment = {
-   __typename?: 'Comment';
+  __typename?: 'Comment';
   /** The SQL ID of this entry */
   id: Scalars['Int'];
   /** The GitHub user who posted the comment */
@@ -739,12 +739,12 @@ export type Comment = {
 
 /** XXX to be removed */
 export type Vote = {
-   __typename?: 'Vote';
+  __typename?: 'Vote';
   vote_value: Scalars['Int'];
 };
 
 export type Mutation = {
-   __typename?: 'Mutation';
+  __typename?: 'Mutation';
   /** Submit a new repository, returns the new submission */
   submitRepository?: Maybe<Entry>;
   /** Vote on a repository submission, returns the submission that was voted on */
@@ -778,7 +778,7 @@ export enum VoteType {
 }
 
 export type Subscription = {
-   __typename?: 'Subscription';
+  __typename?: 'Subscription';
   /** Subscription fires on every comment added */
   commentAdded?: Maybe<Comment>;
 };

--- a/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
+++ b/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
@@ -176,7 +176,7 @@ export type Venue = {
 };
 
 export type GpsPosition = {
-   __typename?: 'GPSPosition';
+  __typename?: 'GPSPosition';
   lat: Scalars['Float'];
   lng: Scalars['Float'];
 };
@@ -187,20 +187,20 @@ export type VenueWithPosition = {
 };
 
 export type Hotel = VenueWithPosition & Venue & {
-   __typename?: 'Hotel';
+  __typename?: 'Hotel';
   id: Scalars['String'];
   gpsPosition: GpsPosition;
   name: Scalars['String'];
 };
 
 export type Transport = Venue & {
-   __typename?: 'Transport';
+  __typename?: 'Transport';
   id: Scalars['String'];
   name: Scalars['String'];
 };
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   hotel: Hotel;
   transport: Transport;
 };
@@ -523,29 +523,29 @@ export type Error = {
 };
 
 export type Error1 = Error & {
-   __typename?: 'Error1';
+  __typename?: 'Error1';
   message: Scalars['String'];
 };
 
 export type Error2 = Error & {
-   __typename?: 'Error2';
+  __typename?: 'Error2';
   message: Scalars['String'];
 };
 
 export type Error3 = Error & {
-   __typename?: 'Error3';
+  __typename?: 'Error3';
   message: Scalars['String'];
   info?: Maybe<AdditionalInfo>;
 };
 
 export type AdditionalInfo = {
-   __typename?: 'AdditionalInfo';
+  __typename?: 'AdditionalInfo';
   message: Scalars['String'];
   message2: Scalars['String'];
 };
 
 export type User = {
-   __typename?: 'User';
+  __typename?: 'User';
   id: Scalars['ID'];
   login: Scalars['String'];
 };
@@ -553,7 +553,7 @@ export type User = {
 export type UserResult = User | Error2 | Error3;
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   user: UserResult;
 };
 export type UserQueryQueryVariables = {};
@@ -614,29 +614,29 @@ export type Error = {
 };
 
 export type Error1 = Error & {
-   __typename?: 'Error1';
+  __typename?: 'Error1';
   message: Scalars['String'];
 };
 
 export type Error2 = Error & {
-   __typename?: 'Error2';
+  __typename?: 'Error2';
   message: Scalars['String'];
 };
 
 export type Error3 = Error & {
-   __typename?: 'Error3';
+  __typename?: 'Error3';
   message: Scalars['String'];
   info?: Maybe<AdditionalInfo>;
 };
 
 export type AdditionalInfo = {
-   __typename?: 'AdditionalInfo';
+  __typename?: 'AdditionalInfo';
   message: Scalars['String'];
   message2: Scalars['String'];
 };
 
 export type User = {
-   __typename?: 'User';
+  __typename?: 'User';
   id: Scalars['ID'];
   login: Scalars['String'];
   test?: Maybe<Scalars['String']>;
@@ -646,7 +646,7 @@ export type User = {
 export type UserResult = User | Error2 | Error3;
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   user: UserResult;
 };
 export type UserQueryQueryVariables = {};


### PR DESCRIPTION
if `config.immutableTypes` is false generated code contains an extra space before __typename:

Expected result:
```ts
export type MyType = {
  __typename?: 'Entry';
  /** Information about the repository from GitHub */
  repository: Repository;
}
```

Actual result:
```ts
export type MyType = {
   __typename?: 'Entry';
  /** Information about the repository from GitHub */
  repository: Repository;
}

```

This PR removes the extra space.