### PR TITLE
fix: don't write duplicate fragments to output

### DIFF
--- a/packages/plugins/typescript/operations/src/index.ts
+++ b/packages/plugins/typescript/operations/src/index.ts
@@ -32,7 +32,7 @@ export const plugin: PluginFunction<TypeScriptDocumentsPluginConfig, Types.Compl
     leave: visitor,
   });
 
-  let content = visitorResult.definitions.join('\n');
+  let content = Array.from(new Set(visitorResult.definitions)).join('\n');
 
   if (config.globalNamespace) {
     content = `


### PR DESCRIPTION
I don't think there is much to explain, #3990 explains it pretty well. `typescript-operations` is writing fragments multiple times to the out file.

I've filtered the output string, and not the objects before it because that resulted in other errors.

This small fix, works quite nice.

---

related #3990