### PR TITLE
Fixed reading of enumValues from config

### DIFF
--- a/.changeset/lemon-owls-marry.md
+++ b/.changeset/lemon-owls-marry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript': patch
+---
+
+Fixed reading of enumValues config values

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -203,7 +203,7 @@ export class TsVisitor<
             node.values
               .map(enumOption => {
                 const name = (enumOption.name as unknown) as string;
-                const enumValue: string | number = getValueFromConfig(name) || name;
+                const enumValue: string | number = getValueFromConfig(name) ?? name;
                 const comment = transformComment((enumOption.description as any) as string, 1);
 
                 return comment + indent('| ' + wrapWithSingleQuotes(enumValue));
@@ -223,7 +223,7 @@ export class TsVisitor<
           node.values
             .map((enumOption, i) => {
               const valueFromConfig = getValueFromConfig((enumOption.name as unknown) as string);
-              const enumValue: string | number = valueFromConfig || i;
+              const enumValue: string | number = valueFromConfig ?? i;
               const comment = transformComment((enumOption.description as any) as string, 1);
 
               return comment + indent((enumOption.name as unknown) as string) + ` = ${enumValue}`;
@@ -253,7 +253,7 @@ export class TsVisitor<
               const optionName = this.convertName(enumOption, { useTypesPrefix: false, transformUnderscore: true });
               const comment = transformComment((enumOption.description as any) as string, 1);
               const name = (enumOption.name as unknown) as string;
-              const enumValue: string | number = getValueFromConfig(name) || name;
+              const enumValue: string | number = getValueFromConfig(name) ?? name;
 
               return comment + indent(`${optionName}: ${wrapWithSingleQuotes(enumValue)}`);
             })

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -228,6 +228,42 @@ describe('TypeScript', () => {
       export type MyEnum = typeof MyEnum[keyof typeof MyEnum];`);
     });
 
+    it('Should work with enum as const combined with enum values', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        enum MyEnum {
+          A_B_C
+          X_Y_Z
+          _TEST
+          My_Value
+        }
+      `);
+      const result = (await plugin(
+        schema,
+        [],
+        {
+          enumsAsConst: true,
+          enumValues: {
+            MyEnum: {
+              A_B_C: 0,
+              X_Y_Z: 'Foo',
+              _TEST: 'Bar',
+              My_Value: 1,
+            },
+          },
+        },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect(result.content).toBeSimilarStringTo(`
+      export const MyEnum = {
+        ABC: 0,
+        XYZ: 'Foo',
+        Test: 'Bar',
+        MyValue: 1
+      } as const;
+      export type MyEnum = typeof MyEnum[keyof typeof MyEnum];`);
+    });
+
     it('Should work with enum and enum values (enumsAsTypes)', async () => {
       const schema = buildSchema(/* GraphQL */ `
         "custom enum"


### PR DESCRIPTION
Related #4870. Bug manifested not only when `enumAsConst` was `true`, but whenever any of the values in `enumValues` was falsy, i.e. `0` or `''`.