### PR TITLE
Types that must be TypeGraphQL decorated can now be specified

### DIFF
--- a/.changeset/nasty-squids-press.md
+++ b/.changeset/nasty-squids-press.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-type-graphql': minor
+---
+
+Types that must be decorated may now be specified

--- a/packages/plugins/typescript/type-graphql/src/config.ts
+++ b/packages/plugins/typescript/type-graphql/src/config.ts
@@ -2,5 +2,37 @@ import { DecoratorConfig } from './visitor';
 import { TypeScriptPluginConfig } from '@graphql-codegen/typescript';
 
 export interface TypeGraphQLPluginConfig extends TypeScriptPluginConfig {
+  /**
+   * @name decoratorName
+   * @description allow overriding of TypeGraphQL decorator types
+   * @default
+   * ```json
+   * {
+   *   type: 'ObjectType',
+   *   interface: 'InterfaceType',
+   *   arguments: 'ArgsType',
+   *   field: 'Field',
+   *   input: 'InputType'
+   * }
+   * ```
+   * @type Partial<DecoratorConfig>
+   */
   decoratorName?: Partial<DecoratorConfig>;
+
+  /**
+   * @name decorateTypes
+   * @description Speciies the objects that will have TypeGraphQL decorators prepended to them, by name. Non-matching types will still be output, but without decorators. If not set, all types will be decorated.
+   * @type string[]
+   * @example Decorate only type User
+   * ```yml
+   * generates:
+   * types.ts:
+   *  plugins:
+   *    - typescript-type-graphql
+   *  config:
+   *    decorateTypes:
+   *      - User
+   * ```
+   */
+  decorateTypes?: string[];
 }

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -436,7 +436,11 @@ export class TypeGraphQLVisitor<
     return str;
   }
 
-  protected hasTypeDecorators(typeName: string) {
+  protected hasTypeDecorators(typeName: string): boolean {
+    if (GRAPHQL_TYPES.includes(typeName)) {
+      return false;
+    }
+
     if (!this.config.decorateTypes) {
       return true;
     }

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -11,6 +11,7 @@ import {
   TypeNode,
   GraphQLEnumType,
   InputObjectTypeDefinitionNode,
+  TypeDefinitionNode,
 } from 'graphql';
 import {
   TypeScriptOperationVariablesToObject,
@@ -33,6 +34,7 @@ export interface TypeGraphQLPluginParsedConfig extends TypeScriptPluginParsedCon
   immutableTypes: boolean;
   maybeValue: string;
   decoratorName: DecoratorConfig;
+  decorateTypes?: string[];
 }
 
 const MAYBE_REGEX = /^Maybe<(.*?)>$/;
@@ -50,7 +52,14 @@ interface Type {
 }
 
 function escapeString(str: string) {
-  return "'" + str.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, "\\'") + "'";
+  return (
+    "'" +
+    str
+      .replace(/\\/g, '\\\\')
+      .replace(/\n/g, '\\n')
+      .replace(/'/g, "\\'") +
+    "'"
+  );
 }
 
 type DecoratorOptions = { [key: string]: string };
@@ -75,6 +84,8 @@ export class TypeGraphQLVisitor<
   TRawConfig extends TypeGraphQLPluginConfig = TypeGraphQLPluginConfig,
   TParsedConfig extends TypeGraphQLPluginParsedConfig = TypeGraphQLPluginParsedConfig
 > extends TsVisitor<TRawConfig, TParsedConfig> {
+  typescriptVisitor: TsVisitor<TRawConfig, TParsedConfig>;
+
   constructor(schema: GraphQLSchema, pluginConfig: TRawConfig, additionalConfig: Partial<TParsedConfig> = {}) {
     super(schema, pluginConfig, {
       avoidOptionals: pluginConfig.avoidOptionals || false,
@@ -97,9 +108,12 @@ export class TypeGraphQLVisitor<
         input: 'InputType',
         ...(pluginConfig.decoratorName || {}),
       },
+      decorateTypes: pluginConfig.decorateTypes || undefined,
       ...(additionalConfig || {}),
     } as TParsedConfig);
     autoBind(this);
+
+    this.typescriptVisitor = new TsVisitor(schema, pluginConfig, additionalConfig);
 
     const enumNames = Object.values(schema.getTypeMap())
       .map(type => (type instanceof GraphQLEnumType ? type.name : undefined))
@@ -120,7 +134,7 @@ export class TypeGraphQLVisitor<
       enumNameValueSeparator: ' =',
     });
   }
-  
+
   getDecoratorOptions(
     node: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode | FieldDefinitionNode | InputObjectTypeDefinitionNode
   ): DecoratorOptions {
@@ -143,14 +157,45 @@ export class TypeGraphQLVisitor<
     return `${this.getExportPrefix()}${FIX_DECORATOR_SIGNATURE}`;
   }
 
+  protected buildArgumentsBlock(node: InterfaceTypeDefinitionNode | ObjectTypeDefinitionNode): string {
+    const fieldsWithArguments = node.fields.filter(field => field.arguments && field.arguments.length > 0) || [];
+    return fieldsWithArguments
+      .map(field => {
+        const name =
+          node.name.value +
+          (this.config.addUnderscoreToArgsType ? '_' : '') +
+          this.convertName(field, {
+            useTypesPrefix: false,
+            useTypesSuffix: false,
+          }) +
+          'Args';
+
+        if (this.hasTypeDecorators(name)) {
+          return this.getArgumentsObjectTypeDefinition(node, name, field);
+        } else {
+          return this.typescriptVisitor.getArgumentsObjectTypeDefinition(node, name, field);
+        }
+      })
+      .join('\n\n');
+  }
+
   ObjectTypeDefinition(node: ObjectTypeDefinitionNode, key: number | string, parent: any): string {
+    const isGraphQLType = GRAPHQL_TYPES.includes((node.name as unknown) as string);
+    if (!isGraphQLType && !this.hasTypeDecorators((node.name as unknown) as string)) {
+      return this.typescriptVisitor.ObjectTypeDefinition(node, key, parent);
+    }
+
     const typeDecorator = this.config.decoratorName.type;
     const originalNode = parent[key] as ObjectTypeDefinitionNode;
 
     const decoratorOptions = this.getDecoratorOptions(node);
 
-    let declarationBlock = this.getObjectTypeDeclarationBlock(node, originalNode);
-    if (!GRAPHQL_TYPES.includes((node.name as unknown) as string)) {
+    let declarationBlock: DeclarationBlock;
+    if (isGraphQLType) {
+      declarationBlock = this.typescriptVisitor.getObjectTypeDeclarationBlock(node, originalNode);
+    } else {
+      declarationBlock = this.getObjectTypeDeclarationBlock(node, originalNode);
+
       // Add type-graphql ObjectType decorator
       const interfaces = originalNode.interfaces.map(i => this.convertName(i));
       if (interfaces.length > 1) {
@@ -167,6 +212,10 @@ export class TypeGraphQLVisitor<
   }
 
   InputObjectTypeDefinition(node: InputObjectTypeDefinitionNode): string {
+    if (!this.hasTypeDecorators((node.name as unknown) as string)) {
+      return this.typescriptVisitor.InputObjectTypeDefinition(node);
+    }
+
     const typeDecorator = this.config.decoratorName.input;
 
     const decoratorOptions = this.getDecoratorOptions(node);
@@ -210,6 +259,10 @@ export class TypeGraphQLVisitor<
   }
 
   InterfaceTypeDefinition(node: InterfaceTypeDefinitionNode, key: number | string, parent: any): string {
+    if (!this.hasTypeDecorators((node.name as unknown) as string)) {
+      return this.typescriptVisitor.InterfaceTypeDefinition(node, key, parent);
+    }
+
     const interfaceDecorator = this.config.decoratorName.interface;
     const originalNode = parent[key] as InterfaceTypeDefinitionNode;
 
@@ -288,7 +341,18 @@ export class TypeGraphQLVisitor<
     return type.isArray || type.isNullable || type.isScalar ? typeString : `FixDecorator<${typeString}>`;
   }
 
-  FieldDefinition(node: FieldDefinitionNode, key?: number | string, parent?: any): string {
+  FieldDefinition(
+    node: FieldDefinitionNode,
+    key?: number | string,
+    parent?: any,
+    path?: any,
+    ancestors?: TypeDefinitionNode[]
+  ): string {
+    const parentName = ancestors?.[ancestors.length - 1].name.value;
+    if (!this.hasTypeDecorators(parentName)) {
+      return this.typescriptVisitor.FieldDefinition(node, key, parent);
+    }
+
     const fieldDecorator = this.config.decoratorName.field;
     let typeString = (node.type as any) as string;
 
@@ -318,7 +382,18 @@ export class TypeGraphQLVisitor<
     return decorator + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}!: ${typeString};`);
   }
 
-  InputValueDefinition(node: InputValueDefinitionNode, key?: number | string, parent?: any): string {
+  InputValueDefinition(
+    node: InputValueDefinitionNode,
+    key?: number | string,
+    parent?: any,
+    path?: any,
+    ancestors?: TypeDefinitionNode[]
+  ): string {
+    const parentName = ancestors?.[ancestors.length - 1].name.value;
+    if (parent && !this.hasTypeDecorators(parentName)) {
+      return this.typescriptVisitor.InputValueDefinition(node, key, parent);
+    }
+
     const fieldDecorator = this.config.decoratorName.field;
     const rawType = node.type as TypeNode | string;
 
@@ -343,6 +418,10 @@ export class TypeGraphQLVisitor<
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {
+    if (!this.hasTypeDecorators((node.name as unknown) as string)) {
+      return this.typescriptVisitor.EnumTypeDefinition(node);
+    }
+
     return (
       super.EnumTypeDefinition(node) +
       `TypeGraphQL.registerEnumType(${this.convertName(node)}, { name: '${this.convertName(node)}' });\n`
@@ -355,5 +434,13 @@ export class TypeGraphQLVisitor<
     }
 
     return str;
+  }
+
+  protected hasTypeDecorators(typeName: string) {
+    if (!this.config.decorateTypes) {
+      return true;
+    }
+
+    return this.config.decorateTypes.some(filter => filter === typeName);
   }
 }

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -413,9 +413,8 @@ describe('type-graphql', () => {
     phone!: Scalars['String'];
   };
   
-  export class Query {
+  export type Query = {
     __typename?: 'Query';
-  
     @TypeGraphQL.Field(type => [Guest], { nullable: true })
     guests!: Maybe<Array<Maybe<Guest>>>;
   };
@@ -489,5 +488,138 @@ describe('type-graphql', () => {
         id!: Maybe<Scalars['ID']>;
       }
     `);
+  });
+
+  it('should only generate TypeGraphQL decorators for included types', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      enum RegularEnum {
+        A
+        B
+      }
+
+      enum TypeGraphQLEnum {
+        A
+        B
+      }
+
+      interface IRegularInterfaceType {
+        id: ID
+      }
+
+      interface ITypeGraphQLInterfaceType {
+        id: ID
+      }
+
+      type RegularType {
+        id: ID
+      }
+
+      type TypeGraphQLType {
+        id: ID
+      }
+
+      input RegularInputType {
+        id: ID
+      }
+
+      input TypeGraphQLInputType {
+        id: ID
+      }
+
+      type Query {
+        regularFunction(mandatoryId: ID!, optionalId: ID): Boolean!
+        typeGraphQLFunction(mandatoryId: ID!, optionalId: ID): Boolean!
+      }
+    `);
+
+    const result = await plugin(
+      schema,
+      [],
+      {
+        decorateTypes: [
+          'TypeGraphQLEnum',
+          'ITypeGraphQLInterfaceType',
+          'TypeGraphQLType',
+          'TypeGraphQLInputType',
+          'QueryTypeGraphQlFunctionArgs',
+        ],
+      },
+      { outputFile: '' }
+    );
+
+    expect(result.content).not.toBeSimilarStringTo(
+      `TypeGraphQL.registerEnumType(RegularEnum, { name: 'RegularEnum' });`
+    );
+
+    expect(result.content).toBeSimilarStringTo(
+      `TypeGraphQL.registerEnumType(TypeGraphQlEnum, { name: 'TypeGraphQlEnum' });`
+    );
+
+    expect(result.content).toBeSimilarStringTo(
+      `export type IRegularInterfaceType = {
+        id?: Maybe<Scalars['ID']>;
+      };`
+    );
+
+    expect(result.content).toBeSimilarStringTo(
+      `
+      @TypeGraphQL.InterfaceType()
+      export abstract class ITypeGraphQlInterfaceType {
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
+      }`
+    );
+
+    expect(result.content).toBeSimilarStringTo(
+      `export type RegularType = {
+        __typename?: 'RegularType';
+        id?: Maybe<Scalars['ID']>;
+      };`
+    );
+
+    expect(result.content).toBeSimilarStringTo(
+      `@TypeGraphQL.ObjectType()
+      export class TypeGraphQlType {
+        __typename?: 'TypeGraphQLType';
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
+      }`
+    );
+
+    expect(result.content).toBeSimilarStringTo(
+      `export type RegularInputType = {
+        id?: Maybe<Scalars['ID']>;
+      };`
+    );
+
+    expect(result.content).toBeSimilarStringTo(
+      `@TypeGraphQL.InputType()
+      export class TypeGraphQlInputType {
+        @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+        id!: Maybe<Scalars['ID']>;
+      }`
+    );
+
+    expect(result.content).toBeSimilarStringTo(`
+    export type Query = {
+      __typename?: 'Query';
+      regularFunction: Scalars['Boolean'];
+      typeGraphQLFunction: Scalars['Boolean'];
+    };`);
+
+    expect(result.content).toBeSimilarStringTo(`export type QueryRegularFunctionArgs = {
+        mandatoryId: Scalars['ID'];
+        optionalId?: Maybe<Scalars['ID']>;
+      };`);
+
+    expect(result.content).toBeSimilarStringTo(` @TypeGraphQL.ArgsType()
+       export class QueryTypeGraphQlFunctionArgs {
+      
+         @TypeGraphQL.Field(type => TypeGraphQL.ID)
+         mandatoryId!: Scalars['ID'];
+      
+         @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
+         optionalId!: Maybe<Scalars['ID']>;
+       };`);
   });
 });

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -415,8 +415,7 @@ describe('type-graphql', () => {
   
   export type Query = {
     __typename?: 'Query';
-    @TypeGraphQL.Field(type => [Guest], { nullable: true })
-    guests!: Maybe<Array<Maybe<Guest>>>;
+    guests?: Maybe<Array<Maybe<Guest>>>;
   };
   `);
   });


### PR DESCRIPTION
Related #4831. New `decorateTypes` config option can now be used to specify types that should be decorated.