### PR TITLE
Types that must be TypeGraphQL decorated can now be specified

### DIFF
--- a/.changeset/nasty-squids-press.md
+++ b/.changeset/nasty-squids-press.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-type-graphql': minor
+---
+
+Types that must be decorated may now be specified

--- a/packages/plugins/typescript/type-graphql/src/config.ts
+++ b/packages/plugins/typescript/type-graphql/src/config.ts
@@ -2,5 +2,37 @@ import { DecoratorConfig } from './visitor';
 import { TypeScriptPluginConfig } from '@graphql-codegen/typescript';
 
 export interface TypeGraphQLPluginConfig extends TypeScriptPluginConfig {
+  /**
+   * @name decoratorName
+   * @description allow overriding of TypeGraphQL decorator types
+   * @default
+   * ```json
+   * {
+   *   type: 'ObjectType',
+   *   interface: 'InterfaceType',
+   *   arguments: 'ArgsType',
+   *   field: 'Field',
+   *   input: 'InputType'
+   * }
+   * ```
+   * @type Partial<DecoratorConfig>
+   */
   decoratorName?: Partial<DecoratorConfig>;
+
+  /**
+   * @name decorateTypes
+   * @description Speciies the objects that will have TypeGraphQL decorators prepended to them, by name. Non-matching types will still be output, but without decorators. If not set, all types will be decorated.
+   * @type string[]
+   * @example Decorate only type User
+   * ```yml
+   * generates:
+   * types.ts:
+   *  plugins:
+   *    - typescript-type-graphql
+   *  config:
+   *    decorateTypes:
+   *      - User
+   * ```
+   */
+  decorateTypes?: string[];
 }

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -300,7 +300,7 @@ export class TypeGraphQLVisitor<
     ancestors?: TypeDefinitionNode[]
   ): string {
     const parentName = ancestors?.[ancestors.length - 1].name.value;
-    if (!this.hasTypeDecorators(parentName)) {
+    if (parent && !this.hasTypeDecorators(parentName)) {
       return super.InputValueDefinition(node, key, parent);
     }
 

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -432,6 +432,10 @@ describe('type-graphql', () => {
       input TypeGraphQLInputType {
         id: ID
       }
+
+      type Query {
+        test(mandatoryId: ID!, optionalId: ID): Boolean!
+      }
     `);
 
     const result = await plugin(


### PR DESCRIPTION
Related #4831. New `decorateTypes` config option can now be used to specify types that should be decorated.