### PR TITLE
[WIP] Small Fixes: typescript-oclif plugin

### DIFF
--- a/packages/plugins/typescript/oclif/src/visitor.ts
+++ b/packages/plugins/typescript/oclif/src/visitor.ts
@@ -31,7 +31,11 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<Config, ClientS
     super(schema, fragments, rawConfig, {});
     this._info = info;
 
-    const { handlerPath = '../../handler' } = rawConfig;
+    const { handlerPath } = rawConfig;
+
+    if (!handlerPath) {
+      throw new Error('Missing configuration value `handlerPath` from `typescript-oclif` plugin');
+    }
 
     autoBind(this);
     this._additionalImports.push(`import { Command, flags } from '@oclif/command'`);

--- a/packages/plugins/typescript/oclif/src/visitor.ts
+++ b/packages/plugins/typescript/oclif/src/visitor.ts
@@ -33,11 +33,6 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<Config, ClientS
 
     const { handlerPath = '../../handler' } = rawConfig;
 
-    // FIXME: This is taken in part from
-    //  presets/near-operation-file/src/index.ts:139. How do I build a path relative to the outputFile in the same way?
-    //  A plugin doesn't appear to have access to the same "options.baseOutputDir" that the preset does.
-    // const absClientPath = resolve(info.outputFile, join(options.baseOutputDir, options.presetConfig.baseTypesPath));
-
     autoBind(this);
     this._additionalImports.push(`import { Command, flags } from '@oclif/command'`);
     this._additionalImports.push(`import handler from '${handlerPath}'`);

--- a/packages/plugins/typescript/oclif/tests/oclif.spec.ts
+++ b/packages/plugins/typescript/oclif/tests/oclif.spec.ts
@@ -17,7 +17,7 @@ describe('oclif', () => {
         }
       `);
 
-      const config = {};
+      const config = { handlerPath: '../../handler' };
       const docs = [{ location: '', document }];
       const result = (await plugin(schema, docs, config, {
         outputFile: 'graphql.ts',
@@ -36,7 +36,7 @@ describe('oclif', () => {
         }
       `);
 
-      const config = {};
+      const config = { handlerPath: '../../handler' };
       const docs = [{ location: '', document }];
       const result = (await plugin(schema, docs, config, {
         outputFile: 'graphql.ts',
@@ -55,7 +55,7 @@ describe('oclif', () => {
         }
       `);
 
-      const config = {};
+      const config = { handlerPath: '../../handler' };
       const docs = [{ location: '', document }];
       const result = (await plugin(schema, docs, config, {
         outputFile: 'graphql.ts',
@@ -73,7 +73,7 @@ describe('oclif', () => {
         }
       `);
 
-      const config = {};
+      const config = { handlerPath: '../../handler' };
       const docs = [{ location: '', document }];
       const result = (await plugin(schema, docs, config, {
         outputFile: 'graphql.ts',
@@ -91,7 +91,7 @@ describe('oclif', () => {
         }
       `);
 
-      const config = {};
+      const config = { handlerPath: '../../handler' };
       const docs = [{ location: '', document }];
       const result = (await plugin(schema, docs, config, {
         outputFile: 'graphql.ts',

--- a/website/docs/plugins/typescript-oclif.md
+++ b/website/docs/plugins/typescript-oclif.md
@@ -132,7 +132,7 @@ generates:
       baseTypesPath: ../types.ts
     plugins:
       - typescript-oclif:
-          client: ../../client
+          handlerPath: ../../client
 ```
 
 Breaking that down:
@@ -145,9 +145,9 @@ Breaking that down:
   This is _required_ for `oclif` to work, since it uses the file structure to generate the command structure.
 - Note: `typescript-operations` plugin isn't required, since this library isn't meant to be consumed
   programmatically (and so nothing reads the types that `typescript-operations` would produce)
-- The `client` path is to the file which has a default export of your `graphql-request` client,
-  relative to the generated files (ie here, `src/commands/something/file.graphql`).
-  Note that it has no extension.
+- The `handlerPath` (default: `../../handler`) is a _relative_ path from your generated command files
+  to the handler which will actually send them to the server and then display the output. See Step 3
+  above for more information.
 
 With that configured, just run `yarn graphql-codegen` or `npx graphql-codegen` to generate all the
 necessary `oclif` command files. With that complete, follow the directions in the


### PR DESCRIPTION
Hey team! 👋 

I wrote the `oclif` plugin back in October and it was merged in March 2020, which surprised me since I still had some pending questions on [the MR](https://github.com/dotansimha/graphql-code-generator/pull/2805). Happily, it all works, and you all have done good work keeping it integrated with all of your changes! There are a couple loose ends IMO worth tying off.

Of the questions in that PR, I'm still most interested in the one about the import paths (question # 2). Presets receive information about where they are in the generated-file tree, but plugins do not appear to (or didn't at the time). This means that this plugin is fragile, and we can't have a file structure like this out-of-the-box:

```
src/commands/hello.ts
src/commands/foo/bar.ts

# ... with handler ...
src/handler.ts
```

^ Since the plugin doesn't know how deep it is in the tree, it doesn't know whether to `import '../../handler'` or `import '../handler'`. We can use a tsconfig.json `baseUrl` to work around this issue, or put `handler.ts` export files everywhere in the tree, but is it possible for a plugin to know its relative file path to the root? If it's not a simple change or lookup, I'll just add a line to the docs about using `baseUrl` (that's what the MR "WIP" is for), although that may not work in all situations.

This also includes some other housekeeping:

* Remove development comments related to the above ^
* Remove the default value for `handlerPath` and require it to be set deliberately. While this is a breaking change, I expect that this is specified in most consuming projects since it's in the docs and example. Setting the default as `../../handler` assumes that users will be generating a two-level, "multi"-form CLI, which is not necessarily the expected or common case.
* A fix in the docs