### PR TITLE
Fix plugin Typescript mongoDB: generate optional type for @map 

### DIFF
--- a/packages/plugins/typescript/mongodb/src/visitor.ts
+++ b/packages/plugins/typescript/mongodb/src/visitor.ts
@@ -168,7 +168,7 @@ export class TsMongoVisitor extends BaseVisitor<TypeScriptMongoPluginConfig, Typ
     const type = this.convertName(coreType, { suffix: this.config.dbTypeSuffix });
 
     tree.addField(
-      mapPath || `${fieldNode.name.value}${addOptionalSign ? '?' : ''}`,
+      `${mapPath || fieldNode.name.value}${addOptionalSign ? '?' : ''}`,
       this._variablesTransformer.wrapAstTypeWithModifiers(`${type}['${this.config.idFieldName}']`, fieldNode.type)
     );
   }
@@ -197,7 +197,7 @@ export class TsMongoVisitor extends BaseVisitor<TypeScriptMongoPluginConfig, Typ
     }
 
     tree.addField(
-      mapPath || `${fieldNode.name.value}${addOptionalSign ? '?' : ''}`,
+      `${mapPath || fieldNode.name.value}${addOptionalSign ? '?' : ''}`,
       overrideType || this._variablesTransformer.wrapAstTypeWithModifiers(type, fieldNode.type)
     );
   }
@@ -212,7 +212,7 @@ export class TsMongoVisitor extends BaseVisitor<TypeScriptMongoPluginConfig, Typ
     const type = this.convertName(coreType, { suffix: this.config.dbTypeSuffix });
 
     tree.addField(
-      mapPath || `${fieldNode.name.value}${addOptionalSign ? '?' : ''}`,
+      `${mapPath || fieldNode.name.value}${addOptionalSign ? '?' : ''}`,
       this._variablesTransformer.wrapAstTypeWithModifiers(type, fieldNode.type)
     );
   }

--- a/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
+++ b/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
@@ -250,11 +250,11 @@ describe('TypeScript Mongo', () => {
       expect(result).toBeSimilarStringTo(`
       nullableColumnMap: {
         level?: Maybe<string>,
-      },`); // map with ;
+      },`); // map with nullable field;
       expect(result).toBeSimilarStringTo(`
       nonNullableColumnMap: {
         level: string,
-      },`);
+      },`); // map with non-nullable field
       await validate(result, schema, {});
     });
 

--- a/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
+++ b/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
@@ -32,6 +32,10 @@ describe('TypeScript Mongo', () => {
       nullableEmbedded: [EmbeddedType] @embedded
       mappedEmbedded: EmbeddedType @embedded @map(path: "innerEmbedded.moreLevel")
       changeName: String @column @map(path: "other_name")
+      nonNullableColumnMap: String! @column @map(path: "nonNullableColumn")
+      nullableLinkMap: LinkType @link @map(path: "nullableLinkId")
+      nullableColumnMapPath: String @column @map(path: "nullableColumnMap.level")
+      nonNullableColumnMapPath: String! @column @map(path: "nonNullableColumnMap.level")
     }
 
     type EmbeddedType @entity {
@@ -229,18 +233,28 @@ describe('TypeScript Mongo', () => {
 
     it('Should output the correct values for @map directive', async () => {
       const result = await plugin(schema, [], {}, { outputFile: '' });
-      expect(result).toContain(`myInnerArray: Maybe<Array<Maybe<number>>>`); // simple @column with array and @map
-      expect(result).toContain(`other_name: Maybe<string>`); // simple @map scalar
+      expect(result).toContain(`myInnerArray?: Maybe<Array<Maybe<number>>>`); // simple @column with array and @map
+      expect(result).toContain(`other_name?: Maybe<string>`); // simple @map scalar
       expect(result).toBeSimilarStringTo(`
       profile: {
         inner: {
-          field: Maybe<string>,
+          field?: Maybe<string>,
         },
       },`); // custom @map with inner fields
       expect(result).toBeSimilarStringTo(`
       innerEmbedded: {
-        moreLevel: Maybe<EmbeddedTypeDbObject>,
+        moreLevel?: Maybe<EmbeddedTypeDbObject>,
       },`); // embedded with @map
+      expect(result).toContain(`nonNullableColumn: string`); // simple @column with @map
+      expect(result).toContain(`nullableLinkId?: Maybe<LinkTypeDbObject['_id']>`); // nullable @link with @map
+      expect(result).toBeSimilarStringTo(`
+      nullableColumnMap: {
+        level?: Maybe<string>,
+      },`); // map with ;
+      expect(result).toBeSimilarStringTo(`
+      nonNullableColumnMap: {
+        level: string,
+      },`);
       await validate(result, schema, {});
     });
 


### PR DESCRIPTION
```gql
name: String @column @map(path: "fullName")
```
output before: 
```js
fullName: Maybe<string>
```
fixed output
```js
fullName?: Maybe<string>
```