### PR TITLE
fix(cli): import relative to user config

### DIFF
--- a/.changeset/yellow-apes-cover.md
+++ b/.changeset/yellow-apes-cover.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Load user provided things relative to the config

--- a/packages/graphql-codegen-cli/src/presets.ts
+++ b/packages/graphql-codegen-cli/src/presets.ts
@@ -1,14 +1,12 @@
 import { DetailedError, Types } from '@graphql-codegen/plugin-helpers';
-import { resolve } from 'path';
 
 export async function getPresetByName(
   name: string,
   loader: Types.PackageLoaderFn<{ preset?: Types.OutputPreset; default?: Types.OutputPreset }>
 ): Promise<Types.OutputPreset> {
   const possibleNames = [`@graphql-codegen/${name}`, `@graphql-codegen/${name}-preset`, name];
-  const possibleModules = possibleNames.concat(resolve(process.cwd(), name));
 
-  for (const moduleName of possibleModules) {
+  for (const moduleName of possibleNames) {
     try {
       const loaded = await loader(moduleName);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@graphql-codegen/cli` is trying to require user provided packages from itself making it rely on hoisting which does not guarantee that the packages are placed in an accessible location and when using PnP the resolution is rejected because `@graphql-codegen/cli` doesn't declare them.

Fixes https://github.com/yarnpkg/berry/issues/1599#issuecomment-686629356 cc @xenoterracide

**How did you fix it?**

Use `createRequire` to resolve packages relative to the user config