### PR TITLE
GenerateOptions: dont require config & documents

### DIFF
--- a/.changeset/khaki-mugs-ring.md
+++ b/.changeset/khaki-mugs-ring.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/plugin-helpers': patch
+---
+
+Unrequire documents and config for GenerateOptions

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -7,8 +7,8 @@ export namespace Types {
     plugins: Types.ConfiguredPlugin[];
     schema: DocumentNode;
     schemaAst?: GraphQLSchema;
-    documents: Types.DocumentFile[];
-    config: { [key: string]: any };
+    documents?: Types.DocumentFile[];
+    config?: { [key: string]: any };
     pluginMap: {
       [name: string]: CodegenPlugin;
     };


### PR DESCRIPTION
These options aren't required in [this tutorial](https://graphql-code-generator.com/docs/getting-started/programmatic-usage) but they are in the code, is this correct? I get the respective ts-error when trying out the example