### PR TITLE
Fix duplicate indentifiers in import statements

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -32,3 +32,5 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
           BRANCH: gh-pages
           FOLDER: website/build
+          CLEAN: true
+          SINGLE_COMMIT: true

--- a/packages/plugins/other/visitor-plugin-common/src/imports.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/imports.ts
@@ -48,7 +48,7 @@ export function generateImportStatement(statement: ImportDeclaration): string {
   const { baseDir, importSource, outputPath } = statement;
   const importPath = resolveImportPath(baseDir, outputPath, importSource.path);
   const importNames =
-    importSource.identifiers && importSource.identifiers.length ? `{ ${importSource.identifiers.join(', ')} }` : '*';
+    importSource.identifiers && importSource.identifiers.length ? `{ ${Array.from(new Set(importSource.identifiers)).join(', ')} }` : '*';
   const importAlias = importSource.namespace ? ` as ${importSource.namespace}` : '';
   return `import ${importNames}${importAlias} from '${importPath}';${importAlias ? '\n' : ''}`;
 }


### PR DESCRIPTION
Related #3990

I had a look into issue #3990 as I was experiencing the same symptoms, the fix proposed in [this comment](https://github.com/dotansimha/graphql-code-generator/issues/3990#issuecomment-636192237) did not work for me as the imports are generated in the `visitor-plugin-common` package.

In my case it seemed like duplicate fragment identifiers were only generated sometimes, for example I would get something like the below in my generated files (unfortunately it's an internal codebase that I'm not able to share - I believe [this comment](https://github.com/dotansimha/graphql-code-generator/issues/3990#issuecomment-639345782) references a codebase that can reproduce the bug):

```ts
import {
  aFieldsFragment, // used multiple times in the queries, single import
  bFieldsFragment, // also used multiple times in the query, import duplicated belowk,,,,
  cFieldsFragment,
  bFieldsFragment,
  cFieldsFragment,
  dFieldsFragment,
} from '../../services/queries.generated'
```

This change deduplicates the list of import identifiers prior to being joined in the import statement. After making the change I get the expected, valid import statement generated.