### PR TITLE
Added `allowParentTypeOverride` to `typescript-resolvers` plugin

### DIFF
--- a/packages/plugins/typescript/resolvers/src/config.ts
+++ b/packages/plugins/typescript/resolvers/src/config.ts
@@ -100,4 +100,17 @@ export interface TypeScriptResolversPluginConfig extends RawResolversConfig {
    * ```
    */
   customResolverFn?: string;
+  /**
+   * @description Allow you to override the `ParentType` generic in each resolver, by avoid enforcing the base type of the generated generic type.
+   *
+   * This will generate `ParentType = Type` instead of `ParentType extends Type = Type` in each resolver.
+   *
+   * @exampleMarkdown
+   * ```yml
+   *   config:
+   *     allowParentTypeOverride: true
+   * ```
+   *
+   */
+  allowParentTypeOverride?: boolean;
 }

--- a/packages/plugins/typescript/resolvers/src/visitor.ts
+++ b/packages/plugins/typescript/resolvers/src/visitor.ts
@@ -15,7 +15,6 @@ import {
   DeclarationKind,
 } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptOperationVariablesToObject } from '@graphql-codegen/typescript';
-import { plugin } from '@graphql-codegen/c-sharp';
 
 export const ENUM_RESOLVERS_SIGNATURE =
   'export type EnumResolverSignature<T, AllowedValues = any> = { [key in keyof T]?: AllowedValues };';

--- a/packages/plugins/typescript/resolvers/src/visitor.ts
+++ b/packages/plugins/typescript/resolvers/src/visitor.ts
@@ -15,6 +15,7 @@ import {
   DeclarationKind,
 } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptOperationVariablesToObject } from '@graphql-codegen/typescript';
+import { plugin } from '@graphql-codegen/c-sharp';
 
 export const ENUM_RESOLVERS_SIGNATURE =
   'export type EnumResolverSignature<T, AllowedValues = any> = { [key in keyof T]?: AllowedValues };';
@@ -23,6 +24,7 @@ export interface ParsedTypeScriptResolversConfig extends ParsedResolversConfig {
   avoidOptionals: boolean;
   useIndexSignature: boolean;
   wrapFieldDefinitions: boolean;
+  allowParentTypeOverride: boolean;
 }
 
 export class TypeScriptResolversVisitor extends BaseResolversVisitor<
@@ -36,6 +38,7 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<
         avoidOptionals: getConfigValue(pluginConfig.avoidOptionals, false),
         useIndexSignature: getConfigValue(pluginConfig.useIndexSignature, false),
         wrapFieldDefinitions: getConfigValue(pluginConfig.wrapFieldDefinitions, false),
+        allowParentTypeOverride: getConfigValue(pluginConfig.allowParentTypeOverride, false),
       } as ParsedTypeScriptResolversConfig,
       schema
     );
@@ -60,6 +63,14 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<
         },
       };
     }
+  }
+
+  protected transformParentGenericType(parentType: string): string {
+    if (this.config.allowParentTypeOverride) {
+      return `ParentType = ${parentType}`;
+    }
+
+    return `ParentType extends ${parentType} = ${parentType}`;
   }
 
   protected formatRootResolver(schemaTypeName: string, resolverType: string, declarationKind: DeclarationKind): string {

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -1,5 +1,237 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TypeScript Resolvers Plugin Config allowParentTypeOverride - should allow to have less strict resolvers by overrding parent type 1`] = `
+"export type Maybe<T> = T | null;
+export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  MyScalar: any;
+};
+
+
+export type MyType = {
+  __typename?: 'MyType';
+  foo: Scalars['String'];
+  otherType?: Maybe<MyOtherType>;
+  withArgs?: Maybe<Scalars['String']>;
+};
+
+
+export type MyTypeWithArgsArgs = {
+  arg?: Maybe<Scalars['String']>;
+  arg2: Scalars['String'];
+};
+
+export type MyOtherType = {
+  __typename?: 'MyOtherType';
+  bar: Scalars['String'];
+};
+
+export type Query = {
+  __typename?: 'Query';
+  something: MyType;
+};
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  somethingChanged?: Maybe<MyOtherType>;
+};
+
+export type Node = {
+  id: Scalars['ID'];
+};
+
+export type SomeNode = Node & {
+  __typename?: 'SomeNode';
+  id: Scalars['ID'];
+};
+
+export type MyUnion = MyType | MyOtherType;
+
+export type WithIndex<TObject> = TObject & Record<string, any>;
+export type ResolversObject<TObject> = WithIndex<TObject>;
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = ResolversObject<{
+  MyType: ResolverTypeWrapper<MyType>;
+  String: ResolverTypeWrapper<Scalars['String']>;
+  MyOtherType: ResolverTypeWrapper<MyOtherType>;
+  Query: ResolverTypeWrapper<{}>;
+  Subscription: ResolverTypeWrapper<{}>;
+  Node: ResolversTypes['SomeNode'];
+  ID: ResolverTypeWrapper<Scalars['ID']>;
+  SomeNode: ResolverTypeWrapper<SomeNode>;
+  MyUnion: ResolversTypes['MyType'] | ResolversTypes['MyOtherType'];
+  MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+  Int: ResolverTypeWrapper<Scalars['Int']>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+}>;
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = ResolversObject<{
+  MyType: MyType;
+  String: Scalars['String'];
+  MyOtherType: MyOtherType;
+  Query: {};
+  Subscription: {};
+  Node: ResolversParentTypes['SomeNode'];
+  ID: Scalars['ID'];
+  SomeNode: SomeNode;
+  MyUnion: ResolversParentTypes['MyType'] | ResolversParentTypes['MyOtherType'];
+  MyScalar: Scalars['MyScalar'];
+  Int: Scalars['Int'];
+  Boolean: Scalars['Boolean'];
+}>;
+
+export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+  arg2: Scalars['String'];
+  arg3: Scalars['Boolean']; };
+
+export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type MyTypeResolvers<ContextType = any, ParentType = ResolversParentTypes['MyType']> = ResolversObject<{
+  foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+  withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+}>;
+
+export type MyOtherTypeResolvers<ContextType = any, ParentType = ResolversParentTypes['MyOtherType']> = ResolversObject<{
+  bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+}>;
+
+export type QueryResolvers<ContextType = any, ParentType = ResolversParentTypes['Query']> = ResolversObject<{
+  something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
+}>;
+
+export type SubscriptionResolvers<ContextType = any, ParentType = ResolversParentTypes['Subscription']> = ResolversObject<{
+  somethingChanged?: SubscriptionResolver<Maybe<ResolversTypes['MyOtherType']>, \\"somethingChanged\\", ParentType, ContextType>;
+}>;
+
+export type NodeResolvers<ContextType = any, ParentType = ResolversParentTypes['Node']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+}>;
+
+export type SomeNodeResolvers<ContextType = any, ParentType = ResolversParentTypes['SomeNode']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+}>;
+
+export type MyUnionResolvers<ContextType = any, ParentType = ResolversParentTypes['MyUnion']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
+}>;
+
+export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
+  name: 'MyScalar';
+}
+
+export type Resolvers<ContextType = any> = ResolversObject<{
+  MyType?: MyTypeResolvers<ContextType>;
+  MyOtherType?: MyOtherTypeResolvers<ContextType>;
+  Query?: QueryResolvers<ContextType>;
+  Subscription?: SubscriptionResolvers<ContextType>;
+  Node?: NodeResolvers;
+  SomeNode?: SomeNodeResolvers<ContextType>;
+  MyUnion?: MyUnionResolvers;
+  MyScalar?: GraphQLScalarType;
+}>;
+
+
+/**
+ * @deprecated
+ * Use \\"Resolvers\\" root object instead. If you wish to get \\"IResolvers\\", add \\"typesPrefix: I\\" to your config.
+ */
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;
+export type DirectiveResolvers<ContextType = any> = ResolversObject<{
+  myDirective?: MyDirectiveDirectiveResolver<any, any, ContextType>;
+}>;
+
+
+/**
+ * @deprecated
+ * Use \\"DirectiveResolvers\\" root object instead. If you wish to get \\"IDirectiveResolvers\\", add \\"typesPrefix: I\\" to your config.
+ */
+export type IDirectiveResolvers<ContextType = any> = DirectiveResolvers<ContextType>;
+        export const myTypeResolvers: MyTypeResolvers<{}, { parentOverride: boolean }> = {
+          foo: (parentValue) => {
+            const a: boolean = parentValue.parentOverride;
+
+            return a.toString();
+          }
+        }; 
+      "
+`;
+
 exports[`TypeScript Resolvers Plugin Config namespacedImportName - should work correctly with imported namespaced type 1`] = `
 "import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -136,6 +136,34 @@ describe('TypeScript Resolvers Plugin', () => {
   });
 
   describe('Config', () => {
+    it('allowParentTypeOverride - should allow to have less strict resolvers by overrding parent type', async () => {
+      const config = {
+        noSchemaStitching: true,
+        useIndexSignature: true,
+        allowParentTypeOverride: true,
+      };
+      const result = await plugin(schema, [], config, { outputFile: '' });
+
+      const content = await validate(
+        result,
+        config,
+        schema,
+        `
+        export const myTypeResolvers: MyTypeResolvers<{}, { parentOverride: boolean }> = {
+          foo: (parentValue) => {
+            const a: boolean = parentValue.parentOverride;
+
+            return a.toString();
+          }
+        }; 
+      `
+      );
+
+      expect(content).not.toContain(`ParentType extends `);
+      expect(content).toContain(`ParentType = `);
+      expect(content).toMatchSnapshot();
+    });
+
     it('namespacedImportName - should work correctly with imported namespaced type', async () => {
       const config = {
         noSchemaStitching: true,


### PR DESCRIPTION
The purpose of this new configuration flag (`allowParentTypeOverride`) is to allow less strict resolvers signature. Setting this to `true` will change the generated code to use the generic `ParentType = MyType` instead of `ParentType extends MyType = MyType`. Changing this will allow developers to have a bridge type that overrides the value they use for parent value (`type MyModifiedResolvers = TypeResolvers<ContextType, { customValue: string }>`. 


