### PR TITLE
Fix DeclarationBlock to omit the semicolon for functions

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -225,7 +225,7 @@ export class DeclarationBlock {
     return (
       (this._comment ? this._comment : '') +
       result +
-      (this._kind === 'interface' || this._kind === 'enum' || this._kind === 'namespace' ? '' : ';') +
+      (this._kind === 'interface' || this._kind === 'enum' || this._kind === 'namespace' || this._kind === "function" ? '' : ';') +
       '\n'
     );
   }


### PR DESCRIPTION
I am using `DeclarationBlock` to [generate a function](https://github.com/Zhouzi/graphql-codegen-factories/blob/ae48ff276e586b9421c8b2725f5ad79a70ca7cfa/src/FactoriesVisitor.ts#L141-L159) but it currently adds a semicolon after blocks with that kind. It generates:

```js
function foo() {
};
```

Instead of:

```js
function foo() {
}
```

Here's a real example of the output: https://github.com/Zhouzi/graphql-codegen-factories/blob/ae48ff276e586b9421c8b2725f5ad79a70ca7cfa/__tests__/types.ts#L75-L87

This PR adds "function" to the list of kinds that should not be followed with a semicolon.