### PR TITLE
Fixing Issue #4437 - Failing tests for unhandledRejection

### DIFF
--- a/dev-test/setup.js
+++ b/dev-test/setup.js
@@ -1,0 +1,3 @@
+process.on('unhandledRejection', (err) => {
+    fail(err);
+});

--- a/jest.project.js
+++ b/jest.project.js
@@ -25,6 +25,7 @@ module.exports = ({ dirname, projectMode = true }) => {
     modulePathIgnorePatterns: ['dist'],
     moduleNameMapper: pathsToModuleNameMapper(tsconfig.compilerOptions.paths, { prefix: `${ROOT_DIR}/` }),
     cacheDirectory: resolve(ROOT_DIR, `${CI ? '' : 'node_modules/'}.cache/jest`),
+    setupFiles: [`${ROOT_DIR}/dev-test/setup.js`],
     collectCoverage: false,
   };
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "clean": "rimraf node_modules packages/{*,plugins/*/*,presets/*,utils/*}/node_modules",
     "prebuild": "rimraf packages/{*,plugins/*/*,presets/*,utils/*}/dist",
     "build": "tsc --project tsconfig.json && bob build",
+    "watch-build": "npx tsc-watch --project tsconfig.json --onSuccess \"bob build\"",
     "test": "jest --no-watchman",
     "lint": "eslint --ext .ts .",
     "prettier": "prettier --ignore-path .gitignore --write --list-different \"**/*.{ts,tsx,graphql,yml}\"",


### PR DESCRIPTION
In regards to issue #4437 I've made two fixes to the angular tests: (i) awaiting all validateTypeScript calls as to not hide failures and (ii) fixing the test that was (silently) failing by updating its gql mutation/subscription to fit the actual schema.

Other than that, this PR also includes a setup file for jest which makes sure the execution fails if there's an unhandledRejection so that they may not stay hidden.