### PR TITLE
modify apollo angular visitor to allow external operation definitions related to #4719

### DIFF
--- a/.changeset/four-ants-lick.md
+++ b/.changeset/four-ants-lick.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-apollo-angular': minor
+---
+
+add support for importing operations from external file in angular-apollo plugin

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -443,6 +443,11 @@ export class ClientSideBaseVisitor<
               `import * as Operations from './${this.clearExtension(basename(this._documents[0].location))}';`
             );
           } else {
+            if (!this.config.importDocumentNodeExternallyFrom) {
+              // eslint-disable-next-line no-console
+              console.warn('importDocumentNodeExternallyFrom must be provided if documentMode=external');
+            }
+
             this._imports.add(
               `import * as Operations from '${this.clearExtension(this.config.importDocumentNodeExternallyFrom)}';`
             );

--- a/packages/plugins/typescript/apollo-angular/package.json
+++ b/packages/plugins/typescript/apollo-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jbarrus/typescript-apollo-angular",
-  "version": "2.0.1-import-fix",
+  "version": "2.0.1-import-fixes2",
   "description": "GraphQL Code Generator plugin for generating ready-to-use Angular Components based on GraphQL operations",
   "repository": {
     "type": "git",

--- a/packages/plugins/typescript/apollo-angular/package.json
+++ b/packages/plugins/typescript/apollo-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-codegen/typescript-apollo-angular",
-  "version": "2.0.1-import-fixes2",
+  "version": "2.0.1",
   "description": "GraphQL Code Generator plugin for generating ready-to-use Angular Components based on GraphQL operations",
   "repository": {
     "type": "git",

--- a/packages/plugins/typescript/apollo-angular/package.json
+++ b/packages/plugins/typescript/apollo-angular/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@graphql-codegen/typescript-apollo-angular",
-  "version": "2.0.1",
+  "name": "@jbarrus/typescript-apollo-angular",
+  "version": "2.0.1-import-fix",
   "description": "GraphQL Code Generator plugin for generating ready-to-use Angular Components based on GraphQL operations",
   "repository": {
     "type": "git",

--- a/packages/plugins/typescript/apollo-angular/package.json
+++ b/packages/plugins/typescript/apollo-angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jbarrus/typescript-apollo-angular",
+  "name": "@graphql-codegen/typescript-apollo-angular",
   "version": "2.0.1-import-fixes2",
   "description": "GraphQL Code Generator plugin for generating ready-to-use Angular Components based on GraphQL operations",
   "repository": {

--- a/packages/plugins/typescript/apollo-angular/src/visitor.ts
+++ b/packages/plugins/typescript/apollo-angular/src/visitor.ts
@@ -225,7 +225,9 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
   }
 
   private _getDocumentNodeVariable(node: OperationDefinitionNode, documentVariableName: string): string {
-    return this.config.documentMode === DocumentMode.external ? `Operations.${node.name.value}` : documentVariableName;
+    return this.config.documentMode === DocumentMode.external
+      ? `Operations.${documentVariableName}`
+      : documentVariableName;
   }
 
   private _operationSuffix(operationType: string): string {

--- a/packages/plugins/typescript/apollo-angular/src/visitor.ts
+++ b/packages/plugins/typescript/apollo-angular/src/visitor.ts
@@ -37,7 +37,7 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
   ApolloAngularRawPluginConfig,
   ApolloAngularPluginConfig
 > {
-  private _externalImportPrefix: string;
+  private _externalImportPrefix = '';
   private _operationsToInclude: {
     node: OperationDefinitionNode;
     documentVariableName: string;
@@ -78,7 +78,16 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
       documents
     );
 
-    this._externalImportPrefix = this.config.importOperationTypesFrom ? `${this.config.importOperationTypesFrom}.` : '';
+    if (this.config.importOperationTypesFrom) {
+      this._externalImportPrefix = `${this.config.importOperationTypesFrom}.`;
+
+      if (this.config.documentMode !== DocumentMode.external || !this.config.importDocumentNodeExternallyFrom) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'apollo-angular "importOperationTypesFrom" should be used with "documentMode=external" and "importDocumentNodeExternallyFrom"'
+        );
+      }
+    }
 
     autoBind(this);
   }

--- a/packages/plugins/typescript/apollo-angular/src/visitor.ts
+++ b/packages/plugins/typescript/apollo-angular/src/visitor.ts
@@ -84,8 +84,13 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
       if (this.config.documentMode !== DocumentMode.external || !this.config.importDocumentNodeExternallyFrom) {
         // eslint-disable-next-line no-console
         console.warn(
-          'apollo-angular "importOperationTypesFrom" should be used with "documentMode=external" and "importDocumentNodeExternallyFrom"'
+          '"importOperationTypesFrom" should be used with "documentMode=external" and "importDocumentNodeExternallyFrom"'
         );
+      }
+
+      if (this.config.importOperationTypesFrom !== 'Operations') {
+        // eslint-disable-next-line no-console
+        console.warn('importOperationTypesFrom only works correctly when left empty or set to "Operations"');
       }
     }
 
@@ -234,8 +239,8 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
   }
 
   private _getDocumentNodeVariable(node: OperationDefinitionNode, documentVariableName: string): string {
-    return this.config.documentMode === DocumentMode.external
-      ? `Operations.${documentVariableName}`
+    return this.config.importOperationTypesFrom
+      ? `${this.config.importOperationTypesFrom}.${documentVariableName}`
       : documentVariableName;
   }
 

--- a/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
+++ b/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
@@ -192,7 +192,82 @@ describe('Apollo Angular', () => {
       await validateTypeScript(content, modifiedSchema, docs, {});
     });
 
-    it('should allow importing operations from another file', async () => {
+    it('should output warning if documentMode = external and importDocumentNodeExternallyFrom is not set', async () => {
+      spyOn(console, 'warn');
+      const docs = [{ location: '', document: basicDoc }];
+      await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.external,
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      );
+
+      expect(console.warn).toHaveBeenCalledWith(
+        'importDocumentNodeExternallyFrom must be provided if documentMode=external'
+      );
+    });
+
+    it('output warning if importOperationTypesFrom is set to something other than "Operations"', async () => {
+      spyOn(console, 'warn');
+      const docs = [{ location: '', document: basicDoc }];
+      await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.external,
+          importOperationTypesFrom: 'Whatever',
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        'importOperationTypesFrom only works correctly when left empty or set to "Operations"'
+      );
+    });
+
+    it('output warning if importOperationTypesFrom is set and documentMode is not "external"', async () => {
+      spyOn(console, 'warn');
+      const docs = [{ location: '', document: basicDoc }];
+      await plugin(
+        schema,
+        docs,
+        {
+          importOperationTypesFrom: 'Operations',
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        '"importOperationTypesFrom" should be used with "documentMode=external" and "importDocumentNodeExternallyFrom"'
+      );
+    });
+
+    it('output warning if importOperationTypesFrom is set and importDocumentNodeExternallyFrom is not', async () => {
+      spyOn(console, 'warn');
+      const docs = [{ location: '', document: basicDoc }];
+      await plugin(
+        schema,
+        docs,
+        {
+          documentMode: DocumentMode.external,
+          importOperationTypesFrom: 'Operations',
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        '"importOperationTypesFrom" should be used with "documentMode=external" and "importDocumentNodeExternallyFrom"'
+      );
+    });
+
+    it('should allow importing operations and documents from another file', async () => {
       const docs = [{ location: '', document: basicDoc }];
       const content = (await plugin(
         schema,
@@ -210,6 +285,7 @@ describe('Apollo Angular', () => {
       expect(content.prepend).toContain(`import * as Operations from '@myproject/generated';`);
       expect(content.content).toContain('Operations.TestQuery');
       expect(content.content).toContain('Operations.TestQueryVariables');
+      expect(content.content).toContain('Operations.TestDocument');
       await validateTypeScript(content, schema, docs, {});
     });
   });

--- a/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
+++ b/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
@@ -206,6 +206,7 @@ describe('Apollo Angular', () => {
         }
       );
 
+      // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalledWith(
         'importDocumentNodeExternallyFrom must be provided if documentMode=external'
       );
@@ -225,6 +226,8 @@ describe('Apollo Angular', () => {
           outputFile: 'graphql.ts',
         }
       );
+
+      // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalledWith(
         'importOperationTypesFrom only works correctly when left empty or set to "Operations"'
       );
@@ -243,6 +246,8 @@ describe('Apollo Angular', () => {
           outputFile: 'graphql.ts',
         }
       );
+
+      // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalledWith(
         '"importOperationTypesFrom" should be used with "documentMode=external" and "importDocumentNodeExternallyFrom"'
       );
@@ -262,6 +267,8 @@ describe('Apollo Angular', () => {
           outputFile: 'graphql.ts',
         }
       );
+
+      // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalledWith(
         '"importOperationTypesFrom" should be used with "documentMode=external" and "importDocumentNodeExternallyFrom"'
       );

--- a/website/docs/generated-config/typescript-apollo-angular.md
+++ b/website/docs/generated-config/typescript-apollo-angular.md
@@ -286,8 +286,9 @@ This is useful if you wish to generate base types from `typescript-operations` p
 type: `string`
 default: ``
 
-This config should be used if `documentMode` is `external`. This has 2 usage:
-- any string: This would be the path to import document nodes from. This can be used if we want to manually create the document nodes e.g. Use `graphql-tag` in a separate file and export the generated document
+This config should be used if `documentMode` is `external`. This has 3 usage:
+- any string: This would be the path to import document nodes from. This can be used if we want to manually create the document nodes e.g. Use `graphql-tag` in a separate file and export the generated document. You can
+also import operations from a separate file with `importOperationTypesFrom`.
 - 'near-operation-file': This is a special mode that is intended to be used with `near-operation-file` preset to import document nodes from those files. If these files are `.graphql` files, we make use of webpack loader.
 
 #### Usage Examples
@@ -296,6 +297,13 @@ This config should be used if `documentMode` is `external`. This has 2 usage:
 config:
   documentMode: external
   importDocumentNodeExternallyFrom: path/to/document-node-file
+```
+
+```yml
+config:
+  documentMode: external
+  importOperationTypesFrom: 'Operations',
+  importDocumentNodeExternallyFrom: near-operation-file
 ```
 
 ```yml

--- a/website/docs/generated-config/typescript-apollo-angular.md
+++ b/website/docs/generated-config/typescript-apollo-angular.md
@@ -286,18 +286,11 @@ This is useful if you wish to generate base types from `typescript-operations` p
 type: `string`
 default: ``
 
-This config should be used if `documentMode` is `external`. This has 3 usage:
-- any string: This would be the path to import document nodes from. This can be used if we want to manually create the document nodes e.g. Use `graphql-tag` in a separate file and export the generated document. You can
-also import operations from a separate file with `importOperationTypesFrom`.
+This config should be used if `documentMode` is `external`. This has 2 usage:
+- any string: This would be the path to import document nodes from. This can be used if we want to manually create the document nodes e.g. Use `graphql-tag` in a separate file and export the generated document `importOperationTypesFrom` and `importOperationTypesFrom` must also be set as well.
 - 'near-operation-file': This is a special mode that is intended to be used with `near-operation-file` preset to import document nodes from those files. If these files are `.graphql` files, we make use of webpack loader.
 
 #### Usage Examples
-
-```yml
-config:
-  documentMode: external
-  importDocumentNodeExternallyFrom: path/to/document-node-file
-```
 
 ```yml
 config:

--- a/website/docs/generated-config/typescript-apollo-angular.md
+++ b/website/docs/generated-config/typescript-apollo-angular.md
@@ -287,7 +287,7 @@ type: `string`
 default: ``
 
 This config should be used if `documentMode` is `external`. This has 2 usage:
-- any string: This would be the path to import document nodes from. This can be used if we want to manually create the document nodes e.g. Use `graphql-tag` in a separate file and export the generated document `importOperationTypesFrom` and `importOperationTypesFrom` must also be set as well.
+- any string: This would be the path to import document nodes from. This can be used if we want to manually create the document nodes e.g. Use `graphql-tag` in a separate file and export the generated document. `importOperationTypesFrom` and `importOperationTypesFrom` must also be set as well.
 - 'near-operation-file': This is a special mode that is intended to be used with `near-operation-file` preset to import document nodes from those files. If these files are `.graphql` files, we make use of webpack loader.
 
 #### Usage Examples

--- a/website/docs/generated-config/typescript-apollo-angular.md
+++ b/website/docs/generated-config/typescript-apollo-angular.md
@@ -296,7 +296,7 @@ This config should be used if `documentMode` is `external`. This has 2 usage:
 config:
   documentMode: external
   importOperationTypesFrom: 'Operations',
-  importDocumentNodeExternallyFrom: near-operation-file
+  importDocumentNodeExternallyFrom: '@myproject/generated'
 ```
 
 ```yml


### PR DESCRIPTION
This is a work in progress. I'm trying to get my types, operations, and angular services to all be in separate files (with angular generated in a separate lib within my project). I couldn't get this working without these code changes. #4719 is related, but more was required.

If there is a better way, great. If not and this works then I'll complete the tests and whatever is needed for the change.

Example codegen.yml
```yml
schema: "schema.graphql"
generates:
  lib/generated/src/lib/types.ts:
    plugins:
      - "typescript"
  libs/generated/src/lib/:
    preset: near-operation-file
    documents: "libs/generated/**/*.graphql"
    config:
      documentMode: graphQLTag
    presetConfig:
      baseTypesPath: types.ts
    plugins:
      - "typescript-operations"
      - "typed-document-node"
  libs/generated-angular/src/lib/graphql-services.ts:
    documents: "libs/generated/**/*.graphql"
    config:
      documentMode: external
      importOperationTypesFrom: "Operations"
      importDocumentNodeExternallyFrom: "@myproject/generated"
    plugins:
      - "typescript-apollo-angular"
```