### PR TITLE
Docs: Correct hook usage in typescript-urql

### DIFF
--- a/website/docs/plugins/typescript-urql.md
+++ b/website/docs/plugins/typescript-urql.md
@@ -38,7 +38,7 @@ We can use the generated code like this:
 Or if you prefer:
 
 ```tsx
-  const withTestData = withTestQuery(...);
+  const [ result ] = useTestQuery(...);
 ```
 
 ## Configuration


### PR DESCRIPTION
Instead of the `HOC`:ish name, a `use`-prefixed function is generated 