### PR TITLE
fix `Maybe` only refers to a type, but is being used as a value here

### DIFF
--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -246,10 +246,20 @@ export class TypeGraphQLVisitor<
     const comment = transformComment((node.description as any) as string, 1);
 
     const type = this.parseType(typeString);
+
+    const maybeType = type.type.match(MAYBE_REGEX);
+
+    let arrayReturnType = `[${type.type}]`;
+
+    if (maybeType) {
+      const [, typeNameWithoutMaybe] = maybeType;
+      arrayReturnType = `[${typeNameWithoutMaybe}]`;
+    }
+
     const decorator =
       '\n' +
       indent(
-        `@TypeGraphQL.${fieldDecorator}(type => ${type.isArray ? `[${type.type}]` : type.type}${
+        `@TypeGraphQL.${fieldDecorator}(type => ${type.isArray ? arrayReturnType : type.type}${
           type.isNullable ? ', { nullable: true }' : ''
         })`
       ) +


### PR DESCRIPTION
Fix the issue related to the comment below.

**comment**
Thanks @borremosch @dotansimha!
Though if you have something like this (tested with 1.8.2-alpha-6ee6e064.78 ): 
```ts
type MyType{
  myProperty: [SomeOtherType]
}
```
Will result in:
```ts
@TypeGraphQL.Field(type => \[**Maybe**\<SomeOtherType>], { nullable: true })
myProperty!: Maybe<Array<Maybe\<SomeOtherType>>>;
```
So ts will say: 'Maybe' only refers to a type, but is being used as a value here.

_Originally posted by @groege in https://github.com/dotansimha/graphql-code-generator/pull/2177#issuecomment-544915163_