### PR TITLE
Fix bug with flow-operations codegeneration and flattenGeneratedTypes config

### DIFF
--- a/dev-test/githunt/flow.flow.js
+++ b/dev-test/githunt/flow.flow.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+// @flow
+
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {|
   ID: string,
@@ -167,7 +169,6 @@ export type SubscriptionCommentAddedArgs = {|
   repoFullName: $ElementType<Scalars, 'String'>,
 |};
 
-// @flow
 type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
 export type OnCommentAddedSubscriptionVariables = {

--- a/dev-test/githunt/flow.flow.js
+++ b/dev-test/githunt/flow.flow.js
@@ -167,6 +167,7 @@ export type SubscriptionCommentAddedArgs = {|
   repoFullName: $ElementType<Scalars, 'String'>,
 |};
 
+// @flow
 type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
 export type OnCommentAddedSubscriptionVariables = {

--- a/packages/plugins/flow/operations/src/index.ts
+++ b/packages/plugins/flow/operations/src/index.ts
@@ -40,5 +40,8 @@ export const plugin: PluginFunction<FlowDocumentsPluginConfig> = (
     leave: new FlowDocumentsVisitor(schema, config, allFragments),
   });
 
-  return ['// @flow', prefix, ...visitorResult.definitions].join('\n');
+  return {
+    prepend: ['// @flow \n'],
+    content: [prefix, ...visitorResult.definitions].join('\n'),
+  };
 };

--- a/packages/plugins/flow/operations/tests/__snapshots__/flow-documents.spec.ts.snap
+++ b/packages/plugins/flow/operations/tests/__snapshots__/flow-documents.spec.ts.snap
@@ -1,3 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Flow Operations Plugin Output options Should respect flow option useFlowReadOnlyTypes 1`] = `undefined`;
+exports[`Flow Operations Plugin Output options Should respect flow option useFlowReadOnlyTypes 1`] = `
+"type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
+
+export type CurrentUserQueryVariables = {};
+
+
+export type CurrentUserQuery = {| +me?: ?({
+      ...$Pick<User, {| +id: *, +username: *, +role?: * |}>,
+    ...{| +profile?: ?$Pick<Profile, {| +age?: * |}> |}
+  }) |};
+"
+`;

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -204,21 +204,29 @@ describe('Flow Operations Plugin', () => {
         await plugin(schema, [{ location: '', document: ast }], { namespacedImportName: 'Types' }, { outputFile: '' }),
       ]);
 
-      expect(result).toBeSimilarStringTo(`
-      export type NotificationsQuery = ({
-        ...{ __typename?: 'Query' },
-      ...{| notifications: Array<({
-          ...{ __typename?: 'TextNotification' },
-        ...$Pick<Types.TextNotification, {| text: *, id: * |}>
-      }) | ({
-          ...{ __typename?: 'ImageNotification' },
-        ...$Pick<Types.ImageNotification, {| imageUrl: *, id: * |}>,
-        ...{| metadata: ({
-            ...{ __typename?: 'ImageMetadata' },
-          ...$Pick<Types.ImageMetadata, {| createdBy: * |}>
-        }) |}
-      })> |}
-    });
+      expect(result).toMatchInlineSnapshot(`
+        "// @flow 
+
+        type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
+
+        export type NotificationsQueryVariables = {};
+
+
+        export type NotificationsQuery = ({
+            ...{ __typename?: 'Query' },
+          ...{| notifications: Array<({
+              ...{ __typename?: 'TextNotification' },
+            ...$Pick<Types.TextNotification, {| text: *, id: * |}>
+          }) | ({
+              ...{ __typename?: 'ImageNotification' },
+            ...$Pick<Types.ImageNotification, {| imageUrl: *, id: * |}>,
+            ...{| metadata: ({
+                ...{ __typename?: 'ImageMetadata' },
+              ...$Pick<Types.ImageMetadata, {| createdBy: * |}>
+            }) |}
+          })> |}
+        });
+        "
       `);
       validateFlow(result);
     });

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -624,6 +624,11 @@ describe('Flow Operations Plugin', () => {
 
         type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
+        export type UserFieldsFragment = ({
+            ...$Pick<User, {| id: *, username: *, role?: * |}>,
+          ...{| profile?: ?$Pick<Profile, {| age?: * |}> |}
+        });
+
         export type MeQueryVariables = {};
 
 
@@ -631,11 +636,6 @@ describe('Flow Operations Plugin', () => {
               ...$Pick<User, {| id: *, username: *, role?: * |}>,
             ...{| profile?: ?$Pick<Profile, {| age?: * |}> |}
           }) |};
-
-        export type UserFieldsFragment = ({
-            ...$Pick<User, {| id: *, username: *, role?: * |}>,
-          ...{| profile?: ?$Pick<Profile, {| age?: * |}> |}
-        });
         "
       `);
       validateFlow(result);
@@ -676,12 +676,12 @@ describe('Flow Operations Plugin', () => {
         "// @flow 
 
 
+        export type UserFieldsFragment = { id: string, username: string, role?: ?Role, profile?: ?{ age?: ?number } };
+
         export type MeQueryVariables = {};
 
 
         export type MeQuery = { me?: ?{ id: string, username: string, role?: ?Role, profile?: ?{ age?: ?number } } };
-
-        export type UserFieldsFragment = { id: string, username: string, role?: ?Role, profile?: ?{ age?: ?number } };
         "
       `);
       validateFlow(result);

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -1,4 +1,4 @@
-import { Types } from '@graphql-codegen/plugin-helpers';
+import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 import '@graphql-codegen/testing';
 import { parse, buildClientSchema, buildSchema } from 'graphql';
 import { plugin } from '../src/index';
@@ -93,17 +93,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { namingConvention: 'lower-case#lowerCase' },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { namingConvention: 'lower-case#lowerCase' },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type notificationsquery = ({
@@ -143,17 +145,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { typesPrefix: 'i', namingConvention: 'lower-case#lowerCase' },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { typesPrefix: 'i', namingConvention: 'lower-case#lowerCase' },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`export type inotificationsqueryvariables = {};`);
       expect(result).toBeSimilarStringTo(`
@@ -196,12 +200,9 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [{ location: '', document: ast }],
-        { namespacedImportName: 'Types' },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(schema, [{ location: '', document: ast }], { namespacedImportName: 'Types' }, { outputFile: '' }),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type NotificationsQuery = ({
@@ -230,17 +231,19 @@ describe('Flow Operations Plugin', () => {
           dummy
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
       expect(result).not.toContain(`__typename`);
       validateFlow(result);
     });
@@ -252,17 +255,19 @@ describe('Flow Operations Plugin', () => {
           dummy
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        {},
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          {},
+          { outputFile: '' }
+        ),
+      ]);
       expect(result).toBeSimilarStringTo(`
       export type Unnamed_1_Query = ({
         ...{ __typename: 'Query' },
@@ -278,17 +283,19 @@ describe('Flow Operations Plugin', () => {
           dummy
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        {},
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          {},
+          { outputFile: '' }
+        ),
+      ]);
       expect(result).toBeSimilarStringTo(`
       export type Unnamed_1_Query = ({
         ...{ __typename?: 'Query' },
@@ -305,17 +312,19 @@ describe('Flow Operations Plugin', () => {
           dummy
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
       expect(result).toBeSimilarStringTo(`
       export type Unnamed_1_Query = ({
         ...{ __typename: 'Query' },
@@ -339,17 +348,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        {},
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          {},
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type UnionTestQuery = ({
@@ -380,17 +391,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { nonOptionalTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { nonOptionalTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type UnionTestQuery = ({
@@ -426,17 +439,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        {},
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          {},
+          { outputFile: '' }
+        ),
+      ]);
       expect(result).toBeSimilarStringTo(`
       export type NotificationsQuery = ({
         ...{ __typename?: 'Query' },
@@ -464,17 +479,19 @@ describe('Flow Operations Plugin', () => {
           dummy
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = $Pick<Query, {| dummy?: * |}>;`);
       expect(result).toBeSimilarStringTo(`export type Unnamed_1_QueryVariables = {};`);
@@ -491,17 +508,19 @@ describe('Flow Operations Plugin', () => {
           dummy
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
       expect(result).toBeSimilarStringTo(`export type Unnamed_1_Query = $Pick<Query, {| dummy?: * |}>;`);
       expect(result).toBeSimilarStringTo(`export type Unnamed_1_QueryVariables = {};`);
       expect(result).toBeSimilarStringTo(`export type Unnamed_2_Query = $Pick<Query, {| dummy?: * |}>;`);
@@ -528,20 +547,23 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toMatchInlineSnapshot(`
-        "// @flow
+        "// @flow 
+
         type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
         export type UserFieldsFragment = ({
@@ -575,20 +597,23 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true, flattenGeneratedTypes: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true, flattenGeneratedTypes: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toMatchInlineSnapshot(`
-        "// @flow
+        "// @flow 
+
         type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
         export type MeQueryVariables = {};
@@ -625,20 +650,23 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true, flattenGeneratedTypes: true, preResolveTypes: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true, flattenGeneratedTypes: true, preResolveTypes: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toMatchInlineSnapshot(`
-        "// @flow
+        "// @flow 
+
 
         export type MeQueryVariables = {};
 
@@ -667,17 +695,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type MeQuery = {| me?: ?({
@@ -709,17 +739,19 @@ describe('Flow Operations Plugin', () => {
         }
       `);
 
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type MeQuery = {| me?: ?({
@@ -750,17 +782,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type NotificationsQuery = {| notifications: Array<$Pick<TextNotification, {| text: *, id: * |}> | ({
@@ -785,17 +819,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type UnionTestQuery = {| unionTest?: ?$Pick<User, {| id: * |}> | $Pick<Profile, {| age?: * |}> |};
@@ -817,17 +853,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type CurrentUserQuery = {| me?: ?({
@@ -855,17 +893,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        gitHuntSchema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          gitHuntSchema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
       expect(result).toBeSimilarStringTo(
         `export type MeQueryVariables = {
           repoFullName: $ElementType<Scalars, 'String'>,
@@ -886,17 +926,19 @@ describe('Flow Operations Plugin', () => {
           dummy
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
       expect(result).toBeSimilarStringTo(`export type DummyQuery = $Pick<Query, {| dummy?: * |}>;`);
       validateFlow(result);
     });
@@ -910,17 +952,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type DummyQuery = ({
@@ -944,17 +988,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type CurrentUserQuery = {| me?: ?({
@@ -978,17 +1024,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type UserFieldsFragment = ({
@@ -1013,17 +1061,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type LoginMutation = {| login?: ?({
@@ -1040,17 +1090,19 @@ describe('Flow Operations Plugin', () => {
           dummy
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`export type TestQuery = $Pick<Query, {| dummy?: * |}>;`);
       validateFlow(result);
@@ -1064,17 +1116,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
       expect(result).toBeSimilarStringTo(
         `export type TestSubscription = {| userCreated?: ?$Pick<User, {| id: * |}> |};`
       );
@@ -1087,17 +1141,19 @@ describe('Flow Operations Plugin', () => {
           dummy
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(
         `export type TestQueryQueryVariables = {
@@ -1120,17 +1176,19 @@ describe('Flow Operations Plugin', () => {
           dummy
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`export type TestQueryQueryVariables = {};`);
       validateFlow(result);
@@ -1151,17 +1209,19 @@ describe('Flow Operations Plugin', () => {
           }
         }
       `);
-      const result = await plugin(
-        schema,
-        [
-          {
-            location: '',
-            document: ast,
-          },
-        ],
-        { skipTypename: true, useFlowExactObjects: false },
-        { outputFile: '' }
-      );
+      const result = mergeOutputs([
+        await plugin(
+          schema,
+          [
+            {
+              location: '',
+              document: ast,
+            },
+          ],
+          { skipTypename: true, useFlowExactObjects: false },
+          { outputFile: '' }
+        ),
+      ]);
 
       expect(result).toBeSimilarStringTo(`
       export type CurrentUserQuery = { me?: ?({
@@ -1198,7 +1258,7 @@ describe('Flow Operations Plugin', () => {
         { outputFile: '' }
       )) as Types.ComplexPluginOutput;
       expect(result.content).toMatchSnapshot();
-      expect(result).toBeSimilarStringTo(`
+      expect(result.content).toBeSimilarStringTo(`
       export type CurrentUserQuery = {| +me?: ?({
         ...$Pick<User, {| +id: *, +username: *, +role?: * |}>,
       ...{| +profile?: ?$Pick<Profile, {| +age?: * |}> |}

--- a/packages/plugins/other/visitor-plugin-common/src/optimize-operations.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/optimize-operations.ts
@@ -2,10 +2,15 @@ import { Types } from '@graphql-codegen/plugin-helpers';
 import { GraphQLSchema } from 'graphql';
 import { optimizeDocuments } from '@graphql-tools/relay-operation-optimizer';
 
-export function optimizeOperations(schema: GraphQLSchema, documents: Types.DocumentFile[]): Types.DocumentFile[] {
+export function optimizeOperations(
+  schema: GraphQLSchema,
+  documents: Types.DocumentFile[],
+  options?: { includeFragments: boolean }
+): Types.DocumentFile[] {
   const newDocuments = optimizeDocuments(
     schema,
-    documents.map(s => s.document)
+    documents.map(s => s.document),
+    options
   );
 
   return newDocuments.map(document => ({


### PR DESCRIPTION
This fixes a bug where fragment types are not generated when `flattenGeneratedTypes` config is provided for flow operations.