### PR TITLE
fix(time): config and default message

### DIFF
--- a/packages/plugins/other/time/src/index.ts
+++ b/packages/plugins/other/time/src/index.ts
@@ -25,7 +25,7 @@ export type TimePluginConfig =
        * @name message
        * @type string
        * @description Customize the comment message
-       * @default Generated in
+       * @default Generated on
        *
        * @example
        * ```yml
@@ -33,7 +33,7 @@ export type TimePluginConfig =
        * path/to/file.ts:
        *  plugins:
        *    - time:
-       *        message: "The file generated in: "
+       *        message: "The file generated on: "
        * ```
        */
       message: string;
@@ -45,18 +45,18 @@ export const plugin: PluginFunction<TimePluginConfig> = async (
   config: TimePluginConfig
 ): Promise<string> => {
   let format;
-  let message = 'Generated in ';
+  let message = 'Generated on ';
 
   if (config && typeof config === 'string') {
     format = config;
-  } else if (config && typeof config === 'object' && config.format) {
-    format = config.format;
+  } else if (config && typeof config === 'object') {
+    if (config.format) {
+      format = config.format;
+    }
 
     if (config.message) {
       message = config.message;
     }
-  } else {
-    config = null;
   }
 
   return '// ' + message + moment().format(format) + '\n';

--- a/website/docs/generated-config/time.md
+++ b/website/docs/generated-config/time.md
@@ -14,7 +14,7 @@ path/to/file.ts:
        format: DD.MM.YY
 ```
 
-### message (`string`, default value: `Generated in`)
+### message (`string`, default value: `Generated on`)
 
 Customize the comment message
 
@@ -26,5 +26,5 @@ generates:
 path/to/file.ts:
  plugins:
    - time:
-       message: "The file generated in: "
+       message: "The file generated on: "
 ```


### PR DESCRIPTION
This PR fixes the following small issues:

- Change default message to "Generated on", which is better English
- when passing config as an object, `format` should not be required.