### PR TITLE
Typescript: Make non nullable input field with default value optional

### DIFF
--- a/.changeset/tender-steaks-do.md
+++ b/.changeset/tender-steaks-do.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript': patch
+---
+
+Make non nullable input field with default value optional

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -153,7 +153,8 @@ export class TsVisitor<
   InputValueDefinition(node: InputValueDefinitionNode, key?: number | string, parent?: any): string {
     const originalFieldNode = parent[key] as FieldDefinitionNode;
     const addOptionalSign =
-      !this.config.avoidOptionals.inputValue && originalFieldNode.type.kind !== Kind.NON_NULL_TYPE;
+      !this.config.avoidOptionals.inputValue &&
+      (originalFieldNode.type.kind !== Kind.NON_NULL_TYPE || node.defaultValue !== undefined);
     const comment = transformComment((node.description as any) as string, 1);
     const { type } = this.config.declarationKind;
     return (

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2259,6 +2259,24 @@ describe('TypeScript', () => {
       `);
       await validateTs(result);
     });
+
+    it('Should generate correctly types for inputs with default value - #4273', async () => {
+      const schema = buildSchema(
+        `input MyInput { a: String = "default", b: String! = "default", c: String, d: String! }`
+      );
+      const result = await plugin(schema, [], {}, { outputFile: '' });
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type MyInput = {
+          a?: Maybe<Scalars['String']>;
+          b?: Scalars['String'];
+          c?: Maybe<Scalars['String']>;
+          d: Scalars['String'];
+        };
+    `);
+
+      validateTs(result);
+    });
   });
 
   describe('Enum', () => {


### PR DESCRIPTION
Related #4273

Similar to #2018, but for inputs. The fixes didn't apply to inputs because input don't use the argument transformer. Maybe it should be the real fix, but that will impact all plugins and I don't know the codebase enough to try it!