### PR TITLE
dont generate fragments because they already come from typescript-rea…

### DIFF
--- a/packages/plugins/typescript/react-apollo-offix/src/index.ts
+++ b/packages/plugins/typescript/react-apollo-offix/src/index.ts
@@ -28,7 +28,7 @@ export const plugin: PluginFunction<RawClientSideBasePluginConfig> = (
 
   return {
     prepend: visitor.getImports(),
-    content: [visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n'),
+    content: [...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n'),
   };
 };
 


### PR DESCRIPTION
Fix issue with fragments.
If there are some, typescript-react-apollo and typescript-react-offix will generate them and create uncompilable code