### PR TITLE
Fixed decorators for non-nullable type-graphql array types

### DIFF
--- a/.changeset/moody-pots-move.md
+++ b/.changeset/moody-pots-move.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-type-graphql': patch
+---
+
+Fixed decorators for nullable type-graphql array types

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -374,50 +374,240 @@ describe('type-graphql', () => {
     `);
   });
 
-  it('should fix `Maybe` only refers to a type, but is being used as a value here for array return type', async () => {
+  it('should correctly set options for nullable types', async () => {
     const schema = buildSchema(/* GraphQL */ `
-      type Guest {
-        id: ID!
-        name: String!
-        phone: String!
+      type MyType {
+        str1: String
+        str2: String!
+        strArr1: [String]
+        strArr2: [String]!
+        strArr3: [String!]
+        strArr4: [String!]!
+
+        int1: Int
+        int2: Int!
+        intArr1: [Int]
+        intArr2: [Int]!
+        intArr3: [Int!]
+        intArr4: [Int!]!
+
+        custom1: MyType2
+        custom2: MyType2!
+        customArr1: [MyType2]
+        customArr2: [MyType2]!
+        customArr3: [MyType2!]
+        customArr4: [MyType2!]!
       }
 
-      type Query {
-        guests: [Guest]
+      input MyInputType {
+        inputStr1: String
+        inputStr2: String!
+        inputStrArr1: [String]
+        inputStrArr2: [String]!
+        inputStrArr3: [String!]
+        inputStrArr4: [String!]!
+
+        inputInt1: Int
+        inputInt2: Int!
+        inputIntArr1: [Int]
+        inputIntArr2: [Int]!
+        inputIntArr3: [Int!]
+        inputIntArr4: [Int!]!
+
+        inputCustom1: MyType2
+        inputCustom2: MyType2!
+        inputCustomArr1: [MyType2]
+        inputCustomArr2: [MyType2]!
+        inputCustomArr3: [MyType2!]
+        inputCustomArr4: [MyType2!]!
+      }
+
+      type MyType2 {
+        id: ID!
       }
     `);
 
     const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
-  /** All built-in and custom scalars, mapped to their actual values */
-  export type Scalars = {
-    ID: string;
-    String: string;
-    Boolean: boolean;
-    Int: number;
-    Float: number;
-  };
-  
-  @TypeGraphQL.ObjectType()
-  export class Guest {
-    __typename?: 'Guest';
-  
-    @TypeGraphQL.Field(type => TypeGraphQL.ID)
-    id!: Scalars['ID'];
-  
-    @TypeGraphQL.Field(type => String)
-    name!: Scalars['String'];
-  
-    @TypeGraphQL.Field(type => String)
-    phone!: Scalars['String'];
-  };
-  
-  export type Query = {
-    __typename?: 'Query';
-    guests?: Maybe<Array<Maybe<Guest>>>;
-  };
-  `);
+      @TypeGraphQL.Field(type => String, { nullable: true })
+      str1!: Maybe<Scalars['String']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => String)
+      str2!: Scalars['String'];
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: 'itemsAndList' })
+      strArr1!: Maybe<Array<Maybe<Scalars['String']>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: 'items' })
+      strArr2!: Array<Maybe<Scalars['String']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: true })
+      strArr3!: Maybe<Array<Scalars['String']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String])
+      strArr4!: Array<Scalars['String']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
+      int1!: Maybe<Scalars['Int']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => TypeGraphQL.Int)
+      int2!: Scalars['Int'];
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: 'itemsAndList' })
+      intArr1!: Maybe<Array<Maybe<Scalars['Int']>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: 'items' })
+      intArr2!: Array<Maybe<Scalars['Int']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: true })
+      intArr3!: Maybe<Array<Scalars['Int']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int])
+      intArr4!: Array<Scalars['Int']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => MyType2, { nullable: true })
+      custom1!: Maybe<MyType2>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => MyType2)
+      custom2!: FixDecorator<MyType2>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: 'itemsAndList' })
+      customArr1!: Maybe<Array<Maybe<MyType2>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: 'items' })
+      customArr2!: Array<Maybe<MyType2>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: true })
+      customArr3!: Maybe<Array<MyType2>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2])
+      customArr4!: Array<MyType2>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => String, { nullable: true })
+      inputStr1!: Maybe<Scalars['String']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => String)
+      inputStr2!: Scalars['String'];
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: 'itemsAndList' })
+      inputStrArr1!: Maybe<Array<Maybe<Scalars['String']>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: 'items' })
+      inputStrArr2!: Array<Maybe<Scalars['String']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String], { nullable: true })
+      inputStrArr3!: Maybe<Array<Scalars['String']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [String])
+      inputStrArr4!: Array<Scalars['String']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
+      inputInt1!: Maybe<Scalars['Int']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => TypeGraphQL.Int)
+      inputInt2!: Scalars['Int'];
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: 'itemsAndList' })
+      inputIntArr1!: Maybe<Array<Maybe<Scalars['Int']>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: 'items' })
+      inputIntArr2!: Array<Maybe<Scalars['Int']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: true })
+      inputIntArr3!: Maybe<Array<Scalars['Int']>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [TypeGraphQL.Int])
+      inputIntArr4!: Array<Scalars['Int']>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => MyType2, { nullable: true })
+      inputCustom1!: Maybe<MyType2>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => MyType2)
+      inputCustom2!: FixDecorator<MyType2>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: 'itemsAndList' })
+      inputCustomArr1!: Maybe<Array<Maybe<MyType2>>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: 'items' })
+      inputCustomArr2!: Array<Maybe<MyType2>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2], { nullable: true })
+      inputCustomArr3!: Maybe<Array<MyType2>>;
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      @TypeGraphQL.Field(type => [MyType2])
+      inputCustomArr4!: Array<MyType2>;
+    `);
   });
 
   it('should put the GraphQL description in the TypeGraphQL options', async () => {


### PR DESCRIPTION
This merge requests is an improvement over #4181 and fixes #4663. In GraphQL arrays, there are several nullable types:

- Items in the array may be null, (`[String]!`)
- The array itself may be null, (`[String!]`)
- Both the array and items in the array may be null (`[String]`)
- Neither the array nor the items in it may be null (`[String!]!]`)

So far, `@graphql-codegen/typescript-type-graphql` did not support either of the cases where the items in the array can be null. This led to uncompilable code, which #4181 attempted to fix. However, there were two problems with this merge request:

- It only fixed fields definitions, but not input value definitions, leaving the bug in #4663
- It removes the compilation error, but actually outputs the incorrect, non-nullable item type

TypeGraphQL supports nullable list types through the options `{ nullable: 'items' }`, and  `{ nullable: 'itemsAndList' }`, which this pull request will properly set on the field and input field decorators.