### PR TITLE
docs: fix typo in `documents` field chapter

### DIFF
--- a/website/docs/getting-started/documents-field.md
+++ b/website/docs/getting-started/documents-field.md
@@ -113,7 +113,7 @@ documents:
     noRequire: true
 ```
 
-> Your operations should be declared as template strings with the `gql` tag or with a GraphQL comment (`` const myQuery = /* GraphQL*/\`query { ... }` ``). This can be configured with `pluckConfig` (see below).
+> Your operations should be declared as template strings with the `gql` tag or with a GraphQL comment (`` const myQuery = /* GraphQL*/`query { ... }` ``). This can be configured with `pluckConfig` (see below).
 
 - ### String
 


### PR DESCRIPTION
The extra \` is apparently a leftover.