### PR TITLE
docs: fix link to default gql tag list

### DIFF
--- a/website/docs/getting-started/documents-field.md
+++ b/website/docs/getting-started/documents-field.md
@@ -157,7 +157,7 @@ const MY_QUERY = /* GraphQL */`
 // ... some components code ...
 ```
 
-By default, it has a predefined list of popular `gql` tags to look for, in order to make sure it's not trying to extract an invalid or unrelated string. [The default list could be found here](https://github.com/ardatan/graphql-toolkit/blob/master/packages/graphql-tag-pluck/src/visitor.ts#L13)
+By default, it has a predefined list of popular `gql` tags to look for, in order to make sure it's not trying to extract an invalid or unrelated string. [The default list could be found here](https://github.com/ardatan/graphql-tools/blob/master/packages/graphql-tag-pluck/src/visitor.ts#L12)
 
 You can add custom tags if you need, by using `pluckConfig` on the root level on your config file:
 


### PR DESCRIPTION
Hi! Looks like [graphql-toolkit](https://github.com/ardatan/graphql-toolkit/) is deprecated now, so this PR updates link to correct default gql tags list.

Thanks!