### PR TITLE
fix(resolvers/federation): only transform federated parent types when they contain @external directive

### DIFF
--- a/packages/plugins/typescript/resolvers/tests/federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/federation.spec.ts
@@ -219,7 +219,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<ParentType, {"name":{"first":true,"last":true}}>, ContextType>;
         name?: Resolver<ResolversTypes['Name'], ParentType, ContextType>;
         username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
         __isTypeOf?: IsTypeOfResolverFn<ParentType>;
@@ -404,8 +404,8 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         allUsers: [User]
       }
 
-      type User @key(fields: "id") @key(fields: "name") {
-        id: ID!
+      extend type User @key(fields: "id") @key(fields: "name") {
+        id: ID! @external
         name: String
         username: String
       }
@@ -426,7 +426,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & (GraphQLRecursivePick<ParentType, {"id":true}> | GraphQLRecursivePick<ParentType, {"name":true}>), ContextType>;
-        id?: Resolver<ResolversTypes['ID'], { __typename: 'User' } & (GraphQLRecursivePick<ParentType, {"id":true}> | GraphQLRecursivePick<ParentType, {"name":true}>), ContextType>;
         name?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'User' } & (GraphQLRecursivePick<ParentType, {"id":true}> | GraphQLRecursivePick<ParentType, {"name":true}>), ContextType>;
         username?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'User' } & (GraphQLRecursivePick<ParentType, {"id":true}> | GraphQLRecursivePick<ParentType, {"name":true}>), ContextType>;
         __isTypeOf?: IsTypeOfResolverFn<ParentType>;
@@ -532,9 +531,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<UnwrappedObject<ParentType>, {"id":true}>, ContextType>;
       `);
       // but ID should not
-      expect(content).toBeSimilarStringTo(
-        `id?: Resolver<ResolversTypes['ID'], { __typename: 'User' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>`
-      );
+      expect(content).toBeSimilarStringTo(`id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>`);
     });
   });
 });


### PR DESCRIPTION
This PR seeks to fix the issue raised in https://github.com/dotansimha/graphql-code-generator/issues/4493

This updates the `transformParentType` function to only transform parent types if one of their fields contains an @external directive, or if the field is named `__resolveReference`. This essentially translates to whether the type extends a type defined in a remote schema, or whether the type is a base type.

The objective is to target only the resolvers that the gateway will call from the `_entities` query in a federated schema. The gateway only guarantees that fields from the `@key` or `@requires` directives will be supplied in the parent type, so we limit the parent type to only contain these fields. If the parent type is a base type, however, then its field resolvers (other than `__resolveReference`) will be called from elsewhere, so we therefore go with the default behavior which is to assume all fields will be available.