### PR TITLE
feature(typescript-resolvers): make enum resolvers work with external enums and internal values mapping

### DIFF
--- a/packages/plugins/flow/resolvers/src/visitor.ts
+++ b/packages/plugins/flow/resolvers/src/visitor.ts
@@ -148,4 +148,18 @@ export class FlowResolversVisitor extends BaseResolversVisitor<RawResolversConfi
 
     return `EnumResolverSignature<${valuesMap}, ${mappedEnumType}>`;
   }
+
+  protected buildEnumResolversExplicitMappedValues(
+    node: EnumTypeDefinitionNode,
+    valuesMapping: { [valueName: string]: string | number }
+  ): string {
+    return `{| ${(node.values || [])
+      .map(v => {
+        const valueName = (v.name as any) as string;
+        const mappedValue = valuesMapping[valueName];
+
+        return `${valueName}: ${typeof mappedValue === 'number' ? mappedValue : `'${mappedValue}'`}`;
+      })
+      .join(', ')} |}`;
+  }
 }

--- a/packages/plugins/flow/resolvers/src/visitor.ts
+++ b/packages/plugins/flow/resolvers/src/visitor.ts
@@ -5,6 +5,7 @@ import {
   GraphQLSchema,
   ScalarTypeDefinitionNode,
   InputValueDefinitionNode,
+  EnumTypeDefinitionNode,
 } from 'graphql';
 import autoBind from 'auto-bind';
 import {
@@ -17,6 +18,9 @@ import {
 } from '@graphql-codegen/visitor-plugin-common';
 import { FlowOperationVariablesToObject } from '@graphql-codegen/flow';
 import { FLOW_REQUIRE_FIELDS_TYPE } from './flow-util-types';
+
+export const ENUM_RESOLVERS_SIGNATURE =
+  'export type EnumResolverSignature<T, AllowedValues = any> = $ObjMap<T, () => AllowedValues>;';
 
 export interface ParsedFlorResolversConfig extends ParsedResolversConfig {}
 
@@ -133,5 +137,15 @@ export class FlowResolversVisitor extends BaseResolversVisitor<RawResolversConfi
 
   protected getPunctuation(declarationKind: DeclarationKind): string {
     return declarationKind === 'type' ? ',' : ';';
+  }
+
+  protected buildEnumResolverContentBlock(node: EnumTypeDefinitionNode, mappedEnumType: string): string {
+    const valuesMap = `{| ${(node.values || [])
+      .map(v => `${(v.name as any) as string}${this.config.avoidOptionals ? '' : '?'}: *`)
+      .join(', ')} |}`;
+
+    this._globalDeclarations.add(ENUM_RESOLVERS_SIGNATURE);
+
+    return `EnumResolverSignature<${valuesMap}, ${mappedEnumType}>`;
   }
 }

--- a/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
@@ -26,7 +26,7 @@ describe('Flow Resolvers Plugin', () => {
       expect(result.content).not.toContain('EnumResolverSignature');
     });
 
-    it('Should not generate enum internal values resolvers when enum has enumValues set as object with values', async () => {
+    it('Should generate enum internal values resolvers when enum has enumValues set as object with explicit values', async () => {
       const testSchema = buildSchema(/* GraphQL */ `
         type Query {
           v: MyEnum
@@ -50,6 +50,7 @@ describe('Flow Resolvers Plugin', () => {
       const result = await plugin(testSchema, [], config, { outputFile: '' });
       expect(result.prepend).not.toContain(ENUM_RESOLVERS_SIGNATURE);
       expect(result.content).not.toContain('EnumResolverSignature');
+      expect(result.content).toContain(`export type MyEnumResolvers = {| A: 'val_1', B: 'val_2', C: 'val_3' |};`);
     });
 
     it('Should generate enum internal values resolvers when enum has enumValues set as external enum', async () => {

--- a/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
@@ -3,8 +3,132 @@ import { buildSchema } from 'graphql';
 import { plugin } from '../src';
 import { schema } from '../../../typescript/resolvers/tests/common';
 import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
+import { ENUM_RESOLVERS_SIGNATURE } from '../src/visitor';
 
 describe('Flow Resolvers Plugin', () => {
+  describe('Enums', () => {
+    it('Should not generate enum internal values resolvers when enum doesnt have enumValues set', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          v: MyEnum
+        }
+
+        enum MyEnum {
+          A
+          B
+          C
+        }
+      `);
+      const config = {};
+      const result = await plugin(testSchema, [], config, { outputFile: '' });
+
+      expect(result.prepend).not.toContain(ENUM_RESOLVERS_SIGNATURE);
+      expect(result.content).not.toContain('EnumResolverSignature');
+    });
+
+    it('Should not generate enum internal values resolvers when enum has enumValues set as object with values', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          v: MyEnum
+        }
+
+        enum MyEnum {
+          A
+          B
+          C
+        }
+      `);
+      const config = {
+        enumValues: {
+          MyEnum: {
+            A: 'val_1',
+            B: 'val_2',
+            C: 'val_3',
+          },
+        },
+      };
+      const result = await plugin(testSchema, [], config, { outputFile: '' });
+      expect(result.prepend).not.toContain(ENUM_RESOLVERS_SIGNATURE);
+      expect(result.content).not.toContain('EnumResolverSignature');
+    });
+
+    it('Should generate enum internal values resolvers when enum has enumValues set as external enum', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          v: MyEnum
+        }
+
+        enum MyEnum {
+          A
+          B
+          C
+        }
+      `);
+      const config = {
+        enumValues: {
+          MyEnum: 'MyCustomEnum',
+        },
+      };
+      const result = await plugin(testSchema, [], config, { outputFile: '' });
+
+      expect(result.prepend).toContain(ENUM_RESOLVERS_SIGNATURE);
+      expect(result.content).toContain('EnumResolverSignature');
+      expect(result.content).toContain(
+        `export type MyEnumResolvers = EnumResolverSignature<{| A?: *, B?: *, C?: * |}, $ElementType<ResolversTypes, 'MyEnum'>>;`
+      );
+    });
+
+    it('Should generate enum internal values resolvers when enum has mappers pointing to external enum', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          v: MyEnum
+        }
+
+        enum MyEnum {
+          A
+          B
+          C
+        }
+      `);
+      const config = {
+        mappers: {
+          MyEnum: 'MyCustomEnum',
+        },
+      };
+      const result = await plugin(testSchema, [], config, { outputFile: '' });
+
+      expect(result.prepend).toContain(ENUM_RESOLVERS_SIGNATURE);
+      expect(result.content).toContain('EnumResolverSignature');
+      expect(result.content).toContain(
+        `export type MyEnumResolvers = EnumResolverSignature<{| A?: *, B?: *, C?: * |}, $ElementType<ResolversTypes, 'MyEnum'>>;`
+      );
+    });
+
+    it('Should generate enum internal values resolvers when enum has enumValues set on a global level of all enums', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          v: MyEnum
+        }
+
+        enum MyEnum {
+          A
+          B
+          C
+        }
+      `);
+      const config = {
+        enumValues: './enums',
+      };
+      const result = await plugin(testSchema, [], config, { outputFile: '' });
+
+      expect(result.prepend).toContain(ENUM_RESOLVERS_SIGNATURE);
+      expect(result.content).toContain('EnumResolverSignature');
+      expect(result.content).toContain(
+        `export type MyEnumResolvers = EnumResolverSignature<{| A?: *, B?: *, C?: * |}, $ElementType<ResolversTypes, 'MyEnum'>>;`
+      );
+    });
+  });
+
   it('Should generate basic type resolvers', () => {
     const result = plugin(schema, [], {}, { outputFile: '' });
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -36,7 +36,6 @@ import {
   GraphQLObjectType,
   InputValueDefinitionNode,
   EnumTypeDefinitionNode,
-  GraphQLEnumType,
 } from 'graphql';
 
 import { OperationVariablesToObject } from './variables-to-object';

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1082,9 +1082,15 @@ export type IDirectiveResolvers${contextType} = ${name}<ContextType>;`
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {
     const rawTypeName = node.name as any;
 
+    // If we have enumValues set, and it's point to an external enum - we need to allow internal values resolvers
+    // In case we have enumValues set but as explicit values, no need to to do mapping since it's already
+    // have type validation (the original enum has been modified by base types plugin).
+    // If we have mapper for that type - we can skip
+
     if (
-      !this.config.enumValues[rawTypeName] ||
-      (this.config.enumValues[rawTypeName] && this.config.enumValues[rawTypeName].mappedValues)
+      !this.config.mappers[rawTypeName] &&
+      (!this.config.enumValues[rawTypeName] ||
+        (this.config.enumValues[rawTypeName] && this.config.enumValues[rawTypeName].mappedValues))
     ) {
       return null;
     }
@@ -1092,7 +1098,7 @@ export type IDirectiveResolvers${contextType} = ${name}<ContextType>;`
     const name = this.convertName(node, { suffix: 'Resolvers' });
     const typeToUse = `{ ${(node.values || [])
       .map(v => `${(v.name as any) as string}${this.config.avoidOptionals ? '' : '?'}: any`)
-      .join(', ')}}`;
+      .join(', ')} }`;
     this._globalDeclarations.add(ENUM_RESOLVERS_SIGNATURE);
     this._collectedResolvers[rawTypeName] = name;
 

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -1,19 +1,39 @@
 import { ASTNode, FragmentDefinitionNode } from 'graphql';
 import { ParsedMapper } from './mappers';
 
+/**
+ * Scalars map or a string, a map between the GraphQL scalar name and the identifier that should be used
+ */
 export type ScalarsMap = string | { [name: string]: string };
+/**
+ * A normalized map between GraphQL scalar name and the identifier name
+ */
 export type NormalizedScalarsMap = { [name: string]: string };
+/**
+ * Parsed scalars map - a mapping between GraphQL scalar name and the parsed mapper object,
+ * including all required information for generting code for that mapping.
+ */
 export type ParsedScalarsMap = { [name: string]: ParsedMapper };
+/**
+ * A raw configuration for enumValues map - can be represented with a single string value for a file path,
+ * a map between enum name and a file path, or a map between enum name and an object with explicit enum values.
+ */
 export type EnumValuesMap<AdditionalProps = {}> =
   | string
   | { [enumName: string]: string | ({ [key: string]: string | number } & AdditionalProps) };
 export type ParsedEnumValuesMap = {
   [enumName: string]: {
+    // If values are explictly set, this will include the mapped values
     mappedValues?: { [valueName: string]: string | number };
+    // The GraphQL enum name
     typeIdentifier: string;
+    // The actual identifier that you should use in the code (original or aliased)
     sourceIdentifier?: string;
+    // In case of external enum, this will contain the source file path
     sourceFile?: string;
+    // If the identifier is external (imported) - this will contain the imported expression (including alias), otherwise null
     importIdentifier?: string;
+    // Is defualt import is used to import the enum
     isDefault?: boolean;
   };
 };

--- a/packages/plugins/typescript/resolvers/src/visitor.ts
+++ b/packages/plugins/typescript/resolvers/src/visitor.ts
@@ -114,4 +114,18 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<
 
     return `EnumResolverSignature<${valuesMap}, ${mappedEnumType}>`;
   }
+
+  protected buildEnumResolversExplicitMappedValues(
+    node: EnumTypeDefinitionNode,
+    valuesMapping: { [valueName: string]: string | number }
+  ): string {
+    return `{ ${(node.values || [])
+      .map(v => {
+        const valueName = (v.name as any) as string;
+        const mappedValue = valuesMapping[valueName];
+
+        return `${valueName}: ${typeof mappedValue === 'number' ? mappedValue : `'${mappedValue}'`}`;
+      })
+      .join(', ')} }`;
+  }
 }

--- a/packages/plugins/typescript/resolvers/tests/common.ts
+++ b/packages/plugins/typescript/resolvers/tests/common.ts
@@ -37,8 +37,17 @@ export const schema = buildSchema(/* GraphQL */ `
   directive @myDirective(arg: Int!, arg2: String!, arg3: Boolean!) on FIELD
 `);
 
-export const validate = async (content: Types.PluginOutput, config: any = {}, pluginSchema = schema) => {
-  const mergedContent = mergeOutputs([await tsPlugin(pluginSchema, [], config, { outputFile: '' }), content]);
+export const validate = async (
+  content: Types.PluginOutput,
+  config: any = {},
+  pluginSchema = schema,
+  additionalCode = ''
+) => {
+  const mergedContent = mergeOutputs([
+    await tsPlugin(pluginSchema, [], config, { outputFile: '' }),
+    content,
+    additionalCode,
+  ]);
 
   validateTs(mergedContent);
 

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -169,7 +169,7 @@ describe('TypeScript Resolvers Plugin', () => {
       expect(mergedOutput).not.toContain('EnumResolverSignature');
     });
 
-    it('Should not generate enum internal values resolvers when enum has enumValues set as object with values', async () => {
+    it('Should generate enum internal values resolvers when enum has enumValues set as object with explicit values', async () => {
       const testSchema = buildSchema(/* GraphQL */ `
         type Query {
           v: MyEnum
@@ -199,6 +199,11 @@ describe('TypeScript Resolvers Plugin', () => {
         testSchema,
         `
         export const resolvers: Resolvers = {
+          MyEnum: {
+            A: 'val_1',
+            B: 'val_2',
+            C: 'val_3',
+          },
           Query: {
             v: () => 'val_1',
           }
@@ -208,6 +213,7 @@ describe('TypeScript Resolvers Plugin', () => {
 
       expect(mergedOutput).not.toContain(ENUM_RESOLVERS_SIGNATURE);
       expect(mergedOutput).not.toContain('EnumResolverSignature');
+      expect(mergedOutput).toContain(`export type MyEnumResolvers = { A: 'val_1', B: 'val_2', C: 'val_3' };`);
     });
 
     it('Should generate enum internal values resolvers when enum has enumValues set as external enum', async () => {

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -4,6 +4,7 @@ import { plugin } from '../src';
 import { plugin as tsPlugin } from '../../typescript/src/index';
 import { schema, validate } from './common';
 import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
+import { ENUM_RESOLVERS_SIGNATURE } from '@graphql-codegen/visitor-plugin-common';
 
 describe('TypeScript Resolvers Plugin', () => {
   describe('Backward Compatability', () => {
@@ -132,6 +133,134 @@ describe('TypeScript Resolvers Plugin', () => {
     `);
 
     await validate(result);
+  });
+
+  describe('Enums', () => {
+    it('Should not generate enum internal values resolvers when enum doesnt have enumValues set', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          v: MyEnum
+        }
+
+        enum MyEnum {
+          A
+          B
+          C
+        }
+      `);
+      const config = {
+        noSchemaStitching: true,
+      };
+      const result = await plugin(testSchema, [], config, { outputFile: '' });
+      const mergedOutput = await validate(
+        result,
+        config,
+        testSchema,
+        `
+        export const resolvers: Resolvers = {
+          Query: {
+            v: () => 'A',
+          }
+        }; 
+      `
+      );
+
+      expect(mergedOutput).not.toContain(ENUM_RESOLVERS_SIGNATURE);
+      expect(mergedOutput).not.toContain('EnumResolverSignature');
+    });
+
+    it('Should not generate enum internal values resolvers when enum has enumValues set as object with values', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          v: MyEnum
+        }
+
+        enum MyEnum {
+          A
+          B
+          C
+        }
+      `);
+      const config = {
+        noSchemaStitching: true,
+        enumValues: {
+          MyEnum: {
+            A: 'val_1',
+            B: 'val_2',
+            C: 'val_3',
+          },
+        },
+      };
+      const result = await plugin(testSchema, [], config, { outputFile: '' });
+
+      const mergedOutput = await validate(
+        result,
+        config,
+        testSchema,
+        `
+        export const resolvers: Resolvers = {
+          Query: {
+            v: () => 'val_1',
+          }
+        }; 
+      `
+      );
+
+      expect(mergedOutput).not.toContain(ENUM_RESOLVERS_SIGNATURE);
+      expect(mergedOutput).not.toContain('EnumResolverSignature');
+    });
+
+    it('Should generate enum internal values resolvers when enum has enumValues set as external enum', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          v: MyEnum
+        }
+
+        enum MyEnum {
+          A
+          B
+          C
+        }
+      `);
+      const config = {
+        noSchemaStitching: true,
+        includeEnumValuesResolvers: true,
+        enumValues: {
+          MyEnum: 'MyCustomEnum',
+        },
+      };
+      const result = await plugin(testSchema, [], config, { outputFile: '' });
+
+      const mergedOutput = await validate(
+        result,
+        config,
+        testSchema,
+        `
+        enum MyCustomEnum {
+          CUSTOM_A,
+          CUSTOM_B,
+          CUSTOM_C
+        }
+
+        export const resolvers: Resolvers = {
+          MyEnum: {
+            A: MyCustomEnum.CUSTOM_A,
+            B: MyCustomEnum.CUSTOM_B,
+            C: MyCustomEnum.CUSTOM_C,
+          },
+          Query: {
+            v: () => MyCustomEnum.CUSTOM_A,
+          }
+        }; 
+      `
+      );
+
+      expect(mergedOutput).toContain(ENUM_RESOLVERS_SIGNATURE);
+      expect(mergedOutput).toContain('EnumResolverSignature');
+      expect(mergedOutput).toContain(
+        `export type MyEnumResolvers = EnumResolverSignature<{ A?: any, B?: any, C?: any}, ResolversTypes['MyEnum']>;`
+      );
+    });
   });
 
   it('Should warn when noSchemaStitching is set to false (deprecated)', async () => {
@@ -283,7 +412,7 @@ describe('TypeScript Resolvers Plugin', () => {
     })) as Types.ComplexPluginOutput;
     const mergedOutputs = mergeOutputs([result, tsContent]);
 
-    expect(mergedOutputs).toContain(`A: A;`);
+    expect(mergedOutputs).not.toContain(`A: A;`);
     expect(mergedOutputs).not.toContain(`A: GQL_A;`);
     expect(mergedOutputs).toContain(`NotMapped: GQL_NotMapped;`);
     expect(mergedOutputs).not.toContain(`NotMapped: NotMapped;`);
@@ -1629,10 +1758,10 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         C = 'C'
       };`);
       expect(o).toBeSimilarStringTo(`
-      export type IResolversParentTypes = {
-        String: Scalars['String'];
-        Boolean: Scalars['Boolean'];
-        Query: {};
+      export type IResolversTypes = {
+        String: ResolverTypeWrapper<Scalars['String']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+        Query: ResolverTypeWrapper<{}>;
         Test: Test;
       };`);
     });
@@ -1719,7 +1848,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
       })) as Types.ComplexPluginOutput;
       const output = await plugin(testSchema, [], config, { outputFile: 'graphql.ts' });
 
-      expect(output.prepend.length).toBe(2);
+      expect(output.prepend.filter(t => t.includes('import')).length).toBe(2);
       expect(output.prepend.filter(t => t.includes('ProjectRole')).length).toBe(0);
       expect(tsContent.prepend.filter(t => t.includes('ProjectRole')).length).toBe(1);
       expect(tsContent.prepend.includes(`import { ProjectRole } from '../entities';`)).toBeTruthy();

--- a/website/docs/plugins/flow-resolvers.md
+++ b/website/docs/plugins/flow-resolvers.md
@@ -5,3 +5,96 @@ title: Flow Resolvers
 
 {@import ../generated-config/flow-resolvers.md}
 
+
+## Usage Example
+
+:::info Quick Start with `flow-resolvers`
+You can find [a blog post we wrote about using and customizing this plugin here](https://the-guild.dev/blog/better-type-safety-for-resolvers-with-graphql-codegen) , it refers to `typescript-resolvers` but everything there is relevant to `flow-resolvers` as well.
+:::
+
+## Enum Resolvers
+
+[Apollo-Server](https://www.apollographql.com/docs/apollo-server/) and schemas built with [`graphql-tools`](https://www.graphql-tools.com/) supports creating resolvers for GraphQL `enum`s. 
+
+This is helpful because you can have internal values that are different from the public enum values, and you can use the internal values in your resolvers. 
+
+Codegen allows you to specify either `mappers` or `enumValues` to map enums in your resolvers, and if you are using it for enums, you'll get a resolver signature for the enum resolvers as well.
+
+#### Usage Example
+
+With the following schema:
+
+```graphql
+type Query {
+  favoriteColor: Color!
+}
+
+type Color {
+  RED,
+  BLUE
+}
+```
+
+```yaml
+schema: schema.graphql
+generates:
+  ./resolvers-types.js:
+    config:
+      enumValues:
+        Colors: ./enums#ColorsCode
+    plugins:
+      - flow
+      - flow-resolvers
+```
+
+```ts
+// in your enums.js
+export enum ColorsCode {
+  MY_RED = '#FF0000',
+  MY_BLUE = '#0000FF',
+}
+
+// in your resolvers.js
+import type { Resolvers } from './resolvers-types';
+import { ColorsCode } from './enums';
+
+const resolvers: Resolvers = {
+  Colors: {
+    RED: ColorsCode.MY_RED,
+    BLUE: ColorsCode.MY_BLUE,
+  },
+  Query: {
+    favoriteColor: () => ColorsCode.MY_RED, // Now you cn return this, and it will be mapped to your actual GraphQL enum
+  }
+}
+```
+
+You can also define the same with explicit enum values:
+
+```yaml
+schema: schema.graphql
+generates:
+  ./resolvers-types.js:
+    config:
+      enumValues:
+        Colors: 
+          RED: '#FF0000'
+          BLUE: '#0000FF'
+    plugins:
+      - flow
+      - flow-resolvers
+```
+
+Or, with `mappers`:
+
+```yaml
+schema: schema.graphql
+generates:
+  ./resolvers-types.js:
+    config:
+      mappers:
+        Colors: ./enums#ColorsCode
+    plugins:
+      - flow
+      - flow-resolvers
+```

--- a/website/docs/plugins/typescript-resolvers.md
+++ b/website/docs/plugins/typescript-resolvers.md
@@ -54,4 +54,111 @@ generates:
       - typescript-resolvers
 ```
 
-If you wish to have an easy start, and have the ability to use resolvers chaining without models types, you can also add to your config `defaultMapper: Partial<{T}>`. This will allow you to return partial typse in your resolvers.
+If you wish to have an easy start, and have the ability to use resolvers chaining without models types, you can also add to your config `defaultMapper: Partial<{T}>`. This will allow you to return partial types in your resolvers.
+
+## Use Your Model Types (`mappers`)
+
+If you wish to use your custom model types, codegen allow you to use `mappers` feature to map GraphQL types to your custom model types. [You can find an article explaining how to use `mappers` here](https://the-guild.dev/blog/better-type-safety-for-resolvers-with-graphql-codegen).
+
+Here's the basic example of using it:
+
+```yaml
+schema: schema.graphql
+generates:
+  ./resolvers-types.ts:
+    config:
+      contextType: models#MyContextType
+      mappers:
+        User: ./models#UserModel
+        Profile: ./models#UserProfile
+    plugins:
+      - typescript
+      - typescript-resolvers
+```
+
+## Enum Resolvers
+
+[Apollo-Server](https://www.apollographql.com/docs/apollo-server/) and schemas built with [`graphql-tools`](https://www.graphql-tools.com/) supports creating resolvers for GraphQL `enum`s. 
+
+This is helpful because you can have internal values that are different from the public enum values, and you can use the internal values in your resolvers. 
+
+Codegen allows you to specify either `mappers` or `enumValues` to map enums in your resolvers, and if you are using it for enums, you'll get a resolver signature for the enum resolvers as well.
+
+#### Usage Example
+
+With the following schema:
+
+```graphql
+type Query {
+  favoriteColor: Color!
+}
+
+type Color {
+  RED,
+  BLUE
+}
+```
+
+```yaml
+schema: schema.graphql
+generates:
+  ./resolvers-types.ts:
+    config:
+      enumValues:
+        Colors: ./enums#ColorsCode
+    plugins:
+      - typescript
+      - typescript-resolvers
+```
+
+```ts
+// in your enums.ts
+export enum ColorsCode {
+  MY_RED = '#FF0000',
+  MY_BLUE = '#0000FF',
+}
+
+// in your resolvers.ts
+import { Resolvers } from './resolvers-types';
+import { ColorsCode } from './enums';
+
+const resolvers: Resolvers = {
+  Colors: {
+    RED: ColorsCode.MY_RED,
+    BLUE: ColorsCode.MY_BLUE,
+  },
+  Query: {
+    favoriteColor: () => ColorsCode.MY_RED, // Now you cn return this, and it will be mapped to your actual GraphQL enum
+  }
+}
+```
+
+You can also define the same with explicit enum values:
+
+```yaml
+schema: schema.graphql
+generates:
+  ./resolvers-types.ts:
+    config:
+      enumValues:
+        Colors: 
+          RED: '#FF0000'
+          BLUE: '#0000FF'
+    plugins:
+      - typescript
+      - typescript-resolvers
+```
+
+Or, with `mappers`:
+
+```yaml
+schema: schema.graphql
+generates:
+  ./resolvers-types.ts:
+    config:
+      mappers:
+        Colors: ./enums#ColorsCode
+    plugins:
+      - typescript
+      - typescript-resolvers
+```

--- a/website/static/config.schema.json
+++ b/website/static/config.schema.json
@@ -2872,6 +2872,7 @@
       }
     },
     "EnumValuesMap": {
+      "description": "A raw configuration for enumValues map - can be represented with a single string value for a file path,\na map between enum name and a file path, or a map between enum name and an object with explicit enum values.",
       "anyOf": [
         {
           "type": "object",
@@ -2937,6 +2938,7 @@
       "type": "string"
     },
     "ScalarsMap": {
+      "description": "Scalars map or a string, a map between the GraphQL scalar name and the identifier that should be used",
       "anyOf": [
         {
           "type": "object",


### PR DESCRIPTION
Related: https://github.com/dotansimha/graphql-code-generator/issues/3985

TODO:
- [x] Make sure we have tests for all use cases
- [x] Fix `flow-resolvers`
- [x] Make sure we cover all options of `enumValues`
- [x] Make sure it's compatible with `mappers` as well.
- [x] Fix for `enumValues` with explicit mapped fields (to enforce the specific values) 
- [x] Add docs