### PR TITLE
fix: do not import the unused DocumentNode for typed-document-node

### DIFF
--- a/dev-test/githunt/typed-document-nodes.ts
+++ b/dev-test/githunt/typed-document-nodes.ts
@@ -1,5 +1,4 @@
-import { DocumentNode } from 'graphql';
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
@@ -419,10 +418,7 @@ export const FeedEntryFragmentDoc: DocumentNode = {
     ...RepoInfoFragmentDoc.definitions,
   ],
 };
-export const OnCommentAddedDocument: TypedDocumentNode<
-  OnCommentAddedSubscription,
-  OnCommentAddedSubscriptionVariables
-> = {
+export const OnCommentAddedDocument: DocumentNode<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables> = {
   kind: 'Document',
   definitions: [
     {
@@ -479,7 +475,7 @@ export const OnCommentAddedDocument: TypedDocumentNode<
     },
   ],
 };
-export const CommentDocument: TypedDocumentNode<CommentQuery, CommentQueryVariables> = {
+export const CommentDocument: DocumentNode<CommentQuery, CommentQueryVariables> = {
   kind: 'Document',
   definitions: [
     {
@@ -626,7 +622,7 @@ export const CommentDocument: TypedDocumentNode<CommentQuery, CommentQueryVariab
     ...CommentsPageCommentFragmentDoc.definitions,
   ],
 };
-export const CurrentUserForProfileDocument: TypedDocumentNode<
+export const CurrentUserForProfileDocument: DocumentNode<
   CurrentUserForProfileQuery,
   CurrentUserForProfileQueryVariables
 > = {
@@ -659,7 +655,7 @@ export const CurrentUserForProfileDocument: TypedDocumentNode<
     },
   ],
 };
-export const FeedDocument: TypedDocumentNode<FeedQuery, FeedQueryVariables> = {
+export const FeedDocument: DocumentNode<FeedQuery, FeedQueryVariables> = {
   kind: 'Document',
   definitions: [
     {
@@ -732,10 +728,7 @@ export const FeedDocument: TypedDocumentNode<FeedQuery, FeedQueryVariables> = {
     ...FeedEntryFragmentDoc.definitions,
   ],
 };
-export const SubmitRepositoryDocument: TypedDocumentNode<
-  SubmitRepositoryMutation,
-  SubmitRepositoryMutationVariables
-> = {
+export const SubmitRepositoryDocument: DocumentNode<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> = {
   kind: 'Document',
   definitions: [
     {
@@ -777,7 +770,7 @@ export const SubmitRepositoryDocument: TypedDocumentNode<
     },
   ],
 };
-export const SubmitCommentDocument: TypedDocumentNode<SubmitCommentMutation, SubmitCommentMutationVariables> = {
+export const SubmitCommentDocument: DocumentNode<SubmitCommentMutation, SubmitCommentMutationVariables> = {
   kind: 'Document',
   definitions: [
     {
@@ -831,7 +824,7 @@ export const SubmitCommentDocument: TypedDocumentNode<SubmitCommentMutation, Sub
     ...CommentsPageCommentFragmentDoc.definitions,
   ],
 };
-export const VoteDocument: TypedDocumentNode<VoteMutation, VoteMutationVariables> = {
+export const VoteDocument: DocumentNode<VoteMutation, VoteMutationVariables> = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -83,3 +83,8 @@ export interface AvoidOptionalsConfig {
   object?: boolean;
   inputValue?: boolean;
 }
+
+export interface ParsedImport {
+  moduleName: string;
+  propName: string;
+}

--- a/packages/plugins/typescript/typed-document-node/src/visitor.ts
+++ b/packages/plugins/typescript/typed-document-node/src/visitor.ts
@@ -7,8 +7,7 @@ import {
   DocumentMode,
   RawClientSideBasePluginConfig,
 } from '@graphql-codegen/visitor-plugin-common';
-import { OperationDefinitionNode , GraphQLSchema } from 'graphql';
-
+import { OperationDefinitionNode, GraphQLSchema } from 'graphql';
 
 export class TypeScriptDocumentNodesVisitor extends ClientSideBaseVisitor<
   RawClientSideBasePluginConfig,
@@ -24,8 +23,9 @@ export class TypeScriptDocumentNodesVisitor extends ClientSideBaseVisitor<
       schema,
       fragments,
       {
-        ...rawConfig,
         documentMode: DocumentMode.documentNodeImportFragments,
+        documentNodeImport: '@graphql-typed-document-node/core#TypedDocumentNode',
+        ...rawConfig,
       },
       {},
       documents
@@ -34,11 +34,7 @@ export class TypeScriptDocumentNodesVisitor extends ClientSideBaseVisitor<
     autoBind(this);
   }
 
-  getImports(): string[] {
-    return [...super.getImports(), `import { TypedDocumentNode } from '@graphql-typed-document-node/core';`];
-  }
-
   protected getDocumentNodeSignature(resultType: string, variablesTypes: string, node: OperationDefinitionNode) {
-    return `TypedDocumentNode<${resultType}, ${variablesTypes}>`;
+    return `DocumentNode<${resultType}, ${variablesTypes}>`;
   }
 }


### PR DESCRIPTION
The new(ish?) typed-document-node plugin includes an unused import of the default DocumentNode from ClientSideBaseVisitor. One issue with this is it triggers ESLint's no-unused-vars rule.

This PR moves the custom DocumentNode import to the base class with added customisability similar to the `gql` import (e.g. it should now be possible to use [graphql-typed](https://www.npmjs.com/package/graphql-typed) should you wish) and removes the unused import.