### PR TITLE
Remove faux prompt because it gets copied to the clipboard

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -8,21 +8,21 @@ title: Installation
 First we gotta make sure that the basic GraphQL package is within our dependencies, since GraphQL Code Generator is depends on it:
   
 :::shell With `yarn`
-    $ yarn add graphql
+    yarn add graphql
 :::
 
 :::shell With `npm`
-    $ npm install --save graphql  
+    npm install --save graphql  
 :::
 
 The we can install GraphQL Code Generator using `yarn` (or `npm`):
 
 :::shell With `yarn`
-    $ yarn add -D @graphql-codegen/cli
+    yarn add -D @graphql-codegen/cli
 :::
 
 :::shell With `npm`
-    $ npm install --save-dev @graphql-codegen/cli
+    npm install --save-dev @graphql-codegen/cli
 :::
 
 :::caution Global Installation
@@ -34,11 +34,11 @@ Please avoid installing `graphql`, `@graphql-codegen/cli` and it's plugins as gl
 GraphQL Code Generator lets you setup everything by simply running the following command:
 
 :::shell With `yarn`
-    $ yarn graphql-codegen init
+    yarn graphql-codegen init
 :::
 
 :::shell With `npm`
-    $ npx graphql-codegen init
+    npx graphql-codegen init
 :::
 
 Question by question, it will guide you through the whole process of setting up a schema, selecting and installing plugins, picking a destination of a generated file and a lot more.
@@ -50,11 +50,11 @@ If you don't want to use the wizard, we've got you covered, just continue readin
 GraphQL Code Generator's behavior is bound into plugins, thus we will need to install one of them, for example:
 
 :::shell With `yarn`
-    $ yarn add -D @graphql-codegen/typescript
+    yarn add -D @graphql-codegen/typescript
 :::
 
 :::shell With `npm`
-    $ npm install --save-dev @graphql-codegen/typescript
+    npm install --save-dev @graphql-codegen/typescript
 :::
 
 Although can be used directly, it's recommended to add the code generation script in your `package.json`:
@@ -84,10 +84,10 @@ generates:
 By running the following command the GraphQL schema will be fetched from the route endpoint and the typescript definitions would be generated in the specified destination:
 
 :::shell With `yarn`
-    $ yarn generate
+    yarn generate
 :::
 
 :::shell With `npm`
-    $ npm run generate
+    npm run generate
 :::
 


### PR DESCRIPTION
The "copy to clipboard" functionality is great, but it's picking up the `$`'s. I think it's pretty self explanatory that the commands are for the command line without the `$`'s there. This seems easier than trimming the string in the clipboard utility.