### PR TITLE
feat: allow use of Observables on subscriptions with generic-sdk

### DIFF
--- a/packages/plugins/typescript/generic-sdk/src/config.ts
+++ b/packages/plugins/typescript/generic-sdk/src/config.ts
@@ -1,0 +1,10 @@
+import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-common';
+
+export interface RawGenericSdkPluginConfig extends RawClientSideBasePluginConfig {
+  /**
+   * usingObservableFrom: "import Observable from 'zen-observable';"
+   * OR
+   * usingObservableFrom: "import { Observable } from 'rxjs';"
+   */
+  usingObservableFrom?: string;
+}

--- a/packages/plugins/typescript/generic-sdk/src/index.ts
+++ b/packages/plugins/typescript/generic-sdk/src/index.ts
@@ -1,13 +1,13 @@
 import { Types, PluginValidateFn, PluginFunction } from '@graphql-codegen/plugin-helpers';
 import { visit, GraphQLSchema, concatAST, Kind, FragmentDefinitionNode } from 'graphql';
 import { RawClientSideBasePluginConfig, LoadedFragment } from '@graphql-codegen/visitor-plugin-common';
-import { GenericSdkVisitor } from './visitor';
+import { GenericSdkVisitor, RawGenericSdkPluginConfig } from './visitor';
 import { extname } from 'path';
 
-export const plugin: PluginFunction<RawClientSideBasePluginConfig> = (
+export const plugin: PluginFunction<RawGenericSdkPluginConfig> = (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
-  config: RawClientSideBasePluginConfig
+  config: RawGenericSdkPluginConfig
 ) => {
   const allAst = concatAST(
     documents.reduce((prev, v) => {

--- a/packages/plugins/typescript/generic-sdk/src/index.ts
+++ b/packages/plugins/typescript/generic-sdk/src/index.ts
@@ -1,8 +1,9 @@
-import { Types, PluginValidateFn, PluginFunction } from '@graphql-codegen/plugin-helpers';
-import { visit, GraphQLSchema, concatAST, Kind, FragmentDefinitionNode } from 'graphql';
-import { RawClientSideBasePluginConfig, LoadedFragment } from '@graphql-codegen/visitor-plugin-common';
-import { GenericSdkVisitor, RawGenericSdkPluginConfig } from './visitor';
+import { PluginFunction, PluginValidateFn, Types } from '@graphql-codegen/plugin-helpers';
+import { LoadedFragment, RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-common';
+import { concatAST, FragmentDefinitionNode, GraphQLSchema, Kind, visit } from 'graphql';
 import { extname } from 'path';
+import { RawGenericSdkPluginConfig } from './config';
+import { GenericSdkVisitor } from './visitor';
 
 export const plugin: PluginFunction<RawGenericSdkPluginConfig> = (
   schema: GraphQLSchema,

--- a/packages/plugins/typescript/generic-sdk/src/visitor.ts
+++ b/packages/plugins/typescript/generic-sdk/src/visitor.ts
@@ -4,14 +4,10 @@ import {
   DocumentMode,
   indentMultiline,
   LoadedFragment,
-  RawClientSideBasePluginConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import autoBind from 'auto-bind';
 import { GraphQLSchema, Kind, OperationDefinitionNode } from 'graphql';
-
-export interface RawGenericSdkPluginConfig extends RawClientSideBasePluginConfig {
-  usingObservableFrom?: string;
-}
+import { RawGenericSdkPluginConfig } from './config';
 
 export interface GenericSdkPluginConfig extends ClientSideBasePluginConfig {
   usingObservableFrom: string;

--- a/packages/plugins/typescript/generic-sdk/src/visitor.ts
+++ b/packages/plugins/typescript/generic-sdk/src/visitor.ts
@@ -76,7 +76,7 @@ export class GenericSdkVisitor extends ClientSideBaseVisitor<RawGenericSdkPlugin
 
     return `export type Requester<C= {}> = <R, V>(doc: ${
       this.config.documentMode === DocumentMode.string ? 'string' : 'DocumentNode'
-    }, vars?: V, options?: C) => ${usingObservable ? 'Promise<R> | Observable<R>' : 'Promise<R>'}
+    }, vars?: V, options?: C) => ${usingObservable ? 'Promise<R> & Observable<R>' : 'Promise<R>'}
 export function getSdk<C>(requester: Requester<C>) {
   return {
 ${allPossibleActions.join(',\n')}

--- a/packages/plugins/typescript/generic-sdk/src/visitor.ts
+++ b/packages/plugins/typescript/generic-sdk/src/visitor.ts
@@ -80,7 +80,7 @@ export class GenericSdkVisitor extends ClientSideBaseVisitor<RawGenericSdkPlugin
 
     return `export type Requester<C= {}> = <R, V>(doc: ${
       this.config.documentMode === DocumentMode.string ? 'string' : 'DocumentNode'
-    }, vars?: V, options?: C) => Promise<R>
+    }, vars?: V, options?: C) => ${usingObservable ? 'Promise<R> | Observable<R>' : 'Promise<R>'}
 export function getSdk<C>(requester: Requester<C>) {
   return {
 ${allPossibleActions.join(',\n')}

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -512,7 +512,7 @@ export const CommentAddedDocument = gql\`
   }
 }
     \`;
-export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | Observable<R>
+export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> & Observable<R>
 export function getSdk<C>(requester: Requester<C>) {
   return {
     feed(variables?: FeedQueryVariables, options?: C): Promise<FeedQuery> {

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -286,7 +286,7 @@ export type Sdk = ReturnType<typeof getSdk>;
 async function test() {
   const requester = <R, V> (doc: DocumentNode, vars: V): Promise<R> => Promise.resolve({} as unknown as R);
   const sdk = getSdk(requester);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -299,6 +299,231 @@ async function test() {
     }
   }
 }"
+`;
+
+exports[`generic-sdk sdk Should generate a correct wrap method when useObservable 1`] = `
+"export type Maybe<T> = T | null;
+export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+import Observable from 'zen-observable';
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  /** A feed of repository submissions */
+  feed?: Maybe<Array<Maybe<Entry>>>;
+  /** A single entry */
+  entry?: Maybe<Entry>;
+  /** Return the currently logged in user, or null if nobody is logged in */
+  currentUser?: Maybe<User>;
+};
+
+
+export type QueryFeedArgs = {
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryEntryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  /** Sort by a combination of freshness and score, using Reddit's algorithm */
+  Hot = 'HOT',
+  /** Newest entries first */
+  New = 'NEW',
+  /** Highest score entries first */
+  Top = 'TOP'
+}
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type Entry = {
+  __typename?: 'Entry';
+  /** Information about the repository from GitHub */
+  repository: Repository;
+  /** The GitHub user who submitted this entry */
+  postedBy: User;
+  /** A timestamp of when the entry was submitted */
+  createdAt: Scalars['Float'];
+  /** The score of this repository, upvotes - downvotes */
+  score: Scalars['Int'];
+  /** The hot score of this repository */
+  hotScore: Scalars['Float'];
+  /** Comments posted about this repository */
+  comments: Array<Maybe<Comment>>;
+  /** The number of comments posted about this repository */
+  commentCount: Scalars['Int'];
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** XXX to be changed */
+  vote: Vote;
+};
+
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type EntryCommentsArgs = {
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+/**
+ * A repository object from the GitHub API. This uses the exact field names returned by the
+ * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
+ */
+export type Repository = {
+  __typename?: 'Repository';
+  /** Just the name of the repository, e.g. GitHunt-API */
+  name: Scalars['String'];
+  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
+  full_name: Scalars['String'];
+  /** The description of the repository */
+  description?: Maybe<Scalars['String']>;
+  /** The link to the repository on GitHub */
+  html_url: Scalars['String'];
+  /** The number of people who have starred this repository on GitHub */
+  stargazers_count: Scalars['Int'];
+  /** The number of open issues on this repository on GitHub */
+  open_issues_count?: Maybe<Scalars['Int']>;
+  /** The owner of this repository on GitHub, e.g. apollostack */
+  owner?: Maybe<User>;
+};
+
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export type User = {
+  __typename?: 'User';
+  /** The name of the user, e.g. apollostack */
+  login: Scalars['String'];
+  /** The URL to a directly embeddable image for this user's avatar */
+  avatar_url: Scalars['String'];
+  /** The URL of this user's GitHub page */
+  html_url: Scalars['String'];
+};
+
+/** A comment about an entry, submitted by a user */
+export type Comment = {
+  __typename?: 'Comment';
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** The GitHub user who posted the comment */
+  postedBy: User;
+  /** A timestamp of when the comment was posted */
+  createdAt: Scalars['Float'];
+  /** The text of the comment */
+  content: Scalars['String'];
+  /** The repository which this comment is about */
+  repoName: Scalars['String'];
+};
+
+/** XXX to be removed */
+export type Vote = {
+  __typename?: 'Vote';
+  vote_value: Scalars['Int'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** Submit a new repository, returns the new submission */
+  submitRepository?: Maybe<Entry>;
+  /** Vote on a repository submission, returns the submission that was voted on */
+  vote?: Maybe<Entry>;
+  /** Comment on a repository, returns the new comment */
+  submitComment?: Maybe<Comment>;
+};
+
+
+export type MutationSubmitRepositoryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+
+export type MutationVoteArgs = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+
+export type MutationSubmitCommentArgs = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  Up = 'UP',
+  Down = 'DOWN',
+  Cancel = 'CANCEL'
+}
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** Subscription fires on every comment added */
+  commentAdded?: Maybe<Comment>;
+};
+
+
+export type SubscriptionCommentAddedArgs = {
+  repoFullName: Scalars['String'];
+};
+export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type FeedQuery = (
+  { __typename?: 'Query' }
+  & { feed?: Maybe<Array<Maybe<(
+    { __typename?: 'Entry' }
+    & Pick<Entry, 'id'>
+  )>>> }
+);
+
+export type CommentAddedSubscriptionVariables = Exact<{ [key: string]: never; }>;
+
+
+export type CommentAddedSubscription = (
+  { __typename?: 'Subscription' }
+  & { commentAdded?: Maybe<(
+    { __typename?: 'Comment' }
+    & Pick<Comment, 'id'>
+  )> }
+);
+
+export const FeedDocument = gql\`
+    query feed {
+  feed {
+    id
+  }
+}
+    \`;
+export const CommentAddedDocument = gql\`
+    subscription commentAdded {
+  commentAdded {
+    id
+  }
+}
+    \`;
+export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+export function getSdk<C>(requester: Requester<C>) {
+  return {
+    feed(variables?: FeedQueryVariables, options?: C): Promise<FeedQuery> {
+      return requester<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options);
+    },
+    commentAdded(variables?: CommentAddedSubscriptionVariables, options?: C): Observable<CommentAddedSubscription> {
+      return requester<CommentAddedSubscription, CommentAddedSubscriptionVariables>(CommentAddedDocument, variables, options);
+    }
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;"
 `;
 
 exports[`generic-sdk sdk Should generate a correct wrap method with documentMode=string 1`] = `
@@ -585,7 +810,7 @@ export type Sdk = ReturnType<typeof getSdk>;
 async function test() {
   const requester = <R, V> (doc: string, vars: V): Promise<R> => Promise.resolve({} as unknown as R);
   const sdk = getSdk(requester);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -301,7 +301,7 @@ async function test() {
 }"
 `;
 
-exports[`generic-sdk sdk Should generate a correct wrap method when useObservable 1`] = `
+exports[`generic-sdk sdk Should generate a correct wrap method when usingObservableFrom is set 1`] = `
 "export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
 import Observable from 'zen-observable';
@@ -512,7 +512,7 @@ export const CommentAddedDocument = gql\`
   }
 }
     \`;
-export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | Observable<R>
 export function getSdk<C>(requester: Requester<C>) {
   return {
     feed(variables?: FeedQueryVariables, options?: C): Promise<FeedQuery> {

--- a/packages/plugins/typescript/generic-sdk/tests/generic-sdk.spec.ts
+++ b/packages/plugins/typescript/generic-sdk/tests/generic-sdk.spec.ts
@@ -1,5 +1,6 @@
-import { DocumentMode, RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-common';
+import { DocumentMode } from '@graphql-codegen/visitor-plugin-common';
 import { validateTs } from '@graphql-codegen/testing';
+import { RawGenericSdkPluginConfig } from 'packages/plugins/typescript/generic-sdk/src/visitor';
 import { plugin } from '../src/index';
 import { parse, buildClientSchema, GraphQLSchema } from 'graphql';
 import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
@@ -39,9 +40,23 @@ const basicDoc = parse(/* GraphQL */ `
   }
 `);
 
+const docWithSubscription = parse(/* GraphQL */ `
+  query feed {
+    feed {
+      id
+    }
+  }
+
+  subscription commentAdded {
+    commentAdded {
+      id
+    }
+  }
+`);
+
 const validate = async (
   content: Types.PluginOutput,
-  config: TypeScriptPluginConfig & TypeScriptDocumentsPluginConfig & RawClientSideBasePluginConfig,
+  config: TypeScriptPluginConfig & TypeScriptDocumentsPluginConfig & RawGenericSdkPluginConfig,
   docs: Types.DocumentFile[],
   pluginSchema: GraphQLSchema,
   usage: string
@@ -71,7 +86,7 @@ describe('generic-sdk', () => {
 async function test() {
   const requester = <R, V> (doc: DocumentNode, vars: V): Promise<R> => Promise.resolve({} as unknown as R);
   const sdk = getSdk(requester);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -100,7 +115,7 @@ async function test() {
 async function test() {
   const requester = <R, V> (doc: string, vars: V): Promise<R> => Promise.resolve({} as unknown as R);
   const sdk = getSdk(requester);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -115,6 +130,15 @@ async function test() {
 }`;
       const output = await validate(result, config, docs, schema, usage);
 
+      expect(output).toMatchSnapshot();
+    });
+
+    it('Should generate a correct wrap method when usingObservableFrom is set', async () => {
+      const config = { usingObservableFrom: "import Observable from 'zen-observable';" };
+      const docs = [{ filePath: '', document: docWithSubscription }];
+      const result = (await plugin(schema, docs, config, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
+
+      const output = await validate(result, config, docs, schema, '');
       expect(output).toMatchSnapshot();
     });
   });

--- a/packages/plugins/typescript/generic-sdk/tests/generic-sdk.spec.ts
+++ b/packages/plugins/typescript/generic-sdk/tests/generic-sdk.spec.ts
@@ -1,6 +1,6 @@
 import { DocumentMode } from '@graphql-codegen/visitor-plugin-common';
 import { validateTs } from '@graphql-codegen/testing';
-import { RawGenericSdkPluginConfig } from 'packages/plugins/typescript/generic-sdk/src/visitor';
+import { RawGenericSdkPluginConfig } from '../src/config';
 import { plugin } from '../src/index';
 import { parse, buildClientSchema, GraphQLSchema } from 'graphql';
 import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';


### PR DESCRIPTION
Allow the use of Observables on subscription operations for Generic SDK

```
config:
  usingObservableFrom: "import Observable from 'zen-observable';"
OR
  usingObservableFrom: "import { Observable } from 'rxjs';"

documents: '../**/document.graphql'
generates:
  ./index.ts:
    schema: '../**/schema.graphql'
    plugins:
      - typescript
      - typescript-operations
      - typescript-generic-sdk
```

Generates a method that returns an Observable instead of a Promise.

```
...
import Observable from 'zen-observable';
OR
import { Observable } from 'rxjs';
...

export function getSdk<C>(requester: Requester<C>) {
  return {
     ...
    onX(variables?: OnXVariables, options?: C): Observable<OnXSubscription> {
      return requester<OnXSubscription, OnXVariables>(OnXDocument, variables, options);
    }
  };
}
```

When this config is enabled, the Requester response will change to this:
```
export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | Observable<R>
```

This is an optional configuration that does not breaks existing setup.