### PR TITLE
Support new schema stitching

### DIFF
--- a/dev-test/test-schema/resolvers-federation.ts
+++ b/dev-test/test-schema/resolvers-federation.ts
@@ -35,11 +35,18 @@ export type ReferenceResolver<TResult, TReference, TContext> = (
   info: GraphQLResolveInfo
 ) => Promise<TResult> | TResult;
 
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
+export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
 
+export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  selectionSet: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;

--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -36,11 +36,18 @@ export type SubscriptionRoot = {
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
+export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
 
+export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  selectionSet: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;

--- a/dev-test/test-schema/resolvers-types.ts
+++ b/dev-test/test-schema/resolvers-types.ts
@@ -38,11 +38,18 @@ export type QueryUserByIdArgs = {
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
+export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
 
+export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  selectionSet: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;

--- a/dev-test/test-schema/typings.ts
+++ b/dev-test/test-schema/typings.ts
@@ -30,11 +30,18 @@ export type User = {
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
+export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
 
+export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  selectionSet: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -53,7 +53,7 @@ export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
   selectionSet: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };`;
-  const stitchingResolverType = `export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver | NewStitchingResolver;`;
+  const stitchingResolverType = `export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;`;
   const resolverType = `export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =`;
   const resolverFnUsage = `ResolverFn<TResult, TParent, TContext, TArgs>`;
   const stitchingResolverUsage = `StitchingResolver<TResult, TParent, TContext, TArgs>`;

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -43,12 +43,17 @@ export const plugin: PluginFunction<TypeScriptResolversPluginConfig, Types.Compl
 
   const prepend: string[] = [];
   const defsToInclude: string[] = [];
-  const stitchingResolverType = `
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
+  const legacyStitchingResolverType = `
+export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
-};
-`;
+};`;
+  const newStitchingResolverType = `
+export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  selectionSet: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};`;
+  const stitchingResolverType = `export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver | NewStitchingResolver;`;
   const resolverType = `export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =`;
   const resolverFnUsage = `ResolverFn<TResult, TParent, TContext, TArgs>`;
   const stitchingResolverUsage = `StitchingResolver<TResult, TParent, TContext, TArgs>`;
@@ -77,7 +82,14 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
     // | ResolverFn
     // | StitchingResolver;
     defsToInclude.push(
-      [stitchingResolverType, resolverType, `  | ${resolverFnUsage}`, `  | ${stitchingResolverUsage};`].join('\n')
+      [
+        legacyStitchingResolverType,
+        newStitchingResolverType,
+        stitchingResolverType,
+        resolverType,
+        `  | ${resolverFnUsage}`,
+        `  | ${stitchingResolverUsage};`,
+      ].join('\n')
     );
   }
 

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -124,12 +124,7 @@ describe('TypeScript Resolvers Plugin', () => {
   it('Should use StitchingResolver by default', async () => {
     const result = await plugin(schema, [], {}, { outputFile: '' });
 
-    expect(result.content).toBeSimilarStringTo(`
-      export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
-        fragment: string;
-        resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
-      };
-    `);
+    expect(result.content).toBeSimilarStringTo(`export type StitchingResolver<TResult, TParent, TContext, TArgs>`);
     expect(result.content).toBeSimilarStringTo(`
       export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
         | ResolverFn<TResult, TParent, TContext, TArgs>


### PR DESCRIPTION
Since GraphQL Tools v6; `fragment` is replaced by `selectionSet` in stitching resolvers.
https://www.graphql-tools.com/docs/schema-stitching#resolvers

So this PR allows to use new schema stitching API.