### PR TITLE
Add context to plugins and custom loaders

### DIFF
--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -35,6 +35,7 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
 
   const context = ensureContext(input);
   const config = context.getConfig();
+  const pluginContext = context.getPluginContext();
   const result: Types.FileOutput[] = [];
   const commonListrOptions = {
     exitOnError: true,
@@ -254,6 +255,7 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
                           documents: outputDocuments,
                           config: mergedConfig,
                           pluginMap,
+                          pluginContext,
                         });
                       } else {
                         outputs = [
@@ -265,6 +267,7 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
                             documents: outputDocuments,
                             config: mergedConfig,
                             pluginMap,
+                            pluginContext,
                           },
                         ];
                       }

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -203,6 +203,7 @@ export class CodegenContext {
   private _graphqlConfig?: GraphQLConfig;
   private config: Types.Config;
   private _project?: string;
+  private _pluginContext: { [key: string]: any } = {};
   cwd: string;
   filepath: string;
 
@@ -234,9 +235,10 @@ export class CodegenContext {
           ...project.extension('codegen'),
           schema: project.schema,
           documents: project.documents,
+          pluginContext: this._pluginContext,
         };
       } else {
-        this.config = this._config;
+        this.config = { ...this._config, pluginContext: this._pluginContext };
       }
     }
 
@@ -248,6 +250,10 @@ export class CodegenContext {
       ...this.getConfig(),
       ...config,
     };
+  }
+
+  getPluginContext(): { [key: string]: any } {
+    return this._pluginContext;
   }
 
   async loadSchema(pointer: Types.Schema) {

--- a/packages/graphql-codegen-cli/tests/codegen.spec.ts
+++ b/packages/graphql-codegen-cli/tests/codegen.spec.ts
@@ -989,4 +989,24 @@ describe('Codegen Executor', () => {
       expect(e.errors[0].message).not.toBe('Query root type must be provided.');
     }
   });
+
+  it('Should allow plugin context to be accessed and modified', async () => {
+    const output = await executeCodegen({
+      schema: [
+        {
+          './tests/test-documents/schema.graphql': {
+            loader: './tests/custom-loaders/custom-schema-loader-with-context.js',
+          },
+        },
+      ],
+      generates: {
+        'out1.ts': {
+          plugins: ['./tests/custom-plugins/context.js'],
+        },
+      },
+    });
+
+    expect(output.length).toBe(1);
+    expect(output[0].content).toContain('Hello world!');
+  });
 });

--- a/packages/graphql-codegen-cli/tests/custom-loaders/custom-schema-loader-with-context.js
+++ b/packages/graphql-codegen-cli/tests/custom-loaders/custom-schema-loader-with-context.js
@@ -1,0 +1,8 @@
+const { buildSchema } = require('graphql');
+const { readFileSync } = require('fs');
+const { join } = require('path');
+
+module.exports = function (schemaString, config) {
+  config.pluginContext.hello = 'world';
+  return buildSchema(readFileSync(join(process.cwd(), schemaString), { encoding: 'utf-8' }));
+};

--- a/packages/graphql-codegen-cli/tests/custom-plugins/context.js
+++ b/packages/graphql-codegen-cli/tests/custom-plugins/context.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugin: (_schema, _documents, _config, { pluginContext }) => {
+    return `Hello ${pluginContext.hello}!`;
+  },
+};

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -114,6 +114,7 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
           outputFilename: options.filename,
           allPlugins: options.plugins,
           skipDocumentsValidation: options.skipDocumentsValidation,
+          pluginContext: options.pluginContext,
         },
         pluginPackage
       );

--- a/packages/graphql-codegen-core/src/execute-plugin.ts
+++ b/packages/graphql-codegen-core/src/execute-plugin.ts
@@ -11,6 +11,7 @@ export interface ExecutePluginOptions {
   outputFilename: string;
   allPlugins: Types.ConfiguredPlugin[];
   skipDocumentsValidation?: boolean;
+  pluginContext?: { [key: string]: any };
 }
 
 export async function executePlugin(options: ExecutePluginOptions, plugin: CodegenPlugin): Promise<Types.PluginOutput> {
@@ -33,10 +34,19 @@ export async function executePlugin(options: ExecutePluginOptions, plugin: Codeg
 
   const outputSchema: GraphQLSchema = options.schemaAst || buildASTSchema(options.schema, options.config as any);
   const documents = options.documents || [];
+  const pluginContext = options.pluginContext || {};
 
   if (plugin.validate && typeof plugin.validate === 'function') {
     try {
-      await plugin.validate(outputSchema, documents, options.config, options.outputFilename, options.allPlugins);
+      // FIXME: Sync validate signature with plugin signature
+      await plugin.validate(
+        outputSchema,
+        documents,
+        options.config,
+        options.outputFilename,
+        options.allPlugins,
+        pluginContext
+      );
     } catch (e) {
       throw new DetailedError(
         `Plugin "${options.name}" validation failed:`,
@@ -55,6 +65,7 @@ export async function executePlugin(options: ExecutePluginOptions, plugin: Codeg
       {
         outputFile: options.outputFilename,
         allPlugins: options.allPlugins,
+        pluginContext,
       }
     )
   );

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -13,6 +13,7 @@ export namespace Types {
       [name: string]: CodegenPlugin;
     };
     skipDocumentsValidation?: boolean;
+    pluginContext?: { [key: string]: any };
   }
 
   export type FileOutput = {
@@ -233,6 +234,9 @@ export namespace Types {
     pluginMap: {
       [name: string]: CodegenPlugin;
     };
+    pluginContext?: {
+      [name: string]: any;
+    };
   };
 
   export type OutputPreset<TPresetConfig = any> = {
@@ -337,6 +341,10 @@ export namespace Types {
      * @description If you are using the programmatic API in a browser environment, you can override this configuration to load your plugins in a way different than require.
      */
     pluginLoader?: PackageLoaderFn<CodegenPlugin>;
+    /**
+     * @description Additional context passed to plugins
+     */
+    pluginContext?: { [key: string]: any };
     /**
      * @description Allows you to override the configuration for `@graphql-tools/graphql-tag-pluck`, the tool that extracts your GraphQL operations from your code files.
      *
@@ -444,6 +452,7 @@ export type PluginFunction<T = any, TOutput extends Types.PluginOutput = Types.P
   info?: {
     outputFile?: string;
     allPlugins?: Types.ConfiguredPlugin[];
+    pluginContext?: { [key: string]: any };
     [key: string]: any;
   }
 ) => Types.Promisable<TOutput>;
@@ -453,7 +462,8 @@ export type PluginValidateFn<T = any> = (
   documents: Types.DocumentFile[],
   config: T,
   outputFile: string,
-  allPlugins: Types.ConfiguredPlugin[]
+  allPlugins: Types.ConfiguredPlugin[],
+  pluginContext?: { [key: string]: any }
 ) => Types.Promisable<void>;
 
 export type AddToSchemaResult = string | DocumentNode | undefined;

--- a/website/docs/getting-started/documents-field.md
+++ b/website/docs/getting-started/documents-field.md
@@ -205,3 +205,5 @@ module.exports = function(docString, config) {
   return parse(readFileSync(docString, { encoding: 'utf-8' }));;
 };
 ```
+
+> The second parameter passed to the loader function is a config object that includes a `pluginContext` property. This value is passed to any executed plugins, so it can be modified by the loader to pass any additional information to those plugins.

--- a/website/docs/getting-started/schema-field.md
+++ b/website/docs/getting-started/schema-field.md
@@ -172,8 +172,10 @@ If your schema has a different or complicated way of loading, you can point to a
 
 ```yml
 schema:
-  - ./my-schema-loader.js:
-      noPluck: true
+  - http://localhost:3000/graphql:
+      loader: my-url-loader.js
+  - schema.graphql:
+      loader: my-file-loader.js
 ```
 
 Your custom loader should export a default function that returns `GraphQLSchema` object, or an identifier called `schema`. For example:
@@ -188,4 +190,4 @@ module.exports = function(schemaString, config) {
 };
 ```
 
-> We need to specify `noPluck: true` because otherwise Codegen will look for GraphQL AST strings in that file. 
+> The second parameter passed to the loader function is a config object that includes a `pluginContext` property. This value is passed to any executed plugins, so it can be modified by the loader to pass any additional information to those plugins.


### PR DESCRIPTION
This exposes a `pluginContext` object that's accessible to plugins, presets and custom loaders. This provides a way to pass arbitrary data from custom loaders (and presets) to plugins.