### PR TITLE
typescript-react-apollo: prevent adding gql alias when documentMode is external

### DIFF
--- a/.changeset/clever-nails-agree.md
+++ b/.changeset/clever-nails-agree.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-apollo': patch
+---
+
+prevent adding aliased gql tag when documentMode is set to "external"

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -80,7 +80,11 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
 
     autoBind(this);
 
-    if (this.config.reactApolloVersion === 3 && this.config.gqlImport === 'gql') {
+    if (
+      this.config.reactApolloVersion === 3 &&
+      this.config.gqlImport === 'gql' &&
+      this.config.documentMode !== DocumentMode.external
+    ) {
       this.imports.add(`const gql = Apollo.gql;`);
     }
   }


### PR DESCRIPTION
Related: https://github.com/dotansimha/graphql-code-generator/issues/4515