### PR TITLE
fix: use 'unknown' instead of 'any' for type Exact

### DIFF
--- a/dev-test/githunt/typed-document-nodes.ts
+++ b/dev-test/githunt/typed-document-nodes.ts
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'graphql';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.apolloAngular.sdk.ts
+++ b/dev-test/githunt/types.apolloAngular.sdk.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import * as Apollo from 'apollo-angular';
 import * as ApolloCore from 'apollo-client';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.apolloAngular.ts
+++ b/dev-test/githunt/types.apolloAngular.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import { Injectable } from '@angular/core';
 import * as Apollo from 'apollo-angular';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.avoidOptionals.ts
+++ b/dev-test/githunt/types.avoidOptionals.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.d.ts
+++ b/dev-test/githunt/types.d.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.enumsAsTypes.ts
+++ b/dev-test/githunt/types.enumsAsTypes.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.flatten.preResolveTypes.ts
+++ b/dev-test/githunt/types.flatten.preResolveTypes.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.immutableTypes.ts
+++ b/dev-test/githunt/types.immutableTypes.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.preResolveTypes.compatibility.ts
+++ b/dev-test/githunt/types.preResolveTypes.compatibility.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.preResolveTypes.onlyOperationTypes.ts
+++ b/dev-test/githunt/types.preResolveTypes.onlyOperationTypes.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.preResolveTypes.ts
+++ b/dev-test/githunt/types.preResolveTypes.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -4,7 +4,7 @@ import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactComponents from '@apollo/react-components';
 import * as ApolloReactHoc from '@apollo/react-hoc';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -5,7 +5,7 @@ import * as ApolloReactComponents from '@apollo/react-components';
 import * as ApolloReactHoc from '@apollo/react-hoc';
 import * as ApolloReactHooks from '@apollo/react-hooks';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -4,7 +4,7 @@ import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactComponents from '@apollo/react-components';
 import * as ApolloReactHoc from '@apollo/react-hoc';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -4,7 +4,7 @@ import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactComponents from '@apollo/react-components';
 import * as ApolloReactHoc from '@apollo/react-hoc';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/dev-test/githunt/types.stencilApollo.tsx
+++ b/dev-test/githunt/types.stencilApollo.tsx
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import * as StencilApollo from 'stencil-apollo';
 import { h } from '@stencil/core';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.ts
+++ b/dev-test/githunt/types.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import * as React from 'react';
 import * as Urql from 'urql';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/dev-test/githunt/types.vueApollo.ts
+++ b/dev-test/githunt/types.vueApollo.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import * as VueApolloComposable from '@vue/apollo-composable';
 import * as VueCompositionApi from '@vue/composition-api';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type ReactiveFunction<TParam> = () => TParam;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/dev-test/star-wars/types.avoidOptionals.ts
+++ b/dev-test/star-wars/types.avoidOptionals.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/star-wars/types.d.ts
+++ b/dev-test/star-wars/types.d.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/star-wars/types.globallyAvailable.d.ts
+++ b/dev-test/star-wars/types.globallyAvailable.d.ts
@@ -1,5 +1,5 @@
 type Maybe<T> = T | null;
-type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 type Scalars = {
   ID: string;

--- a/dev-test/star-wars/types.immutableTypes.ts
+++ b/dev-test/star-wars/types.immutableTypes.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts
+++ b/dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/star-wars/types.preResolveTypes.ts
+++ b/dev-test/star-wars/types.preResolveTypes.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/star-wars/types.refetchFn.tsx
+++ b/dev-test/star-wars/types.refetchFn.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import * as ApolloReactComponents from '@apollo/react-components';
 import * as ApolloReactHoc from '@apollo/react-hoc';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/dev-test/star-wars/types.skipSchema.ts
+++ b/dev-test/star-wars/types.skipSchema.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/star-wars/types.ts
+++ b/dev-test/star-wars/types.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/test-message/types.tsx
+++ b/dev-test/test-message/types.tsx
@@ -2,7 +2,7 @@ import * as Operations from './documents';
 import * as ApolloReactCommon from '@apollo/client';
 import * as ApolloReactHooks from '@apollo/client';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/test-schema/env.types.ts
+++ b/dev-test/test-schema/env.types.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/test-schema/resolvers-federation.ts
+++ b/dev-test/test-schema/resolvers-federation.ts
@@ -1,6 +1,6 @@
 import { GraphQLResolveInfo } from 'graphql';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -1,6 +1,6 @@
 import { GraphQLResolveInfo } from 'graphql';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } &
   { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */

--- a/dev-test/test-schema/resolvers-types.ts
+++ b/dev-test/test-schema/resolvers-types.ts
@@ -1,6 +1,6 @@
 import { GraphQLResolveInfo } from 'graphql';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } &
   { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */

--- a/dev-test/test-schema/types.preResolveTypes.onlyOperationTypes.ts
+++ b/dev-test/test-schema/types.preResolveTypes.onlyOperationTypes.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/test-schema/types.preResolveTypes.ts
+++ b/dev-test/test-schema/types.preResolveTypes.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/test-schema/typings.avoidOptionals.ts
+++ b/dev-test/test-schema/typings.avoidOptionals.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/test-schema/typings.enum.ts
+++ b/dev-test/test-schema/typings.enum.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/test-schema/typings.immutableTypes.ts
+++ b/dev-test/test-schema/typings.immutableTypes.ts
@@ -1,5 +1,5 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/test-schema/typings.ts
+++ b/dev-test/test-schema/typings.ts
@@ -1,6 +1,6 @@
 import { GraphQLResolveInfo } from 'graphql';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } &
   { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */

--- a/dev-test/test-schema/typings.wrapped.ts
+++ b/dev-test/test-schema/typings.wrapped.ts
@@ -1,6 +1,6 @@
 declare namespace GraphQL {
   export type Maybe<T> = T | null;
-  export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+  export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 
   /** All built-in and custom scalars, mapped to their actual values */
   export type Scalars = {

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`generic-sdk sdk Should generate a correct wrap method 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
@@ -303,7 +303,7 @@ async function test() {
 
 exports[`generic-sdk sdk Should generate a correct wrap method when usingObservableFrom is set 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import Observable from 'zen-observable';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
@@ -528,7 +528,7 @@ export type Sdk = ReturnType<typeof getSdk>;"
 
 exports[`generic-sdk sdk Should generate a correct wrap method with documentMode=string 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`graphql-request sdk Should allow passing wrapper arg to generated getSdk 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import { GraphQLClient } from 'graphql-request';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -313,7 +313,7 @@ async function test() {
 
 exports[`graphql-request sdk Should generate a correct wrap method 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import { GraphQLClient } from 'graphql-request';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
@@ -619,7 +619,7 @@ async function test() {
 
 exports[`graphql-request sdk Should generate a correct wrap method with documentMode=string 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import { GraphQLClient } from 'graphql-request';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -923,7 +923,7 @@ async function test() {
 
 exports[`graphql-request sdk Should support useTypeImports 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import type { GraphQLClient } from 'graphql-request';
 import { print } from 'graphql';
 import gql from 'graphql-tag';

--- a/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
+++ b/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
@@ -161,7 +161,7 @@ export type QQuery = (
 
 exports[`TypeScript Operations Plugin Issues #3064 - fragments over interfaces causes issues with fields 2`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -510,7 +510,7 @@ export type UserResultFragment = UserResult_User_Fragment | UserResult_Error2_Fr
 
 exports[`TypeScript Operations Plugin Union & Interfaces Should handle union selection sets with both FragmentSpreads and InlineFragments with flattenGeneratedTypes 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -600,7 +600,7 @@ export type UserQueryQuery = (
 
 exports[`TypeScript Operations Plugin Union & Interfaces Should handle union selection sets with both FragmentSpreads and InlineFragments with flattenGeneratedTypes and directives 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
+++ b/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`React Apollo Issues Issue #2742 - Incorrect import prefix 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import gql from 'graphql-tag';
 import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactHooks from '@apollo/react-hooks';
@@ -192,7 +192,7 @@ export type Get_SomethingQueryResult = ApolloReactCommon.QueryResult<Types.Get_S
 
 exports[`React Apollo Issues Issue #2826 - Incorrect prefix 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import gql from 'graphql-tag';
 import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactHooks from '@apollo/react-hooks';
@@ -382,7 +382,7 @@ export type Get_SomethingQueryResult = ApolloReactCommon.QueryResult<GQLGet_Some
 
 exports[`React Apollo Issues PR #2725 - transformUnderscore: true causes invalid output 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import gql from 'graphql-tag';
 import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactHooks from '@apollo/react-hooks';
@@ -572,7 +572,7 @@ export type GetSomethingQueryResult = ApolloReactCommon.QueryResult<GetSomething
 
 exports[`React Apollo Issues PR #2725 - transformUnderscore: true causes invalid output 2`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import gql from 'graphql-tag';
 import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactHooks from '@apollo/react-hooks';

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`TypeScript Resolvers Plugin Config allowParentTypeOverride - should allow to have less strict resolvers by overrding parent type 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
@@ -406,7 +406,7 @@ export type IDirectiveResolvers<ContextType = any> = DirectiveResolvers<ContextT
 
 exports[`TypeScript Resolvers Plugin Config optionalInfoArgument - should allow to have optional info argument 1`] = `
 "export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -38,7 +38,7 @@ export interface TypeScriptPluginParsedConfig extends ParsedTypesConfig {
   noExport: boolean;
 }
 
-export const EXACT_SIGNATURE = `type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };`;
+export const EXACT_SIGNATURE = `type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };`;
 
 export class TsVisitor<
   TRawConfig extends TypeScriptPluginConfig = TypeScriptPluginConfig,


### PR DESCRIPTION
Resolves _"Unexpected any. Specify a different type."_ from `@typescript-eslint/no-explicit-any`.

___Why am I linting generated files?___

1. It's useful when [using ESLint as a lifecycle hook](https://graphql-code-generator.com/docs/integrations/prettier#eslint).
2. It's useful to prevent `any` being used for custom scalar types.