### PR TITLE
Fix operation name suffix

### DIFF
--- a/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
@@ -129,11 +129,11 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
   private _operationSuffix(operationType: string): string {
     const defaultSuffix = 'GQL';
     switch (operationType) {
-      case 'Query':
+      case 'query':
         return this.config.querySuffix || defaultSuffix;
-      case 'Mutation':
+      case 'mutation':
         return this.config.mutationSuffix || defaultSuffix;
-      case 'Subscription':
+      case 'subscription':
         return this.config.subscriptionSuffix || defaultSuffix;
       default:
         return defaultSuffix;


### PR DESCRIPTION
Fixes the suffix bug as described in #4221 

Comparison was against Pascal Cased operation type string while operation type is always camel case, regardless of the operation type's "alias". 