### PR TITLE
Fix punctuation in typescript-resolvers

### DIFF
--- a/packages/plugins/flow/resolvers/src/visitor.ts
+++ b/packages/plugins/flow/resolvers/src/visitor.ts
@@ -48,8 +48,10 @@ export class FlowResolversVisitor extends BaseResolversVisitor<RawResolversConfi
     return `import { ${types.map(t => `type ${t.identifier}`).join(', ')} } from '${source}';`;
   }
 
-  protected formatRootResolver(schemaTypeName: string, resolverType: string): string {
-    return `${schemaTypeName}?: ${resolverType}${resolverType.includes('<') ? '' : '<>'},`;
+  protected formatRootResolver(schemaTypeName: string, resolverType: string, declarationKind: DeclarationKind): string {
+    return `${schemaTypeName}?: ${resolverType}${resolverType.includes('<') ? '' : '<>'}${this.getPunctuation(
+      declarationKind
+    )}`;
   }
 
   protected transformParentGenericType(parentType: string): string {

--- a/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
+++ b/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
@@ -130,7 +130,7 @@ export type SomeNodeResolvers<ContextType = any, ParentType = $ElementType<Resol
 };
 
 export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversParentTypes, 'MyUnion'>> = {
-  __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+  __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>,
 };
 
 export type MyScalarScalarConfig = {

--- a/packages/plugins/flow/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/mapping.spec.ts
@@ -237,7 +237,7 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversParentTypes, 'MyUnion'>> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>,
       };
     `);
 
@@ -315,7 +315,7 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversParentTypes, 'MyUnion'>> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>,
       };
     `);
 
@@ -392,7 +392,7 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversParentTypes, 'MyUnion'>> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>,
       };
     `);
 
@@ -468,7 +468,7 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversParentTypes, 'MyUnion'>> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>,
       };
     `);
 
@@ -544,7 +544,7 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType = $ElementType<ResolversParentTypes, 'MyUnion'>> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>,
       };
     `);
 

--- a/packages/plugins/typescript/resolvers/src/visitor.ts
+++ b/packages/plugins/typescript/resolvers/src/visitor.ts
@@ -52,8 +52,10 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<
     }
   }
 
-  protected formatRootResolver(schemaTypeName: string, resolverType: string): string {
-    return `${schemaTypeName}${this.config.avoidOptionals ? '' : '?'}: ${resolverType},`;
+  protected formatRootResolver(schemaTypeName: string, resolverType: string, declarationKind: DeclarationKind): string {
+    return `${schemaTypeName}${this.config.avoidOptionals ? '' : '?'}: ${resolverType}${this.getPunctuation(
+      declarationKind
+    )}`;
   }
 
   private clearOptional(str: string): string {

--- a/packages/plugins/typescript/resolvers/tests/federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/federation.spec.ts
@@ -50,11 +50,11 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
     // User should have it
     expect(content).toBeSimilarStringTo(`
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & Pick<ParentType, 'id'>, ContextType>,
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & Pick<ParentType, 'id'>, ContextType>;
     `);
     // Foo shouldn't because it doesn't have @key
     expect(content).not.toBeSimilarStringTo(`
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Book']>, ParentType, ContextType>,
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Book']>, ParentType, ContextType>;
     `);
   });
 
@@ -84,11 +84,11 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
     // User should have it
     expect(content).toBeSimilarStringTo(`
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & Pick<ParentType, 'id'>, ContextType>,
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & Pick<ParentType, 'id'>, ContextType>;
     `);
     // Foo shouldn't because it doesn't have @key
     expect(content).not.toBeSimilarStringTo(`
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Book']>, ParentType, ContextType>,
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Book']>, ParentType, ContextType>;
     `);
   });
 
@@ -116,10 +116,10 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // User should have it
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & Pick<ParentType, 'id'>, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & Pick<ParentType, 'id'>, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
   });
@@ -151,10 +151,10 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // UserResolver should not have a resolver function of name field
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & Pick<ParentType, 'id'>, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & Pick<ParentType, 'id'>, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
   });
@@ -278,11 +278,11 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // User should have it
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & (Pick<ParentType, 'id'> | Pick<ParentType, 'name'>), ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
-        username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & (Pick<ParentType, 'id'> | Pick<ParentType, 'name'>), ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+        username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
   });
@@ -314,9 +314,9 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // User should have it
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & Pick<ParentType, 'id'>, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], UserExtension & ParentType, ContextType>,
-        username?: Resolver<Maybe<ResolversTypes['String']>, UserExtension & ParentType & Pick<ParentType, 'name', 'age'>, ContextType>,
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & Pick<ParentType, 'id'>, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], UserExtension & ParentType, ContextType>;
+        username?: Resolver<Maybe<ResolversTypes['String']>, UserExtension & ParentType & Pick<ParentType, 'name', 'age'>, ContextType>;
       };
     `);
   });

--- a/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
@@ -10,18 +10,18 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
-      String: ResolverTypeWrapper<Scalars['String']>,
-      Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-      MyType: ResolverTypeWrapper<MyType>,
-      MyOtherType: ResolverTypeWrapper<MyOtherType>,
-      Query: ResolverTypeWrapper<{}>,
-      Subscription: ResolverTypeWrapper<{}>,
-      Node: ResolversTypes['SomeNode'],
-      ID: ResolverTypeWrapper<Scalars['ID']>,
-      SomeNode: ResolverTypeWrapper<SomeNode>,
-      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-      Int: ResolverTypeWrapper<Scalars['Int']>,
+      String: ResolverTypeWrapper<Scalars['String']>;
+      Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+      MyType: ResolverTypeWrapper<MyType>;
+      MyOtherType: ResolverTypeWrapper<MyOtherType>;
+      Query: ResolverTypeWrapper<{}>;
+      Subscription: ResolverTypeWrapper<{}>;
+      Node: ResolversTypes['SomeNode'];
+      ID: ResolverTypeWrapper<Scalars['ID']>;
+      SomeNode: ResolverTypeWrapper<SomeNode>;
+      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+      Int: ResolverTypeWrapper<Scalars['Int']>;
     };`);
   });
 
@@ -40,18 +40,18 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<number>,
-        Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-        MyType: ResolverTypeWrapper<MyTypeDb>,
-        MyOtherType: ResolverTypeWrapper<Omit<MyOtherType, 'bar'> & { bar: ResolversTypes['String'] }>,
-        Query: ResolverTypeWrapper<{}>,
-        Subscription: ResolverTypeWrapper<{}>,
-        Node: ResolversTypes['SomeNode'],
-        ID: ResolverTypeWrapper<Scalars['ID']>,
-        SomeNode: ResolverTypeWrapper<SomeNode>,
-        MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-        Int: ResolverTypeWrapper<Scalars['Int']>,
+        String: ResolverTypeWrapper<number>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+        MyType: ResolverTypeWrapper<MyTypeDb>;
+        MyOtherType: ResolverTypeWrapper<Omit<MyOtherType, 'bar'> & { bar: ResolversTypes['String'] }>;
+        Query: ResolverTypeWrapper<{}>;
+        Subscription: ResolverTypeWrapper<{}>;
+        Node: ResolversTypes['SomeNode'];
+        ID: ResolverTypeWrapper<Scalars['ID']>;
+        SomeNode: ResolverTypeWrapper<SomeNode>;
+        MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+        Int: ResolverTypeWrapper<Scalars['Int']>;
       };
     `);
   });
@@ -89,13 +89,13 @@ describe('ResolversTypes', () => {
     const content = mergeOutputs([result]);
     expect(content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<Scalars['String']>,
-        Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-        Movie: ResolverTypeWrapper<MovieEntity>,
-        ID: ResolverTypeWrapper<Scalars['ID']>,
-        Book: ResolverTypeWrapper<Book>,
-        MovieLike: ResolversTypes['Movie'] | ResolversTypes['Book'],
-        NonInterfaceHasNarrative: ResolverTypeWrapper<Omit<NonInterfaceHasNarrative, 'narrative' | 'movie'> & { narrative: ResolversTypes['MovieLike'], movie: ResolversTypes['Movie'] }>,
+        String: ResolverTypeWrapper<Scalars['String']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+        Movie: ResolverTypeWrapper<MovieEntity>;
+        ID: ResolverTypeWrapper<Scalars['ID']>;
+        Book: ResolverTypeWrapper<Book>;
+        MovieLike: ResolversTypes['Movie'] | ResolversTypes['Book'];
+        NonInterfaceHasNarrative: ResolverTypeWrapper<Omit<NonInterfaceHasNarrative, 'narrative' | 'movie'> & { narrative: ResolversTypes['MovieLike'], movie: ResolversTypes['Movie'] }>;
       };
     `);
   });
@@ -141,15 +141,15 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
     const content = mergeOutputs([result]);
     expect(content).toBeSimilarStringTo(`export type ResolversTypes = {
-      String: ResolverTypeWrapper<Scalars['String']>,
-      Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-      Movie: ResolverTypeWrapper<MovieEntity>,
-      ID: ResolverTypeWrapper<Scalars['ID']>,
-      Book: ResolverTypeWrapper<Book>,
-      MovieLike: ResolversTypes['Movie'] | ResolversTypes['Book'],
-      NonInterfaceHasNarrative: ResolverTypeWrapper<Omit<NonInterfaceHasNarrative, 'narrative' | 'movie'> & { narrative: ResolversTypes['MovieLike'], movie: ResolversTypes['Movie'] }>,
-      LayerOfIndirection: ResolverTypeWrapper<Omit<LayerOfIndirection, 'movies'> & { movies: Array<ResolversTypes['NonInterfaceHasNarrative']> }>,
-      AnotherLayerOfIndirection: ResolverTypeWrapper<Omit<AnotherLayerOfIndirection, 'inner'> & { inner: ResolversTypes['LayerOfIndirection'] }>,
+      String: ResolverTypeWrapper<Scalars['String']>;
+      Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+      Movie: ResolverTypeWrapper<MovieEntity>;
+      ID: ResolverTypeWrapper<Scalars['ID']>;
+      Book: ResolverTypeWrapper<Book>;
+      MovieLike: ResolversTypes['Movie'] | ResolversTypes['Book'];
+      NonInterfaceHasNarrative: ResolverTypeWrapper<Omit<NonInterfaceHasNarrative, 'narrative' | 'movie'> & { narrative: ResolversTypes['MovieLike'], movie: ResolversTypes['Movie'] }>;
+      LayerOfIndirection: ResolverTypeWrapper<Omit<LayerOfIndirection, 'movies'> & { movies: Array<ResolversTypes['NonInterfaceHasNarrative']> }>;
+      AnotherLayerOfIndirection: ResolverTypeWrapper<Omit<AnotherLayerOfIndirection, 'inner'> & { inner: ResolversTypes['LayerOfIndirection'] }>;
     };`);
   });
 
@@ -184,11 +184,11 @@ describe('ResolversTypes', () => {
     const content = mergeOutputs([result]);
 
     expect(content).toBeSimilarStringTo(`export type GqlResolversTypes = {
-      String: ResolverTypeWrapper<Partial<Scalars['String']>>,
-      Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']>>,
-      Account: ResolverTypeWrapper<Partial<GqlAccount>>,
-      ID: ResolverTypeWrapper<Partial<Scalars['ID']>>,
-      Program: ResolverTypeWrapper<Partial<GqlProgram>>,
+      String: ResolverTypeWrapper<Partial<Scalars['String']>>;
+      Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']>>;
+      Account: ResolverTypeWrapper<Partial<GqlAccount>>;
+      ID: ResolverTypeWrapper<Partial<Scalars['ID']>>;
+      Program: ResolverTypeWrapper<Partial<GqlProgram>>;
     };`);
   });
 
@@ -267,18 +267,18 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
-      String: ResolverTypeWrapper<Partial<Scalars['String']>>,
-      Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']>>,
-      MyType: ResolverTypeWrapper<Partial<MyType>>,
-      MyOtherType: ResolverTypeWrapper<Partial<MyOtherType>>,
-      Query: ResolverTypeWrapper<{}>,
-      Subscription: ResolverTypeWrapper<{}>,
-      Node: ResolversTypes['SomeNode'],
-      ID: ResolverTypeWrapper<Partial<Scalars['ID']>>,
-      SomeNode: ResolverTypeWrapper<Partial<SomeNode>>,
-      MyUnion: Partial<ResolversTypes['MyType'] | ResolversTypes['MyOtherType']>,
-      MyScalar: ResolverTypeWrapper<Partial<Scalars['MyScalar']>>,
-      Int: ResolverTypeWrapper<Partial<Scalars['Int']>>,
+      String: ResolverTypeWrapper<Partial<Scalars['String']>>;
+      Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']>>;
+      MyType: ResolverTypeWrapper<Partial<MyType>>;
+      MyOtherType: ResolverTypeWrapper<Partial<MyOtherType>>;
+      Query: ResolverTypeWrapper<{}>;
+      Subscription: ResolverTypeWrapper<{}>;
+      Node: ResolversTypes['SomeNode'];
+      ID: ResolverTypeWrapper<Partial<Scalars['ID']>>;
+      SomeNode: ResolverTypeWrapper<Partial<SomeNode>>;
+      MyUnion: Partial<ResolversTypes['MyType'] | ResolversTypes['MyOtherType']>;
+      MyScalar: ResolverTypeWrapper<Partial<Scalars['MyScalar']>>;
+      Int: ResolverTypeWrapper<Partial<Scalars['Int']>>;
     };`);
   });
 
@@ -296,18 +296,18 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { CustomPartial } from './my-wrapper';`);
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
-      String: ResolverTypeWrapper<CustomPartial<Scalars['String']>>,
-      Boolean: ResolverTypeWrapper<CustomPartial<Scalars['Boolean']>>,
-      MyType: ResolverTypeWrapper<CustomPartial<MyType>>,
-      MyOtherType: ResolverTypeWrapper<CustomPartial<MyOtherType>>,
-      Query: ResolverTypeWrapper<{}>,
-      Subscription: ResolverTypeWrapper<{}>,
-      Node: ResolversTypes['SomeNode'],
-      ID: ResolverTypeWrapper<CustomPartial<Scalars['ID']>>,
-      SomeNode: ResolverTypeWrapper<CustomPartial<SomeNode>>,
-      MyUnion: CustomPartial<ResolversTypes['MyType'] | ResolversTypes['MyOtherType']>,
-      MyScalar: ResolverTypeWrapper<CustomPartial<Scalars['MyScalar']>>,
-      Int: ResolverTypeWrapper<CustomPartial<Scalars['Int']>>,
+      String: ResolverTypeWrapper<CustomPartial<Scalars['String']>>;
+      Boolean: ResolverTypeWrapper<CustomPartial<Scalars['Boolean']>>;
+      MyType: ResolverTypeWrapper<CustomPartial<MyType>>;
+      MyOtherType: ResolverTypeWrapper<CustomPartial<MyOtherType>>;
+      Query: ResolverTypeWrapper<{}>;
+      Subscription: ResolverTypeWrapper<{}>;
+      Node: ResolversTypes['SomeNode'];
+      ID: ResolverTypeWrapper<CustomPartial<Scalars['ID']>>;
+      SomeNode: ResolverTypeWrapper<CustomPartial<SomeNode>>;
+      MyUnion: CustomPartial<ResolversTypes['MyType'] | ResolversTypes['MyOtherType']>;
+      MyScalar: ResolverTypeWrapper<CustomPartial<Scalars['MyScalar']>>;
+      Int: ResolverTypeWrapper<CustomPartial<Scalars['Int']>>;
     };`);
   });
 
@@ -327,18 +327,18 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { CustomPartial } from './my-wrapper';`);
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
-      String: ResolverTypeWrapper<Scalars['String']>,
-      Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-      MyType: ResolverTypeWrapper<CustomPartial<MyType>>,
-      MyOtherType: ResolverTypeWrapper<MyOtherType>,
-      Query: ResolverTypeWrapper<{}>,
-      Subscription: ResolverTypeWrapper<{}>,
-      Node: ResolversTypes['SomeNode'],
-      ID: ResolverTypeWrapper<Scalars['ID']>,
-      SomeNode: ResolverTypeWrapper<SomeNode>,
-      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-      Int: ResolverTypeWrapper<Scalars['Int']>,
+      String: ResolverTypeWrapper<Scalars['String']>;
+      Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+      MyType: ResolverTypeWrapper<CustomPartial<MyType>>;
+      MyOtherType: ResolverTypeWrapper<MyOtherType>;
+      Query: ResolverTypeWrapper<{}>;
+      Subscription: ResolverTypeWrapper<{}>;
+      Node: ResolversTypes['SomeNode'];
+      ID: ResolverTypeWrapper<Scalars['ID']>;
+      SomeNode: ResolverTypeWrapper<SomeNode>;
+      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+      Int: ResolverTypeWrapper<Scalars['Int']>;
     };`);
   });
 
@@ -374,12 +374,12 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<Partial<Scalars['String']>>,
-        Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']>>,
-        User: ResolverTypeWrapper<number>,
-        ID: ResolverTypeWrapper<Partial<Scalars['ID']>>,
-        Chat: ResolverTypeWrapper<Partial<Omit<Chat, 'owner' | 'members'> & { owner: ResolversTypes['User'], members?: Maybe<Array<ResolversTypes['User']>> }>>,
-        Query: ResolverTypeWrapper<{}>,
+        String: ResolverTypeWrapper<Partial<Scalars['String']>>;
+        Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']>>;
+        User: ResolverTypeWrapper<number>;
+        ID: ResolverTypeWrapper<Partial<Scalars['ID']>>;
+        Chat: ResolverTypeWrapper<Partial<Omit<Chat, 'owner' | 'members'> & { owner: ResolversTypes['User'], members?: Maybe<Array<ResolversTypes['User']>> }>>;
+        Query: ResolverTypeWrapper<{}>;
       };
     `);
 
@@ -431,18 +431,18 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { MyType as DatabaseMyType } from './my-type';`);
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
-      String: ResolverTypeWrapper<Scalars['String']>,
-      Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-      MyType: ResolverTypeWrapper<DatabaseMyType>,
-      MyOtherType: ResolverTypeWrapper<MyOtherType>,
-      Query: ResolverTypeWrapper<{}>,
-      Subscription: ResolverTypeWrapper<{}>,
-      Node: ResolversTypes['SomeNode'],
-      ID: ResolverTypeWrapper<Scalars['ID']>,
-      SomeNode: ResolverTypeWrapper<SomeNode>,
-      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-      Int: ResolverTypeWrapper<Scalars['Int']>,
+      String: ResolverTypeWrapper<Scalars['String']>;
+      Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+      MyType: ResolverTypeWrapper<DatabaseMyType>;
+      MyOtherType: ResolverTypeWrapper<MyOtherType>;
+      Query: ResolverTypeWrapper<{}>;
+      Subscription: ResolverTypeWrapper<{}>;
+      Node: ResolversTypes['SomeNode'];
+      ID: ResolverTypeWrapper<Scalars['ID']>;
+      SomeNode: ResolverTypeWrapper<SomeNode>;
+      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+      Int: ResolverTypeWrapper<Scalars['Int']>;
     };`);
   });
 
@@ -463,18 +463,18 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import DatabaseMyOtherType, { MyType as DatabaseMyType } from './my-type';`);
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
-      String: ResolverTypeWrapper<Scalars['String']>,
-      Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-      MyType: ResolverTypeWrapper<DatabaseMyType>,
-      MyOtherType: ResolverTypeWrapper<DatabaseMyOtherType>,
-      Query: ResolverTypeWrapper<{}>,
-      Subscription: ResolverTypeWrapper<{}>,
-      Node: ResolversTypes['SomeNode'],
-      ID: ResolverTypeWrapper<Scalars['ID']>,
-      SomeNode: ResolverTypeWrapper<SomeNode>,
-      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-      Int: ResolverTypeWrapper<Scalars['Int']>,
+      String: ResolverTypeWrapper<Scalars['String']>;
+      Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+      MyType: ResolverTypeWrapper<DatabaseMyType>;
+      MyOtherType: ResolverTypeWrapper<DatabaseMyOtherType>;
+      Query: ResolverTypeWrapper<{}>;
+      Subscription: ResolverTypeWrapper<{}>;
+      Node: ResolversTypes['SomeNode'];
+      ID: ResolverTypeWrapper<Scalars['ID']>;
+      SomeNode: ResolverTypeWrapper<SomeNode>;
+      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+      Int: ResolverTypeWrapper<Scalars['Int']>;
     };`);
   });
 
@@ -495,18 +495,18 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
-      String: ResolverTypeWrapper<string>,
-      Boolean: ResolverTypeWrapper<any>,
-      MyType: ResolverTypeWrapper<MyTypeDb>,
-      MyOtherType: ResolverTypeWrapper<any>,
-      Query: ResolverTypeWrapper<{}>,
-      Subscription: ResolverTypeWrapper<{}>,
-      Node: ResolversTypes['SomeNode'],
-      ID: ResolverTypeWrapper<any>,
-      SomeNode: ResolverTypeWrapper<any>,
-      MyUnion: ResolverTypeWrapper<any>,
-      MyScalar: ResolverTypeWrapper<any>,
-      Int: ResolverTypeWrapper<any>,
+      String: ResolverTypeWrapper<string>;
+      Boolean: ResolverTypeWrapper<any>;
+      MyType: ResolverTypeWrapper<MyTypeDb>;
+      MyOtherType: ResolverTypeWrapper<any>;
+      Query: ResolverTypeWrapper<{}>;
+      Subscription: ResolverTypeWrapper<{}>;
+      Node: ResolversTypes['SomeNode'];
+      ID: ResolverTypeWrapper<any>;
+      SomeNode: ResolverTypeWrapper<any>;
+      MyUnion: ResolverTypeWrapper<any>;
+      MyScalar: ResolverTypeWrapper<any>;
+      Int: ResolverTypeWrapper<any>;
     };`);
   });
 
@@ -526,18 +526,18 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
-      String: ResolverTypeWrapper<Scalars['String']>,
-      Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-      MyType: ResolverTypeWrapper<MyTypeDb>,
-      MyOtherType: ResolverTypeWrapper<CustomMyOtherType>,
-      Query: ResolverTypeWrapper<{}>,
-      Subscription: ResolverTypeWrapper<{}>,
-      Node: ResolversTypes['SomeNode'],
-      ID: ResolverTypeWrapper<Scalars['ID']>,
-      SomeNode: ResolverTypeWrapper<SomeNode>,
-      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-      Int: ResolverTypeWrapper<Scalars['Int']>,
+      String: ResolverTypeWrapper<Scalars['String']>;
+      Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+      MyType: ResolverTypeWrapper<MyTypeDb>;
+      MyOtherType: ResolverTypeWrapper<CustomMyOtherType>;
+      Query: ResolverTypeWrapper<{}>;
+      Subscription: ResolverTypeWrapper<{}>;
+      Node: ResolversTypes['SomeNode'];
+      ID: ResolverTypeWrapper<Scalars['ID']>;
+      SomeNode: ResolverTypeWrapper<SomeNode>;
+      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+      Int: ResolverTypeWrapper<Scalars['Int']>;
     };`);
   });
 
@@ -556,18 +556,18 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<Scalars['String']>,
-        Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-        MyType: ResolverTypeWrapper<Partial<MyType>>,
-        MyOtherType: ResolverTypeWrapper<MyOtherType>,
-        Query: ResolverTypeWrapper<{}>,
-        Subscription: ResolverTypeWrapper<{}>,
-        Node: ResolversTypes['SomeNode'],
-        ID: ResolverTypeWrapper<Scalars['ID']>,
-        SomeNode: ResolverTypeWrapper<SomeNode>,
-        MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-        Int: ResolverTypeWrapper<Scalars['Int']>,
+        String: ResolverTypeWrapper<Scalars['String']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+        MyType: ResolverTypeWrapper<Partial<MyType>>;
+        MyOtherType: ResolverTypeWrapper<MyOtherType>;
+        Query: ResolverTypeWrapper<{}>;
+        Subscription: ResolverTypeWrapper<{}>;
+        Node: ResolversTypes['SomeNode'];
+        ID: ResolverTypeWrapper<Scalars['ID']>;
+        SomeNode: ResolverTypeWrapper<SomeNode>;
+        MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+        Int: ResolverTypeWrapper<Scalars['Int']>;
       };
     `);
   });
@@ -673,55 +673,55 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
         export type MyOtherTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = {
-          bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-          __isTypeOf?: isTypeOfResolverFn<ParentType>,
+          bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+          __isTypeOf?: isTypeOfResolverFn<ParentType>;
         };
       `);
 
     expect(result.content)
       .toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
-      name: 'MyScalar'
+      name: 'MyScalar';
         }
       `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>,
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>;
       };
     `);
     await validate(result);
@@ -752,55 +752,55 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
         export type MyOtherTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = {
-          bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-          __isTypeOf?: isTypeOfResolverFn<ParentType>,
+          bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+          __isTypeOf?: isTypeOfResolverFn<ParentType>;
         };
       `);
 
     expect(result.content)
       .toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
-      name: 'MyScalar'
+      name: 'MyScalar';
         }
       `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>,
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>;
       };
     `);
     await validate(result);
@@ -829,55 +829,55 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
-        name: 'MyScalar'
+        name: 'MyScalar';
       }
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>,
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>;
       };
     `);
     await validate(mergeOutputs([result, `type MyNodeType = {};`]));
@@ -898,55 +898,55 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
-        name: 'MyScalar'
+        name: 'MyScalar';
       }
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>,
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>;
       };
     `);
     await validate(result);
@@ -967,55 +967,55 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
-        name: 'MyScalar'
+        name: 'MyScalar';
       }
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>,
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>;
       };
     `);
     await validate(result);
@@ -1036,18 +1036,18 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
-      String: ResolverTypeWrapper<Scalars['String']>,
-      Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-      MyType: ResolverTypeWrapper<Omit<MyType, 'otherType'> & { otherType?: Maybe<ResolversTypes['MyOtherType']> }>,
-      MyOtherType: ResolverTypeWrapper<MyOtherTypeCustom>,
-      Query: ResolverTypeWrapper<{}>,
-      Subscription: ResolverTypeWrapper<{}>,
-      Node: ResolversTypes['SomeNode'],
-      ID: ResolverTypeWrapper<Scalars['ID']>,
-      SomeNode: ResolverTypeWrapper<SomeNode>,
-      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-      Int: ResolverTypeWrapper<Scalars['Int']>,
+      String: ResolverTypeWrapper<Scalars['String']>;
+      Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+      MyType: ResolverTypeWrapper<Omit<MyType, 'otherType'> & { otherType?: Maybe<ResolversTypes['MyOtherType']> }>;
+      MyOtherType: ResolverTypeWrapper<MyOtherTypeCustom>;
+      Query: ResolverTypeWrapper<{}>;
+      Subscription: ResolverTypeWrapper<{}>;
+      Node: ResolversTypes['SomeNode'];
+      ID: ResolverTypeWrapper<Scalars['ID']>;
+      SomeNode: ResolverTypeWrapper<SomeNode>;
+      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+      Int: ResolverTypeWrapper<Scalars['Int']>;
     };`);
     await validate(mergeOutputs([result, 'type MyOtherTypeCustom = {};']));
   });
@@ -1068,18 +1068,18 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
-      String: ResolverTypeWrapper<Scalars['String']>,
-      Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-      MyType: ResolverTypeWrapper<MyTypeCustom>,
-      MyOtherType: ResolverTypeWrapper<MyOtherTypeCustom>,
-      Query: ResolverTypeWrapper<{}>,
-      Subscription: ResolverTypeWrapper<{}>,
-      Node: ResolversTypes['SomeNode'],
-      ID: ResolverTypeWrapper<Scalars['ID']>,
-      SomeNode: ResolverTypeWrapper<SomeNode>,
-      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-      Int: ResolverTypeWrapper<Scalars['Int']>,
+      String: ResolverTypeWrapper<Scalars['String']>;
+      Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+      MyType: ResolverTypeWrapper<MyTypeCustom>;
+      MyOtherType: ResolverTypeWrapper<MyOtherTypeCustom>;
+      Query: ResolverTypeWrapper<{}>;
+      Subscription: ResolverTypeWrapper<{}>;
+      Node: ResolversTypes['SomeNode'];
+      ID: ResolverTypeWrapper<Scalars['ID']>;
+      SomeNode: ResolverTypeWrapper<SomeNode>;
+      MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+      MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+      Int: ResolverTypeWrapper<Scalars['Int']>;
     };`);
     await validate(mergeOutputs([result, `type MyTypeCustom = {}; type MyOtherTypeCustom = {};`]));
   });
@@ -1089,18 +1089,18 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<Scalars['String']>,
-        Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-        MyType: ResolverTypeWrapper<MyType>,
-        MyOtherType: ResolverTypeWrapper<MyOtherType>,
-        Query: ResolverTypeWrapper<{}>,
-        Subscription: ResolverTypeWrapper<{}>,
-        Node: ResolversTypes['SomeNode'],
-        ID: ResolverTypeWrapper<Scalars['ID']>,
-        SomeNode: ResolverTypeWrapper<SomeNode>,
-        MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-        Int: ResolverTypeWrapper<Scalars['Int']>,
+        String: ResolverTypeWrapper<Scalars['String']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+        MyType: ResolverTypeWrapper<MyType>;
+        MyOtherType: ResolverTypeWrapper<MyOtherType>;
+        Query: ResolverTypeWrapper<{}>;
+        Subscription: ResolverTypeWrapper<{}>;
+        Node: ResolversTypes['SomeNode'];
+        ID: ResolverTypeWrapper<Scalars['ID']>;
+        SomeNode: ResolverTypeWrapper<SomeNode>;
+        MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+        Int: ResolverTypeWrapper<Scalars['Int']>;
       };
     `);
   });
@@ -1122,35 +1122,35 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<Scalars['String']>,
-        Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-        MyType: ResolverTypeWrapper<Omit<MyType, 'otherType'> & { otherType?: Maybe<ResolversTypes['MyOtherType']> }>,
-        MyOtherType: ResolverTypeWrapper<MyNamespace.MyCustomOtherType>,
-        Query: ResolverTypeWrapper<{}>,
-        Subscription: ResolverTypeWrapper<{}>,
-        Node: ResolversTypes['SomeNode'],
-        ID: ResolverTypeWrapper<Scalars['ID']>,
-        SomeNode: ResolverTypeWrapper<SomeNode>,
-        MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-        Int: ResolverTypeWrapper<Scalars['Int']>,
+        String: ResolverTypeWrapper<Scalars['String']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+        MyType: ResolverTypeWrapper<Omit<MyType, 'otherType'> & { otherType?: Maybe<ResolversTypes['MyOtherType']> }>;
+        MyOtherType: ResolverTypeWrapper<MyNamespace.MyCustomOtherType>;
+        Query: ResolverTypeWrapper<{}>;
+        Subscription: ResolverTypeWrapper<{}>;
+        Node: ResolversTypes['SomeNode'];
+        ID: ResolverTypeWrapper<Scalars['ID']>;
+        SomeNode: ResolverTypeWrapper<SomeNode>;
+        MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+        Int: ResolverTypeWrapper<Scalars['Int']>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversParentTypes = {
-      String: Scalars['String'],
-      Boolean: Scalars['Boolean'],
-      MyType: Omit<MyType, 'otherType'> & { otherType?: Maybe<ResolversParentTypes['MyOtherType']> },
-      MyOtherType: MyNamespace.MyCustomOtherType,
-      Query: {},
-      Subscription: {},
-      Node: ResolversParentTypes['SomeNode'],
-      ID: Scalars['ID'],
-      SomeNode: SomeNode,
-      MyUnion: ResolversParentTypes['MyType'] | ResolversParentTypes['MyOtherType'],
-      MyScalar: Scalars['MyScalar'],
-      Int: Scalars['Int'],
+      String: Scalars['String'];
+      Boolean: Scalars['Boolean'];
+      MyType: Omit<MyType, 'otherType'> & { otherType?: Maybe<ResolversParentTypes['MyOtherType']> };
+      MyOtherType: MyNamespace.MyCustomOtherType;
+      Query: {};
+      Subscription: {};
+      Node: ResolversParentTypes['SomeNode'];
+      ID: Scalars['ID'];
+      SomeNode: SomeNode;
+      MyUnion: ResolversParentTypes['MyType'] | ResolversParentTypes['MyOtherType'];
+      MyScalar: Scalars['MyScalar'];
+      Int: Scalars['Int'];
     };
     `);
   });
@@ -1187,35 +1187,35 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>,
-        Boolean: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>,
-        MyType: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>,
-        MyOtherType: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>,
-        Query: ResolverTypeWrapper<{}>,
-        Subscription: ResolverTypeWrapper<{}>,
-        Node: ResolversTypes['SomeNode'],
-        ID: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>,
-        SomeNode: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>,
-        MyUnion: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>,
-        MyScalar: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>,
-        Int: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>,
+        String: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
+        Boolean: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
+        MyType: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
+        MyOtherType: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
+        Query: ResolverTypeWrapper<{}>;
+        Subscription: ResolverTypeWrapper<{}>;
+        Node: ResolversTypes['SomeNode'];
+        ID: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
+        SomeNode: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
+        MyUnion: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
+        MyScalar: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
+        Int: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversParentTypes = {
-        String: MyNamespace.MyDefaultMapper,
-        Boolean: MyNamespace.MyDefaultMapper,
-        MyType: MyNamespace.MyDefaultMapper,
-        MyOtherType: MyNamespace.MyDefaultMapper,
-        Query: {},
-        Subscription: {},
-        Node: ResolversParentTypes['SomeNode'],
-        ID: MyNamespace.MyDefaultMapper,
-        SomeNode: MyNamespace.MyDefaultMapper,
-        MyUnion: MyNamespace.MyDefaultMapper,
-        MyScalar: MyNamespace.MyDefaultMapper,
-        Int: MyNamespace.MyDefaultMapper,
+        String: MyNamespace.MyDefaultMapper;
+        Boolean: MyNamespace.MyDefaultMapper;
+        MyType: MyNamespace.MyDefaultMapper;
+        MyOtherType: MyNamespace.MyDefaultMapper;
+        Query: {};
+        Subscription: {};
+        Node: ResolversParentTypes['SomeNode'];
+        ID: MyNamespace.MyDefaultMapper;
+        SomeNode: MyNamespace.MyDefaultMapper;
+        MyUnion: MyNamespace.MyDefaultMapper;
+        MyScalar: MyNamespace.MyDefaultMapper;
+        Int: MyNamespace.MyDefaultMapper;
       };
     `);
   });
@@ -1235,35 +1235,35 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<Scalars['String']>,
-        Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-        MyType: ResolverTypeWrapper<MyType>,
-        MyOtherType: ResolverTypeWrapper<MyOtherType>,
-        Query: ResolverTypeWrapper<MyNamespace.MyRootType>,
-        Subscription: ResolverTypeWrapper<MyNamespace.MyRootType>,
-        Node: ResolversTypes['SomeNode'],
-        ID: ResolverTypeWrapper<Scalars['ID']>,
-        SomeNode: ResolverTypeWrapper<SomeNode>,
-        MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'],
-        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>,
-        Int: ResolverTypeWrapper<Scalars['Int']>,
+        String: ResolverTypeWrapper<Scalars['String']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+        MyType: ResolverTypeWrapper<MyType>;
+        MyOtherType: ResolverTypeWrapper<MyOtherType>;
+        Query: ResolverTypeWrapper<MyNamespace.MyRootType>;
+        Subscription: ResolverTypeWrapper<MyNamespace.MyRootType>;
+        Node: ResolversTypes['SomeNode'];
+        ID: ResolverTypeWrapper<Scalars['ID']>;
+        SomeNode: ResolverTypeWrapper<SomeNode>;
+        MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+        Int: ResolverTypeWrapper<Scalars['Int']>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversParentTypes = {
-      String: Scalars['String'],
-      Boolean: Scalars['Boolean'],
-      MyType: MyType,
-      MyOtherType: MyOtherType,
-      Query: MyNamespace.MyRootType,
-      Subscription: MyNamespace.MyRootType,
-      Node: ResolversParentTypes['SomeNode'],
-      ID: Scalars['ID'],
-      SomeNode: SomeNode,
-      MyUnion: ResolversParentTypes['MyType'] | ResolversParentTypes['MyOtherType'],
-      MyScalar: Scalars['MyScalar'],
-      Int: Scalars['Int'],
+      String: Scalars['String'];
+      Boolean: Scalars['Boolean'];
+      MyType: MyType;
+      MyOtherType: MyOtherType;
+      Query: MyNamespace.MyRootType;
+      Subscription: MyNamespace.MyRootType;
+      Node: ResolversParentTypes['SomeNode'];
+      ID: Scalars['ID'];
+      SomeNode: SomeNode;
+      MyUnion: ResolversParentTypes['MyType'] | ResolversParentTypes['MyOtherType'];
+      MyScalar: Scalars['MyScalar'];
+      Int: Scalars['Int'];
     };
     `);
   });
@@ -1285,35 +1285,35 @@ describe('ResolversTypes', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['String']>>,
-        Boolean: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['Boolean']>>,
-        MyType: ResolverTypeWrapper<MyNamespace.MyType<MyType>>,
-        MyOtherType: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<MyOtherType>>,
-        Query: ResolverTypeWrapper<{}>,
-        Subscription: ResolverTypeWrapper<{}>,
-        Node: ResolversTypes['SomeNode'],
-        ID: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['ID']>>,
-        SomeNode: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<SomeNode>>,
-        MyUnion: MyNamespace.MyDefaultMapper<ResolversTypes['MyType'] | ResolversTypes['MyOtherType']>,
-        MyScalar: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['MyScalar']>>,
-        Int: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['Int']>>,
+        String: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['String']>>;
+        Boolean: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['Boolean']>>;
+        MyType: ResolverTypeWrapper<MyNamespace.MyType<MyType>>;
+        MyOtherType: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<MyOtherType>>;
+        Query: ResolverTypeWrapper<{}>;
+        Subscription: ResolverTypeWrapper<{}>;
+        Node: ResolversTypes['SomeNode'];
+        ID: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['ID']>>;
+        SomeNode: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<SomeNode>>;
+        MyUnion: MyNamespace.MyDefaultMapper<ResolversTypes['MyType'] | ResolversTypes['MyOtherType']>;
+        MyScalar: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['MyScalar']>>;
+        Int: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['Int']>>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversParentTypes = {
-      String: MyNamespace.MyDefaultMapper<Scalars['String']>,
-      Boolean: MyNamespace.MyDefaultMapper<Scalars['Boolean']>,
-      MyType: MyNamespace.MyType<MyType>,
-      MyOtherType: MyNamespace.MyDefaultMapper<MyOtherType>,
-      Query: {},
-      Subscription: {},
-      Node: ResolversParentTypes['SomeNode'],
-      ID: MyNamespace.MyDefaultMapper<Scalars['ID']>,
-      SomeNode: MyNamespace.MyDefaultMapper<SomeNode>,
-      MyUnion: MyNamespace.MyDefaultMapper<ResolversParentTypes['MyType'] | ResolversParentTypes['MyOtherType']>,
-      MyScalar: MyNamespace.MyDefaultMapper<Scalars['MyScalar']>,
-      Int: MyNamespace.MyDefaultMapper<Scalars['Int']>,
+      String: MyNamespace.MyDefaultMapper<Scalars['String']>;
+      Boolean: MyNamespace.MyDefaultMapper<Scalars['Boolean']>;
+      MyType: MyNamespace.MyType<MyType>;
+      MyOtherType: MyNamespace.MyDefaultMapper<MyOtherType>;
+      Query: {};
+      Subscription: {};
+      Node: ResolversParentTypes['SomeNode'];
+      ID: MyNamespace.MyDefaultMapper<Scalars['ID']>;
+      SomeNode: MyNamespace.MyDefaultMapper<SomeNode>;
+      MyUnion: MyNamespace.MyDefaultMapper<ResolversParentTypes['MyType'] | ResolversParentTypes['MyOtherType']>;
+      MyScalar: MyNamespace.MyDefaultMapper<Scalars['MyScalar']>;
+      Int: MyNamespace.MyDefaultMapper<Scalars['Int']>;
     };
     `);
   });

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -112,8 +112,8 @@ describe('TypeScript Resolvers Plugin', () => {
 
       expect(content).toBeSimilarStringTo(`
         export type Resolvers<ContextType = Context> = ResolversObject<{
-          Query?: QueryResolvers<ContextType>,
-          User?: UserResolvers<ContextType>,
+          Query?: QueryResolvers<ContextType>;
+          User?: UserResolvers<ContextType>;
         }>;
       `);
 
@@ -249,7 +249,7 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(mergedOutputs).toContain(`export type RequireFields`);
     expect(mergedOutputs).toContain(
-      `something?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<QuerySomethingArgs, 'arg'>>,`
+      `something?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<QuerySomethingArgs, 'arg'>>;`
     );
     validate(mergedOutputs);
   });
@@ -288,11 +288,11 @@ describe('TypeScript Resolvers Plugin', () => {
     })) as Types.ComplexPluginOutput;
     const mergedOutputs = mergeOutputs([result, tsContent]);
 
-    expect(mergedOutputs).toContain(`A: A,`);
-    expect(mergedOutputs).not.toContain(`A: GQL_A,`);
-    expect(mergedOutputs).toContain(`NotMapped: GQL_NotMapped,`);
-    expect(mergedOutputs).not.toContain(`NotMapped: NotMapped,`);
-    expect(mergedOutputs).toContain(`B: GQL_B,`);
+    expect(mergedOutputs).toContain(`A: A;`);
+    expect(mergedOutputs).not.toContain(`A: GQL_A;`);
+    expect(mergedOutputs).toContain(`NotMapped: GQL_NotMapped;`);
+    expect(mergedOutputs).not.toContain(`NotMapped: NotMapped;`);
+    expect(mergedOutputs).toContain(`B: GQL_B;`);
   });
 
   it('Should allow to generate optional __resolveType', async () => {
@@ -305,14 +305,14 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
-        __resolveType?: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType?: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType?: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType?: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
   });
@@ -331,54 +331,54 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content)
       .toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
-      name: 'MyScalar'
+      name: 'MyScalar';
     }`);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>,
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>;
       };
     `);
 
@@ -403,54 +403,54 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = {
-        bar: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        bar: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content)
       .toBeSimilarStringTo(`export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
-      name: 'MyScalar'
+      name: 'MyScalar';
     }`);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        otherType: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
-        withArgs: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        foo: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        otherType: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+        withArgs: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-        id: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+        id: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-        something: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
+        something: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = {
-        id: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        id: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
-        somethingChanged: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>,
+        somethingChanged: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>;
       };
     `);
 
@@ -478,49 +478,49 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>,
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>;
       };
     `);
 
@@ -566,49 +566,49 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>,
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>;
       };
     `);
 
@@ -638,49 +638,49 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyOtherTypeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = {
-        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyUnionResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = {
-        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>
+        __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>,
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SomeNodeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = {
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type SubscriptionResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
-        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>,
+        somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>;
       };
     `);
 
@@ -705,16 +705,16 @@ describe('TypeScript Resolvers Plugin', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, ContextTypeOne>,
-        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, SpecialContextType>,
-        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>,
-        __isTypeOf?: isTypeOfResolverFn<ParentType>,
+        foo?: Resolver<ResolversTypes['String'], ParentType, ContextTypeOne>;
+        otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, SpecialContextType>;
+        withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+        __isTypeOf?: isTypeOfResolverFn<ParentType>;
       };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
       export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextTypeTwo>,
+        something?: Resolver<ResolversTypes['MyType'], ParentType, ContextTypeTwo>;
       };
     `);
   });
@@ -847,7 +847,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     expect(content.content).toBeSimilarStringTo(`CCCUnion: ResolversTypes['CCCFoo'] | ResolversTypes['CCCBar']`); // In ResolversTypes
     expect(content.content).toBeSimilarStringTo(`
     export type CccUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['CCCUnion'] = ResolversParentTypes['CCCUnion']> = {
-      __resolveType: TypeResolveFn<'CCCFoo' | 'CCCBar', ParentType, ContextType>
+      __resolveType: TypeResolveFn<'CCCFoo' | 'CCCBar', ParentType, ContextType>;
     };
     `);
 
@@ -860,7 +860,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     const result = await plugin(testSchema, [], config, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(
-      `f?: Resolver<Maybe<TResolversTypes['String']>, ParentType, ContextType, RequireFields<TMyTypeFArgs, never>>,`
+      `f?: Resolver<Maybe<TResolversTypes['String']>, ParentType, ContextType, RequireFields<TMyTypeFArgs, never>>;`
     );
     await validate(result, config, testSchema);
   });
@@ -871,7 +871,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     const result = await plugin(testSchema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(
-      `f?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeFArgs, never>>,`
+      `f?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeFArgs, never>>;`
     );
     await validate(result, {}, testSchema);
   });
@@ -882,7 +882,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     const result = await plugin(testSchema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(
-      `f?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,`
+      `f?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;`
     );
     await validate(result, {}, testSchema);
   });
@@ -922,18 +922,18 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
 
     expect(content.content).toBeSimilarStringTo(`
       export type Resolvers<ContextType = any> = {
-        Date?: GraphQLScalarType,
-        Query?: QueryResolvers<ContextType>,
-        Node?: NodeResolvers,
-        PostOrUser?: PostOrUserResolvers,
-        Post?: PostResolvers<ContextType>,
-        User?: UserResolvers<ContextType>,
+        Date?: GraphQLScalarType;
+        Query?: QueryResolvers<ContextType>;
+        Node?: NodeResolvers;
+        PostOrUser?: PostOrUserResolvers;
+        Post?: PostResolvers<ContextType>;
+        User?: UserResolvers<ContextType>;
       };
     `);
 
     expect(content.content).toBeSimilarStringTo(`
       export type DirectiveResolvers<ContextType = any> = {
-        modify?: ModifyDirectiveResolver<any, any, ContextType>,
+        modify?: ModifyDirectiveResolver<any, any, ContextType>;
       };
     `);
   });
@@ -1092,12 +1092,12 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
 
     expect(content.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<Scalars['String']>,
-        Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-        Subscription: ResolverTypeWrapper<{}>,
-        Query: ResolverTypeWrapper<{}>,
-        Mutation: ResolverTypeWrapper<{}>,
-        Post: ResolverTypeWrapper<Post>,
+        String: ResolverTypeWrapper<Scalars['String']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+        Subscription: ResolverTypeWrapper<{}>;
+        Query: ResolverTypeWrapper<{}>;
+        Mutation: ResolverTypeWrapper<{}>;
+        Post: ResolverTypeWrapper<Post>;
       };
     `);
   });
@@ -1125,12 +1125,12 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
 
     expect(content.content).toBeSimilarStringTo(`
       export type ResolversParentTypes = {
-        String: Scalars['String'],
-        Boolean: Scalars['Boolean'],
-        Subscription: {},
-        Query: {},
-        Mutation: {},
-        Post: Post,
+        String: Scalars['String'];
+        Boolean: Scalars['Boolean'];
+        Subscription: {};
+        Query: {};
+        Mutation: {};
+        Post: Post;
       };
     `);
   });
@@ -1165,12 +1165,12 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
 
     expect(content.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<Scalars['String']>,
-        Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-        Subscription: ResolverTypeWrapper<RootValueType>,
-        Query: ResolverTypeWrapper<RootValueType>,
-        Mutation: ResolverTypeWrapper<RootValueType>,
-        Post: ResolverTypeWrapper<Post>,
+        String: ResolverTypeWrapper<Scalars['String']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+        Subscription: ResolverTypeWrapper<RootValueType>;
+        Query: ResolverTypeWrapper<RootValueType>;
+        Mutation: ResolverTypeWrapper<RootValueType>;
+        Post: ResolverTypeWrapper<Post>;
       };
     `);
 
@@ -1213,12 +1213,12 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
 
     expect(content.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
-        String: ResolverTypeWrapper<Scalars['String']>,
-        Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-        MySubscription: ResolverTypeWrapper<MyRoot>,
-        MyQuery: ResolverTypeWrapper<MyRoot>,
-        MyMutation: ResolverTypeWrapper<MyRoot>,
-        Post: ResolverTypeWrapper<Post>,
+        String: ResolverTypeWrapper<Scalars['String']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+        MySubscription: ResolverTypeWrapper<MyRoot>;
+        MyQuery: ResolverTypeWrapper<MyRoot>;
+        MyMutation: ResolverTypeWrapper<MyRoot>;
+        Post: ResolverTypeWrapper<Post>;
       };
     `);
   });
@@ -1305,8 +1305,8 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
 
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<null, ParentType, ContextType>,
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+        __resolveType: TypeResolveFn<null, ParentType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
   });
@@ -1635,10 +1635,10 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
       };`);
       expect(o).toBeSimilarStringTo(`
       export type IResolversParentTypes = {
-        String: Scalars['String'],
-        Boolean: Scalars['Boolean'],
-        Query: {},
-        Test: Test,
+        String: Scalars['String'];
+        Boolean: Scalars['Boolean'];
+        Query: {};
+        Test: Test;
       };`);
     });
 
@@ -1680,7 +1680,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
       // filter should be non-optional
       expect(output.content).toBeSimilarStringTo(`
         export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-          list?: Resolver<ResolversTypes['Connection'], ParentType, ContextType, RequireFields<QueryListArgs, 'orderBy' | 'filter'>>,
+          list?: Resolver<ResolversTypes['Connection'], ParentType, ContextType, RequireFields<QueryListArgs, 'orderBy' | 'filter'>>;
         };
       `);
     });


### PR DESCRIPTION
This is a followup to https://github.com/dotansimha/graphql-code-generator/issues/3486 for typescript-resolvers . 

I chose not to implement declarationKind because it would have required a heavier refactoring (because of the `useIndexSignature` option), but I made the plugin use the `getPunctuation` function so that semicolons are now correctly used.