### PR TITLE
Types that must be TypeGraphQL decorated can now be specified

### DIFF
--- a/.changeset/nasty-squids-press.md
+++ b/.changeset/nasty-squids-press.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-type-graphql': minor
+---
+
+Types that must be decorated may now be specified

--- a/packages/plugins/typescript/type-graphql/src/config.ts
+++ b/packages/plugins/typescript/type-graphql/src/config.ts
@@ -2,5 +2,37 @@ import { DecoratorConfig } from './visitor';
 import { TypeScriptPluginConfig } from '@graphql-codegen/typescript';
 
 export interface TypeGraphQLPluginConfig extends TypeScriptPluginConfig {
+  /**
+   * @name decoratorName
+   * @description allow overriding of TypeGraphQL decorator types
+   * @default
+   * ```json
+   * {
+   *   type: 'ObjectType',
+   *   interface: 'InterfaceType',
+   *   arguments: 'ArgsType',
+   *   field: 'Field',
+   *   input: 'InputType'
+   * }
+   * ```
+   * @type Partial<DecoratorConfig>
+   */
   decoratorName?: Partial<DecoratorConfig>;
+
+  /**
+   * @name decorateTypes
+   * @description Speciies the objects that will have TypeGraphQL decorators prepended to them, by name. Non-matching types will still be output, but without decorators. If not set, all types will be decorated.
+   * @type string[]
+   * @example Decorate only type User
+   * ```yml
+   * generates:
+   * types.ts:
+   *  plugins:
+   *    - typescript-type-graphql
+   *  config:
+   *    decorateTypes:
+   *      - User
+   * ```
+   */
+  decorateTypes?: string[];
 }

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -380,7 +380,11 @@ export class TypeGraphQLVisitor<
     return str;
   }
 
-  protected hasTypeDecorators(typeName: string) {
+  protected hasTypeDecorators(typeName: string): boolean {
+    if (GRAPHQL_TYPES.includes(typeName)) {
+      return false;
+    }
+
     if (!this.config.decorateTypes) {
       return true;
     }

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -390,8 +390,7 @@ describe('type-graphql', () => {
   
   export type Query = {
     __typename?: 'Query';
-    @TypeGraphQL.Field(type => [Guest], { nullable: true })
-    guests!: Maybe<Array<Maybe<Guest>>>;
+    guests?: Maybe<Array<Maybe<Guest>>>;
   };
   `);
   });


### PR DESCRIPTION
Resolves #4831. New `decorateTypes` config option can now be used to specify types that should be decorated.