### PR TITLE
add support for resolvers written with es6 classes

### DIFF
--- a/packages/plugins/flow/resolvers/src/config.ts
+++ b/packages/plugins/flow/resolvers/src/config.ts
@@ -1,0 +1,35 @@
+import { RawResolversConfig } from '@graphql-codegen/visitor-plugin-common';
+
+/**
+ * @description This plugin generates Flow signature for `resolve` functions of your GraphQL API.
+ * You can use this plugin a to generate simple resolvers signature based on your GraphQL types, or you can change it's behavior be providing custom model types (mappers).
+ *
+ */
+export interface FlowResolversPluginConfig extends RawResolversConfig {
+  /**
+   * @description You can provide your custom ResolveFn instead the default.
+   * @default "(parent: Parent, args: Args, context: Context, info: GraphQLResolveInfo) => Promise<Result> | Result"
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - flow
+   *    - flow-resolvers
+   *  config:
+   *    customResolverFn: |
+   *      (
+   *        args: Args,
+   *        context: Context,
+   *        info: GraphQLResolveInfo
+   *      ) => Promise<Result> | Result;
+   * ```
+   */
+  customResolverFn?: string;
+  /**
+   * @description You can define read only resolvers.
+   * @default false
+   */
+  resolverReadOnly?: boolean;
+}

--- a/packages/plugins/flow/resolvers/src/index.ts
+++ b/packages/plugins/flow/resolvers/src/index.ts
@@ -47,20 +47,13 @@ export const plugin: PluginFunction<RawFlowResolversConfig, Types.ComplexPluginO
   }
 
   // ES6 class resolvers methods only contain 3 argument (args, context, info). see https://github.com/apollographql/apollo-server/issues/1996
-  const resolverType = config.supportES6Classes
-    ? `export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
-  args: Args,
-  context: Context,
-  info: GraphQLResolveInfo
-) => Promise<Result> | Result;`
-    : `export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
-  parent: Parent,
-  args: Args,
-  context: Context,
-  info: GraphQLResolveInfo
-) => Promise<Result> | Result;`;
 
-  const header = `${resolverType}
+  const header = `export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
+  ${config.supportES6Classes ? `` : `parent: Parent,`}
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
+) => Promise<Result> | Result;
 
 export type SubscriptionSubscribeFn<Result, Parent, Context, Args> = (
   parent: Parent,

--- a/packages/plugins/flow/resolvers/src/index.ts
+++ b/packages/plugins/flow/resolvers/src/index.ts
@@ -46,12 +46,22 @@ export const plugin: PluginFunction<RawFlowResolversConfig, Types.ComplexPluginO
     defsToInclude.push(`export type RecursivePick<T, U> = T`);
   }
 
-  const header = `export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
+  // ES6 class resolvers methods only contain 3 argument (args, context, info). see https://github.com/apollographql/apollo-server/issues/1996
+  const resolverType =
+    config.declarationKindResolvers === 'interface'
+      ? `export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
+  args: Args,
+  context: Context,
+  info: GraphQLResolveInfo
+) => Promise<Result> | Result;`
+      : `export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
   parent: Parent,
   args: Args,
   context: Context,
   info: GraphQLResolveInfo
-) => Promise<Result> | Result;
+) => Promise<Result> | Result;`;
+
+  const header = `${resolverType}
 
 export type SubscriptionSubscribeFn<Result, Parent, Context, Args> = (
   parent: Parent,

--- a/packages/plugins/flow/resolvers/src/index.ts
+++ b/packages/plugins/flow/resolvers/src/index.ts
@@ -47,14 +47,13 @@ export const plugin: PluginFunction<RawFlowResolversConfig, Types.ComplexPluginO
   }
 
   // ES6 class resolvers methods only contain 3 argument (args, context, info). see https://github.com/apollographql/apollo-server/issues/1996
-  const resolverType =
-    config.declarationKindResolvers === 'interface'
-      ? `export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
+  const resolverType = config.supportES6Classes
+    ? `export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
   args: Args,
   context: Context,
   info: GraphQLResolveInfo
 ) => Promise<Result> | Result;`
-      : `export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
+    : `export type Resolver<Result, Parent = {}, Context = {}, Args = {}> = (
   parent: Parent,
   args: Args,
   context: Context,

--- a/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
@@ -283,7 +283,13 @@ describe('Flow Resolvers Plugin', () => {
       testSchema,
       [],
       {
-        supportES6Classes: 'true',
+        resolverDeclarationKind: 'interface',
+        resolverReadOnly: true,
+        customResolverFn: `(
+           args: Args,
+           context: Context,
+           info: GraphQLResolveInfo
+         ) => Promise<Result> | Result;`,
       } as any,
       { outputFile: 'graphql.ts' }
     )) as Types.ComplexPluginOutput;
@@ -295,8 +301,8 @@ describe('Flow Resolvers Plugin', () => {
     `);
     expect(content.content)
       .toBeSimilarStringTo(`export interface PostResolvers<ContextType = any, ParentType = $ElementType<ResolversParentTypes, 'Post'>> {
-        author?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
-        comment?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
+        +author?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
+        +comment?: Resolver<?$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
         __isTypeOf?: IsTypeOfResolverFn<ParentType>;
       }
     `);

--- a/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
@@ -283,7 +283,7 @@ describe('Flow Resolvers Plugin', () => {
       testSchema,
       [],
       {
-        declarationKindResolvers: 'interface',
+        supportES6Classes: 'true',
       } as any,
       { outputFile: 'graphql.ts' }
     )) as Types.ComplexPluginOutput;

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -63,7 +63,7 @@ export interface ParsedResolversConfig extends ParsedConfig {
   namespacedImportName: string;
   resolverTypeSuffix: string;
   allResolversTypeName: string;
-  declarationKindResolvers: DeclarationKind;
+  supportES6Classes: boolean;
 }
 
 export interface RawResolversConfig extends RawConfig {
@@ -295,16 +295,10 @@ export interface RawResolversConfig extends RawConfig {
    */
   allResolversTypeName?: string;
   /**
-   * @default 'type'
-   * @description  Overrides the default output for resolvers.
-   * @exampleMarkdown
-   * ## overrides resolvers as interface
-   * ```yml
-   *   config:
-   *     declarationKindResolvers: interface
-   * ```
+   * @default false
+   * @description  Overrides the default output for resolvers to support ES6 classes style resolvers.
    */
-  declarationKindResolvers?: DeclarationKind;
+  supportES6Classes?: boolean;
 }
 
 export type ResolverTypes = { [gqlType: string]: string };
@@ -355,7 +349,7 @@ export class BaseResolversVisitor<
       defaultMapper: rawConfig.defaultMapper
         ? parseMapper(rawConfig.defaultMapper || 'any', 'DefaultMapperType')
         : null,
-      declarationKindResolvers: getConfigValue(rawConfig.declarationKindResolvers, 'type'),
+      supportES6Classes: getConfigValue(rawConfig.supportES6Classes, false),
       mappers: transformMappers(rawConfig.mappers || {}, rawConfig.mapperTypeSuffix),
       scalars: buildScalars(_schema, rawConfig.scalars, defaultScalars),
       ...(additionalConfig || {}),
@@ -1016,7 +1010,7 @@ export type IDirectiveResolvers${contextType} = ${name}<ContextType>;`
   }
 
   ObjectTypeDefinition(node: ObjectTypeDefinitionNode): string {
-    const declarationKind = this.config.declarationKindResolvers;
+    const declarationKind = this.config.supportES6Classes ? 'interface' : 'type';
     const name = this.convertName(node, {
       suffix: this.config.resolverTypeSuffix,
     });

--- a/packages/utils/config-schema/src/plugins.ts
+++ b/packages/utils/config-schema/src/plugins.ts
@@ -128,7 +128,7 @@ export const relevantConfigurations: PluginConfig[] = [
   },
   {
     file: '../../plugins/flow/resolvers/src/index.ts',
-    identifier: 'RawFlowResolversConfig',
+    identifier: 'FlowResolversPluginConfig',
     pluginName: 'flow-resolvers',
   },
   {

--- a/website/static/config.schema.json
+++ b/website/static/config.schema.json
@@ -2323,7 +2323,7 @@
         }
       }
     },
-    "RawFlowResolversConfig": {
+    "FlowResolversPluginConfig": {
       "description": "This plugin generates resolvers signature based on your `GraphQLSchema`.\n\nIt generates types for your entire schema: types, input types, enum, interface, scalar and union.\n\nThis plugin requires you to use `@graphql-codegen/flow` as well, because it depends on it's types.",
       "type": "object",
       "properties": {
@@ -3384,7 +3384,7 @@
           "then": {
             "properties": {
               "config": {
-                "$ref": "#/definitions/RawFlowResolversConfig"
+                "$ref": "#/definitions/FlowResolversPluginConfig"
               }
             }
           }
@@ -4538,11 +4538,11 @@
             },
             "flow-resolvers": {
               "additionalProperties": false,
-              "$ref": "#/definitions/RawFlowResolversConfig"
+              "$ref": "#/definitions/FlowResolversPluginConfig"
             },
             "@graphql-codegen/flow-resolvers": {
               "additionalProperties": false,
-              "$ref": "#/definitions/RawFlowResolversConfig"
+              "$ref": "#/definitions/FlowResolversPluginConfig"
             },
             "flow-operations": {
               "additionalProperties": false,


### PR DESCRIPTION
Improvement for this issue: https://github.com/dotansimha/graphql-code-generator/issues/4623
This pr include these changes:
Add two new config for flow-resovlers plugin:
1. `customResolverFn:string` let people to custom the Resolver Function. (so that we can change `type Resolver` into 3 arguments(args, context, info), because ES6 class resolvers methods only contain 3 argument . see https://github.com/apollographql/apollo-server/issues/1996)
2. `resolverReadOnly:boolean` resolver functions can be read only. (Flow provide [read-only ](https://flow.org/en/docs/types/interfaces/#toc-interface-property-variance-read-only-and-write-only)vs writable properties under interface)  

Add a new config under base resolvers:
`resolverDeclarationKind:DeclarationKind` let people to define the resolver object type. (so that we can change resolvers output from `type` to `interface`, cause to flow type a ES6 class, we need interface. see https://flow.org/en/docs/types/interfaces/) 
Note: My change won't affect any existing plugin and its config behavior. 
## Testing Done: 
created unit test and it passed.
yarn build, yarn test passed. 
Also, linked the local package to my local graphql service and tested, got expected results. 