### PR TITLE
docs: fix typo in import-types example

### DIFF
--- a/website/docs/generated-config/import-types.md
+++ b/website/docs/generated-config/import-types.md
@@ -11,7 +11,7 @@ generates:
 path/to/file.ts:
  preset: import-types
  presetConfig:
-   typesPath: types.ts
+   baseTypesPath: types.ts
  plugins:
    - typescript-operations
 ```


### PR DESCRIPTION
The current example is incorrect, the PR fixes that.

(Sorry about the EOL change creeping in, but that's odd that it wasn't there in the first place, as most sane editors always add it. Don't you want to enforce it? And perhaps adopt `.editorconfig`?)