### PR TITLE
Add useExplicitTyping to fragment matcher config

### DIFF
--- a/packages/plugins/other/fragment-matcher/tests/plugin.spec.ts
+++ b/packages/plugins/other/fragment-matcher/tests/plugin.spec.ts
@@ -272,6 +272,70 @@ describe('Fragment Matcher Plugin', () => {
       expect(tsContent).toBeSimilarStringTo(output);
       expect(tsxContent).toBeSimilarStringTo(output);
     });
+
+    it('should support exportAsConst for apolloClientVersion 2', async () => {
+      const tsContent = await plugin(
+        schema,
+        [],
+        {
+          exportAsConst: true,
+        },
+        {
+          outputFile: 'foo.ts',
+        }
+      );
+      const tsxContent = await plugin(
+        schema,
+        [],
+        {
+          exportAsConst: true,
+        },
+        {
+          outputFile: 'foo.tsx',
+        }
+      );
+      const output = `
+        export type IntrospectionResultData = ${introspection};
+        const result: IntrospectionResultData = ${introspection};  
+        export default result;
+      `;
+
+      expect(tsContent).toBeSimilarStringTo(output);
+      expect(tsxContent).toBeSimilarStringTo(output);
+    });
+
+    it('should support exportAsConst for apolloClientVersion 3', async () => {
+      const tsContent = await plugin(
+        schema,
+        [],
+        {
+          apolloClientVersion: 3,
+          exportAsConst: true,
+        },
+        {
+          outputFile: 'foo.ts',
+        }
+      );
+      const tsxContent = await plugin(
+        schema,
+        [],
+        {
+          apolloClientVersion: 3,
+          exportAsConst: true,
+        },
+        {
+          outputFile: 'foo.tsx',
+        }
+      );
+      const output = `
+        export type PossibleTypesResultData = ${apolloClient3Result};
+        const result: PossibleTypesResultData = ${apolloClient3Result};  
+        export default result;
+      `;
+
+      expect(tsContent).toBeSimilarStringTo(output);
+      expect(tsxContent).toBeSimilarStringTo(output);
+    });
   });
 
   it('should support Apollo Federation', async () => {

--- a/packages/plugins/other/fragment-matcher/tests/plugin.spec.ts
+++ b/packages/plugins/other/fragment-matcher/tests/plugin.spec.ts
@@ -278,7 +278,7 @@ describe('Fragment Matcher Plugin', () => {
         schema,
         [],
         {
-          exportAsConst: true,
+          useExplicitTyping: true,
         },
         {
           outputFile: 'foo.ts',
@@ -288,7 +288,7 @@ describe('Fragment Matcher Plugin', () => {
         schema,
         [],
         {
-          exportAsConst: true,
+          useExplicitTyping: true,
         },
         {
           outputFile: 'foo.tsx',
@@ -304,13 +304,13 @@ describe('Fragment Matcher Plugin', () => {
       expect(tsxContent).toBeSimilarStringTo(output);
     });
 
-    it('should support exportAsConst for apolloClientVersion 3', async () => {
+    it('should support useExplicitTyping for apolloClientVersion 3', async () => {
       const tsContent = await plugin(
         schema,
         [],
         {
           apolloClientVersion: 3,
-          exportAsConst: true,
+          useExplicitTyping: true,
         },
         {
           outputFile: 'foo.ts',
@@ -321,7 +321,7 @@ describe('Fragment Matcher Plugin', () => {
         [],
         {
           apolloClientVersion: 3,
-          exportAsConst: true,
+          useExplicitTyping: true,
         },
         {
           outputFile: 'foo.tsx',

--- a/website/docs/generated-config/fragment-matcher.md
+++ b/website/docs/generated-config/fragment-matcher.md
@@ -30,3 +30,19 @@ path/to/file.ts:
  config:
    apolloClientVersion: 3
 ```
+
+### useExplicitTyping (`boolean`, default value: `false`)
+
+Create an explicit type based on your schema. This can help IDEs autofill your fragment matcher. This is mostly useful if you do more with your fragment matcher than just pass it to an Apollo-Client.
+
+
+#### Usage Example
+
+```yml
+generates:
+path/to/file.ts:
+ plugins:
+   - fragment-matcher
+ config:
+   useExplicitTyping: true
+```


### PR DESCRIPTION
This is my first time contributing to this repo, so apologies in advance if I need to change something – please just let me know what needs changing, and I'll be happy to do it. 

I was using the fragment matcher for a project that didn't use Apollo Client at all. I was doing some custom logic on objects based on if it inherited from a particular interface. The fragment matcher was really useful – I was storing typenames, so I could just check `fragmentMatcher.possibleTypes.[INTERFACE].includes(object.__typename)`, and it worked like a charm.

But, there wasn't any typescript support, since the `possibleTypes` property had a generic `{ [key: string]: string[] }` type. So, this pull request add more explicit types. Specifically – it just defined the type by the content actually created. I tested it in my local repository, and it doesn't seem to produce any type errors, and it does suggest the names of each fragment in VSCode.

For now, I just add it is as a configuration option, leaving it off by default. If other people would find this useful, and if it wouldn't create any issues, it may be worth making this the default behavior to limit the number of options for a fairly simple plugin, and I'd be happy to make that change. But for now, I figured it was best to err on the side of leaving the current behavior in place.