### PR TITLE
Deduplicate definitions before code generation

### DIFF
--- a/dev-test/githunt/__generated__/comment.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/comment.query.stencil-component.tsx
@@ -1,5 +1,4 @@
 import gql from 'graphql-tag';
-import { CommentsPageCommentFragmentDoc } from './comments-page-comment.fragment.stencil-component';
 import 'stencil-apollo';
 import { Component, Prop, h } from '@stencil/core';
 
@@ -23,8 +22,24 @@ declare global {
         }
     >;
   };
+
+  export type CommentsPageCommentFragment = { __typename?: 'Comment' } & Pick<
+    Types.Comment,
+    'id' | 'createdAt' | 'content'
+  > & { postedBy: { __typename?: 'User' } & Pick<Types.User, 'login' | 'html_url'> };
 }
 
+export const CommentsPageCommentFragmentDoc = gql`
+  fragment CommentsPageComment on Comment {
+    id
+    postedBy {
+      login
+      html_url
+    }
+    createdAt
+    content
+  }
+`;
 const CommentDocument = gql`
   query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
     currentUser {

--- a/dev-test/githunt/comment.query.graphql
+++ b/dev-test/githunt/comment.query.graphql
@@ -1,3 +1,5 @@
+# import './comments-page-comment.fragment.graphql'
+
 query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
   # Eventually move this into a no fetch query right on the entry
   # since we literally just need this info to determine whether to

--- a/dev-test/githunt/graphql-declared-modules.d.ts
+++ b/dev-test/githunt/graphql-declared-modules.d.ts
@@ -10,13 +10,6 @@ declare module '*/comment.query.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
   export const Comment: DocumentNode;
-
-  export default defaultDocument;
-}
-
-declare module '*/comments-page-comment.fragment.graphql' {
-  import { DocumentNode } from 'graphql';
-  const defaultDocument: DocumentNode;
   export const CommentsPageComment: DocumentNode;
 
   export default defaultDocument;

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -248,10 +248,12 @@ function validateDuplicateDocuments(files: Types.DocumentFile[]) {
     `.trimRight()
         )
         .join('');
+
+      const definitionKindName = kind.replace('Definition', '').toLowerCase();
       throw new DetailedError(
-        `Not all ${kind.toLowerCase()}s have an unique name: ${duplicated.join(', ')}`,
+        `Not all ${definitionKindName}s have an unique name: ${duplicated.join(', ')}`,
         `
-          Not all ${kind.toLowerCase()}s have an unique name
+          Not all ${definitionKindName}s have an unique name
           ${list}
         `
       );

--- a/packages/plugins/typescript/named-operations-object/src/index.ts
+++ b/packages/plugins/typescript/named-operations-object/src/index.ts
@@ -68,7 +68,7 @@ ${Array.from(relevantOperations)
 
   if (objectItems.length === 0) {
     // eslint-disable-next-line no-console
-    console.warn(`Plugin "named-oeprations-object" has an empty output, since there are no valid operations!`);
+    console.warn(`Plugin "named-operations-object" has an empty output, since there are no valid operations!`);
 
     return '';
   }

--- a/packages/plugins/typescript/operations/src/index.ts
+++ b/packages/plugins/typescript/operations/src/index.ts
@@ -32,7 +32,7 @@ export const plugin: PluginFunction<TypeScriptDocumentsPluginConfig, Types.Compl
     leave: visitor,
   });
 
-  let content = Array.from(new Set(visitorResult.definitions)).join('\n');
+  let content = visitorResult.definitions.join('\n');
 
   if (config.globalNamespace) {
     content = `


### PR DESCRIPTION
Instead of deduplicating the generated output, this PR does the same thing before code generation step.
https://github.com/dotansimha/graphql-code-generator/pull/4134