### PR TITLE
Added a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+packages/plugins/other/jsdoc* @CarloPalinckx


### PR DESCRIPTION
This PR adds a CODEOWNERS file that could help a bit with the maintenance of all the plugins in this repo. If you are open to this idea, I could try and track down some of the contributors of other plugins and see if they would like to have a more active role in maintaining their plugins as well 🙂 . This could potentially also help newer contributors know who to tag for feedback on PR's on a plugin.