### PR TITLE
Improve support for unnamed queries

### DIFF
--- a/.changeset/late-spoons-vanish.md
+++ b/.changeset/late-spoons-vanish.md
@@ -1,0 +1,8 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-react-apollo': patch
+'@graphql-codegen/typescript-react-offix': patch
+'@graphql-codegen/typescript-urql': patch
+---
+
+Support unnamed queries in operation visitors

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -222,7 +222,7 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
     operationType: string
   ): string {
     const { omitOperationSuffix = false, dedupeOperationSuffix = false } = this.config as { [key: string]: any };
-    const operationName = typeof node === 'string' ? node : node.name.value;
+    const operationName = typeof node === 'string' ? node : node.name ? node.name.value : '';
     return omitOperationSuffix
       ? ''
       : dedupeOperationSuffix && operationName.toLowerCase().endsWith(operationType.toLowerCase())

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -496,10 +496,6 @@ export class ClientSideBaseVisitor<
   }
 
   public OperationDefinition(node: OperationDefinitionNode): string {
-    if (!node.name || !node.name.value) {
-      return null;
-    }
-
     this._collectedOperations.push(node);
 
     const documentVariableName = this.convertName(node, {
@@ -520,13 +516,16 @@ export class ClientSideBaseVisitor<
 
     let documentString = '';
     if (this.config.documentMode !== DocumentMode.external) {
-      documentString = `${
-        this.config.noExport ? '' : 'export'
-      } const ${documentVariableName}${this.getDocumentNodeSignature(
-        operationResultType,
-        operationVariablesTypes,
-        node
-      )} =${this.config.pureMagicComment ? ' /*#__PURE__*/' : ''} ${this._gql(node)};`;
+      // only generate exports for named queries
+      if (documentVariableName !== '') {
+        documentString = `${
+          this.config.noExport ? '' : 'export'
+        } const ${documentVariableName}${this.getDocumentNodeSignature(
+          operationResultType,
+          operationVariablesTypes,
+          node
+        )} =${this.config.pureMagicComment ? ' /*#__PURE__*/' : ''} ${this._gql(node)};`;
+      }
     }
 
     const additional = this.buildOperation(

--- a/packages/plugins/other/visitor-plugin-common/src/naming.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/naming.ts
@@ -17,6 +17,10 @@ function getKind(node: ASTNode | string): keyof NamingConventionMap {
 }
 
 function getName(node: ASTNode | string): string | undefined {
+  if (node == null) {
+    return undefined;
+  }
+
   if (typeof node === 'string') {
     return node;
   }

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -4435,4 +4435,30 @@ function test(q: GetEntityBrandDataQuery): void {
       `);
     });
   });
+
+  it('handles unnamed queries', async () => {
+    const ast = parse(/* GraphQL */ `
+      query {
+        notifications {
+          id
+        }
+      }
+    `);
+
+    const result = await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' });
+    expect(result.content).toBeSimilarStringTo(`
+      export type Unnamed_1_QueryVariables = Exact<{ [key: string]: never; }>;
+
+      export type Unnamed_1_Query = (
+          { __typename?: 'Query' }
+        & { notifications: Array<(
+            { __typename?: 'TextNotification' }
+          & Pick<TextNotification, 'id'>
+        ) | (
+            { __typename?: 'ImageNotification' }
+          & Pick<ImageNotification, 'id'>
+        )> }
+      );
+    `);
+  });
 });

--- a/packages/plugins/typescript/react-apollo-offix/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo-offix/src/visitor.ts
@@ -56,7 +56,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<RawClientSideBaseP
     operationResultType: string,
     operationVariablesTypes: string
   ): string {
-    const operationName: string = this.convertName(node.name.value, {
+    const operationName: string = this.convertName(node.name?.value ?? '', {
       useTypesPrefix: false,
     });
 

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -139,7 +139,9 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
   }
 
   private getDocumentNodeVariable(node: OperationDefinitionNode, documentVariableName: string): string {
-    return this.config.documentMode === DocumentMode.external ? `Operations.${node.name.value}` : documentVariableName;
+    return this.config.documentMode === DocumentMode.external
+      ? `Operations.${node.name?.value ?? ''}`
+      : documentVariableName;
   }
 
   public getImports(): string[] {
@@ -180,7 +182,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     if (node.operation === 'mutation') {
       this.imports.add(this.getApolloReactCommonImport(true));
       return `export type ${this.convertName(
-        node.name.value + 'MutationFn'
+        (node.name?.value ?? '') + 'MutationFn'
       )} = ${this.getApolloReactCommonIdentifier()}.MutationFunction<${operationResultType}, ${operationVariablesTypes}>;`;
     }
     return null;
@@ -194,12 +196,13 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
   ): string {
     this.imports.add(this.getApolloReactCommonImport(false));
     this.imports.add(this.getApolloReactHocImport(false));
-    const operationName: string = this.convertName(node.name.value, { useTypesPrefix: false });
-    const propsTypeName: string = this.convertName(node.name.value, { suffix: 'Props' });
+    const nodeName = node.name?.value ?? '';
+    const operationName: string = this.convertName(nodeName, { useTypesPrefix: false });
+    const propsTypeName: string = this.convertName(nodeName, { suffix: 'Props' });
 
     const defaultDataName = node.operation === 'mutation' ? 'mutate' : 'data';
     const propsVar = `export type ${propsTypeName}<TChildProps = {}, TDataName extends string = '${defaultDataName}'> = {
-      [key in TDataName]: ${this._buildHocProps(node.name.value, node.operation)}
+      [key in TDataName]: ${this._buildHocProps(nodeName, node.operation)}
     } & TChildProps;`;
 
     const hocString = `export function with${operationName}<TProps, TChildProps = {}, TDataName extends string = '${defaultDataName}'>(operationOptions?: ApolloReactHoc.OperationOption<
@@ -228,11 +231,12 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     operationResultType: string,
     operationVariablesTypes: string
   ): string {
-    const componentPropsName: string = this.convertName(node.name.value, {
+    const nodeName = node.name?.value ?? '';
+    const componentPropsName: string = this.convertName(nodeName, {
       suffix: this.config.componentSuffix + 'Props',
       useTypesPrefix: false,
     });
-    const componentName: string = this.convertName(node.name.value, {
+    const componentName: string = this.convertName(nodeName, {
       suffix: this.config.componentSuffix,
       useTypesPrefix: false,
     });
@@ -314,8 +318,9 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     operationResultType: string,
     operationVariablesTypes: string
   ): string {
-    const suffix = this._getHookSuffix(node.name.value, operationType);
-    const operationName: string = this.convertName(node.name.value, {
+    const nodeName = node.name?.value ?? '';
+    const suffix = this._getHookSuffix(nodeName, operationType);
+    const operationName: string = this.convertName(nodeName, {
       suffix,
       useTypesPrefix: false,
     });
@@ -339,7 +344,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     const hookResults = [`export type ${operationName}HookResult = ReturnType<typeof use${operationName}>;`];
 
     if (operationType === 'Query') {
-      const lazyOperationName: string = this.convertName(node.name.value, {
+      const lazyOperationName: string = this.convertName(nodeName, {
         suffix: pascalCase('LazyQuery'),
         useTypesPrefix: false,
       });
@@ -376,7 +381,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     operationResultType: string,
     operationVariablesTypes: string
   ): string {
-    const componentResultType = this.convertName(node.name.value, {
+    const componentResultType = this.convertName(node.name?.value ?? '', {
       suffix: `${operationType}Result`,
       useTypesPrefix: false,
     });
@@ -407,7 +412,10 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
 
     this.imports.add(this.getApolloReactCommonImport(true));
 
-    const mutationOptionsType = this.convertName(node.name.value, { suffix: 'MutationOptions', useTypesPrefix: false });
+    const mutationOptionsType = this.convertName(node.name?.value ?? '', {
+      suffix: 'MutationOptions',
+      useTypesPrefix: false,
+    });
 
     return `export type ${mutationOptionsType} = ${this.getApolloReactCommonIdentifier()}.BaseMutationOptions<${operationResultType}, ${operationVariablesTypes}>;`;
   }
@@ -422,8 +430,9 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
       return '';
     }
 
-    const operationName: string = this.convertName(node.name.value, {
-      suffix: this._getHookSuffix(node.name.value, operationType),
+    const nodeName = node.name?.value ?? '';
+    const operationName: string = this.convertName(nodeName, {
+      suffix: this._getHookSuffix(nodeName, operationType),
       useTypesPrefix: false,
     });
 

--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -56,7 +56,10 @@ export class UrqlVisitor extends ClientSideBaseVisitor<UrqlRawPluginConfig, Urql
     operationResultType: string,
     operationVariablesTypes: string
   ): string {
-    const componentName: string = this.convertName(node.name.value, { suffix: 'Component', useTypesPrefix: false });
+    const componentName: string = this.convertName(node.name?.value ?? '', {
+      suffix: 'Component',
+      useTypesPrefix: false,
+    });
 
     const isVariablesRequired =
       operationType === 'Query' &&
@@ -83,7 +86,7 @@ export const ${componentName} = (props: Omit<Urql.${operationType}Props<${generi
     operationResultType: string,
     operationVariablesTypes: string
   ): string {
-    const operationName: string = this.convertName(node.name.value, {
+    const operationName: string = this.convertName(node.name?.value ?? '', {
       suffix: this.config.omitOperationSuffix ? '' : pascalCase(operationType),
       useTypesPrefix: false,
     });


### PR DESCRIPTION
Previously, `ClientSideBaseVisitor#OperationDefinition` aborted eagerly if the node name was not set, since the `getName` function invoked from `BaseVisitor#getOperationSuffix` did not correctly handle scenarios where the node name was unset. This caused the `typed-document-node` plugin not to be able to generate a `DocumentNode` export for unnamed queries.

Related dotansimha/graphql-typed-document-node#40