### PR TITLE
Fix incorrectly renamed config key

### DIFF
--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -18,7 +18,7 @@ export type NearOperationFileConfig = {
    * src/:
    *  preset: near-operation-file
    *  presetConfig:
-   *    schemaTypesPath: types.ts
+   *    baseTypesPath: types.ts
    *  plugins:
    *    - typescript-operations
    * ```

--- a/website/docs/generated-config/near-operation-file.md
+++ b/website/docs/generated-config/near-operation-file.md
@@ -1,5 +1,5 @@
 
-### schemaTypesPath (`string`)
+### baseTypesPath (`string`)
 
 Required, should point to the base schema types file. The key of the output is used a the base path for this file.
 
@@ -11,7 +11,7 @@ generates:
 src/:
  preset: near-operation-file
  presetConfig:
-   schemaTypesPath: types.ts
+   baseTypesPath: types.ts
  plugins:
    - typescript-operations
 ```


### PR DESCRIPTION
Refs #3109. Currently the actual key is `baseTypesPath` so this is just a docs fix.