### PR TITLE
feat(typescript-resolvers): use `import type` when importing from graphql

### DIFF
--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -102,10 +102,11 @@ export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
     );
   }
 
+  const importType = config.useTypeImports ? 'import type' : 'import';
+
   if (config.customResolverFn) {
     const parsedMapper = parseMapper(config.customResolverFn);
     if (parsedMapper.isExternal) {
-      const importType = config.useTypeImports ? 'import type' : 'import';
       if (parsedMapper.default) {
         prepend.push(`${importType} ResolverFn from '${parsedMapper.source}';`);
       } else {
@@ -202,7 +203,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   }
 
   if (imports.length) {
-    prepend.push(`import { ${imports.join(', ')} } from 'graphql';`);
+    prepend.push(`${importType} { ${imports.join(', ')} } from 'graphql';`);
   }
 
   if (config.customResolveInfo) {


### PR DESCRIPTION
Another one for #3695. For my own use case I _believe_ I'm just missing `react-apollo`. However, I'm not sure when it's safe to do `import type` and when not to there - help would be appreciated 🙂 This is however enough for the stuff we have server side 🎉 