### PR TITLE
Add operation export name

### DIFF
--- a/packages/plugins/typescript/operations/src/config.ts
+++ b/packages/plugins/typescript/operations/src/config.ts
@@ -89,4 +89,23 @@ export interface TypeScriptDocumentsPluginConfig extends RawDocumentsConfig {
    */
   noExport?: boolean;
   globalNamespace?: boolean;
+    /**
+   * @name addOperationExport
+   * @type boolean
+   * @description Add const export of the operation name to output file. It will allow you to get everything with one import: ```import { GetClient, GetClientQuery, GetClientQueryVariables, } from "./GetClient.gql";```.
+   * @default false
+   * @see https://github.com/dotansimha/graphql-code-generator/issues/3949
+   *
+   * @example
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *  config:
+   *    addOperationExport: true
+   * ```
+   */
+  addOperationExport?: boolean;
 }

--- a/packages/plugins/typescript/operations/src/config.ts
+++ b/packages/plugins/typescript/operations/src/config.ts
@@ -89,11 +89,12 @@ export interface TypeScriptDocumentsPluginConfig extends RawDocumentsConfig {
    */
   noExport?: boolean;
   globalNamespace?: boolean;
-    /**
+  /**
    * @name addOperationExport
    * @type boolean
    * @description Add const export of the operation name to output file. Pay attention that the file should be `d.ts`. 
-   * You can combine it with  `near-operation-file preset` and therefore the generated types will be generate along with graphql file. Then you need to set extension in `presetConfig` to be `.gql.d.ts` and by that you can import gql file in ts files. It will allow you to get everything with one import: ```import { GetClient, GetClientQuery, GetClientQueryVariables, } from "./GetClient.gql";```.
+   * You can combine it with `near-operation-file preset` and therefore the types will be generated along with graphql file. Then you need to set extension in `presetConfig` to be `.gql.d.ts` and by that you can import `gql` file in `ts` files. 
+   * It will allow you to get everything with one import: ```import { GetClient, GetClientQuery, GetClientQueryVariables, } from "./GetClient.gql";```.
    * @default false
    * @see https://github.com/dotansimha/graphql-code-generator/issues/3949
    *
@@ -112,7 +113,7 @@ export interface TypeScriptDocumentsPluginConfig extends RawDocumentsConfig {
    *     - '@graphql-codegen/typescript-operations'
    *   config:
    *     addOperationExport: true
-```
+   * ```
    */
   addOperationExport?: boolean;
 }

--- a/packages/plugins/typescript/operations/src/config.ts
+++ b/packages/plugins/typescript/operations/src/config.ts
@@ -92,20 +92,27 @@ export interface TypeScriptDocumentsPluginConfig extends RawDocumentsConfig {
     /**
    * @name addOperationExport
    * @type boolean
-   * @description Add const export of the operation name to output file. It will allow you to get everything with one import: ```import { GetClient, GetClientQuery, GetClientQueryVariables, } from "./GetClient.gql";```.
+   * @description Add const export of the operation name to output file. Pay attention that the file should be `d.ts`. 
+   * You can combine it with  `near-operation-file preset` and therefore the generated types will be generate along with graphql file. Then you need to set extension in `presetConfig` to be `.gql.d.ts` and by that you can import gql file in ts files. It will allow you to get everything with one import: ```import { GetClient, GetClientQuery, GetClientQueryVariables, } from "./GetClient.gql";```.
    * @default false
    * @see https://github.com/dotansimha/graphql-code-generator/issues/3949
    *
    * @example
    * ```yml
    * generates:
-   * path/to/file.ts:
-   *  plugins:
-   *    - typescript
-   *    - typescript-operations
-   *  config:
-   *    addOperationExport: true
-   * ```
+   * ./typings/api.ts:
+   *   plugins:
+   *     - '@graphql-codegen/typescript'
+   * ./:
+   *   preset: near-operation-file
+   *   presetConfig:
+   *     baseTypesPath: ./typings/api.ts
+   *     extension: .gql.d.ts
+   *   plugins:
+   *     - '@graphql-codegen/typescript-operations'
+   *   config:
+   *     addOperationExport: true
+```
    */
   addOperationExport?: boolean;
 }

--- a/packages/plugins/typescript/operations/src/index.ts
+++ b/packages/plugins/typescript/operations/src/index.ts
@@ -34,6 +34,18 @@ export const plugin: PluginFunction<TypeScriptDocumentsPluginConfig, Types.Compl
 
   let content = visitorResult.definitions.join('\n');
 
+  if (config.addOperationExport) {
+    const exportConsts = [];
+
+    allAst.definitions.forEach(d => {
+      if ('name' in d) {
+        exportConsts.push(`export const ${d.name.value}: import("graphql").DocumentNode`)
+      }
+    })
+
+    content = visitorResult.definitions.concat(exportConsts).join('\n');
+  }
+
   if (config.globalNamespace) {
     content = `
     declare global { 

--- a/packages/plugins/typescript/operations/src/index.ts
+++ b/packages/plugins/typescript/operations/src/index.ts
@@ -39,7 +39,7 @@ export const plugin: PluginFunction<TypeScriptDocumentsPluginConfig, Types.Compl
 
     allAst.definitions.forEach(d => {
       if ('name' in d) {
-        exportConsts.push(`export const ${d.name.value}: import("graphql").DocumentNode`)
+        exportConsts.push(`export const ${d.name.value}: import("graphql").DocumentNode;`)
       }
     })
 

--- a/packages/plugins/typescript/operations/src/index.ts
+++ b/packages/plugins/typescript/operations/src/index.ts
@@ -39,7 +39,7 @@ export const plugin: PluginFunction<TypeScriptDocumentsPluginConfig, Types.Compl
 
     allAst.definitions.forEach(d => {
       if ('name' in d) {
-        exportConsts.push(`export const ${d.name.value}: import("graphql").DocumentNode;`)
+        exportConsts.push(`export declare const ${d.name.value}: import("graphql").DocumentNode;`)
       }
     })
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -3538,8 +3538,8 @@ describe('TypeScript Operations Plugin', () => {
         ) }
       );
       
-      export const UserIdQuery: import("graphql").DocumentNode
-      export const UserLoginQuery: import("graphql").DocumentNode
+      export const UserIdQuery: import("graphql").DocumentNode;
+      export const UserLoginQuery: import("graphql").DocumentNode;
       `);
     });
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -3538,8 +3538,8 @@ describe('TypeScript Operations Plugin', () => {
         ) }
       );
       
-      export const UserIdQuery: import("graphql").DocumentNode;
-      export const UserLoginQuery: import("graphql").DocumentNode;
+      export declare const UserIdQuery: import("graphql").DocumentNode;
+      export declare const UserLoginQuery: import("graphql").DocumentNode;
       `);
     });
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -3484,6 +3484,65 @@ describe('TypeScript Operations Plugin', () => {
       `);
     });
 
+    it('Should add operation name when addOperationExport is true', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type User {
+          id: ID!
+          login: String!
+        }
+
+        type Query {
+          user: User!
+        }
+      `);
+
+      const query = parse(/* GraphQL */ `
+        query UserIdQuery {
+          user {
+            id
+          }
+        }
+        query UserLoginQuery {
+          user {
+            login
+          }
+        }
+      `);
+
+      const config = {
+        addOperationExport: true,
+      };
+
+      const { content } = await plugin(testSchema, [{ location: '', document: query }], config, {
+        outputFile: 'graphql.ts',
+      });
+
+      expect(content).toBeSimilarStringTo(`
+      export type UserIdQueryQueryVariables = {};
+
+      export type UserIdQueryQuery = (
+        { __typename?: 'Query' }
+        & { user: (
+          { __typename?: 'User' }
+          & Pick<User, 'id'>
+        ) }
+      );
+      
+      export type UserLoginQueryQueryVariables = {};
+
+      export type UserLoginQueryQuery = (
+        { __typename?: 'Query' }
+        & { user: (
+          { __typename?: 'User' }
+          & Pick<User, 'login'>
+        ) }
+      );
+      
+      export const UserIdQuery: import("graphql").DocumentNode
+      export const UserLoginQuery: import("graphql").DocumentNode
+      `);
+    });
+
     it('Should handle union selection sets with both FragmentSpreads and InlineFragments with flattenGeneratedTypes and directives', async () => {
       const testSchema = buildSchema(/* GraphQL */ `
         interface Error {


### PR DESCRIPTION
This PR is relative to this issue https://github.com/dotansimha/graphql-code-generator/issues/3949

It allows you to add operation name to output file.