### PR TITLE
feat(types-import): support useTypeImports

### DIFF
--- a/.changeset/slimy-forks-work.md
+++ b/.changeset/slimy-forks-work.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/import-types-preset': minor
+---
+
+Adds support for `useTypeImports` when using the preset `import-types`

--- a/packages/presets/import-types/src/index.ts
+++ b/packages/presets/import-types/src/index.ts
@@ -72,9 +72,10 @@ export const preset: Types.OutputPreset<ImportTypesConfig> = {
           options.schemaAst
         )
       ) {
+        const importType = options.config.useTypeImports ? 'import type' : 'import';
         plugins.unshift({
           add: {
-            content: `import * as ${importTypesNamespace} from '${options.presetConfig.typesPath}';\n`,
+            content: `${importType} * as ${importTypesNamespace} from '${options.presetConfig.typesPath}';\n`,
           },
         });
       }

--- a/packages/presets/import-types/tests/types-import.spec.ts
+++ b/packages/presets/import-types/tests/types-import.spec.ts
@@ -111,6 +111,32 @@ describe('import-types preset', () => {
     );
   });
 
+  it('Should prepend the "add" plugin with the correct import type', async () => {
+    const result = await preset.buildGeneratesSection({
+      baseOutputDir: './src/operation.ts',
+      config: {
+        useTypeImports: true,
+      },
+      presetConfig: {
+        typesPath: './types',
+      },
+      schema: schemaDocumentNode,
+      documents: testDocuments.slice(0, 2),
+      plugins: [{ typescript: {} }],
+      pluginMap: { typescript: {} as any },
+    });
+
+    expect(result.map(o => o.plugins)[0]).toEqual(
+      expect.arrayContaining([
+        {
+          add: {
+            content: `import type * as Types from './types';\n`,
+          },
+        },
+      ])
+    );
+  });
+
   it('Should prepend the "add" plugin with the correct import, when only using fragment spread', async () => {
     const result = await preset.buildGeneratesSection({
       baseOutputDir: './src/operation.ts',


### PR DESCRIPTION
This PR adds support for the `useTypeImports` config when using the `types-import` preset. 