### PR TITLE
JSDoc: Removed incorrect results for documents containing operations

### DIFF
--- a/packages/plugins/other/jsdoc/src/index.ts
+++ b/packages/plugins/other/jsdoc/src/index.ts
@@ -175,6 +175,18 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
         return createDocBlock([`@typedef {${valueType}} ${node.name}`, createDescriptionBlock(node)]);
       },
     },
+    OperationDefinition: {
+      enter() {
+        /** This plugin currently does not support operations yet. */
+        return null;
+      },
+    },
+    FragmentDefinition: {
+      enter() {
+        /** This plugin currently does not support fragments yet. */
+        return null;
+      },
+    },
   });
 
   return schemaTypes.join('\n\n');

--- a/packages/plugins/other/jsdoc/tests/jsdoc-document-types.spec.ts
+++ b/packages/plugins/other/jsdoc/tests/jsdoc-document-types.spec.ts
@@ -1,0 +1,60 @@
+import '@graphql-codegen/testing';
+import { buildSchema, parse } from 'graphql';
+import { plugin } from '../src/index';
+
+describe('JSDoc Plugin', () => {
+  describe('Document types', () => {
+    it('should not contain an [object Object] when passing in a document', async () => {
+      const document = parse(/* GraphQL */ `
+        query getUser {
+          users {
+            id
+          }
+        }
+
+        mutation updateUser($user: UserInput!) {
+          id
+        }
+      `);
+
+      const schema = buildSchema(/* Graphql */ `
+                type Query {
+                  users: [User!]!
+                  user(id: ID!): User
+                }
+
+                # Describes the level of access a user has
+                enum Role {
+                  ADMIN
+                  USER
+                }
+
+                # Represents a registered user
+                type User {
+                  # UUID of the user
+                  id: ID!
+                  # The user's name
+                  name: String
+                  # The user's level of access
+                  role: Role!
+                }
+
+                input UserInput {
+                    id: ID!
+                    name: String
+                    role: Role
+                }
+
+                fragment UserFields on User {
+                    name
+                    role
+                }
+            `);
+
+      const config = {};
+      const result = await plugin(schema, [{ location: '', document }], config, { outputFile: '' });
+
+      expect(result).not.toEqual(expect.stringContaining('[object Object]'));
+    });
+  });
+});

--- a/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
+++ b/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
@@ -1,5 +1,5 @@
 import '@graphql-codegen/testing';
-import { buildSchema, parse } from 'graphql';
+import { buildSchema } from 'graphql';
 import { plugin } from '../src/index';
 
 describe('JSDoc Plugin', () => {

--- a/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
+++ b/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
@@ -1,8 +1,8 @@
 import '@graphql-codegen/testing';
-import { buildSchema } from 'graphql';
+import { buildSchema, parse } from 'graphql';
 import { plugin } from '../src/index';
 
-describe('JSDoc Operations Plugin', () => {
+describe('JSDoc Plugin', () => {
   describe('description', () => {
     it('Should work with described schemas', async () => {
       const schema = buildSchema(/* Graphql */ `
@@ -40,7 +40,6 @@ describe('JSDoc Operations Plugin', () => {
         multiline test
         """
         union TestU = Foo
-
     `);
 
       const config = {};


### PR DESCRIPTION
This plugin does not yet support operations as output, however when your documents contain operations it breaks the output by casting an object to string. Resulting in a `[object Object]` in the output. Which could turn out to be trouble when ran with a bundler. This PR removes that behaviour and makes it so that the plugin no-op's when encountering a operation or fragment.