### PR TITLE
Info about required C# library + example code

### DIFF
--- a/website/docs/plugins/c-sharp-operations.md
+++ b/website/docs/plugins/c-sharp-operations.md
@@ -2,6 +2,20 @@
 id: c-sharp-operations
 title: C# Operations
 ---
+The `c-sharp-operations` plugin generates C# methods for the resolvers signature.
+
+It works with [GraphQL.Client](https://www.nuget.org/packages/GraphQL.Client/) library and methods can be invoked through the `GraphQLHttpClient`.
+
+Example code:
+
+```C#
+using GraphQL.Client.Http;
+using GraphQL.Client.Serializer.Newtonsoft;
+
+  ...
+  using var client = new GraphQLHttpClient("https://gqlserver", new NewtonsoftJsonSerializer());
+  var response = await client.SendQueryAsync<Types.Query>(UsersGQL.getUsersGQL());
+```
 
 {@import ../plugins/client-note.md}
 


### PR DESCRIPTION
Had some hard time figuring out for which GraphQL library it generates the C# code for. The author [mentioned](https://github.com/dotansimha/graphql-code-generator/pull/3726) GraphQL.Net which seems to be the wrong one. Then tried GraphQL for .NET, also the wrong one. 

Finally figured out that it requires [GraphQL.Client](https://www.nuget.org/packages/GraphQL.Client/). Would really be useful if there is a reference to that library in the docs. Not sure if example codes are allowed, added it anyway, helpful for starters.