### PR TITLE
JSDoc - Added support for @deprecated directive

### DIFF
--- a/packages/plugins/other/jsdoc/src/index.ts
+++ b/packages/plugins/other/jsdoc/src/index.ts
@@ -9,7 +9,6 @@ import {
   concatAST,
   InputValueDefinitionNode,
   StringValueNode,
-  DirectiveNode,
 } from 'graphql';
 import { DEFAULT_SCALARS, RawDocumentsConfig } from '@graphql-codegen/visitor-plugin-common';
 

--- a/packages/plugins/other/jsdoc/src/index.ts
+++ b/packages/plugins/other/jsdoc/src/index.ts
@@ -9,6 +9,7 @@ import {
   concatAST,
   InputValueDefinitionNode,
   StringValueNode,
+  DirectiveNode,
 } from 'graphql';
 import { DEFAULT_SCALARS, RawDocumentsConfig } from '@graphql-codegen/visitor-plugin-common';
 
@@ -114,6 +115,21 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
         return node.type;
       },
     },
+    Directive: {
+      enter(node) {
+        if (node.name.value !== 'deprecated') {
+          return null;
+        }
+
+        const reason = node.arguments?.find(arg => arg.name.value === 'reason');
+
+        if (reason?.value.kind !== 'StringValue') {
+          return null;
+        }
+
+        return ` - DEPRECATED: ${reason.value.value}`;
+      },
+    },
     FieldDefinition: {
       enter(node) {
         if (node.type.kind === 'NonNullType') {
@@ -124,10 +140,10 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
       },
       leave(node: FieldDefinitionNode & { nonNullable?: boolean }) {
         const fieldName = node.nonNullable ? node.name : `[${node.name}]`;
+        const description = node.description && node.description.value ? ` - ${node.description.value}` : '';
+        const directives = node?.directives?.filter(d => d !== null && d !== undefined);
 
-        return `@property {${node.type}} ${fieldName}${
-          node.description && node.description.value ? ` - ${node.description.value}` : ''
-        }`;
+        return `@property {${node.type}} ${fieldName}${description}${directives}`;
       },
     },
     InputValueDefinition: {

--- a/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
+++ b/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
@@ -187,7 +187,7 @@ describe('JSDoc Operations Plugin', () => {
 
     it('should generate a typedef for enums', async () => {
       const schema = buildSchema(/* Graphql */ `
-        enum FooOrBar{
+        enum FooOrBar {
             FOO
             BAR
         }
@@ -197,6 +197,21 @@ describe('JSDoc Operations Plugin', () => {
       const result = await plugin(schema, [], config, { outputFile: '' });
 
       expect(result).toEqual(expect.stringContaining('* @typedef {("FOO"|"BAR")} FooOrBar'));
+    });
+
+    it('should generate an annotation for deprecated fields', async () => {
+      const warning = 'the field foo is no longer supported, prefer bar';
+      const schema = buildSchema(/* Graphql */ `
+        type Query {
+            foo: String! @deprecated(reason: "${warning}")
+            bar: String!
+        }
+    `);
+
+      const config = {};
+      const result = await plugin(schema, [], config, { outputFile: '' });
+      console.log(result);
+      expect(result).toEqual(expect.stringContaining(`* @property {string} foo - DEPRECATED: ${warning}`));
     });
   });
 });

--- a/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
+++ b/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
@@ -210,7 +210,7 @@ describe('JSDoc Operations Plugin', () => {
 
       const config = {};
       const result = await plugin(schema, [], config, { outputFile: '' });
-      console.log(result);
+
       expect(result).toEqual(expect.stringContaining(`* @property {string} foo - DEPRECATED: ${warning}`));
     });
   });


### PR DESCRIPTION
This PR adds support for the `@deprecated` directive by appending a textual warning to the `@property` of a `@typedef`. Sadly JSDoc does not allow you to use the actual `@deprecated` annotation on properties but only on symbols. Would have been cool to have added actual IDE warnings and compiler warnings... ah well 🤷‍♂️ 