### PR TITLE
fix(cli): resolve modules provided through the -r flags relative to the cwd

### DIFF
--- a/.changeset/sweet-avocados-unite.md
+++ b/.changeset/sweet-avocados-unite.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Resolve modules passed through the -r flag relative to the cwd

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -4,6 +4,7 @@ import { DetailedError, Types } from '@graphql-codegen/plugin-helpers';
 import { env } from 'string-env-interpolation';
 import yargs from 'yargs';
 import { GraphQLConfig } from 'graphql-config';
+// eslint-disable-next-line
 import { createRequire, createRequireFromPath } from 'module';
 import { findAndLoadGraphQLConfig } from './graphql-config';
 import { loadSchema, loadDocuments } from './load';

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -4,6 +4,7 @@ import { DetailedError, Types } from '@graphql-codegen/plugin-helpers';
 import { env } from 'string-env-interpolation';
 import yargs from 'yargs';
 import { GraphQLConfig } from 'graphql-config';
+import { createRequire, createRequireFromPath } from 'module';
 import { findAndLoadGraphQLConfig } from './graphql-config';
 import { loadSchema, loadDocuments } from './load';
 
@@ -171,7 +172,8 @@ export function parseArgv(argv = process.argv): YamlCliFlags {
 
 export async function createContext(cliFlags: YamlCliFlags = parseArgv(process.argv)): Promise<CodegenContext> {
   if (cliFlags.require && cliFlags.require.length > 0) {
-    await Promise.all(cliFlags.require.map(mod => import(mod)));
+    const relativeRequire = (createRequire || createRequireFromPath)(process.cwd());
+    await Promise.all(cliFlags.require.map(mod => import(relativeRequire.resolve(mod))));
   }
 
   const customConfigPath = getCustomConfigPath(cliFlags);


### PR DESCRIPTION
**What's the problem this PR addresses?**

The CLI is requiring modules passed through the `-r` flag from itself and not the users project.

Related https://github.com/dotansimha/graphql-code-generator/issues/4947

**How did you fix it?**

Resolve all modules provided to the `-r` flag relative to the CWD