### PR TITLE
Correcting typescript glob to avoid 'buildError' of undefined

### DIFF
--- a/website/docs/getting-started/documents-field.md
+++ b/website/docs/getting-started/documents-field.md
@@ -47,7 +47,7 @@ You can tell it to find documents in TypeScript files:
 
 ```yml
 schema: http://server1.com/graphql
-documents: "src/**/*.{ts,tsx}"
+documents: "src/**/!(*.d).{ts,tsx}"
 ```
 
 ## Available Formats


### PR DESCRIPTION
With the suggested glob here, this error can occur:

> graphql-codegen --config codegen.yml

  ✔ Parse configuration
  ❯ Generate outputs
    ❯ Generate src/generated/types.ts
      ✔ Load GraphQL schemas
      ✖ Load GraphQL documents
        → Cannot read property 'buildError' of undefined
        Generate


 Found 1 error

  ✖ src/generated/types.ts
    TypeError: Cannot read property 'buildError' of undefined
        at Scope.checkBlockScopedCollisions (node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@babel/traverse/lib/scope/index
.js:421:22)

I was able to trace this back through some issues to an error in babel caused by attempting to process type files containing module decelerations. 
Using an updated glob pattern: "src/**/!(*.d).{ts,tsx}" avoids that.