### PR TITLE
C# plugin improvements

### DIFF
--- a/packages/plugins/c-sharp/c-sharp/src/common/common.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/common/common.ts
@@ -1,3 +1,4 @@
 export * from './c-sharp-declaration-block';
 export * from './scalars';
 export * from './utils';
+export * from './field-types';

--- a/packages/plugins/c-sharp/c-sharp/src/common/field-types.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/common/field-types.ts
@@ -1,0 +1,27 @@
+export interface Field {
+  baseType: string;
+  isScalar: boolean;
+  nullableValueType: boolean;
+  listType?: string;
+}
+
+export class FieldType implements Field {
+  baseType: string;
+  isScalar: boolean;
+  nullableValueType: boolean;
+  listType?: string;
+
+  constructor(fieldType: Field) {
+    Object.assign(this, fieldType);
+  }
+
+  get innerTypeName(): string {
+    const nullable = this.nullableValueType ? '?' : '';
+    return `${this.baseType}${nullable}`;
+  }
+
+  get fullTypeName(): string {
+    const innerType = this.innerTypeName;
+    return this.listType ? `${this.listType}<${innerType}>` : innerType;
+  }
+}

--- a/packages/plugins/c-sharp/c-sharp/src/common/scalars.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/common/scalars.ts
@@ -1,8 +1,26 @@
 export const C_SHARP_SCALARS = {
   ID: 'string',
   String: 'string',
-  Boolean: 'Boolean',
+  Boolean: 'bool',
   Int: 'int',
   Float: 'float',
   Date: 'DateTime'
 };
+
+// All native C# built-in value types
+// See https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types
+export const csharpNativeValueTypes = [
+  'bool',
+  'byte',
+  'sbyte',
+  'char',
+  'decimal',
+  'double',
+  'float',
+  'int',
+  'uint',	
+  'long',
+  'ulong',	
+  'short',
+  'ushort'
+]

--- a/packages/plugins/c-sharp/c-sharp/src/common/utils.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/common/utils.ts
@@ -1,4 +1,6 @@
-import { Kind, TypeNode } from 'graphql';
+import { Kind, TypeNode, StringValueNode } from 'graphql';
+import { indent } from '@graphql-codegen/visitor-plugin-common';
+import { csharpNativeValueTypes } from './common';
 
 export function buildPackageNameFromPath(path: string): string {
   const unixify = require('unixify');
@@ -7,7 +9,7 @@ export function buildPackageNameFromPath(path: string): string {
     .replace(/\//g, '.');
 }
 
-export function wrapTypeWithModifiers(baseType: string, typeNode: TypeNode, listType = 'Iterable'): string {
+export function wrapTypeWithModifiers(baseType: string, typeNode: TypeNode, listType = 'IEnumerable'): string {
   if (typeNode.kind === Kind.NON_NULL_TYPE) {
     return wrapTypeWithModifiers(baseType, typeNode.type, listType);
   } else if (typeNode.kind === Kind.LIST_TYPE) {
@@ -17,4 +19,27 @@ export function wrapTypeWithModifiers(baseType: string, typeNode: TypeNode, list
   } else {
     return baseType;
   }
+}
+
+export function transformComment(comment: string | StringValueNode, indentLevel = 0): string {
+  if (!comment) {
+      return '';
+  }
+  if (isStringValueNode(comment)) {
+      comment = comment.value;
+  }
+  comment = comment.trimStart().split('*/').join('*\\/');
+  let lines = comment.split('\n');
+  lines = ['/// <summary>', ...lines.map(line => `/// ${line}`), '/// </summary>'];
+  return lines.map(line => indent(line, indentLevel)).concat('').join('\n');
+}
+
+function isStringValueNode(node: any): node is StringValueNode {
+  return node && typeof node === 'object' && node.kind === Kind.STRING;
+}
+
+export function isValueType(type: string): boolean {
+  // Limitation: only checks the list of known built in value types
+  // Eg .NET types and struct types won't be detected correctly
+  return csharpNativeValueTypes.includes(type);
 }

--- a/packages/plugins/c-sharp/c-sharp/src/common/utils.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/common/utils.ts
@@ -9,29 +9,32 @@ export function buildPackageNameFromPath(path: string): string {
     .replace(/\//g, '.');
 }
 
-export function wrapTypeWithModifiers(baseType: string, typeNode: TypeNode, listType = 'IEnumerable'): string {
-  if (typeNode.kind === Kind.NON_NULL_TYPE) {
-    return wrapTypeWithModifiers(baseType, typeNode.type, listType);
-  } else if (typeNode.kind === Kind.LIST_TYPE) {
-    const innerType = wrapTypeWithModifiers(baseType, typeNode.type, listType);
-
-    return `${listType}<${innerType}>`;
-  } else {
-    return baseType;
+export function getListInnerTypeNode(typeNode: TypeNode): TypeNode {
+  if (typeNode.kind === Kind.LIST_TYPE) {
+    return typeNode.type;
+  } else if (typeNode.kind === Kind.NON_NULL_TYPE && typeNode.type.kind === Kind.LIST_TYPE) {
+    return typeNode.type.type;
   }
+  return typeNode;
 }
 
 export function transformComment(comment: string | StringValueNode, indentLevel = 0): string {
   if (!comment) {
-      return '';
+    return '';
   }
   if (isStringValueNode(comment)) {
-      comment = comment.value;
+    comment = comment.value;
   }
-  comment = comment.trimStart().split('*/').join('*\\/');
+  comment = comment
+    .trimStart()
+    .split('*/')
+    .join('*\\/');
   let lines = comment.split('\n');
   lines = ['/// <summary>', ...lines.map(line => `/// ${line}`), '/// </summary>'];
-  return lines.map(line => indent(line, indentLevel)).concat('').join('\n');
+  return lines
+    .map(line => indent(line, indentLevel))
+    .concat('')
+    .join('\n');
 }
 
 function isStringValueNode(node: any): node is StringValueNode {

--- a/packages/plugins/c-sharp/c-sharp/src/index.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/index.ts
@@ -6,7 +6,6 @@ import { dirname, normalize } from 'path';
 import { CSharpResolversPluginRawConfig } from './config';
 
 export const plugin: PluginFunction<CSharpResolversPluginRawConfig> = async (schema: GraphQLSchema, documents: Types.DocumentFile[], config: CSharpResolversPluginRawConfig, { outputFile }): Promise<string> => {
-  const openNameSpace = 'namespace GraphQLCodeGen {';
   const relevantPath = dirname(normalize(outputFile));
   const defaultPackageName = buildPackageNameFromPath(relevantPath);
   const visitor = new CSharpResolversVisitor(config, schema, defaultPackageName);
@@ -15,7 +14,8 @@ export const plugin: PluginFunction<CSharpResolversPluginRawConfig> = async (sch
   const visitorResult = visit(astNode, { leave: visitor as any });
   const imports = visitor.getImports();
   const blockContent = visitorResult.definitions.filter(d => typeof d === 'string').join('\n');
-  const wrappedContent = visitor.wrapWithClass(blockContent);
+  const wrappedBlockContent = visitor.wrapWithClass(blockContent);
+  const wrappedContent = visitor.wrapWithNamespace(wrappedBlockContent);
 
-  return [imports, openNameSpace, wrappedContent, '}'].join('\n');
+  return [imports, wrappedContent].join('\n');
 };

--- a/packages/plugins/c-sharp/c-sharp/test/c-sharp.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp/test/c-sharp.spec.ts
@@ -1,0 +1,419 @@
+import '@graphql-codegen/testing';
+import { buildSchema } from 'graphql';
+import { plugin } from '../src/index';
+
+describe('C#', () => {
+  describe('Using directives', () => {
+    it('Should include dotnet using directives', async () => {
+      const result = await plugin(
+        buildSchema(`
+        enum ns { dummy }
+      `),
+        [],
+        {},
+        { outputFile: '' }
+      );
+
+      expect(result).toContain('using System;');
+      expect(result).toContain('using System.Collections.Generic;');
+      expect(result).toContain('using Newtonsoft.Json;');
+      expect(result).toContain('using GraphQL;');
+    });
+  });
+
+  describe('Namespaces', () => {
+    it('Should wrap generated code block in namespace', async () => {
+      const result = await plugin(
+        buildSchema(`
+        enum ns { dummy }
+      `),
+        [],
+        {},
+        { outputFile: '' }
+      );
+      expect(result).toContain('namespace GraphQLCodeGen {');
+    });
+  });
+
+  describe('Enums', () => {
+    describe('Basic conversion', () => {
+      const enumSchema = buildSchema(`
+        enum UserRole {
+          ADMIN
+          USER
+        }
+      `);
+
+      it('Should convert enums to C# enums', async () => {
+        const result = await plugin(enumSchema, [], {}, { outputFile: '' });
+        expect(result).toBeSimilarStringTo(`
+          public enum UserRole {
+            ADMIN,
+            USER
+          }
+        `);
+      });
+
+      it('Should allow to override enum values with custom values', async () => {
+        const result = await plugin(
+          enumSchema,
+          [],
+          {
+            enumValues: {
+              UserRole: {
+                ADMIN: 'AdminRoleValue',
+              },
+            },
+          },
+          { outputFile: '' }
+        );
+
+        expect(result).toContain('AdminRoleValue');
+        expect(result).toContain('USER');
+      });
+    });
+
+    describe('Comment and directives', () => {
+      const enumSchema = buildSchema(`
+        """ Allowed user roles """
+        enum UserRole {
+          """ Administrator role """
+          admin
+          """ 
+          User role 
+          Note: normal users
+          """
+          user
+          guest @deprecated (reason: "Guests not welcome")
+        }
+      `);
+
+      it('Should generate summary header for the enum type', async () => {
+        const result = await plugin(enumSchema, [], {}, { outputFile: '' });
+        expect(result).toBeSimilarStringTo(`
+          /// <summary>
+          /// Allowed user roles
+          /// </summary>
+          public enum UserRole
+        `);
+      });
+
+      it('Should generate summary header for enum values', async () => {
+        const result = await plugin(enumSchema, [], {}, { outputFile: '' });
+        expect(result).toBeSimilarStringTo(`
+          /// <summary>
+          /// Administrator role
+          /// </summary>
+          admin
+        `);
+        expect(result).toBeSimilarStringTo(`
+          /// <summary>
+          /// User role 
+          /// Note: normal users
+          /// </summary>
+          user
+        `);
+      });
+
+      it('Should mark deprecated enum values with Obsolete attribute', async () => {
+        const result = await plugin(enumSchema, [], {}, { outputFile: '' });
+        expect(result).toBeSimilarStringTo(`[Obsolete("Guests not welcome")]
+          guest
+        `);
+      });
+    });
+  });
+
+  describe('Input Types', () => {
+    const inputSchema = buildSchema(`
+      input UserInput {
+        id: Int
+        email: String
+      }
+    `);
+
+    it('Should generate C# class for input type', async () => {
+      const result = await plugin(inputSchema, [], {}, { outputFile: '' });
+      expect(result).toContain('public class UserInput {');
+    });
+
+    it('Should generate properties for input type fields', async () => {
+      const result = await plugin(inputSchema, [], {}, { outputFile: '' });
+      expect(result).toBeSimilarStringTo(`
+        public int? id { get; set; }
+        public string email { get; set; }
+      `);
+    });
+
+    it('Should generate C# method for creating input object', async () => {
+      const result = await plugin(inputSchema, [], {}, { outputFile: '' });
+      expect(result).toContain('public dynamic GetInputObject()');
+    });
+
+    it('Should generate summary header for class and properties', async () => {
+      const result = await plugin(
+        buildSchema(`
+        """ User Input values """
+        input UserInput {
+          """ User id """
+          id: Int!
+        }
+      `),
+        [],
+        {},
+        { outputFile: '' }
+      );
+
+      expect(result).toBeSimilarStringTo(`
+        /// <summary>
+        /// User Input values
+        /// </summary>
+        public class UserInput {
+      `);
+      expect(result).toBeSimilarStringTo(`
+        /// <summary>
+        /// User id
+        /// </summary>
+        [JsonRequired]
+        public int id { get; set; }
+      `);
+    });
+  });
+
+  describe('Types', () => {
+    const typeSchema = buildSchema(`
+      type User {
+        id: Int
+        email: String
+      }
+    `);
+
+    it('Should generate C# class for type', async () => {
+      const result = await plugin(typeSchema, [], {}, { outputFile: '' });
+      expect(result).toContain('public class User {');
+    });
+
+    it('Should wrap generated classes in Type class', async () => {
+      const result = await plugin(typeSchema, [], {}, { outputFile: '' });
+      expect(result).toContain('public class Types {');
+    });
+
+    it('Should wrap generated classes in custom Type class name', async () => {
+      const result = await plugin(typeSchema, [], { className: 'MyGqlTypes' }, { outputFile: '' });
+      expect(result).toContain('public class MyGqlTypes {');
+    });
+
+    it('Should generate properties for types', async () => {
+      const result = await plugin(typeSchema, [], {}, { outputFile: '' });
+      expect(result).toBeSimilarStringTo(`
+        [JsonProperty("id")]
+        public int? id { get; set; }
+        [JsonProperty("email")]
+        public string email { get; set; }
+      `);
+    });
+
+    it('Should generate summary header for class and properties', async () => {
+      const result = await plugin(
+        buildSchema(`
+        """ User values """
+        type User {
+          """ User id """
+          id: Int!
+        }
+      `),
+        [],
+        {},
+        { outputFile: '' }
+      );
+
+      expect(result).toBeSimilarStringTo(`
+        /// <summary>
+        /// User values
+        /// </summary>
+        public class User {
+      `);
+      expect(result).toBeSimilarStringTo(`
+        /// <summary>
+        /// User id
+        /// </summary>
+        [JsonProperty("id")]
+        public int id { get; set; }
+      `);
+    });
+
+    it('Should mark deprecated properties with Obsolete attribute', async () => {
+      const result = await plugin(
+        buildSchema(`
+        type User {
+          age: Int @deprecated
+          ref: String @deprecated(reason: "Field is obsolete, use id")
+        }
+      `),
+        [],
+        {},
+        { outputFile: '' }
+      );
+
+      expect(result).toBeSimilarStringTo(`
+        [Obsolete("Field no longer supported")]
+        [JsonProperty("age")]
+        public int? age { get; set; }
+      `);
+      expect(result).toBeSimilarStringTo(`
+        [Obsolete("Field is obsolete, use id")]
+        [JsonProperty("ref")]
+        public string ref { get; set; }      
+      `);
+    });
+  });
+
+  describe('GraphQL Value Types', () => {
+    describe('Scalar', () => {
+      it('Should generate properties for mandatory scalar types', async () => {
+        const result = await plugin(
+          buildSchema(`
+          input BasicTypeInput {
+            intReq: Int!
+            fltReq: Float!
+            idReq: ID!
+            strReq: String!
+            boolReq: Boolean!
+          }
+        `),
+          [],
+          { listType: 'IEnumerable' },
+          { outputFile: '' }
+        );
+
+        expect(result).toBeSimilarStringTo(`
+          [JsonRequired]
+          public int intReq { get; set; }
+          [JsonRequired]
+          public float fltReq { get; set; }
+          [JsonRequired]
+          public string idReq { get; set; }
+          [JsonRequired]
+          public string strReq { get; set; }
+          [JsonRequired]
+          public bool boolReq { get; set; }
+        `);
+      });
+
+      it('Should generate properties for optional scalar types', async () => {
+        const result = await plugin(
+          buildSchema(`
+          input BasicTypeInput {
+            intOpt: Int
+            fltOpt: Float
+            idOpt: ID
+            strOpt: String
+            boolOpt: Boolean
+          }
+        `),
+          [],
+          { listType: 'IEnumerable' },
+          { outputFile: '' }
+        );
+
+        expect(result).toBeSimilarStringTo(`
+          public int? intOpt { get; set; }
+          public float? fltOpt { get; set; }
+          public string idOpt { get; set; }
+          public string strOpt { get; set; }
+          public bool? boolOpt { get; set; }
+        `);
+      });
+    });
+
+    describe('Array', () => {
+      const inputSchema = buildSchema(`
+        input ArrayInput {
+          arr1: [ Int! ]
+          arr2: [ Float ]
+          arr3: [ Int ]!
+          arr4: [ Boolean! ]!
+        }
+      `);
+
+      it('Should use default list type for arrays', async () => {
+        const result = await plugin(inputSchema, [], {}, { outputFile: '' });
+        expect(result).toBeSimilarStringTo('public List<int> arr1 { get; set; }');
+      });
+
+      it('Should use custom list type for arrays when listType is specified', async () => {
+        const result1 = await plugin(inputSchema, [], { listType: 'IEnumerable' }, { outputFile: '' });
+        expect(result1).toContain('public IEnumerable<int> arr1 { get; set; }');
+
+        const result2 = await plugin(inputSchema, [], { listType: 'HashSet' }, { outputFile: '' });
+        expect(result2).toContain('public HashSet<int> arr1 { get; set; }');
+      });
+
+      it('Should use correct array inner types', async () => {
+        const result = await plugin(inputSchema, [], { listType: 'IEnumerable' }, { outputFile: '' });
+
+        expect(result).toBeSimilarStringTo(`
+          public IEnumerable<int> arr1 { get; set; }
+          public IEnumerable<float?> arr2 { get; set; }
+          [JsonRequired]
+          public IEnumerable<int?> arr3 { get; set; }
+          [JsonRequired]
+          public IEnumerable<bool> arr4 { get; set; }
+        `);
+      });
+    });
+  });
+
+  describe('Initial Values', () => {
+    it('Should generate correct initial values for basic types', async () => {
+      const result = await plugin(
+        buildSchema(`
+        enum Length { None, Short, Long }
+        input InitialInput {
+          val: Int = 5
+          flt: Float = 3.1415
+          str: ID = "Dummy string"
+          flag: Boolean = true
+          hair: Length = Short
+        }
+      `),
+        [],
+        { listType: 'HashSet' },
+        { outputFile: '' }
+      );
+
+      expect(result).toBeSimilarStringTo(`
+        public int? val { get; set; } = 5;
+        public float? flt { get; set; } = 3.1415f;
+        public string str { get; set; } = "Dummy string";
+        public bool? flag { get; set; } = true;
+        public Length? hair { get; set; } = Length.Short;
+      `);
+    });
+
+    it('Should generate correct initial values for arrays', async () => {
+      const result = await plugin(
+        buildSchema(`
+        input InitialInput {
+          arr1: [ Int ] = [ null, 2, 3 ]
+          arr2: [ Int! ] = [ 1, 2, 3 ]
+          arr3: [ String ]! = [ "a", null, "c" ]
+          arr4: [ String! ]! = [ "a", "b", "c" ]
+        }
+      `),
+        [],
+        { listType: 'HashSet' },
+        { outputFile: '' }
+      );
+
+      expect(result).toBeSimilarStringTo(`
+        public HashSet<int?> arr1 { get; set; } = new HashSet<int?>(new int?[] { null, 2, 3 });
+        public HashSet<int> arr2 { get; set; } = new HashSet<int>(new int[] { 1, 2, 3 });
+        [JsonRequired]
+        public HashSet<string> arr3 { get; set; } = new HashSet<string>(new string[] { "a", null, "c" });
+        [JsonRequired]
+        public HashSet<string> arr4 { get; set; } = new HashSet<string>(new string[] { "a", "b", "c" });
+      `);
+    });
+  });
+});


### PR DESCRIPTION
Solves #4214. 

Additionally added some more improvements:
- Nullable value types
- Initial value support
- Class and field documentation in summary block
- Deprecated fields have DeprecatedAttribute
- Required input fields have JsonRequiredAttribute
- Generic implementation to compose input object
- Code in namespace indented and wrapped

There's one incompatibility though: the generated C# method `getInputObject` is renamed to `GetInputObject` just to follow the general C# naming convention. If breaking compatibility is a no-go to you, it can be reverted.