### PR TITLE
Fix typo in website

### DIFF
--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -79,7 +79,7 @@ You can go over [the list of available plugins](../plugins/index) and find more 
 
 If you are having issues, you can reach us this the following:
 
-- Found a bug? [report it in your GitHub repo](https://github.com/dotansimha/graphql-code-generator)
+- Found a bug? [report it in our GitHub repo](https://github.com/dotansimha/graphql-code-generator)
 - Need help or have a question? You can use the live chat box in the corner of the screen, [ask it in our GitHub Discussions page](https://github.com/dotansimha/graphql-code-generator/discussions) or [reach us directly in our Discord](http://bit.ly/guild-chat).
 - We have more awesome [open source tools](https://github.com/the-guild-org/Stack)!
 - You can [visit our website](http://the-guild.dev/) for more information about us and what we do  


### PR DESCRIPTION
The website mistakenly refers to "our" GitHub repo as "your" GitHub repo.