### PR TITLE
as is types path for near-operation-file docs

### DIFF
--- a/website/docs/generated-config/near-operation-file.md
+++ b/website/docs/generated-config/near-operation-file.md
@@ -3,6 +3,7 @@
 
 Required, should point to the base schema types file. The key of the output is used a the base path for this file.
 
+> If the specified path starts with `~` it will be used as is.
 
 #### Usage Example
 


### PR DESCRIPTION
I was configurating `graphql-codegen` for a monorepo project and I needed an absolute types path, but the docs didn't specify anything about using absolute paths, for example, for node_modules reference, and I found while looking at the source code about this undocumented feature

https://github.com/dotansimha/graphql-code-generator/blob/master/packages/presets/near-operation-file/src/index.ts#L148