### PR TITLE
fix(jsdoc): Correctly placed description in typedef

### DIFF
--- a/.changeset/sour-vans-repeat.md
+++ b/.changeset/sour-vans-repeat.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/jsdoc": patch
+---
+
+JSDoc plugin now outputs correct JSDoc annotations for types with a description

--- a/packages/plugins/other/jsdoc/src/index.ts
+++ b/packages/plugins/other/jsdoc/src/index.ts
@@ -36,7 +36,7 @@ const createDocBlock = (lines: Array<string>) => {
 
 const createDescriptionBlock = (nodeWithDesc: any | { description?: StringValueNode }): string => {
   if (nodeWithDesc?.description?.value) {
-    return `@description ${nodeWithDesc.description.value}`;
+    return nodeWithDesc.description.value;
   }
 
   return '';
@@ -58,8 +58,8 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
         const typedNode = node as { name: string; fields: Array<string> };
 
         return createDocBlock([
-          `@typedef {Object} ${typedNode.name}`,
           createDescriptionBlock(node),
+          `@typedef {Object} ${typedNode.name}`,
           ...typedNode.fields,
         ]);
       },
@@ -69,8 +69,8 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
         const typedNode = node as { name: string; fields: Array<string> };
 
         return createDocBlock([
-          `@typedef {Object} ${typedNode.name}`,
           createDescriptionBlock(node),
+          `@typedef {Object} ${typedNode.name}`,
           ...typedNode.fields,
         ]);
       },
@@ -80,8 +80,8 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
         const typedNode = node as { name: string; fields: Array<string> };
 
         return createDocBlock([
-          `@typedef {Object} ${typedNode.name}`,
           createDescriptionBlock(node),
+          `@typedef {Object} ${typedNode.name}`,
           ...typedNode.fields,
         ]);
       },
@@ -89,7 +89,7 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
     UnionTypeDefinition: {
       leave(node) {
         if (node.types !== undefined) {
-          return createDocBlock([`@typedef {(${node.types.join('|')})} ${node.name}`, createDescriptionBlock(node)]);
+          return createDocBlock([createDescriptionBlock(node), `@typedef {(${node.types.join('|')})} ${node.name}`]);
         }
 
         return node;
@@ -177,7 +177,7 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
     },
     ScalarTypeDefinition: {
       leave(node) {
-        return createDocBlock([`@typedef {*} ${node.name}`, createDescriptionBlock(node)]);
+        return createDocBlock([createDescriptionBlock(node), `@typedef {*} ${node.name}`]);
       },
     },
     EnumTypeDefinition: {
@@ -187,7 +187,7 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
         /** If for some reason the enum does not contain any values we fallback to "any" or "*" */
         const valueType = values ? `(${values})` : '*';
 
-        return createDocBlock([`@typedef {${valueType}} ${node.name}`, createDescriptionBlock(node)]);
+        return createDocBlock([createDescriptionBlock(node), `@typedef {${valueType}} ${node.name}`]);
       },
     },
     OperationDefinition: {

--- a/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
+++ b/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
@@ -6,30 +6,30 @@ describe('JSDoc Plugin', () => {
   describe('description', () => {
     it('Should work with described schemas', async () => {
       const schema = buildSchema(/* Graphql */ `
-        """ type desc """
+        """type desc"""
         type Foo {
-          """ type field desc """
+          """type field desc"""
             foo: Int!
         }
 
-        """ input desc """
+        """input desc"""
         input FooInput {
-            """ input field desc """
+            """input field desc"""
             foo: Int!
         }
 
-        """ enum desc """
+        """enum desc"""
         enum Test {
             A
             B
-            """ enum value desc """
+            """enum value desc"""
             C
         }
 
-        """ scalar desc """
+        """scalar desc"""
         scalar Date
 
-        """ interface desc """
+        """interface desc"""
         interface Node {
           """ interface field desc """
           id: ID!
@@ -46,26 +46,26 @@ describe('JSDoc Plugin', () => {
       const result = await plugin(schema, [], config, { outputFile: '' });
 
       expect(result).toBeSimilarStringTo(`/**
+      * enum desc
       * @typedef {("A"|"B"|"C")} Test
-      * @description  enum desc
       */`);
       expect(result).toBeSimilarStringTo(`/**
-      * @typedef {(Foo)} TestU
-      * @description union desc
+      * union desc
       * multiline test
+      * @typedef {(Foo)} TestU
       */`);
       expect(result).toBeSimilarStringTo(`/**
+      * scalar desc 
       * @typedef {*} Date
-      * @description  scalar desc 
       */`);
       expect(result).toBeSimilarStringTo(`/**
+      * input desc 
       * @typedef {Object} FooInput
-      * @description  input desc 
       * @property {number} foo -  input field desc 
       */`);
       expect(result).toBeSimilarStringTo(`/**
+      * type desc 
       * @typedef {Object} Foo
-      * @description  type desc 
       * @property {number} foo -  type field desc 
       */`);
     });


### PR DESCRIPTION
Turns out that you are not supposed to add an `@description` annotation under an `@typedef` annotation or it will end being invalid