### PR TITLE
[near-operation-files] More fixes for `importAllFragmentsFrom`

### DIFF
--- a/packages/presets/near-operation-file/src/fragment-resolver.ts
+++ b/packages/presets/near-operation-file/src/fragment-resolver.ts
@@ -93,7 +93,7 @@ function buildFragmentRegistry(
         }
 
         const possibleTypes = getPossibleTypes(schemaObject, schemaType);
-        const filePath = generateFilePath(documentRecord.location, true);
+        const filePath = generateFilePath(documentRecord.location);
         const imports = getFragmentImports(
           possibleTypes.map(t => t.name),
           fragment.name.value

--- a/packages/presets/near-operation-file/src/resolve-document-imports.ts
+++ b/packages/presets/near-operation-file/src/resolve-document-imports.ts
@@ -20,7 +20,7 @@ export type DocumentImportResolverOptions = {
   /**
    * Generates a target file path from the source `document.location`
    */
-  generateFilePath: (location: string, isExternalFragment: boolean) => string;
+  generateFilePath: (location: string) => string;
   /**
    *  Schema base types source
    */
@@ -53,7 +53,7 @@ export function resolveDocumentImports<T>(
   const { generateFilePath, schemaTypesSource, baseDir } = importResolverOptions;
 
   return documents.map(documentFile => {
-    const generatedFilePath = generateFilePath(documentFile.location, false);
+    const generatedFilePath = generateFilePath(documentFile.location);
     const importStatements: string[] = [];
     const { externalFragments, fragmentImports } = resolveFragments(generatedFilePath, documentFile.document);
 


### PR DESCRIPTION
The current implementation causes the preset sometimes to add unused fragment imports when `importAllFragmentsFrom` is set. This PR fixes that by changing the timing of the import override (at the moment, it's doing that while building the fragments map, this PR changes it to be done after building all the graph and imports, and it's just acts as override without effecting behaviour).
