### PR TITLE
🐛: double quotes gql queries are not correctly escaped in c-sharp operations plugin

### DIFF
--- a/.changeset/many-owls-bathe.md
+++ b/.changeset/many-owls-bathe.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-codegen/c-sharp-operations': minor
+'@graphql-codegen/c-sharp-operations': patch
 ---
 
 Correctly escape double quotes for constant strings

--- a/.changeset/many-owls-bathe.md
+++ b/.changeset/many-owls-bathe.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/c-sharp-operations': minor
+---
+
+Correctly escape double quotes for constant strings

--- a/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
@@ -131,7 +131,7 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
     const fragments = this._transformFragments(node);
     const doc = this._prepareDocument([print(node), this._includeFragments(fragments)].join('\n'));
 
-    return doc.replace(/"/g, '"""');
+    return doc.replace(/"/g, '""');
   }
 
   private _getDocumentNodeVariable(node: OperationDefinitionNode, documentVariableName: string): string {

--- a/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
@@ -74,6 +74,27 @@ describe('C# Operations', () => {
       expect(result.content).toContain('public class FindYouGQL {');
     });
 
+    it('Should escape string constants in c#', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          me(a: String!): Int!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query findMe {
+          me(a: "test")
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        {},
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toContain('me(a: ""test"")');
+    });
+
     it('Should generate a document string containing original query operation', async () => {
       const schema = buildSchema(/* GraphQL */ `
         type Query {


### PR DESCRIPTION
If a double quotes for a constant string are used in a graphql
query these are escaped in c-sharp code as `"""` in the
verbatim string, but in a verbatim string the escape sequence
for a `"` is `""`.

Change-type: patch
Signed-off-by: Andreas Fitzek <andreas.fitzek@gmail.com>