### PR TITLE
fix: @graphql-codegen/typescript-graphql-request peerDependencies of graphql-tag 

### DIFF
--- a/packages/plugins/typescript/graphql-request/package.json
+++ b/packages/plugins/typescript/graphql-request/package.json
@@ -13,9 +13,6 @@
     "test": "jest --no-watchman --config ../../../../jest.config.js",
     "prepack": "bob prepack"
   },
-  "peerDependenxcies": {
-    "graphql-tag": "^2.0.0"
-  },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^1.17.7",
     "@graphql-codegen/visitor-plugin-common": "^1.17.7",
@@ -23,7 +20,8 @@
     "tslib": "~2.0.0"
   },
   "peerDependencies": {
-    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0",
+    "graphql-tag": "^2.0.0"
   },
   "devDependencies": {
     "nock": "13.0.3"


### PR DESCRIPTION
There is a typo of `peerDependenxcies` and `graphql-tag` is needed to use `@graphql-codegen/typescript-graphql-request`.