### PR TITLE
Fix type graphql nullable types

### DIFF
--- a/.changeset/moody-pots-move.md
+++ b/.changeset/moody-pots-move.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-type-graphql': patch
+---
+
+Fixed decorators for nullable type-graphql array types

--- a/.changeset/rude-scissors-wait.md
+++ b/.changeset/rude-scissors-wait.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-type-graphql': patch
+---
+
+GraphQL descriptions are now set in their corresponding TypeGraphQL decorator options

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -1,9 +1,4 @@
-import {
-  transformComment,
-  indent,
-  DeclarationBlock,
-  AvoidOptionalsConfig,
-} from '@graphql-codegen/visitor-plugin-common';
+import { indent, DeclarationBlock, AvoidOptionalsConfig } from '@graphql-codegen/visitor-plugin-common';
 import { TypeGraphQLPluginConfig } from './config';
 import autoBind from 'auto-bind';
 import {
@@ -52,6 +47,26 @@ interface Type {
   isNullable: boolean;
   isArray: boolean;
   isScalar: boolean;
+}
+
+function escapeString(str: string) {
+  return "'" + str.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, "\\'") + "'";
+}
+
+type DecoratorOptions = { [key: string]: string };
+function formatDecoratorOptions(options: DecoratorOptions, isFirstArgument = true) {
+  if (!Object.keys(options).length) {
+    return '';
+  } else {
+    return (
+      (isFirstArgument ? '' : ', ') +
+      ('{ ' +
+        Object.entries(options)
+          .map(([key, value]) => `${key}: ${value}`)
+          .join(', ') +
+        ' }')
+    );
+  }
 }
 
 export class TypeGraphQLVisitor<
@@ -104,21 +119,38 @@ export class TypeGraphQLVisitor<
     });
   }
 
+  getDecoratorOptions(
+    node: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode | FieldDefinitionNode | InputObjectTypeDefinitionNode
+  ): DecoratorOptions {
+    const decoratorOptions: DecoratorOptions = {};
+
+    if (node.description) {
+      // Add description as TypeGraphQL description instead of comment
+      decoratorOptions.description = escapeString((node.description as unknown) as string);
+      (node as any).description = undefined;
+    }
+
+    return decoratorOptions;
+  }
+
   ObjectTypeDefinition(node: ObjectTypeDefinitionNode, key: number | string, parent: any): string {
     const typeDecorator = this.config.decoratorName.type;
     const originalNode = parent[key] as ObjectTypeDefinitionNode;
+
+    const decoratorOptions = this.getDecoratorOptions(node);
 
     let declarationBlock = this.getObjectTypeDeclarationBlock(node, originalNode);
     if (!GRAPHQL_TYPES.includes((node.name as unknown) as string)) {
       // Add type-graphql ObjectType decorator
       const interfaces = originalNode.interfaces.map(i => this.convertName(i));
-      let decoratorOptions = '';
       if (interfaces.length > 1) {
-        decoratorOptions = `{ implements: [${interfaces.join(', ')}] }`;
+        decoratorOptions.implements = `[${interfaces.join(', ')}]`;
       } else if (interfaces.length === 1) {
-        decoratorOptions = `{ implements: ${interfaces[0]} }`;
+        decoratorOptions.implements = interfaces[0];
       }
-      declarationBlock = declarationBlock.withDecorator(`@TypeGraphQL.${typeDecorator}(${decoratorOptions})`);
+      declarationBlock = declarationBlock.withDecorator(
+        `@TypeGraphQL.${typeDecorator}(${formatDecoratorOptions(decoratorOptions)})`
+      );
     }
 
     return [declarationBlock.string, this.buildArgumentsBlock(originalNode)].filter(f => f).join('\n\n');
@@ -127,10 +159,14 @@ export class TypeGraphQLVisitor<
   InputObjectTypeDefinition(node: InputObjectTypeDefinitionNode): string {
     const typeDecorator = this.config.decoratorName.input;
 
+    const decoratorOptions = this.getDecoratorOptions(node);
+
     let declarationBlock = this.getInputObjectDeclarationBlock(node);
 
     // Add type-graphql InputType decorator
-    declarationBlock = declarationBlock.withDecorator(`@TypeGraphQL.${typeDecorator}()`);
+    declarationBlock = declarationBlock.withDecorator(
+      `@TypeGraphQL.${typeDecorator}(${formatDecoratorOptions(decoratorOptions)})`
+    );
 
     return declarationBlock.string;
   }
@@ -167,8 +203,10 @@ export class TypeGraphQLVisitor<
     const interfaceDecorator = this.config.decoratorName.interface;
     const originalNode = parent[key] as InterfaceTypeDefinitionNode;
 
+    const decoratorOptions = this.getDecoratorOptions(node);
+
     const declarationBlock = this.getInterfaceTypeDeclarationBlock(node, originalNode).withDecorator(
-      `@TypeGraphQL.${interfaceDecorator}()`
+      `@TypeGraphQL.${interfaceDecorator}(${formatDecoratorOptions(decoratorOptions)})`
     );
 
     return [declarationBlock.string, this.buildArgumentsBlock(originalNode)].filter(f => f).join('\n\n');
@@ -243,33 +281,36 @@ export class TypeGraphQLVisitor<
   FieldDefinition(node: FieldDefinitionNode, key?: number | string, parent?: any): string {
     const fieldDecorator = this.config.decoratorName.field;
     let typeString = (node.type as any) as string;
-    const comment = transformComment((node.description as any) as string, 1);
 
     const type = this.parseType(typeString);
 
     const maybeType = type.type.match(MAYBE_REGEX);
     const arrayType = `[${maybeType ? this.clearOptional(type.type) : type.type}]`;
 
+    const decoratorOptions = this.getDecoratorOptions(node);
+
+    if (type.isNullable) {
+      decoratorOptions.nullable = 'true';
+    }
+
     const decorator =
       '\n' +
       indent(
-        `@TypeGraphQL.${fieldDecorator}(type => ${type.isArray ? arrayType : type.type}${
-          type.isNullable ? ', { nullable: true }' : ''
-        })`
+        `@TypeGraphQL.${fieldDecorator}(type => ${type.isArray ? arrayType : type.type}${formatDecoratorOptions(
+          decoratorOptions,
+          false
+        )})`
       ) +
       '\n';
 
     typeString = this.fixDecorator(type, typeString);
 
-    return (
-      comment + decorator + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}!: ${typeString};`)
-    );
+    return decorator + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}!: ${typeString};`);
   }
 
   InputValueDefinition(node: InputValueDefinitionNode, key?: number | string, parent?: any): string {
     const fieldDecorator = this.config.decoratorName.field;
     const rawType = node.type as TypeNode | string;
-    const comment = transformComment((node.description as any) as string, 1);
 
     const type = this.parseType(rawType);
     const typeGraphQLType =
@@ -288,9 +329,7 @@ export class TypeGraphQLVisitor<
       ? this.buildTypeString(type)
       : this.fixDecorator(type, rawType as string);
 
-    return (
-      comment + decorator + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${nameString}!: ${typeString};`)
-    );
+    return decorator + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${nameString}!: ${typeString};`);
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -47,6 +47,7 @@ interface Type {
   isNullable: boolean;
   isArray: boolean;
   isScalar: boolean;
+  isItemsNullable: boolean;
 }
 
 function escapeString(str: string) {
@@ -67,6 +68,20 @@ function formatDecoratorOptions(options: DecoratorOptions, isFirstArgument = tru
         ' }')
     );
   }
+}
+
+function getTypeGraphQLNullableValue(type: Type): string | undefined {
+  if (type.isNullable) {
+    if (type.isItemsNullable) {
+      return "'itemsAndList'";
+    } else {
+      return 'true';
+    }
+  } else if (type.isItemsNullable) {
+    return "'items'";
+  }
+
+  return undefined;
 }
 
 export class TypeGraphQLVisitor<
@@ -120,7 +135,12 @@ export class TypeGraphQLVisitor<
   }
 
   getDecoratorOptions(
-    node: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode | FieldDefinitionNode | InputObjectTypeDefinitionNode
+    node:
+      | ObjectTypeDefinitionNode
+      | InterfaceTypeDefinitionNode
+      | FieldDefinitionNode
+      | InputObjectTypeDefinitionNode
+      | InputValueDefinitionNode
   ): DecoratorOptions {
     const decoratorOptions: DecoratorOptions = {};
 
@@ -236,6 +256,7 @@ export class TypeGraphQLVisitor<
         type: typeNode.name.value,
         isNullable: true,
         isArray: false,
+        isItemsNullable: false,
         isScalar: SCALARS.includes(typeNode.name.value),
       };
     } else if (typeNode.kind === 'NonNullType') {
@@ -255,8 +276,10 @@ export class TypeGraphQLVisitor<
     const nonNullableType = (rawType as string).replace(MAYBE_REGEX, '$1');
     const isArray = !!nonNullableType.match(ARRAY_REGEX);
     const singularType = nonNullableType.replace(ARRAY_REGEX, '$1');
-    const isScalar = !!singularType.match(SCALAR_REGEX);
-    const type = singularType.replace(SCALAR_REGEX, (match, type) => {
+    const isSingularTypeNullable = !!singularType.match(MAYBE_REGEX);
+    const singularNonNullableType = singularType.replace(MAYBE_REGEX, '$1');
+    const isScalar = !!singularNonNullableType.match(SCALAR_REGEX);
+    const type = singularNonNullableType.replace(SCALAR_REGEX, (match, type) => {
       if (TYPE_GRAPHQL_SCALARS.includes(type)) {
         // This is a TypeGraphQL type
         return `TypeGraphQL.${type}`;
@@ -271,7 +294,7 @@ export class TypeGraphQLVisitor<
       }
     });
 
-    return { type, isNullable, isArray, isScalar };
+    return { type, isNullable, isArray, isScalar, isItemsNullable: isArray && isSingularTypeNullable };
   }
 
   fixDecorator(type: Type, typeString: string) {
@@ -284,19 +307,17 @@ export class TypeGraphQLVisitor<
 
     const type = this.parseType(typeString);
 
-    const maybeType = type.type.match(MAYBE_REGEX);
-    const arrayType = `[${maybeType ? this.clearOptional(type.type) : type.type}]`;
-
     const decoratorOptions = this.getDecoratorOptions(node);
 
-    if (type.isNullable) {
-      decoratorOptions.nullable = 'true';
+    const nullableValue = getTypeGraphQLNullableValue(type);
+    if (nullableValue) {
+      decoratorOptions.nullable = nullableValue;
     }
 
     const decorator =
       '\n' +
       indent(
-        `@TypeGraphQL.${fieldDecorator}(type => ${type.isArray ? arrayType : type.type}${formatDecoratorOptions(
+        `@TypeGraphQL.${fieldDecorator}(type => ${type.isArray ? `[${type.type}]` : type.type}${formatDecoratorOptions(
           decoratorOptions,
           false
         )})`
@@ -315,12 +336,20 @@ export class TypeGraphQLVisitor<
     const type = this.parseType(rawType);
     const typeGraphQLType =
       type.isScalar && TYPE_GRAPHQL_SCALARS.includes(type.type) ? `TypeGraphQL.${type.type}` : type.type;
+
+    const decoratorOptions = this.getDecoratorOptions(node);
+
+    const nullableValue = getTypeGraphQLNullableValue(type);
+    if (nullableValue) {
+      decoratorOptions.nullable = nullableValue;
+    }
+
     const decorator =
       '\n' +
       indent(
-        `@TypeGraphQL.${fieldDecorator}(type => ${type.isArray ? `[${typeGraphQLType}]` : typeGraphQLType}${
-          type.isNullable ? ', { nullable: true }' : ''
-        })`
+        `@TypeGraphQL.${fieldDecorator}(type => ${
+          type.isArray ? `[${typeGraphQLType}]` : typeGraphQLType
+        }${formatDecoratorOptions(decoratorOptions, false)})`
       ) +
       '\n';
 

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -349,52 +349,240 @@ describe('type-graphql', () => {
     `);
   });
 
-  it('should fix `Maybe` only refers to a type, but is being used as a value here for array return type', async () => {
+  it('should correctly set options for nullable types', async () => {
     const schema = buildSchema(/* GraphQL */ `
-      type Guest {
-        id: ID!
-        name: String!
-        phone: String!
+      type MyType {
+        str1: String
+        str2: String!
+        strArr1: [String]
+        strArr2: [String]!
+        strArr3: [String!]
+        strArr4: [String!]!
+
+        int1: Int
+        int2: Int!
+        intArr1: [Int]
+        intArr2: [Int]!
+        intArr3: [Int!]
+        intArr4: [Int!]!
+
+        custom1: MyType2
+        custom2: MyType2!
+        customArr1: [MyType2]
+        customArr2: [MyType2]!
+        customArr3: [MyType2!]
+        customArr4: [MyType2!]!
       }
 
-      type Query {
-        guests: [Guest]
+      input MyInputType {
+        inputStr1: String
+        inputStr2: String!
+        inputStrArr1: [String]
+        inputStrArr2: [String]!
+        inputStrArr3: [String!]
+        inputStrArr4: [String!]!
+
+        inputInt1: Int
+        inputInt2: Int!
+        inputIntArr1: [Int]
+        inputIntArr2: [Int]!
+        inputIntArr3: [Int!]
+        inputIntArr4: [Int!]!
+
+        inputCustom1: MyType2
+        inputCustom2: MyType2!
+        inputCustomArr1: [MyType2]
+        inputCustomArr2: [MyType2]!
+        inputCustomArr3: [MyType2!]
+        inputCustomArr4: [MyType2!]!
+      }
+
+      type MyType2 {
+        id: ID!
       }
     `);
 
     const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
-  /** All built-in and custom scalars, mapped to their actual values */
-  export type Scalars = {
-    ID: string;
-    String: string;
-    Boolean: boolean;
-    Int: number;
-    Float: number;
-  };
-  
-  @TypeGraphQL.ObjectType()
-  export class Guest {
-    __typename?: 'Guest';
-  
-    @TypeGraphQL.Field(type => TypeGraphQL.ID)
-    id!: Scalars['ID'];
-  
-    @TypeGraphQL.Field(type => String)
-    name!: Scalars['String'];
-  
-    @TypeGraphQL.Field(type => String)
-    phone!: Scalars['String'];
-  };
-  
-  export class Query {
-    __typename?: 'Query';
-  
-    @TypeGraphQL.Field(type => [Guest], { nullable: true })
-    guests!: Maybe<Array<Maybe<Guest>>>;
-  };
-  `);
+      @TypeGraphQL.Field(type => String, { nullable: true })
+      str1!: Maybe<Scalars['String']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => String)
+      str2!: Scalars['String'];
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: 'itemsAndList' })
+      strArr1!: Maybe<Array<Maybe<Scalars['String']>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: 'items' })
+      strArr2!: Array<Maybe<Scalars['String']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: true })
+      strArr3!: Maybe<Array<Scalars['String']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String])
+      strArr4!: Array<Scalars['String']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
+      int1!: Maybe<Scalars['Int']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => TypeGraphQL.Int)
+      int2!: Scalars['Int'];
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: 'itemsAndList' })
+      intArr1!: Maybe<Array<Maybe<Scalars['Int']>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: 'items' })
+      intArr2!: Array<Maybe<Scalars['Int']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: true })
+      intArr3!: Maybe<Array<Scalars['Int']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int])
+      intArr4!: Array<Scalars['Int']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => MyType2, { nullable: true })
+      custom1!: Maybe<MyType2>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => MyType2)
+      custom2!: FixDecorator<MyType2>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: 'itemsAndList' })
+      customArr1!: Maybe<Array<Maybe<MyType2>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: 'items' })
+      customArr2!: Array<Maybe<MyType2>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: true })
+      customArr3!: Maybe<Array<MyType2>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2])
+      customArr4!: Array<MyType2>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => String, { nullable: true })
+      inputStr1!: Maybe<Scalars['String']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => String)
+      inputStr2!: Scalars['String'];
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: 'itemsAndList' })
+      inputStrArr1!: Maybe<Array<Maybe<Scalars['String']>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: 'items' })
+      inputStrArr2!: Array<Maybe<Scalars['String']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: true })
+      inputStrArr3!: Maybe<Array<Scalars['String']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String])
+      inputStrArr4!: Array<Scalars['String']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
+      inputInt1!: Maybe<Scalars['Int']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => TypeGraphQL.Int)
+      inputInt2!: Scalars['Int'];
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: 'itemsAndList' })
+      inputIntArr1!: Maybe<Array<Maybe<Scalars['Int']>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: 'items' })
+      inputIntArr2!: Array<Maybe<Scalars['Int']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: true })
+      inputIntArr3!: Maybe<Array<Scalars['Int']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int])
+      inputIntArr4!: Array<Scalars['Int']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => MyType2, { nullable: true })
+      inputCustom1!: Maybe<MyType2>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => MyType2)
+      inputCustom2!: FixDecorator<MyType2>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: 'itemsAndList' })
+      inputCustomArr1!: Maybe<Array<Maybe<MyType2>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: 'items' })
+      inputCustomArr2!: Array<Maybe<MyType2>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: true })
+      inputCustomArr3!: Maybe<Array<MyType2>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2])
+      inputCustomArr4!: Array<MyType2>;
+    `);
   });
 
   it('should put the GraphQL description in the TypeGraphQL options', async () => {

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -396,4 +396,73 @@ describe('type-graphql', () => {
   };
   `);
   });
+
+  it('should put the GraphQL description in the TypeGraphQL options', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      """
+      Test type description
+      """
+      type Test implements ITest {
+        """
+        id field description
+        inside Test class
+        """
+        id: ID
+
+        """
+        mandatoryStr field description
+        """
+        mandatoryStr: String!
+      }
+
+      """
+      ITest interface description
+      """
+      interface ITest {
+        """
+        id field description
+        inside ITest interface
+        """
+        id: ID
+      }
+
+      """
+      TestInput input description
+      """
+      input TestInput {
+        id: ID
+      }
+    `);
+
+    const result = await plugin(schema, [], {}, { outputFile: '' });
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.ObjectType({ description: 'Test type description', implements: ITest })
+      export class Test extends ITest {
+        __typename?: 'Test';
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { description: 'id field description\\ninside Test class', nullable: true })
+        id!: Maybe<Scalars['ID']>;
+        @TypeGraphQL.Field(type => String, { description: 'mandatoryStr field description' })
+        mandatoryStr!: Scalars['String'];
+      }
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.InterfaceType({ description: 'ITest interface description' })
+      export abstract class ITest {
+        
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { description: 'id field description\\ninside ITest interface', nullable: true })
+        id!: Maybe<Scalars['ID']>;
+      }
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.InputType({ description: 'TestInput input description' })
+      export class TestInput {
+
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
:warning: This pull request includes the changes in #4833. Unfortunately there was no other way to do it, as #4833 includes a refactored way of setting TypeGraphQL decorator options

This merge requests is an improvement over #4181 and fixes #4663. In GraphQL arrays, there are several nullable types:

- Items in the array may be null, (`[String]!`)
- The array itself may be null, (`[String!]`)
- Both the array and items in the array may be null (`[String]`)
- Neither the array nor the items in it may be null (`[String!]!]`)

So far, `@graphql-codegen/typescript-type-graphql` did not support either of the cases where the items in the array can be null. This led to uncompilable code, which #4181 attempted to fix. However, there were two problems with this merge request:

- It only fixed fields definitions, but not input value definitions, leaving the bug in #4663
- It removes the compilation error, but actually outputs the incorrect, non-nullable item type

TypeGraphQL supports nullable list types through the options `{ nullable: 'items' }`, and  `{ nullable: 'itemsAndList' }`, which this pull request will properly set on the field and input field decorators.