### PR TITLE
Improve gql tag output in ts-react-apollo and ts-apollo-angular, fixed empty lines added by `add` plugin

### DIFF
--- a/.changeset/gold-hats-allow.md
+++ b/.changeset/gold-hats-allow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/core': patch
+---
+
+Filter `prepend` and `append` coming from plugins, make sure not to add empty lines when not needed

--- a/.changeset/plenty-dodos-argue.md
+++ b/.changeset/plenty-dodos-argue.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/add': patch
+---
+
+Fix for empty lines added by add plugin

--- a/.changeset/small-kiwis-hunt.md
+++ b/.changeset/small-kiwis-hunt.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-apollo-angular': patch
+---
+
+Improve output by using gql tag from apollo-angular package, when apollo-angular@v2 is used

--- a/.changeset/tricky-pigs-smile.md
+++ b/.changeset/tricky-pigs-smile.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-apollo': patch
+---
+
+Improve output reliability by using separate import for gql tag, ensuring it will be there also for fragments when presets are used. This will bring back the separate import for gql tag (and remove the aliased one)

--- a/dev-test/githunt/types.apolloAngular.sdk.ts
+++ b/dev-test/githunt/types.apolloAngular.sdk.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from 'apollo-angular';
 import { Injectable } from '@angular/core';
 import * as Apollo from 'apollo-angular';
 import * as ApolloCore from '@apollo/client/core';

--- a/dev-test/githunt/types.apolloAngular.ts
+++ b/dev-test/githunt/types.apolloAngular.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from 'apollo-angular';
 import { Injectable } from '@angular/core';
 import * as Apollo from 'apollo-angular';
 export type Maybe<T> = T | null;

--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -1,7 +1,7 @@
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-const gql = Apollo.gql;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -1,7 +1,7 @@
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-const gql = Apollo.gql;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -1,7 +1,7 @@
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-const gql = Apollo.gql;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -1,7 +1,7 @@
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-const gql = Apollo.gql;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/star-wars/__generated__/CreateReviewForEpisode.tsx
+++ b/dev-test/star-wars/__generated__/CreateReviewForEpisode.tsx
@@ -1,7 +1,7 @@
 import * as Types from '../types.d';
 
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-const gql = Apollo.gql;
 
 export type CreateReviewForEpisodeMutationVariables = Types.Exact<{
   episode: Types.Episode;

--- a/dev-test/star-wars/__generated__/CreateReviewForEpisode.tsx
+++ b/dev-test/star-wars/__generated__/CreateReviewForEpisode.tsx
@@ -2,7 +2,6 @@ import * as Types from '../types.d';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type CreateReviewForEpisodeMutationVariables = Types.Exact<{
   episode: Types.Episode;
   review: Types.ReviewInput;

--- a/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
+++ b/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
@@ -1,7 +1,7 @@
 import * as Types from '../types.d';
 
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-const gql = Apollo.gql;
 
 export type HeroAndFriendsNamesQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;

--- a/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
+++ b/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
@@ -2,7 +2,6 @@ import * as Types from '../types.d';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type HeroAndFriendsNamesQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;
 }>;

--- a/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
+++ b/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
@@ -1,7 +1,7 @@
 import * as Types from '../types.d';
 
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-const gql = Apollo.gql;
 
 export type HeroAppearsInQueryVariables = Types.Exact<{ [key: string]: never }>;
 

--- a/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
+++ b/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
@@ -2,7 +2,6 @@ import * as Types from '../types.d';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type HeroAppearsInQueryVariables = Types.Exact<{ [key: string]: never }>;
 
 export type HeroAppearsInQuery = { __typename?: 'Query' } & {

--- a/dev-test/star-wars/__generated__/HeroDetails.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetails.tsx
@@ -1,7 +1,7 @@
 import * as Types from '../types.d';
 
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-const gql = Apollo.gql;
 
 export type HeroDetailsQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;

--- a/dev-test/star-wars/__generated__/HeroDetails.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetails.tsx
@@ -2,7 +2,6 @@ import * as Types from '../types.d';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type HeroDetailsQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;
 }>;

--- a/dev-test/star-wars/__generated__/HeroDetailsFragment.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetailsFragment.tsx
@@ -1,5 +1,7 @@
 import * as Types from '../types.d';
 
+import { gql } from '@apollo/client';
+
 export type HeroDetails_Human_Fragment = { __typename?: 'Human' } & Pick<Types.Human, 'height' | 'name'>;
 
 export type HeroDetails_Droid_Fragment = { __typename?: 'Droid' } & Pick<Types.Droid, 'primaryFunction' | 'name'>;

--- a/dev-test/star-wars/__generated__/HeroDetailsFragment.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetailsFragment.tsx
@@ -1,7 +1,6 @@
 import * as Types from '../types.d';
 
 import { gql } from '@apollo/client';
-
 export type HeroDetails_Human_Fragment = { __typename?: 'Human' } & Pick<Types.Human, 'height' | 'name'>;
 
 export type HeroDetails_Droid_Fragment = { __typename?: 'Droid' } & Pick<Types.Droid, 'primaryFunction' | 'name'>;

--- a/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
@@ -1,9 +1,9 @@
 import * as Types from '../types.d';
 
 import { HeroDetails_Human_Fragment, HeroDetails_Droid_Fragment } from './HeroDetailsFragment';
+import { gql } from '@apollo/client';
 import { HeroDetailsFragmentDoc } from './HeroDetailsFragment';
 import * as Apollo from '@apollo/client';
-const gql = Apollo.gql;
 
 export type HeroDetailsWithFragmentQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;

--- a/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
@@ -4,7 +4,6 @@ import { HeroDetails_Human_Fragment, HeroDetails_Droid_Fragment } from './HeroDe
 import { gql } from '@apollo/client';
 import { HeroDetailsFragmentDoc } from './HeroDetailsFragment';
 import * as Apollo from '@apollo/client';
-
 export type HeroDetailsWithFragmentQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;
 }>;

--- a/dev-test/star-wars/__generated__/HeroName.tsx
+++ b/dev-test/star-wars/__generated__/HeroName.tsx
@@ -2,7 +2,6 @@ import * as Types from '../types.d';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type HeroNameQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;
 }>;

--- a/dev-test/star-wars/__generated__/HeroName.tsx
+++ b/dev-test/star-wars/__generated__/HeroName.tsx
@@ -1,7 +1,7 @@
 import * as Types from '../types.d';
 
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-const gql = Apollo.gql;
 
 export type HeroNameQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;

--- a/dev-test/star-wars/__generated__/HeroNameConditional.tsx
+++ b/dev-test/star-wars/__generated__/HeroNameConditional.tsx
@@ -2,7 +2,6 @@ import * as Types from '../types.d';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type HeroNameConditionalInclusionQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;
   includeName: Types.Scalars['Boolean'];

--- a/dev-test/star-wars/__generated__/HeroNameConditional.tsx
+++ b/dev-test/star-wars/__generated__/HeroNameConditional.tsx
@@ -1,7 +1,7 @@
 import * as Types from '../types.d';
 
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-const gql = Apollo.gql;
 
 export type HeroNameConditionalInclusionQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;

--- a/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
+++ b/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
@@ -1,7 +1,7 @@
 import * as Types from '../types.d';
 
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-const gql = Apollo.gql;
 
 export type HeroParentTypeDependentFieldQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;

--- a/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
+++ b/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
@@ -2,7 +2,6 @@ import * as Types from '../types.d';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type HeroParentTypeDependentFieldQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;
 }>;

--- a/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
+++ b/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
@@ -2,7 +2,6 @@ import * as Types from '../types.d';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type HeroTypeDependentAliasedFieldQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;
 }>;

--- a/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
+++ b/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
@@ -1,7 +1,7 @@
 import * as Types from '../types.d';
 
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-const gql = Apollo.gql;
 
 export type HeroTypeDependentAliasedFieldQueryVariables = Types.Exact<{
   episode?: Types.Maybe<Types.Episode>;

--- a/dev-test/star-wars/__generated__/HumanFields.tsx
+++ b/dev-test/star-wars/__generated__/HumanFields.tsx
@@ -1,7 +1,6 @@
 import * as Types from '../types.d';
 
 import { gql } from '@apollo/client';
-
 export type HumanFieldsFragment = { __typename?: 'Human' } & Pick<Types.Human, 'name' | 'mass'>;
 
 export const HumanFieldsFragmentDoc = gql`

--- a/dev-test/star-wars/__generated__/HumanFields.tsx
+++ b/dev-test/star-wars/__generated__/HumanFields.tsx
@@ -1,5 +1,7 @@
 import * as Types from '../types.d';
 
+import { gql } from '@apollo/client';
+
 export type HumanFieldsFragment = { __typename?: 'Human' } & Pick<Types.Human, 'name' | 'mass'>;
 
 export const HumanFieldsFragmentDoc = gql`

--- a/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
+++ b/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
@@ -1,9 +1,9 @@
 import * as Types from '../types.d';
 
 import { HumanFieldsFragment } from './HumanFields';
+import { gql } from '@apollo/client';
 import { HumanFieldsFragmentDoc } from './HumanFields';
 import * as Apollo from '@apollo/client';
-const gql = Apollo.gql;
 
 export type HumanWithNullHeightQueryVariables = Types.Exact<{ [key: string]: never }>;
 

--- a/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
+++ b/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
@@ -4,7 +4,6 @@ import { HumanFieldsFragment } from './HumanFields';
 import { gql } from '@apollo/client';
 import { HumanFieldsFragmentDoc } from './HumanFields';
 import * as Apollo from '@apollo/client';
-
 export type HumanWithNullHeightQueryVariables = Types.Exact<{ [key: string]: never }>;
 
 export type HumanWithNullHeightQuery = { __typename?: 'Query' } & {

--- a/dev-test/star-wars/__generated__/TwoHeroes.tsx
+++ b/dev-test/star-wars/__generated__/TwoHeroes.tsx
@@ -1,7 +1,7 @@
 import * as Types from '../types.d';
 
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-const gql = Apollo.gql;
 
 export type TwoHeroesQueryVariables = Types.Exact<{ [key: string]: never }>;
 

--- a/dev-test/star-wars/__generated__/TwoHeroes.tsx
+++ b/dev-test/star-wars/__generated__/TwoHeroes.tsx
@@ -2,7 +2,6 @@ import * as Types from '../types.d';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type TwoHeroesQueryVariables = Types.Exact<{ [key: string]: never }>;
 
 export type TwoHeroesQuery = { __typename?: 'Query' } & {

--- a/dev-test/star-wars/types.refetchFn.tsx
+++ b/dev-test/star-wars/types.refetchFn.tsx
@@ -1,7 +1,7 @@
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-const gql = Apollo.gql;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/dev-test/test-schema/typings.wrapped.ts
+++ b/dev-test/test-schema/typings.wrapped.ts
@@ -1,7 +1,6 @@
 declare namespace GraphQL {
   export type Maybe<T> = T | null;
   export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-
   /** All built-in and custom scalars, mapped to their actual values */
   export type Scalars = {
     ID: string;

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -124,13 +124,17 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
       } else if (isComplexPluginOutput(result)) {
         if (result.append && result.append.length > 0) {
           for (const item of result.append) {
-            append.add(item);
+            if (item) {
+              append.add(item);
+            }
           }
         }
 
         if (result.prepend && result.prepend.length > 0) {
           for (const item of result.prepend) {
-            prepend.add(item);
+            if (item) {
+              prepend.add(item);
+            }
           }
         }
         return result.content || '';
@@ -140,7 +144,9 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
     })
   );
 
-  return [...sortPrependValues(Array.from(prepend.values())), ...output, ...Array.from(append.values())].join('\n');
+  return [...sortPrependValues(Array.from(prepend.values())), ...output, ...Array.from(append.values())]
+    .filter(Boolean)
+    .join('\n');
 }
 
 function resolveCompareValue(a: string) {

--- a/packages/plugins/other/add/src/index.ts
+++ b/packages/plugins/other/add/src/index.ts
@@ -19,11 +19,11 @@ export const plugin: PluginFunction<AddPluginConfig> = async (
   }
 
   if (!content) {
-    throw Error(`Configuration provided for 'add' plugin is invalid`);
+    throw Error(`Configuration provided for 'add' plugin is invalid: "content" is missing!`);
   }
 
   return {
-    content: '',
+    content: null,
     [placement]: Array.isArray(content) ? content : [content],
   };
 };

--- a/packages/plugins/typescript/apollo-angular/src/visitor.ts
+++ b/packages/plugins/typescript/apollo-angular/src/visitor.ts
@@ -4,6 +4,7 @@ import {
   DocumentMode,
   LoadedFragment,
   indentMultiline,
+  getConfigValue,
 } from '@graphql-codegen/visitor-plugin-common';
 import autoBind from 'auto-bind';
 import { OperationDefinitionNode, print, visit, GraphQLSchema, Kind } from 'graphql';
@@ -66,8 +67,12 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
         querySuffix: rawConfig.querySuffix,
         mutationSuffix: rawConfig.mutationSuffix,
         subscriptionSuffix: rawConfig.subscriptionSuffix,
-        apolloAngularPackage: rawConfig.apolloAngularPackage || 'apollo-angular',
-        apolloAngularVersion: rawConfig.apolloAngularVersion || 2,
+        apolloAngularPackage: getConfigValue(rawConfig.apolloAngularPackage, 'apollo-angular'),
+        apolloAngularVersion: getConfigValue(rawConfig.apolloAngularVersion, 2),
+        gqlImport: getConfigValue(
+          rawConfig.gqlImport,
+          !rawConfig.apolloAngularVersion || rawConfig.apolloAngularVersion === 2 ? `apollo-angular#gql` : null
+        ),
       },
       documents
     );

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -72,21 +72,16 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
       withResultType: getConfigValue(rawConfig.withResultType, true),
       withMutationOptionsType: getConfigValue(rawConfig.withMutationOptionsType, true),
       addDocBlocks: getConfigValue(rawConfig.addDocBlocks, true),
-      gqlImport: getConfigValue(rawConfig.gqlImport, rawConfig.reactApolloVersion === 2 ? null : `gql`),
+      gqlImport: getConfigValue(
+        rawConfig.gqlImport,
+        rawConfig.reactApolloVersion === 2 ? null : `${APOLLO_CLIENT_3_UNIFIED_PACKAGE}#gql`
+      ),
     });
 
     this._externalImportPrefix = this.config.importOperationTypesFrom ? `${this.config.importOperationTypesFrom}.` : '';
     this._documents = documents;
 
     autoBind(this);
-
-    if (
-      this.config.reactApolloVersion === 3 &&
-      this.config.gqlImport === 'gql' &&
-      this.config.documentMode !== DocumentMode.external
-    ) {
-      this.imports.add(`const gql = Apollo.gql;`);
-    }
   }
 
   private getImportStatement(isTypeImport: boolean): string {

--- a/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
+++ b/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`React Apollo Issues Issue #2742 - Incorrect import prefix 1`] = `
 "export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-const gql = Apollo.gql;
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -192,7 +192,7 @@ export type Get_SomethingQueryResult = Apollo.QueryResult<Types.Get_SomethingQue
 exports[`React Apollo Issues Issue #2826 - Incorrect prefix 1`] = `
 "export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-const gql = Apollo.gql;
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -381,7 +381,7 @@ export type Get_SomethingQueryResult = Apollo.QueryResult<GQLGet_SomethingQuery,
 exports[`React Apollo Issues PR #2725 - transformUnderscore: true causes invalid output 1`] = `
 "export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-const gql = Apollo.gql;
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -570,7 +570,7 @@ export type GetSomethingQueryResult = Apollo.QueryResult<GetSomethingQuery, GetS
 exports[`React Apollo Issues PR #2725 - transformUnderscore: true causes invalid output 2`] = `
 "export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-const gql = Apollo.gql;
+import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -326,12 +326,11 @@ describe('React Apollo', () => {
       )) as Types.ComplexPluginOutput;
 
       expect(content.prepend).toContain(`import * as Apollo from '@apollo/client';`);
-      expect(content.prepend).toContain(`const gql = Apollo.gql;`);
+      expect(content.prepend).toContain(`import { gql } from '@apollo/client';`);
       expect(content.prepend).toContain(`import * as ApolloReactComponents from '@apollo/client/react/components';`);
       expect(content.prepend).toContain(`import * as React from 'react';`);
 
       // To make sure all imports are unified correctly under Apollo namespaced import
-      expect(content.prepend).not.toContain(`import { gql } from '@apollo/client';`);
       expect(content.content).toContain(` gql\``);
       await validateTypeScript(content, schema, docs, {});
     });


### PR DESCRIPTION
The PR fixes the following:
- [x] https://github.com/dotansimha/graphql-code-generator/issues/4532 - by using `gql` tag with import, like we had before, without unified import for Apollo (`import * as Apollo`). This won't cause duplication in import, since namespace and named imports are treated separately. We can't merge these 2 together, because otherwise the `ts-react-apollo` plugin is in charge of creating the `gql` tag import, and this breaks fragments files in presets mode (since there are not hooks or anything generated from the `ts-react-apollo` plugin)
- [x] Import gql-tag from `apollo-angular` when v2 is used. 
- [x] https://github.com/dotansimha/graphql-code-generator/issues/4528