### PR TITLE
Allow passing partial hooks when generating programatically.

### DIFF
--- a/.changeset/wet-trainers-reply.md
+++ b/.changeset/wet-trainers-reply.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/plugin-helpers': patch
+---
+
+Allow hooks to be defined as partial object

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -295,7 +295,7 @@ export namespace Types {
      *
      * For more details: https://graphql-code-generator.com/docs/getting-started/lifecycle-hooks
      */
-    hooks?: LifecycleHooksDefinition;
+    hooks?: Partial<LifecycleHooksDefinition>;
   }
 
   /* Output Builder Preset */


### PR DESCRIPTION
Hello, I believe this is typed incorrectly?
This change allows me to pass hooks like:

```ts
{
      hooks: {
        afterAllFileWrite: ['prettier --write'],
      },
}
```

instead of:

```ts
{
      hooks: {
        afterStart: [],
        beforeDone: [],
        onWatchTriggered: [],
        onError: [],
        afterOneFileWrite: [],
        afterAllFileWrite: ['prettier --write'],
        beforeOneFileWrite: [],
        beforeAllFileWrite: [],
      },
}
```

Thanks! Love you :)