### PR TITLE
chore(generic-sdk): use import type

### DIFF
--- a/packages/plugins/typescript/generic-sdk/src/visitor.ts
+++ b/packages/plugins/typescript/generic-sdk/src/visitor.ts
@@ -33,7 +33,8 @@ export class GenericSdkVisitor extends ClientSideBaseVisitor<RawGenericSdkPlugin
       this._additionalImports.push(this.config.usingObservableFrom);
     }
     if (this.config.documentMode !== DocumentMode.string) {
-      this._additionalImports.push(`import { DocumentNode } from 'graphql';`);
+      const importType = this.config.useTypeImports ? 'import type' : 'import';
+      this._additionalImports.push(`${importType} { DocumentNode } from 'graphql';`);
     }
   }
 


### PR DESCRIPTION
For #3695. Last one I personally need for server side stuff, probably still missing from other plugins/presets.