### PR TITLE
Use stat instead of extname when creating require

### DIFF
--- a/.changeset/rotten-flies-sort.md
+++ b/.changeset/rotten-flies-sort.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Use `fs.statSync` when creating custom require instead of `path.extname`

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -15,12 +15,13 @@ import { getPresetByName } from './presets';
 import { debugLog } from './utils/debugging';
 import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import { CodegenContext, ensureContext } from './config';
+import fs from 'fs';
 import path from 'path';
 // eslint-disable-next-line
 import { createRequire, createRequireFromPath } from 'module';
 
 const makeDefaultLoader = (from: string) => {
-  if (!path.extname(from)) {
+  if (fs.statSync(from).isDirectory()) {
     from = path.join(from, '__fake.js');
   }
 


### PR DESCRIPTION
This PR will make use of `fs.statSync` instead of `path.extname` when creating the custom `require` function. The issue with the previous version is discussed in #4859. But to summarize the previous version creates issues when the folder the script is running from has a name ending with something that might be mistaken for a file extension – for example `mysite.com` (`path.extname('mysite.com') === '.com'`).

One could argue if we even need to do the check since `makeDefaultLoader` is always passed `context.cwd` which I guess is always a directory? We could probably just do with `from = path.join(from, '__fake.js')`. Please let me know if you think I should remove the check completely.

Related #4859 