### PR TITLE
#4216: remove broken isTypeOf call (always undefined in graphql-tools v6)

### DIFF
--- a/.changeset/chilled-trees-act.md
+++ b/.changeset/chilled-trees-act.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+remove broken isTypeOf call for expanding fragments with flattenGeneratedTypes = true

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -102,7 +102,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
           this._appendToTypeMap(types, typeOnSchema.name, fields);
           this._appendToTypeMap(types, typeOnSchema.name, spreadsUsage[typeOnSchema.name]);
           this._collectInlineFragments(typeOnSchema, inlines, types);
-        } else if (isInterfaceType(typeOnSchema) && parentType.isTypeOf(typeOnSchema, null, null)) {
+        } else if (isInterfaceType(typeOnSchema)) {
           this._appendToTypeMap(types, parentType.name, fields);
           this._appendToTypeMap(types, parentType.name, spreadsUsage[parentType.name]);
           this._collectInlineFragments(typeOnSchema, inlines, types);

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -102,7 +102,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
           this._appendToTypeMap(types, typeOnSchema.name, fields);
           this._appendToTypeMap(types, typeOnSchema.name, spreadsUsage[typeOnSchema.name]);
           this._collectInlineFragments(typeOnSchema, inlines, types);
-        } else if (isInterfaceType(typeOnSchema)) {
+        } else if (isInterfaceType(typeOnSchema) && parentType.getInterfaces().includes(typeOnSchema)) {
           this._appendToTypeMap(types, parentType.name, fields);
           this._appendToTypeMap(types, parentType.name, spreadsUsage[parentType.name]);
           this._collectInlineFragments(typeOnSchema, inlines, types);

--- a/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
+++ b/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
@@ -443,6 +443,59 @@ export type UserQueryQuery = (
 "
 `;
 
+exports[`TypeScript Operations Plugin Union & Interfaces #4216 - handle fragments against unions and interfaces with flattenGeneratedTypes 1`] = `
+"export type Maybe<T> = T | null;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  search?: Maybe<Array<Searchable>>;
+};
+
+export type Concept = {
+  id?: Maybe<Scalars['String']>;
+};
+
+export type Dimension = Concept & {
+  __typename?: 'Dimension';
+  id?: Maybe<Scalars['String']>;
+};
+
+export type DimValue = {
+  __typename?: 'DimValue';
+  dimension?: Maybe<Dimension>;
+  value: Scalars['String'];
+};
+
+export type Searchable = Dimension | DimValue;
+export type SearchPopularQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type SearchPopularQuery = (
+  { __typename?: 'Query' }
+  & { search?: Maybe<Array<(
+    { __typename?: 'Dimension' }
+    & Pick<Dimension, 'id'>
+  ) | (
+    { __typename?: 'DimValue' }
+    & Pick<DimValue, 'value'>
+    & { dimension?: Maybe<(
+      { __typename?: 'Dimension' }
+      & Pick<Dimension, 'id'>
+    )> }
+  )>> }
+);
+"
+`;
+
 exports[`TypeScript Operations Plugin Union & Interfaces Should handle union selection sets with both FragmentSpreads and InlineFragments 1`] = `
 "export type UserQueryQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -3593,6 +3593,119 @@ describe('TypeScript Operations Plugin', () => {
       `);
     });
 
+    it('#4216 - handle fragments against unions and interfaces with flattenGeneratedTypes', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        schema {
+          query: Query
+        }
+
+        type Query {
+          search: [Searchable!]
+        }
+
+        interface Concept {
+          id: String
+        }
+
+        type Dimension implements Concept {
+          id: String
+        }
+
+        type DimValue {
+          dimension: Dimension
+          value: String!
+        }
+
+        union Searchable = Dimension | DimValue
+      `);
+
+      const query = parse(/* GraphQL */ `
+        query SearchPopular {
+          search {
+            ...SearchableFragment
+          }
+        }
+
+        fragment SearchableFragment on Searchable {
+          ...SearchConceptFragment
+          ...SearchDimValueFragment
+        }
+
+        fragment SearchConceptFragment on Concept {
+          id
+        }
+
+        fragment SearchDimValueFragment on DimValue {
+          dimension {
+            ...SearchConceptFragment
+          }
+          value
+        }
+      `);
+
+      const config = {
+        flattenGeneratedTypes: true,
+      };
+
+      const { content } = await plugin(testSchema, [{ location: '', document: query }], config, {
+        outputFile: 'graphql.ts',
+      });
+
+      const output = await validate(content, config, testSchema);
+      expect(mergeOutputs([output])).toMatchSnapshot();
+
+      expect(output).toBeSimilarStringTo(`
+        export type Maybe<T> = T | null;
+        export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+        /** All built-in and custom scalars, mapped to their actual values */
+        export type Scalars = {
+          ID: string;
+          String: string;
+          Boolean: boolean;
+          Int: number;
+          Float: number;
+        };
+
+        export type Query = {
+          __typename?: 'Query';
+          search?: Maybe<Array<Searchable>>;
+        };
+
+        export type Concept = {
+          id?: Maybe<Scalars['String']>;
+        };
+
+        export type Dimension = Concept & {
+          __typename?: 'Dimension';
+          id?: Maybe<Scalars['String']>;
+        };
+
+        export type DimValue = {
+          __typename?: 'DimValue';
+          dimension?: Maybe<Dimension>;
+          value: Scalars['String'];
+        };
+
+        export type Searchable = Dimension | DimValue;
+        export type SearchPopularQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type SearchPopularQuery = (
+          { __typename?: 'Query' }
+          & { search?: Maybe<Array<(
+            { __typename?: 'Dimension' }
+            & Pick<Dimension, 'id'>
+          ) | (
+            { __typename?: 'DimValue' }
+            & Pick<DimValue, 'value'>
+            & { dimension?: Maybe<(
+              { __typename?: 'Dimension' }
+              & Pick<Dimension, 'id'>
+            )> }
+          )>> }
+        );`);
+    });
+
     it('Should add operation name when addOperationExport is true', async () => {
       const testSchema = buildSchema(/* GraphQL */ `
         type User {


### PR DESCRIPTION
This change passes all tests (I ran `yarn test` locally) plus one new test, and "fixes" the TypeError from later comments in issue #4216.

"fixes" is in quotes because I honestly don't understand exactly what is happening here, so I am not sure what the possible impact might be. And I would guess that this line wasn't ever covered by tests to begin with -- I believe it is triggered by fragments against interfaces directly, possibly co-interacting with the union.

I did look at the `package.json` in the commit when this line was created, and it was using graphql-tools v4, so I am suspicious this may be a consequence of a breaking change in graphql-tools between v4 and v6.

I was unable to find anything replacing it or any upgrade notes in the graphql-tools migration guide.

I created a new test from a minimal repro derived from my actual code. It does reproduce the TypeError from #4216 if line 105 of `selection-set-to-object.ts` is reverted.

The resulting types look good to me but definitely would like more eyes on it!

Thanks much for this excellent tool.