### PR TITLE
Add errors-only flag to graphql-codegen-cli

### DIFF
--- a/.changeset/brown-eels-chew.md
+++ b/.changeset/brown-eels-chew.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/cli': minor
+'@graphql-codegen/plugin-helpers': minor
+---
+
+Adds the --errors-only flag to the cli to print errors only.

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -8,7 +8,7 @@ import {
 } from '@graphql-codegen/plugin-helpers';
 import { codegen } from '@graphql-codegen/core';
 
-import { Renderer } from './utils/listr-renderer';
+import { Renderer, ErrorRenderer } from './utils/listr-renderer';
 import { GraphQLError, GraphQLSchema, DocumentNode, parse } from 'graphql';
 import { getPluginByName } from './plugins';
 import { getPresetByName } from './presets';
@@ -72,7 +72,7 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
   } else {
     listr = new Listr({
       ...commonListrOptions,
-      renderer: config.silent ? 'silent' : Renderer,
+      renderer: config.silent ? 'silent' : config.errorsOnly ? ErrorRenderer : Renderer,
       nonTTYRenderer: config.silent ? 'silent' : 'default',
       collapse: true,
       clearOutput: false,

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -14,6 +14,7 @@ export type YamlCliFlags = {
   overwrite: boolean;
   project: string;
   silent: boolean;
+  errorsOnly: boolean;
 };
 
 function generateSearchPlaces(moduleName: string) {
@@ -151,6 +152,11 @@ export function buildOptions() {
       describe: 'Suppresses printing errors',
       type: 'boolean' as const,
     },
+    e: {
+      alias: 'errors-only',
+      describe: 'Only print errors',
+      type: 'boolean' as const,
+    },
     p: {
       alias: 'project',
       describe: 'Name of a project in GraphQL Config',
@@ -189,6 +195,10 @@ export function updateContextWithCliFlags(context: CodegenContext, cliFlags: Yam
 
   if (cliFlags.silent === true) {
     config.silent = cliFlags.silent;
+  }
+
+  if (cliFlags.errorsOnly === true) {
+    config.errorsOnly = cliFlags.errorsOnly;
   }
 
   if (cliFlags.project) {

--- a/packages/graphql-codegen-cli/src/utils/listr-renderer.ts
+++ b/packages/graphql-codegen-cli/src/utils/listr-renderer.ts
@@ -79,6 +79,46 @@ export class Renderer {
   }
 }
 
+const render = tasks => {
+  for (const task of tasks) {
+    task.subscribe(
+      event => {
+        if (event.type === 'SUBTASKS') {
+          render(task.subtasks);
+          return;
+        }
+
+        if (event.type === 'DATA') {
+          logUpdate.emit(chalk.dim(`${event.data}`));
+        }
+        logUpdate.done();
+      },
+      err => {
+        logUpdate.emit(err);
+        logUpdate.done();
+      }
+    );
+  }
+};
+
+export class ErrorRenderer {
+  private tasks: any;
+
+  constructor(tasks, options) {
+    this.tasks = tasks;
+  }
+
+  render() {
+    render(this.tasks);
+  }
+
+  static get nonTTY() {
+    return true;
+  }
+
+  end() {}
+}
+
 class LogUpdate {
   private stream = process.stdout;
   // state

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -430,6 +430,10 @@ export namespace Types {
      */
     silent?: boolean;
     /**
+     * @description A flag to print only errors.
+     */
+    errorsOnly?: boolean;
+    /**
      * @description If you are using the programmatic API in a browser environment, you can override this configuration to load your plugins in a way different than require.
      */
     pluginLoader?: PackageLoaderFn<CodegenPlugin>;


### PR DESCRIPTION
When watching multiple processes in parallel, the output from the graphql-cli can be quite verbose. This PR allows the --errors-only flag to be passed to the cli which suppresses all other output. 

There are some things that might be questionable: for example the nested ternary, even though I think in this case it's actually quite clear to understand. However I'm happy for any feedback, since I'm quite new to the open source world.




