### PR TITLE
Update read-only flow type generation to be compatible with both FlowWithPickSelectionSetProcessor and PreResolveTypesProcessor

### DIFF
--- a/.changeset/modern-emus-allow.md
+++ b/.changeset/modern-emus-allow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/flow-operations': minor
+---
+
+Fix bug with read-only type generation when using preResolveTypes flag

--- a/packages/plugins/flow/operations/src/flow-selection-set-processor.ts
+++ b/packages/plugins/flow/operations/src/flow-selection-set-processor.ts
@@ -11,7 +11,6 @@ import { GraphQLObjectType, GraphQLInterfaceType } from 'graphql';
 
 export interface FlowSelectionSetProcessorConfig extends SelectionSetProcessorConfig {
   useFlowExactObjects: boolean;
-  useFlowReadOnlyTypes: boolean;
 }
 
 export class FlowWithPickSelectionSetProcessor extends BaseSelectionSetProcessor<FlowSelectionSetProcessorConfig> {
@@ -24,7 +23,8 @@ export class FlowWithPickSelectionSetProcessor extends BaseSelectionSetProcessor
     }
 
     const useFlowExactObject = this.config.useFlowExactObjects;
-    const useFlowReadOnlyTypes = this.config.useFlowReadOnlyTypes;
+    const formatNamedField = this.config.formatNamedField;
+    const fieldObj = schemaType.getFields();
     const parentName =
       (this.config.namespacedImportName ? `${this.config.namespacedImportName}.` : '') +
       this.config.convertName(schemaType.name, {
@@ -35,9 +35,10 @@ export class FlowWithPickSelectionSetProcessor extends BaseSelectionSetProcessor
       `{${useFlowExactObject ? '|' : ''} ${fields
         .map(
           aliasedField =>
-            `${useFlowReadOnlyTypes ? '+' : ''}${aliasedField.alias}: $ElementType<${parentName}, '${
-              aliasedField.fieldName
-            }'>`
+            `${formatNamedField(
+              aliasedField.alias,
+              fieldObj[aliasedField.fieldName].type
+            )}: $ElementType<${parentName}, '${aliasedField.fieldName}'>`
         )
         .join(', ')} ${useFlowExactObject ? '|' : ''}}`,
     ];
@@ -63,11 +64,9 @@ export class FlowWithPickSelectionSetProcessor extends BaseSelectionSetProcessor
     }
 
     const useFlowExactObject = this.config.useFlowExactObjects;
-    const useFlowReadOnlyTypes = this.config.useFlowReadOnlyTypes;
-
     return [
       `{${useFlowExactObject ? '|' : ''} ${fields
-        .map(field => `${useFlowReadOnlyTypes ? '+' : ''}${field.alias || field.name}: ${field.selectionSet}`)
+        .map(field => `${field.alias || field.name}: ${field.selectionSet}`)
         .join(', ')} ${useFlowExactObject ? '|' : ''}}`,
     ];
   }
@@ -81,7 +80,6 @@ export class FlowWithPickSelectionSetProcessor extends BaseSelectionSetProcessor
     }
 
     const useFlowExactObject = this.config.useFlowExactObjects;
-    const useFlowReadOnlyTypes = this.config.useFlowReadOnlyTypes;
     const formatNamedField = this.config.formatNamedField;
     const parentName =
       (this.config.namespacedImportName ? `${this.config.namespacedImportName}.` : '') +
@@ -91,9 +89,7 @@ export class FlowWithPickSelectionSetProcessor extends BaseSelectionSetProcessor
     const fieldObj = schemaType.getFields();
     return [
       `$Pick<${parentName}, {${useFlowExactObject ? '|' : ''} ${fields
-        .map(
-          fieldName => `${useFlowReadOnlyTypes ? '+' : ''}${formatNamedField(fieldName, fieldObj[fieldName].type)}: *`
-        )
+        .map(fieldName => `${formatNamedField(fieldName, fieldObj[fieldName].type)}: *`)
         .join(', ')} ${useFlowExactObject ? '|' : ''}}>`,
     ];
   }

--- a/packages/plugins/flow/operations/src/visitor.ts
+++ b/packages/plugins/flow/operations/src/visitor.ts
@@ -34,12 +34,13 @@ export class FlowDocumentsVisitor extends BaseDocumentsVisitor<FlowDocumentsPlug
 
     autoBind(this);
 
-    const wrapArray = (type: string) => `Array<${type}>`;
+    const wrapArray = (type: string) => `${this.config.useFlowReadOnlyTypes ? '$ReadOnlyArray' : 'Array'}<${type}>`;
     const wrapOptional = (type: string) => `?${type}`;
 
+    const useFlowReadOnlyTypes = this.config.useFlowReadOnlyTypes;
     const formatNamedField = (name: string, type: GraphQLOutputType | null): string => {
       const optional = !!type && !isNonNullType(type);
-      return `${name}${optional ? '?' : ''}`;
+      return `${useFlowReadOnlyTypes ? '+' : ''}${name}${optional ? '?' : ''}`;
     };
 
     const processorConfig: SelectionSetProcessorConfig = {
@@ -52,12 +53,12 @@ export class FlowDocumentsVisitor extends BaseDocumentsVisitor<FlowDocumentsPlug
         return wrapTypeWithModifiers(baseType, type, { wrapOptional, wrapArray });
       },
     };
+
     const processor = config.preResolveTypes
       ? new PreResolveTypesProcessor(processorConfig)
       : new FlowWithPickSelectionSetProcessor({
           ...processorConfig,
           useFlowExactObjects: this.config.useFlowExactObjects,
-          useFlowReadOnlyTypes: this.config.useFlowReadOnlyTypes,
         });
     const enumsNames = Object.keys(schema.getTypeMap()).filter(typeName => isEnumType(schema.getType(typeName)));
     this.setSelectionSetHandler(

--- a/packages/plugins/flow/operations/tests/__snapshots__/flow-documents.spec.ts.snap
+++ b/packages/plugins/flow/operations/tests/__snapshots__/flow-documents.spec.ts.snap
@@ -7,7 +7,8 @@ export type CurrentUserQueryVariables = {};
 
 
 export type CurrentUserQuery = {| +me?: ?({
-      ...$Pick<User, {| +id: *, +username: *, +role?: * |}>,
+      ...$Pick<User, {| +id: *, +username: * |}>,
+    ...{| +adminRole?: $ElementType<User, 'role'> |},
     ...{| +profile?: ?$Pick<Profile, {| +age?: * |}> |}
   }) |};
 "

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -976,7 +976,7 @@ describe('Flow Operations Plugin', () => {
 
       expect(result).toBeSimilarStringTo(`
       export type DummyQuery = ({
-        ...{| customName: $ElementType<Query, 'dummy'> |},
+        ...{| customName?: $ElementType<Query, 'dummy'> |},
       ...{| customName2?: ?$Pick<Profile, {| age?: * |}> |}
     });
       `);
@@ -1247,7 +1247,7 @@ describe('Flow Operations Plugin', () => {
           me {
             id
             username
-            role
+            adminRole: role(id: 1)
             profile {
               age
             }
@@ -1268,8 +1268,9 @@ describe('Flow Operations Plugin', () => {
       expect(result.content).toMatchSnapshot();
       expect(result.content).toBeSimilarStringTo(`
       export type CurrentUserQuery = {| +me?: ?({
-        ...$Pick<User, {| +id: *, +username: *, +role?: * |}>,
-      ...{| +profile?: ?$Pick<Profile, {| +age?: * |}> |}
+        ...$Pick<User, {| +id: *, +username: * |}>,
+        ...{| +adminRole?: $ElementType<User, 'role'> |},
+        ...{| +profile?: ?$Pick<Profile, {| +age?: * |}> |}
     }) |};
       `);
 


### PR DESCRIPTION
When generating flow operations, the `useFlowReadOnlyTypes:true` flag was not working when `preResolveTypes:true`. This diff updates the `FlowDocumentsVisitor` logic to insert the read-only modifier when formatting the name field so that it's consistent across processors. It also updates the `wrapArray` logic to use `$ReadOnlyArray` when `useFlowReadOnlyTypes:true`.

Output from live demo:

**schema.graphql**
<pre lang="graphql">
scalar Date

schema {
  query: Query
}

type Query {
  user(id: ID!): User
  allUsers: [User]
}

enum Role {
  USER,
  ADMIN,
}

interface Node {
  id: ID!
}

type User implements Node {
  id: ID!
  username: String!
  email: String!
  role: Role!
  friends: [Friend!]!
}

type Friend implements Node {
  id: ID!
  name: String!
}
</pre>

**operation.graphql**
<pre lang="graphql">
query findUser($userId: ID!) {
  user(id: $userId) {
    ...UserFields
    friends {
        ...FriendFields
    }
  }
}

fragment UserFields on User {
  id
  username
  role
}

fragment FriendFields on Friend {
    id
    name
}
</pre>

**codegen.yml**
<pre lang="yaml">
generates:
  types.flow.js:
    plugins:
      - flow
      - flow-operations
    config:
      preResolveTypes: true
      useFlowReadOnlyTypes: true
</pre>

**types.flow.js**
<table>
  <thead>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
<pre lang="js">
// @flow 


// @flow 

/** All built-in and custom scalars, mapped to their actual values */
export type Scalars = {|
  ID: string,
  String: string,
  Boolean: boolean,
  Int: number,
  Float: number,
  Date: any,
|};


export type Query = {|
  __typename?: 'Query',
  +user?: ?User,
  +allUsers?: ?Array<?User>,
|};


export type QueryUserArgs = {|
  id: $ElementType<Scalars, 'ID'>,
|};

export const RoleValues = Object.freeze({
  User: 'USER', 
  Admin: 'ADMIN'
});


export type Role = $Values<typeof RoleValues>;

export type Node = {|
  +id: $ElementType<Scalars, 'ID'>,
|};

export type User = {|
  ...Node,
  ...{|
    __typename?: 'User',
    +id: $ElementType<Scalars, 'ID'>,
    +username: $ElementType<Scalars, 'String'>,
    +email: $ElementType<Scalars, 'String'>,
    +role: Role,
    +friends: Array<Friend>,
  |}
|};

export type Friend = {|
  ...Node,
  ...{|
    __typename?: 'Friend',
    +id: $ElementType<Scalars, 'ID'>,
    +name: $ElementType<Scalars, 'String'>,
  |}
|};


export type FindUserQueryVariables = {
  userId: $ElementType<Scalars, 'ID'>,
};


export type FindUserQuery = { __typename?: 'Query', user?: ?(
    { __typename?: 'User', friends: Array<(
      { __typename?: 'Friend' }
      & FriendFieldsFragment
    )> }
    & UserFieldsFragment
  ) };

export type UserFieldsFragment = { __typename?: 'User', id: string, username: string, role: Role };

export type FriendFieldsFragment = { __typename?: 'Friend', id: string, name: string };

</pre>
      </td>
      <td>
<pre lang="js">
// @flow 


// @flow 

/** All built-in and custom scalars, mapped to their actual values */
export type Scalars = {|
  ID: string,
  String: string,
  Boolean: boolean,
  Int: number,
  Float: number,
  Date: any,
|};


export type Friend = {|
  ...Node,
  ...{|
    __typename?: 'Friend',
    +id: $ElementType<Scalars, 'ID'>,
    +name: $ElementType<Scalars, 'String'>,
  |}
|};

export type Node = {|
  +id: $ElementType<Scalars, 'ID'>,
|};

export type Query = {|
  __typename?: 'Query',
  +user?: ?User,
  +allUsers?: ?Array<?User>,
|};


export type QueryUserArgs = {|
  id: $ElementType<Scalars, 'ID'>,
|};

export const RoleValues = Object.freeze({
  User: 'USER', 
  Admin: 'ADMIN'
});


export type Role = $Values<typeof RoleValues>;

export type User = {|
  ...Node,
  ...{|
    __typename?: 'User',
    +id: $ElementType<Scalars, 'ID'>,
    +username: $ElementType<Scalars, 'String'>,
    +email: $ElementType<Scalars, 'String'>,
    +role: Role,
    +friends: Array<Friend>,
  |}
|};


export type FindUserQueryVariables = {
  userId: $ElementType<Scalars, 'ID'>,
};


export type FindUserQuery = { +__typename?: 'Query', +user?: ?(
    { +__typename?: 'User', +friends: $ReadOnlyArray<(
      { +__typename?: 'Friend' }
      & FriendFieldsFragment
    )> }
    & UserFieldsFragment
  ) };

export type UserFieldsFragment = { +__typename?: 'User', +id: string, +username: string, +role: Role };

export type FriendFieldsFragment = { +__typename?: 'Friend', +id: string, +name: string };

</pre>
      </td>
    </tr>
  </tbody>
</table>