### PR TITLE
Fixes #4944, fragment import statement generation for flow

### DIFF
--- a/.changeset/hot-pants-vanish.md
+++ b/.changeset/hot-pants-vanish.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/flow-operations': patch
+---
+
+Fixes generation of type imports for fragments

--- a/packages/plugins/flow/operations/src/index.ts
+++ b/packages/plugins/flow/operations/src/index.ts
@@ -30,12 +30,14 @@ export const plugin: PluginFunction<FlowDocumentsPluginConfig> = (
     ...(config.externalFragments || []),
   ];
 
+  const visitor = new FlowDocumentsVisitor(schema, config, allFragments);
+
   const visitorResult = visit(allAst, {
-    leave: new FlowDocumentsVisitor(schema, config, allFragments),
+    leave: visitor,
   });
 
   return {
-    prepend: ['// @flow\n'],
+    prepend: ['// @flow\n', ...visitor.getImports()],
     content: [prefix, ...visitorResult.definitions].join('\n'),
   };
 };

--- a/packages/plugins/flow/operations/src/visitor.ts
+++ b/packages/plugins/flow/operations/src/visitor.ts
@@ -12,6 +12,7 @@ import {
   SelectionSetToObject,
   getConfigValue,
   DeclarationKind,
+  generateFragmentImportStatement,
 } from '@graphql-codegen/visitor-plugin-common';
 
 import autoBind from 'auto-bind';
@@ -85,5 +86,14 @@ export class FlowDocumentsVisitor extends BaseDocumentsVisitor<FlowDocumentsPlug
 
   protected getPunctuation(declarationKind: DeclarationKind): string {
     return declarationKind === 'type' ? ',' : ';';
+  }
+
+  public getImports(): Array<string> {
+    return !this.config.globalNamespace
+      ? this.config.fragmentImports
+          // In flow, all non ` * as x` imports must be type imports
+          .map(fragmentImport => ({ ...fragmentImport, typesImport: true }))
+          .map(fragmentImport => generateFragmentImportStatement(fragmentImport, 'type'))
+      : [];
   }
 }


### PR DESCRIPTION
Related: #4944

The typescript visitors already do this — but looks like the flow implementations were missed out.