### PR TITLE
Better errors in presets

### DIFF
--- a/.changeset/breezy-clocks-ring.md
+++ b/.changeset/breezy-clocks-ring.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/near-operation-file-preset': patch
+---
+
+Improve error messages when document validation fails


### PR DESCRIPTION
This PR makes errors coming from presets more readable, and with more details, by wrapping it with `DetailedError`. 