### PR TITLE
Remove extra `// @flow` declaration from flow operations

### DIFF
--- a/.changeset/fair-spoons-drum.md
+++ b/.changeset/fair-spoons-drum.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/flow': patch
+'@graphql-codegen/flow-operations': patch
+---
+
+Consolidate `// @flow` declarations to avoid duplicates

--- a/dev-test/githunt/flow.flow.js
+++ b/dev-test/githunt/flow.flow.js
@@ -1,7 +1,5 @@
 // @flow
 
-// @flow
-
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {|
   ID: string,

--- a/packages/plugins/flow/flow/src/index.ts
+++ b/packages/plugins/flow/flow/src/index.ts
@@ -11,7 +11,7 @@ export const plugin: PluginFunction<FlowPluginConfig, Types.ComplexPluginOutput>
   documents: Types.DocumentFile[],
   config: FlowPluginConfig
 ) => {
-  const header = `// @flow \n\n`;
+  const header = `// @flow\n`;
   const printedSchema = printSchema(schema);
   const astNode = parse(printedSchema);
   const visitor = new FlowVisitor(schema, config);

--- a/packages/plugins/flow/operations/src/index.ts
+++ b/packages/plugins/flow/operations/src/index.ts
@@ -35,7 +35,7 @@ export const plugin: PluginFunction<FlowDocumentsPluginConfig> = (
   });
 
   return {
-    prepend: ['// @flow \n'],
+    prepend: [''],
     content: [prefix, ...visitorResult.definitions].join('\n'),
   };
 };

--- a/packages/plugins/flow/operations/src/index.ts
+++ b/packages/plugins/flow/operations/src/index.ts
@@ -35,7 +35,7 @@ export const plugin: PluginFunction<FlowDocumentsPluginConfig> = (
   });
 
   return {
-    prepend: [''],
+    prepend: ['// @flow\n'],
     content: [prefix, ...visitorResult.definitions].join('\n'),
   };
 };

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -205,7 +205,8 @@ describe('Flow Operations Plugin', () => {
       ]);
 
       expect(result).toMatchInlineSnapshot(`
-        "
+        "// @flow
+
         type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
         export type NotificationsQueryVariables = {};
@@ -569,7 +570,8 @@ describe('Flow Operations Plugin', () => {
       ]);
 
       expect(result).toMatchInlineSnapshot(`
-        "
+        "// @flow
+
         type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
         export type UserFieldsFragment = ({
@@ -618,7 +620,8 @@ describe('Flow Operations Plugin', () => {
       ]);
 
       expect(result).toMatchInlineSnapshot(`
-        "
+        "// @flow
+
         type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
         export type UserFieldsFragment = ({
@@ -670,8 +673,9 @@ describe('Flow Operations Plugin', () => {
       ]);
 
       expect(result).toMatchInlineSnapshot(`
-        "
-        
+        "// @flow
+
+
         export type UserFieldsFragment = { id: string, username: string, role?: ?Role, profile?: ?{ age?: ?number } };
 
         export type MeQueryVariables = {};

--- a/packages/plugins/flow/operations/tests/flow-documents.spec.ts
+++ b/packages/plugins/flow/operations/tests/flow-documents.spec.ts
@@ -205,8 +205,7 @@ describe('Flow Operations Plugin', () => {
       ]);
 
       expect(result).toMatchInlineSnapshot(`
-        "// @flow 
-
+        "
         type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
         export type NotificationsQueryVariables = {};
@@ -570,8 +569,7 @@ describe('Flow Operations Plugin', () => {
       ]);
 
       expect(result).toMatchInlineSnapshot(`
-        "// @flow 
-
+        "
         type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
         export type UserFieldsFragment = ({
@@ -620,8 +618,7 @@ describe('Flow Operations Plugin', () => {
       ]);
 
       expect(result).toMatchInlineSnapshot(`
-        "// @flow 
-
+        "
         type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
 
         export type UserFieldsFragment = ({
@@ -673,9 +670,8 @@ describe('Flow Operations Plugin', () => {
       ]);
 
       expect(result).toMatchInlineSnapshot(`
-        "// @flow 
-
-
+        "
+        
         export type UserFieldsFragment = { id: string, username: string, role?: ?Role, profile?: ?{ age?: ?number } };
 
         export type MeQueryVariables = {};


### PR DESCRIPTION
Related: https://github.com/dotansimha/graphql-code-generator/issues/4911

`// @flow` declaration is removed from [flow operations](https://github.com/dotansimha/graphql-code-generator/blob/master/packages/plugins/flow/operations/src/index.ts#L38) since [flow plugin](https://github.com/dotansimha/graphql-code-generator/blob/c0f7e16f2e9ddaab61421643da7e4851cadccf97/packages/plugins/flow/flow/src/index.ts#L10) already prepends this to the final output.

Not sure if this affects other part of the lib though. 