### PR TITLE
fix: apollo v3 should not use type import

### DIFF
--- a/.changeset/odd-dancers-pump.md
+++ b/.changeset/odd-dancers-pump.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-apollo': patch
+---
+
+apollo v3 should not use type import

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -109,9 +109,11 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
   }
 
   private getApolloReactCommonImport(isTypeImport: boolean): string {
-    return `${this.getImportStatement(isTypeImport)} * as ${this.getApolloReactCommonIdentifier()} from '${
-      this.config.apolloReactCommonImportFrom
-    }';`;
+    const apolloReactCommonIdentifier = this.getApolloReactCommonIdentifier();
+
+    return `${this.getImportStatement(
+      isTypeImport && apolloReactCommonIdentifier !== GROUPED_APOLLO_CLIENT_3_IDENTIFIER
+    )} * as ${apolloReactCommonIdentifier} from '${this.config.apolloReactCommonImportFrom}';`;
   }
 
   private getApolloReactComponentsImport(isTypeImport: boolean): string {


### PR DESCRIPTION
Otherwise output is

```ts
import type * as Apollo from '@apollo/client';
import * as Apollo from '@apollo/client';
```

Which both complains about duplicate identifiers and using type import as value