### PR TITLE
fix(cli): handle missing dependencies correctly

### DIFF
--- a/.changeset/twenty-dingos-remain.md
+++ b/.changeset/twenty-dingos-remain.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Check the error code instead of the error message to determine if a package wasn't found

--- a/packages/graphql-codegen-cli/src/plugins.ts
+++ b/packages/graphql-codegen-cli/src/plugins.ts
@@ -22,7 +22,7 @@ export async function getPluginByName(
     try {
       return await pluginLoader(moduleName);
     } catch (err) {
-      if (err.message.indexOf(`Cannot find module '${moduleName}'`) === -1) {
+      if (err.code !== 'MODULE_NOT_FOUND') {
         throw new DetailedError(
           `Unable to load template plugin matching ${name}`,
           `

--- a/packages/graphql-codegen-cli/src/presets.ts
+++ b/packages/graphql-codegen-cli/src/presets.ts
@@ -18,7 +18,7 @@ export async function getPresetByName(
 
       return loaded as Types.OutputPreset;
     } catch (err) {
-      if (err.message.indexOf(`Cannot find module '${moduleName}'`) === -1) {
+      if (err.code !== 'MODULE_NOT_FOUND') {
         throw new DetailedError(
           `Unable to load preset matching ${name}`,
           `

--- a/packages/graphql-codegen-cli/tests/cli-flags.spec.ts
+++ b/packages/graphql-codegen-cli/tests/cli-flags.spec.ts
@@ -192,7 +192,7 @@ describe('CLI Flags', () => {
       await createContext(parseArgv(args));
       expect(true).toBeFalsy();
     } catch (e) {
-      expect(e.message).toContain(`Cannot find module 'my-extension'`);
+      expect(e.code).toEqual('MODULE_NOT_FOUND');
     }
   });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

When the CLI is trying to require dependencies dynamically it checks for module not found errors by scanning the error message to see if a package is missing, instead of checking the error code.

Related https://github.com/dotansimha/graphql-code-generator/issues/4766

**How did you fix it?**

Check `code !== 'MODULE_NOT_FOUND'` instead of searching the error message
