### PR TITLE
Allow the vue-apollo plugin to write code to .tsx files

### DIFF
--- a/.changeset/fluffy-snakes-vanish.md
+++ b/.changeset/fluffy-snakes-vanish.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-vue-apollo': patch
+---
+
+Allow the vue-apollo plugin to write code to .tsx files

--- a/packages/plugins/typescript/vue-apollo/src/index.ts
+++ b/packages/plugins/typescript/vue-apollo/src/index.ts
@@ -42,8 +42,8 @@ export const validate: PluginValidateFn<any> = async (
   _config: VueApolloRawPluginConfig,
   outputFile: string
 ) => {
-  if (extname(outputFile) !== '.ts') {
-    throw new Error(`Plugin "vue-apollo" requires extension to be ".ts"!`);
+  if (extname(outputFile) !== '.ts' && extname(outputFile) !== '.tsx') {
+    throw new Error(`Plugin "vue-apollo" requires extension to be ".ts" or ".tsx"!`);
   }
 };
 


### PR DESCRIPTION
Allowing the vue-apollo plugin to write to .tsx files means that piglovesyou/graphql-let will work out of the box with the the `typescript-vue-apollo` plugin.

Without it writing to a `.tsx` file throws this error: **Plugin "vue-apollo" requires extension to be ".ts"!**