### PR TITLE
JSDoc: Fixed incorrect enum type generation

### DIFF
--- a/packages/plugins/other/jsdoc/src/index.ts
+++ b/packages/plugins/other/jsdoc/src/index.ts
@@ -167,15 +167,12 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
     },
     EnumTypeDefinition: {
       leave(node) {
-        return createDocBlock([
-          `@typedef {String} ${node.name}`,
-          '@readonly',
-          createDescriptionBlock(node),
-          ...(node.values || []).map(
-            v =>
-              `@property {String} ${v.name}${v.description && v.description.value ? ` - ${v.description.value}` : ''}`
-          ),
-        ]);
+        const values = node?.values?.map(value => `"${value.name}"`).join('|');
+
+        /** If for some reason the enum does not contain any values we fallback to "any" or "*" */
+        const valueType = values ? `(${values})` : '*';
+
+        return createDocBlock([`@typedef {${valueType}} ${node.name}`, createDescriptionBlock(node)]);
       },
     },
   });

--- a/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
+++ b/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
@@ -47,12 +47,8 @@ describe('JSDoc Operations Plugin', () => {
       const result = await plugin(schema, [], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`/**
-      * @typedef {String} Test
-      * @readonly
+      * @typedef {("A"|"B"|"C")} Test
       * @description  enum desc
-      * @property {String} A
-      * @property {String} B
-      * @property {String} C -  enum value desc
       */`);
       expect(result).toBeSimilarStringTo(`/**
       * @typedef {(Foo)} TestU
@@ -187,6 +183,20 @@ describe('JSDoc Operations Plugin', () => {
 
       expect(result).toEqual(expect.stringContaining('@typedef {*} Bar'));
       expect(result).toEqual(expect.stringContaining('@property {Bar} [foo]'));
+    });
+
+    it('should generate a typedef for enums', async () => {
+      const schema = buildSchema(/* Graphql */ `
+        enum FooOrBar{
+            FOO
+            BAR
+        }
+    `);
+
+      const config = {};
+      const result = await plugin(schema, [], config, { outputFile: '' });
+
+      expect(result).toEqual(expect.stringContaining('@typedef {("FOO"|"BAR")} FooOrBar'));
     });
   });
 });

--- a/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
+++ b/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
@@ -196,7 +196,7 @@ describe('JSDoc Operations Plugin', () => {
       const config = {};
       const result = await plugin(schema, [], config, { outputFile: '' });
 
-      expect(result).toEqual(expect.stringContaining('@typedef {("FOO"|"BAR")} FooOrBar'));
+      expect(result).toEqual(expect.stringContaining('* @typedef {("FOO"|"BAR")} FooOrBar'));
     });
   });
 });

--- a/website/docs/plugins/jsdoc.md
+++ b/website/docs/plugins/jsdoc.md
@@ -5,7 +5,7 @@ title: JSDoc
 
 > developed by [`CarloPalinckx`](https://github.com/CarloPalinckx) 
 
-This plugin generated JSDoc comments based in your GraphQLSchema.
+This plugin generates types in the form of JSDoc comments based on your GraphQLSchema.
 
 ## Installation
 


### PR DESCRIPTION
#3223 introduced enums that were typed like readonly objects. Which is sort of true when applying it to the context of a value instead of the context of just types. Which the jsdoc plugin currently only is. For enum "variables" there is an actual `@enum` type. Which will be used once generating implementations is introduced. For now a union of strings is the correct application here.