### PR TITLE
Remove unused code in c-sharp plugins

### DIFF
--- a/.changeset/eight-eyes-type.md
+++ b/.changeset/eight-eyes-type.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/c-sharp-operations': patch
+---
+
+Fix c-sharp-operations package description

--- a/.changeset/nine-cameras-agree.md
+++ b/.changeset/nine-cameras-agree.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/c-sharp': patch
+---
+
+Remove unused c-sharp code

--- a/packages/plugins/c-sharp/c-sharp-operations/package.json
+++ b/packages/plugins/c-sharp/c-sharp-operations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@graphql-codegen/c-sharp-operations",
   "version": "1.17.8",
-  "description": "GraphQL Code Generator plugin for generating ready-to-use Angular Components based on GraphQL operations",
+  "description": "GraphQL Code Generator plugin for generating CSharp code based on GraphQL operations",
   "repository": "git@github.com:dotansimha/graphql-code-generator.git",
   "license": "MIT",
   "scripts": {

--- a/packages/plugins/c-sharp/c-sharp/src/index.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/index.ts
@@ -1,8 +1,6 @@
 import { parse, GraphQLSchema, printSchema, visit } from 'graphql';
 import { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
 import { CSharpResolversVisitor } from './visitor';
-import { buildPackageNameFromPath } from '../../common/common';
-import { dirname, normalize } from 'path';
 import { CSharpResolversPluginRawConfig } from './config';
 
 export const plugin: PluginFunction<CSharpResolversPluginRawConfig> = async (
@@ -11,9 +9,7 @@ export const plugin: PluginFunction<CSharpResolversPluginRawConfig> = async (
   config: CSharpResolversPluginRawConfig,
   { outputFile }
 ): Promise<string> => {
-  const relevantPath = dirname(normalize(outputFile));
-  const defaultPackageName = buildPackageNameFromPath(relevantPath);
-  const visitor = new CSharpResolversVisitor(config, schema, defaultPackageName);
+  const visitor = new CSharpResolversVisitor(config, schema);
   const printedSchema = printSchema(schema);
   const astNode = parse(printedSchema);
   const visitorResult = visit(astNode, { leave: visitor as any });

--- a/packages/plugins/c-sharp/c-sharp/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/visitor.ts
@@ -49,7 +49,7 @@ export interface CSharpResolverParsedConfig extends ParsedConfig {
 export class CSharpResolversVisitor extends BaseVisitor<CSharpResolversPluginRawConfig, CSharpResolverParsedConfig> {
   private readonly keywords = new Set(csharpKeywords);
 
-  constructor(rawConfig: CSharpResolversPluginRawConfig, private _schema: GraphQLSchema, defaultPackageName: string) {
+  constructor(rawConfig: CSharpResolversPluginRawConfig, private _schema: GraphQLSchema) {
     super(rawConfig, {
       enumValues: rawConfig.enumValues || {},
       listType: rawConfig.listType || 'List',

--- a/packages/plugins/c-sharp/common/c-sharp-declaration-block.ts
+++ b/packages/plugins/c-sharp/common/c-sharp-declaration-block.ts
@@ -1,29 +1,9 @@
 import { indentMultiline } from '@graphql-codegen/visitor-plugin-common';
 import { StringValueNode, NameNode } from 'graphql';
 import { transformComment } from './utils';
-const stripIndent = require('strip-indent');
 
 export type Access = 'private' | 'public' | 'protected';
 export type Kind = 'namespace' | 'class' | 'interface' | 'enum';
-export type MemberFlags = { transient?: boolean; final?: boolean; volatile?: boolean; static?: boolean };
-export type ClassMember = {
-  value: string;
-  name: string;
-  access: Access;
-  type: string;
-  annotations: string[];
-  flags: MemberFlags;
-};
-export type ClassMethod = {
-  methodAnnotations: string[];
-  args: Partial<ClassMember>[];
-  implementation: string;
-  name: string;
-  access: Access;
-  returnType: string | null;
-  returnTypeAnnotations: string[];
-  flags: MemberFlags;
-};
 
 export class CSharpDeclarationBlock {
   _name: string = null;
@@ -35,9 +15,6 @@ export class CSharpDeclarationBlock {
   _static = false;
   _block = null;
   _comment = null;
-  _annotations: string[] = [];
-  _members: ClassMember[] = [];
-  _methods: ClassMethod[] = [];
   _nestedClasses: CSharpDeclarationBlock[] = [];
 
   nestedClass(nstCls: CSharpDeclarationBlock): CSharpDeclarationBlock {
@@ -66,12 +43,6 @@ export class CSharpDeclarationBlock {
 
   static(): CSharpDeclarationBlock {
     this._static = true;
-
-    return this;
-  }
-
-  annotate(annotations: string[]): CSharpDeclarationBlock {
-    this._annotations = annotations;
 
     return this;
   }
@@ -108,99 +79,6 @@ export class CSharpDeclarationBlock {
     return this;
   }
 
-  private printMember(member: Partial<ClassMember>): string {
-    const flags = member.flags || {};
-
-    const pieces = [
-      member.access,
-      flags.static ? 'static' : null,
-      flags.final ? 'final' : null,
-      flags.transient ? 'transient' : null,
-      flags.volatile ? 'volatile' : null,
-      ...(member.annotations || []).map(annotation => `@${annotation}`),
-      member.type,
-      member.name,
-    ].filter(f => f);
-
-    return pieces.join(' ') + (member.value ? ` = ${member.value}` : '');
-  }
-
-  private printMethod(method: ClassMethod): string {
-    const pieces = [
-      ...method.methodAnnotations.map(a => `@${a}\n`),
-      method.access,
-      method.flags.static ? 'static' : null,
-      method.flags.final ? 'final' : null,
-      method.flags.transient ? 'transient' : null,
-      method.flags.volatile ? 'volatile' : null,
-      ...(method.returnTypeAnnotations || []).map(annotation => `@${annotation}`),
-      method.returnType,
-      method.name,
-    ].filter(f => f);
-
-    const args = method.args.map(arg => this.printMember(arg)).join(', ');
-
-    return `${pieces.join(' ')}(${args}) {
-${indentMultiline(method.implementation)}
-}`;
-  }
-
-  addClassMember(
-    name: string,
-    type: string,
-    value: string,
-    typeAnnotations: string[] = [],
-    access: Access = null,
-    flags: MemberFlags = {}
-  ): CSharpDeclarationBlock {
-    this._members.push({
-      name,
-      type,
-      value,
-      annotations: typeAnnotations,
-      access,
-      flags: {
-        final: false,
-        transient: false,
-        volatile: false,
-        static: false,
-        ...flags,
-      },
-    });
-
-    return this;
-  }
-
-  addClassMethod(
-    name: string,
-    returnType: string | null,
-    impl: string,
-    args: Partial<ClassMember>[] = [],
-    returnTypeAnnotations: string[] = [],
-    access: Access = null,
-    flags: MemberFlags = {},
-    methodAnnotations: string[] = []
-  ): CSharpDeclarationBlock {
-    this._methods.push({
-      name,
-      returnType,
-      implementation: impl,
-      args,
-      returnTypeAnnotations,
-      access,
-      flags: {
-        final: false,
-        transient: false,
-        volatile: false,
-        static: false,
-        ...flags,
-      },
-      methodAnnotations: methodAnnotations || [],
-    });
-
-    return this;
-  }
-
   public get string(): string {
     let result = '';
 
@@ -216,7 +94,6 @@ ${indentMultiline(method.implementation)}
       } else {
         let extendStr = '';
         let implementsStr = '';
-        let annotatesStr = '';
         const final = this._final ? ' final' : '';
         const isStatic = this._static ? ' static' : '';
 
@@ -228,26 +105,16 @@ ${indentMultiline(method.implementation)}
           implementsStr = ` : ${this._implementsStr.join(', ')}`;
         }
 
-        if (this._annotations.length > 0) {
-          annotatesStr = this._annotations.map(a => `@${a}`).join('\n') + '\n';
-        }
-
-        result += `${annotatesStr}${this._access}${isStatic}${final} ${this._kind} ${name}${extendStr}${implementsStr} `;
+        result += `${this._access}${isStatic}${final} ${this._kind} ${name}${extendStr}${implementsStr} `;
       }
     }
 
-    const members = this._members.length
-      ? indentMultiline(stripIndent(this._members.map(member => this.printMember(member) + ';').join('\n')))
-      : null;
-    const methods = this._methods.length
-      ? indentMultiline(stripIndent(this._methods.map(method => this.printMethod(method)).join('\n\n')))
-      : null;
     const nestedClasses = this._nestedClasses.length
       ? this._nestedClasses.map(c => indentMultiline(c.string)).join('\n\n')
       : null;
     const before = '{';
     const after = '}';
-    const block = [before, members, methods, nestedClasses, this._block, after].filter(f => f).join('\n');
+    const block = [before, nestedClasses, this._block, after].filter(f => f).join('\n');
     result += block;
 
     return (this._comment ? this._comment : '') + result + '\n';

--- a/packages/plugins/c-sharp/common/utils.ts
+++ b/packages/plugins/c-sharp/common/utils.ts
@@ -3,13 +3,6 @@ import { indent } from '@graphql-codegen/visitor-plugin-common';
 import { csharpNativeValueTypes } from './scalars';
 import { ListTypeField, CSharpFieldType } from './c-sharp-field-types';
 
-export function buildPackageNameFromPath(path: string): string {
-  const unixify = require('unixify');
-  return unixify(path || '')
-    .replace(/src\/main\/.*?\//, '')
-    .replace(/\//g, '.');
-}
-
 export function transformComment(comment: string | StringValueNode, indentLevel = 0): string {
   if (!comment) {
     return '';


### PR DESCRIPTION
While preparing another change I noticed some code in the c-sharp plugin that seems to be a left over from a fork. This PR removes this code.

This PR also fixes the package description of the c-sharp-operations package.