### PR TITLE
C sharp operations improvements

### DIFF
--- a/packages/plugins/c-sharp/c-sharp-operations/src/config.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/config.ts
@@ -5,6 +5,17 @@ import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-c
  */
 export interface CSharpOperationsRawPluginConfig extends RawClientSideBasePluginConfig {
   /**
+   * @default GraphQLCodeGen
+   * @description Allow you to customize the namespace name.
+   *
+   * @exampleMarkdown
+   * ```yml
+   * config:
+   *   namespaceName: MyCompany.MyNamespace
+   * ```
+   */
+  namespaceName?: string;
+  /**
    * @description Defined the global value of `namedClient`.
    *
    * @exampleMarkdown
@@ -14,16 +25,6 @@ export interface CSharpOperationsRawPluginConfig extends RawClientSideBasePlugin
    * ```
    */
   namedClient?: string;
-  /**
-   * @description Defined the global value of `serviceName`.
-   *
-   * @exampleMarkdown
-   * ```yml
-   * config:
-   *   serviceName: 'MySDK'
-   * ```
-   */
-  serviceName?: string;
   /**
    * @description Allows to define a custom suffix for query operations.
    * @default GQL

--- a/packages/plugins/c-sharp/c-sharp-operations/src/index.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/index.ts
@@ -11,25 +11,25 @@ export const plugin: PluginFunction<CSharpOperationsRawPluginConfig> = (
   documents: Types.DocumentFile[],
   config
 ) => {
-  const openNameSpace = 'namespace GraphQLCodeGen {';
   const allAst = concatAST(documents.map(v => v.document));
   const allFragments: LoadedFragment[] = [
-    ...(allAst.definitions.filter(
-      d => d.kind === Kind.FRAGMENT_DEFINITION
-    ) as FragmentDefinitionNode[]).map(fragmentDef => ({
-      node: fragmentDef,
-      name: fragmentDef.name.value,
-      onType: fragmentDef.typeCondition.name.value,
-      isExternal: false,
-    })),
+    ...(allAst.definitions.filter(d => d.kind === Kind.FRAGMENT_DEFINITION) as FragmentDefinitionNode[]).map(
+      fragmentDef => ({
+        node: fragmentDef,
+        name: fragmentDef.name.value,
+        onType: fragmentDef.typeCondition.name.value,
+        isExternal: false,
+      })
+    ),
     ...(config.externalFragments || []),
   ];
 
   const visitor = new CSharpOperationsVisitor(schema, allFragments, config, documents);
   const visitorResult = visit(allAst, { leave: visitor });
+  const openNameSpace = `namespace ${visitor.config.namespaceName} {`;
   return {
     prepend: [],
-    content: [openNameSpace, visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string'), '}']
+    content: [openNameSpace, ...visitorResult.definitions.filter(t => typeof t === 'string'), '}']
       .filter(a => a)
       .join('\n'),
   };

--- a/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
@@ -6,11 +6,11 @@ import {
   indentMultiline,
 } from '@graphql-codegen/visitor-plugin-common';
 import autoBind from 'auto-bind';
-import { OperationDefinitionNode, print, visit, GraphQLSchema, Kind } from 'graphql';
+import { OperationDefinitionNode, print, visit, GraphQLSchema } from 'graphql';
 import { CSharpOperationsRawPluginConfig } from './config';
-import { camelCase } from 'camel-case';
 import { Types } from '@graphql-codegen/plugin-helpers';
 
+const defaultSuffix = 'GQL';
 const R_NAME = /name:\s*"([^"]+)"/;
 
 function R_DEF(directive: string) {
@@ -18,8 +18,8 @@ function R_DEF(directive: string) {
 }
 
 export interface CSharpOperationsPluginConfig extends ClientSideBasePluginConfig {
+  namespaceName: string;
   namedClient: string;
-  serviceName: string;
   querySuffix: string;
   mutationSuffix: string;
   subscriptionSuffix: string;
@@ -35,7 +35,6 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
     operationType: string;
     operationResultType: string;
     operationVariablesTypes: string;
-    serviceName: string;
   }[] = [];
 
   constructor(
@@ -49,16 +48,25 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
       fragments,
       rawConfig,
       {
+        namespaceName: rawConfig.namespaceName || 'GraphQLCodeGen',
         namedClient: rawConfig.namedClient,
-        serviceName: rawConfig.serviceName,
-        querySuffix: rawConfig.querySuffix,
-        mutationSuffix: rawConfig.mutationSuffix,
-        subscriptionSuffix: rawConfig.subscriptionSuffix,
+        querySuffix: rawConfig.querySuffix || defaultSuffix,
+        mutationSuffix: rawConfig.mutationSuffix || defaultSuffix,
+        subscriptionSuffix: rawConfig.subscriptionSuffix || defaultSuffix,
       },
       documents
     );
 
+    this.overruleConfigSettings();
     autoBind(this);
+  }
+
+  // Some settings aren't supported with C#, overruled here
+  private overruleConfigSettings() {
+    if (this.config.documentMode === DocumentMode.graphQLTag) {
+      // C# operations does not (yet) support graphQLTag mode
+      this.config.documentMode = DocumentMode.documentNode;
+    }
   }
 
   private _operationHasDirective(operation: string | OperationDefinitionNode, directive: string) {
@@ -109,17 +117,9 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
 
   protected _gql(node: OperationDefinitionNode): string {
     const fragments = this._transformFragments(node);
-    let doc = this._prepareDocument(`
-    ${print(node).split('\\').join('\\\\')}
-    ${this._includeFragments(fragments)}`);
+    const doc = this._prepareDocument([print(node), this._includeFragments(fragments)].join('\n'));
 
-    doc = doc.replace(/"/g, '""');
-
-    if (this.config.documentMode === DocumentMode.string) {
-      return '@"' + doc + '"';
-    }
-
-    return '@"' + doc + '"';
+    return doc.replace(/"/g, '"""');
   }
 
   private _getDocumentNodeVariable(node: OperationDefinitionNode, documentVariableName: string): string {
@@ -127,126 +127,16 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
   }
 
   private _operationSuffix(operationType: string): string {
-    const defaultSuffix = 'GQL';
     switch (operationType) {
       case 'query':
-        return this.config.querySuffix || defaultSuffix;
+        return this.config.querySuffix;
       case 'mutation':
-        return this.config.mutationSuffix || defaultSuffix;
+        return this.config.mutationSuffix;
       case 'subscription':
-        return this.config.subscriptionSuffix || defaultSuffix;
+        return this.config.subscriptionSuffix;
       default:
         return defaultSuffix;
     }
-  }
-
-  protected buildOperation(
-    node: OperationDefinitionNode,
-    documentVariableName: string,
-    operationType: string,
-    operationResultType: string,
-    operationVariablesTypes: string
-  ): string {
-    const serviceName = `${this.convertName(node)}${this._operationSuffix(operationType)}`;
-    this._operationsToInclude.push({
-      node,
-      documentVariableName,
-      operationType,
-      operationResultType,
-      operationVariablesTypes,
-      serviceName,
-    });
-
-    const content = `
-  public class ${serviceName}{
-
-    public static GraphQLRequest get${serviceName}() {
-      return new GraphQLRequest {
-        Query = ${this._getDocumentNodeVariable(node, documentVariableName)},
-        OperationName = "${this.convertName(node)}"
-      };
-    }
-    ${this._namedClient(node)}
-  }
-  `;
-
-    return content;
-  }
-
-  public get sdkClass(): string {
-    const actionType = operation => {
-      switch (operation) {
-        case 'Mutation':
-          return 'mutate';
-        case 'Subscription':
-          return 'subscribe';
-        default:
-          return 'fetch';
-      }
-    };
-
-    const allPossibleActions = this._operationsToInclude
-      .map(o => {
-        const optionalVariables =
-          !o.node.variableDefinitions ||
-          o.node.variableDefinitions.length === 0 ||
-          o.node.variableDefinitions.every(v => v.type.kind !== Kind.NON_NULL_TYPE || !!v.defaultValue);
-
-        const options =
-          o.operationType === 'Mutation'
-            ? `${o.operationType}OptionsAlone<${o.operationResultType}, ${o.operationVariablesTypes}>`
-            : `${o.operationType}OptionsAlone<${o.operationVariablesTypes}>`;
-
-        const method = `
-${camelCase(o.node.name.value)}(variables${optionalVariables ? '?' : ''}: ${
-          o.operationVariablesTypes
-        }, options?: ${options}) {
-  return this.${camelCase(o.serviceName)}.${actionType(o.operationType)}(variables, options)
-}`;
-
-        let watchMethod;
-
-        if (o.operationType === 'Query') {
-          watchMethod = `
-
-${camelCase(o.node.name.value)}Watch(variables${optionalVariables ? '?' : ''}: ${
-            o.operationVariablesTypes
-          }, options?: WatchQueryOptionsAlone<${o.operationVariablesTypes}>) {
-  return this.${camelCase(o.serviceName)}.watch(variables, options)
-}`;
-        }
-        return [method, watchMethod].join('');
-      })
-      .map(s => indentMultiline(s, 2));
-
-    const injectString = (service: string) => `private ${camelCase(service)}: ${service}`;
-    const injections = this._operationsToInclude
-      .map(op => injectString(op.serviceName))
-      .map(s => indentMultiline(s, 3))
-      .join(',\n');
-
-    const serviceName = this.config.serviceName || 'GraphQLSDK';
-
-    return `
-  type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
-  interface WatchQueryOptionsAlone<V>
-    extends Omit<ApolloCore.WatchQueryOptions<V>, 'query' | 'variables'> {}
-
-  interface QueryOptionsAlone<V>
-    extends Omit<ApolloCore.QueryOptions<V>, 'query' | 'variables'> {}
-
-  interface MutationOptionsAlone<T, V>
-    extends Omit<ApolloCore.MutationOptions<T, V>, 'mutation' | 'variables'> {}
-
-  interface SubscriptionOptionsAlone<V>
-    extends Omit<ApolloCore.SubscriptionOptions<V>, 'query' | 'variables'> {}
-  public class ${serviceName} {
-    constructor(
-${injections}
-    ) {}
-  ${allPossibleActions.join('\n')}
-  }`;
   }
 
   public OperationDefinition(node: OperationDefinitionNode): string {
@@ -264,10 +154,10 @@ ${injections}
 
     let documentString = '';
     if (this.config.documentMode !== DocumentMode.external) {
-      const isDocumentNode = this.config.documentMode === DocumentMode.documentNode;
-      documentString = `${this.config.noExport ? '' : 'public'} static string ${documentVariableName}${
-        isDocumentNode ? ': DocumentNode' : ''
-      } = ${this._gql(node)};`;
+      const gqlBlock = indentMultiline(this._gql(node), 4);
+      documentString = `${
+        this.config.noExport ? '' : 'public'
+      } static string ${documentVariableName} = @"\n${gqlBlock}";`;
     }
 
     const operationType: string = node.operation;
@@ -292,16 +182,15 @@ ${injections}
       operationType,
       operationResultType,
       operationVariablesTypes,
-      serviceName,
     });
 
     const content = `
-    public class ${serviceName}{
+    public class ${serviceName} {
 
       public static GraphQLRequest get${serviceName}() {
         return new GraphQLRequest {
           Query = ${this._getDocumentNodeVariable(node, documentVariableName)},
-          OperationName = "${this.convertName(node)}"
+          OperationName = "${node.name.value}"
         };
       }
       ${this._namedClient(node)}

--- a/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
@@ -1,0 +1,429 @@
+import '@graphql-codegen/testing';
+import { buildSchema, parse } from 'graphql';
+import { plugin } from '../src/index';
+import { CSharpOperationsRawPluginConfig } from '../src/config';
+import { Types } from '@graphql-codegen/plugin-helpers';
+
+describe('C# Operations', () => {
+  describe('Namespaces', () => {
+    it('Should wrap generated code block in namespace using default name', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          me: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query findMe {
+          me
+        }
+      `);
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toContain('namespace GraphQLCodeGen {');
+    });
+
+    it('Should wrap generated code block in namespace using custom name', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          me: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query findMe {
+          me
+        }
+      `);
+      const config: CSharpOperationsRawPluginConfig = {
+        namespaceName: 'MyCompany.MyGeneratedGql',
+      };
+      const result = (await plugin(schema, [{ location: '', document: operation }], config, {
+        outputFile: '',
+      })) as Types.ComplexPluginOutput;
+      expect(result.content).toContain('namespace MyCompany.MyGeneratedGql {');
+    });
+  });
+
+  describe('Query', () => {
+    it('Should wrap each query operation in a class', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          me: Int!
+          you: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query findMe {
+          me
+        }
+        query findYou {
+          you
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toContain('public class FindMeGQL {');
+      expect(result.content).toContain('public class FindYouGQL {');
+    });
+
+    it('Should generate a document string containing original query operation', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          me: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query findMe {
+          me
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public static string FindMeDocument = @"
+          query findMe {
+            me
+          }
+        ";
+      `);
+    });
+
+    it('Should generate request method for each query operation', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          me: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query findMe {
+          me
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public static GraphQLRequest getFindMeGQL() {
+          return new GraphQLRequest {
+            Query = FindMeDocument,
+            OperationName = "findMe"
+          };
+        }
+      `);
+    });
+  });
+
+  describe('Mutation', () => {
+    it('Should wrap each mutation operation in a class', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Mutation {
+          me: Int!
+          you: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        mutation updateMe {
+          me
+        }
+        mutation updateYou {
+          you
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toContain('public class UpdateMeGQL {');
+      expect(result.content).toContain('public class UpdateYouGQL {');
+    });
+
+    it('Should generate a document string containing original mutation operation', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Mutation {
+          me: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        mutation updateMe {
+          me
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public static string UpdateMeDocument = @"
+          mutation updateMe {
+            me
+          }
+        ";
+      `);
+    });
+
+    it('Should generate request method for each mutation operation', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Mutation {
+          me: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        mutation updateMe {
+          me
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public static GraphQLRequest getUpdateMeGQL() {
+          return new GraphQLRequest {
+            Query = UpdateMeDocument,
+            OperationName = "updateMe"
+          };
+        }
+      `);
+    });
+  });
+
+  describe('Subscription', () => {
+    it('Should wrap each subscription operation in a class', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Subscription {
+          you: Int!
+          them: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        subscription onNotifyYou {
+          you
+        }
+        subscription onNotifyThem {
+          them
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toContain('public class OnNotifyYouGQL {');
+      expect(result.content).toContain('public class OnNotifyThemGQL {');
+    });
+
+    it('Should generate a document string containing original subscription operation', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Subscription {
+          them: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        subscription onNotifyThem {
+          them
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public static string OnNotifyThemDocument = @"
+          subscription onNotifyThem {
+            them
+          }
+        ";
+      `);
+    });
+
+    it('Should generate request method for each subscription operation', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Subscription {
+          them: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        subscription onNotifyThem {
+          them
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public static GraphQLRequest getOnNotifyThemGQL() {
+          return new GraphQLRequest {
+            Query = OnNotifyThemDocument,
+            OperationName = "onNotifyThem"
+          };
+        }
+      `);
+    });
+  });
+
+  describe('Fragments', () => {
+    it('Should generate request method for each subscription operation', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type User {
+          id: ID!
+          username: String!
+          email: String!
+        }
+        type Query {
+          user: User!
+          allWorking: [User!]
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query user {
+          user {
+            ...UserFields
+          }
+          allWorking {
+            ...UserFields
+          }
+        }
+
+        fragment UserFields on User {
+          id
+          username
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toContain('Query = UserDocument');
+      expect(result.content).toBeSimilarStringTo(`
+        public static string UserDocument = @"
+          query user {
+            user {
+              ...UserFields
+            }
+            allWorking {
+              ...UserFields
+            }
+          }
+
+          fragment UserFields on User {
+            id
+            username
+          }"
+      `);
+    });
+  });
+
+  describe('Issues', () => {
+    it('#4221 - suffix query mutation subscription', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          me: Int!
+        }
+        type Mutation {
+          you: Int!
+          them: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query findMe {
+          me
+        }
+        mutation updateYou {
+          you
+        }
+        subscription onNotifyThem {
+          them
+        }
+      `);
+
+      const config: CSharpOperationsRawPluginConfig = {
+        querySuffix: 'Query',
+        mutationSuffix: 'Mutation',
+        subscriptionSuffix: 'Subscription',
+      };
+      const result = (await plugin(schema, [{ location: '', document: operation }], config, {
+        outputFile: '',
+      })) as Types.ComplexPluginOutput;
+
+      expect(result.content).toContain('public class FindMeQuery {');
+      expect(result.content).toContain('public class UpdateYouMutation {');
+      expect(result.content).toContain('public class OnNotifyThemSubscription {');
+
+      expect(result.content).toContain('public static GraphQLRequest getFindMeQuery() {');
+      expect(result.content).toContain('public static GraphQLRequest getUpdateYouMutation() {');
+      expect(result.content).toContain('public static GraphQLRequest getOnNotifyThemSubscription() {');
+    });
+
+    it('#4260 - operation name casing', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          me: Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query findMe1 {
+          me
+        }
+        query FindMe2 {
+          me
+        }
+        query findme3 {
+          me
+        }
+        query FINDME4 {
+          me
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect(result.content).toContain('OperationName = "findMe1"');
+      expect(result.content).toContain('OperationName = "FindMe2"');
+      expect(result.content).toContain('OperationName = "findme3"');
+      expect(result.content).toContain('OperationName = "FINDME4"');
+    });
+  });
+});

--- a/packages/plugins/c-sharp/c-sharp/src/config.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/config.ts
@@ -17,6 +17,21 @@ export interface CSharpResolversPluginRawConfig extends RawConfig {
    */
   enumValues?: EnumValuesMap;
   /**
+   * @default GraphQLCodeGen
+   * @description Allow you to customize the namespace name.
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   src/main/c-sharp/my-org/my-app/MyTypes.cs:
+   *     plugins:
+   *       - c-sharp
+   *     config:
+   *       namespaceName: MyCompany.MyNamespace
+   * ```
+   */
+  namespaceName?: string;
+  /**
    * @default Types
    * @description Allow you to customize the parent class name.
    *

--- a/packages/plugins/c-sharp/c-sharp/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/visitor.ts
@@ -38,19 +38,20 @@ import {
 } from './common/common';
 
 export interface CSharpResolverParsedConfig extends ParsedConfig {
+  namespaceName: string;
   className: string;
   listType: string;
   enumValues: EnumValuesMap;
 }
 
 export class CSharpResolversVisitor extends BaseVisitor<CSharpResolversPluginRawConfig, CSharpResolverParsedConfig> {
-  private readonly namespaceName = 'GraphQLCodeGen';
   private readonly keywords = new Set(csharpKeywords);
 
   constructor(rawConfig: CSharpResolversPluginRawConfig, private _schema: GraphQLSchema, defaultPackageName: string) {
     super(rawConfig, {
       enumValues: rawConfig.enumValues || {},
       listType: rawConfig.listType || 'List',
+      namespaceName: rawConfig.namespaceName || 'GraphQLCodeGen',
       className: rawConfig.className || 'Types',
       scalars: buildScalars(_schema, rawConfig.scalars, C_SHARP_SCALARS),
     });
@@ -79,7 +80,7 @@ export class CSharpResolversVisitor extends BaseVisitor<CSharpResolversPluginRaw
   public wrapWithNamespace(content: string): string {
     return new CSharpDeclarationBlock()
       .asKind('namespace')
-      .withName(this.namespaceName)
+      .withName(this.config.namespaceName)
       .withBlock(indentMultiline(content)).string;
   }
 

--- a/packages/plugins/c-sharp/c-sharp/test/c-sharp.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp/test/c-sharp.spec.ts
@@ -21,15 +21,24 @@ describe('C#', () => {
   });
 
   describe('Namespaces', () => {
-    it('Should wrap generated code block in namespace', async () => {
+    it('Should wrap generated code block in namespace using default name', async () => {
       const schema = buildSchema(/* GraphQL */ `
         enum ns {
           dummy
         }
       `);
       const result = await plugin(schema, [], {}, { outputFile: '' });
-
       expect(result).toContain('namespace GraphQLCodeGen {');
+    });
+
+    it('Should wrap generated code block in namespace using custom name', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        enum ns {
+          dummy
+        }
+      `);
+      const result = await plugin(schema, [], { namespaceName: 'MyCompany.MyGeneratedGql' }, { outputFile: '' });
+      expect(result).toContain('namespace MyCompany.MyGeneratedGql {');
     });
   });
 


### PR DESCRIPTION
Improvements in the C# operations part including:

- Bug solving: operation different casing (#4260)
- Support for custom namespace
- DocumentMode.graphQLTag unsupported, fall back to documentNode
- Removed unused serviceName config item

Also added unit tests for C# operations.

Note: this is based on branch "c-sharp-reserved-keywords" so when that branch is merged to master (#4250) I may need to rebase this one. Let me know if you want me to do this. 