### PR TITLE
Improve typescript vue apollo plugin

### DIFF
--- a/.changeset/neat-lemons-drive.md
+++ b/.changeset/neat-lemons-drive.md
@@ -1,0 +1,7 @@
+---
+'@graphql-codegen/typescript-vue-apollo': minor
+---
+
+* Support the `useTypeImports` options
+* Fix typing errors for operations without variables
+* Improve jsdoc

--- a/dev-test/githunt/types.vueApollo.ts
+++ b/dev-test/githunt/types.vueApollo.ts
@@ -340,14 +340,13 @@ export const OnCommentAddedDocument = gql`
  * When your component renders, `useOnCommentAddedSubscription` returns an object from Apollo Client that contains result, loading and error properties
  * you can use to render your UI.
  *
+ * @param variables that will be passed into the subscription
  * @param options that will be passed into the subscription, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/subscription.html#options;
  *
  * @example
- * const { result, loading, error } = useOnCommentAddedSubscription(
- *   {
- *      repoFullName: // value for 'repoFullName'
- *   }
- * );
+ * const { result, loading, error } = useOnCommentAddedSubscription({
+ *   repoFullName: // value for 'repoFullName'
+ * });
  */
 export function useOnCommentAddedSubscription(
   variables:
@@ -411,16 +410,15 @@ export const CommentDocument = gql`
  * When your component renders, `useCommentQuery` returns an object from Apollo Client that contains result, loading and error properties
  * you can use to render your UI.
  *
+ * @param variables that will be passed into the query
  * @param options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
  *
  * @example
- * const { result, loading, error } = useCommentQuery(
- *   {
- *      repoFullName: // value for 'repoFullName'
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *   }
- * );
+ * const { result, loading, error } = useCommentQuery({
+ *   repoFullName: // value for 'repoFullName'
+ *   limit: // value for 'limit'
+ *   offset: // value for 'offset'
+ * });
  */
 export function useCommentQuery(
   variables:
@@ -457,10 +455,7 @@ export const CurrentUserForProfileDocument = gql`
  * @param options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
  *
  * @example
- * const { result, loading, error } = useCurrentUserForProfileQuery(
- *   {
- *   }
- * );
+ * const { result, loading, error } = useCurrentUserForProfileQuery();
  */
 export function useCurrentUserForProfileQuery(
   options:
@@ -472,9 +467,9 @@ export function useCurrentUserForProfileQuery(
         VueApolloComposable.UseQueryOptions<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>
       > = {}
 ) {
-  return VueApolloComposable.useQuery<CurrentUserForProfileQuery, undefined>(
+  return VueApolloComposable.useQuery<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>(
     CurrentUserForProfileDocument,
-    undefined,
+    {},
     options
   );
 }
@@ -501,16 +496,15 @@ export const FeedDocument = gql`
  * When your component renders, `useFeedQuery` returns an object from Apollo Client that contains result, loading and error properties
  * you can use to render your UI.
  *
+ * @param variables that will be passed into the query
  * @param options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
  *
  * @example
- * const { result, loading, error } = useFeedQuery(
- *   {
- *      type: // value for 'type'
- *      offset: // value for 'offset'
- *      limit: // value for 'limit'
- *   }
- * );
+ * const { result, loading, error } = useFeedQuery({
+ *   type: // value for 'type'
+ *   offset: // value for 'offset'
+ *   limit: // value for 'limit'
+ * });
  */
 export function useFeedQuery(
   variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunction<FeedQueryVariables>,
@@ -543,7 +537,7 @@ export const SubmitRepositoryDocument = gql`
  * @example
  * const { mutate, loading, error, onDone } = useSubmitRepositoryMutation({
  *   variables: {
- *      repoFullName: // value for 'repoFullName'
+ *     repoFullName: // value for 'repoFullName'
  *   },
  * });
  */
@@ -585,8 +579,8 @@ export const SubmitCommentDocument = gql`
  * @example
  * const { mutate, loading, error, onDone } = useSubmitCommentMutation({
  *   variables: {
- *      repoFullName: // value for 'repoFullName'
- *      commentContent: // value for 'commentContent'
+ *     repoFullName: // value for 'repoFullName'
+ *     commentContent: // value for 'commentContent'
  *   },
  * });
  */
@@ -629,8 +623,8 @@ export const VoteDocument = gql`
  * @example
  * const { mutate, loading, error, onDone } = useVoteMutation({
  *   variables: {
- *      repoFullName: // value for 'repoFullName'
- *      type: // value for 'type'
+ *     repoFullName: // value for 'repoFullName'
+ *     type: // value for 'type'
  *   },
  * });
  */

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -212,39 +212,33 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
     operationHasVariables,
     documentNodeVariable,
   }: BuildCompositionFunctions): string {
+    const variables = operationHasVariables
+      ? `variables${
+          operationHasNonNullableVariable ? '' : '?'
+        }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>, `
+      : '';
+
     switch (operationType) {
       case 'Query': {
-        return `export function use${operationName}(${
-          operationHasVariables
-            ? `variables${
-                operationHasNonNullableVariable ? '' : '?'
-              }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>, `
-            : ''
-        }options: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> = {}) {
-            return VueApolloComposable.use${operationType}<${operationResultType}, ${
-          operationHasVariables ? operationVariablesTypes : 'undefined'
-        }>(${documentNodeVariable}, ${operationHasVariables ? 'variables' : 'undefined'}, options);
-          }`;
+        return `export function use${operationName}(${variables}options: VueApolloComposable.UseQueryOptions<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<${operationResultType}, ${operationVariablesTypes}>> = {}) {
+  return VueApolloComposable.useQuery<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, ${
+          operationHasVariables ? 'variables' : '{}'
+        }, options);
+}`;
       }
       case 'Mutation': {
-        return `export function use${operationName}(options: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>>${
+        return `export function use${operationName}(options: VueApolloComposable.UseMutationOptions<${operationResultType}, ${operationVariablesTypes}> | ReactiveFunction<VueApolloComposable.UseMutationOptions<${operationResultType}, ${operationVariablesTypes}>>${
           operationHasNonNullableVariable ? '' : ' = {}'
         }) {
-            return VueApolloComposable.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, options);
-          }`;
+  return VueApolloComposable.useMutation<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, options);
+}`;
       }
       case 'Subscription': {
-        return `export function use${operationName}(${
-          operationHasVariables
-            ? `variables${
-                operationHasNonNullableVariable ? '' : '?'
-              }: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>, `
-            : ''
-        }options: VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.Use${operationType}Options<${operationResultType}, ${operationVariablesTypes}>> = {}) {
-          return VueApolloComposable.use${operationType}<${operationResultType}, ${
-          operationHasVariables ? operationVariablesTypes : 'undefined'
-        }>(${documentNodeVariable}, ${operationHasVariables ? 'variables' : 'undefined'}, options);
-        }`;
+        return `export function use${operationName}(${variables}options: VueApolloComposable.UseSubscriptionOptions<${operationResultType}, ${operationVariablesTypes}> | VueCompositionApi.Ref<VueApolloComposable.UseSubscriptionOptions<${operationResultType}, ${operationVariablesTypes}>> | ReactiveFunction<VueApolloComposable.UseSubscriptionOptions<${operationResultType}, ${operationVariablesTypes}>> = {}) {
+  return VueApolloComposable.useSubscription<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, ${
+          operationHasVariables ? 'variables' : '{}'
+        }, options);
+}`;
       }
     }
   }

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -60,6 +60,10 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
   }
 
   private get vueCompositionApiImport(): string {
+    if (this.config.useTypeImports) {
+      return `import type * as VueCompositionApi from '${this.config.vueCompositionApiImportFrom}';`;
+    }
+
     return `import * as VueCompositionApi from '${this.config.vueCompositionApiImportFrom}';`;
   }
 

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -85,6 +85,24 @@ describe('Vue Apollo', () => {
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('should support typeImports', async () => {
+      const docs = [{ location: '', document: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          useTypeImports: true,
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.prepend).toContain(`import * as VueApolloComposable from '@vue/apollo-composable';`);
+      expect(content.prepend).toContain(`import type * as VueCompositionApi from '@vue/composition-api';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('should import VueApollo and VueCompositionApi dependencies from configured packages', async () => {
       const docs = [{ location: '', document: basicDoc }];
       const content = (await plugin(

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -443,7 +443,7 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
       expect(content.content).toBeSimilarStringTo(
         `export function useFeedQuery(options: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> = {}) {
-             return VueApolloComposable.useQuery<FeedQuery, undefined>(FeedDocument, undefined, options);
+             return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, {}, options);
            }`
       );
 
@@ -490,7 +490,7 @@ query MyFeed {
 
       expect(content.content).toBeSimilarStringTo(
         `export function useFeedQuery(options: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> = {}) {
-          return VueApolloComposable.useQuery<FeedQuery, undefined>(FeedQueryDocument, undefined, options);
+          return VueApolloComposable.useQuery<FeedQuery, FeedQueryVariables>(FeedQueryDocument, {}, options);
         }`
       );
 

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -744,14 +744,13 @@ query MyFeed {
  * When your component renders, \`useFeedQuery\` returns an object from Apollo Client that contains result, loading and error properties
  * you can use to render your UI.
  *
+ * @param variables that will be passed into the query
  * @param options that will be passed into the query, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/query.html#options;
  *
  * @example
- * const { result, loading, error } = useFeedQuery(
- *   {
- *      id: // value for 'id'
- *   }
- * );
+ * const { result, loading, error } = useFeedQuery({
+ *   id: // value for 'id'
+ * });
  */`;
 
     const subscriptionDocBlockSnapshot = `/**
@@ -761,14 +760,13 @@ query MyFeed {
  * When your component renders, \`useCommentAddedSubscription\` returns an object from Apollo Client that contains result, loading and error properties
  * you can use to render your UI.
  *
+ * @param variables that will be passed into the subscription
  * @param options that will be passed into the subscription, supported options are listed on: https://v4.apollo.vuejs.org/guide-composable/subscription.html#options;
  *
  * @example
- * const { result, loading, error } = useCommentAddedSubscription(
- *   {
- *      name: // value for 'name'
- *   }
- * );
+ * const { result, loading, error } = useCommentAddedSubscription({
+ *   name: // value for 'name'
+ * });
  */`;
 
     const mutationDocBlockSnapshot = `/**
@@ -784,7 +782,7 @@ query MyFeed {
  * @example
  * const { mutate, loading, error, onDone } = useSubmitRepositoryMutation({
  *   variables: {
- *      name: // value for 'name'
+ *     name: // value for 'name'
  *   },
  * });
  */`;


### PR DESCRIPTION
This PR consists of 3 commits, explained below.

## Support type imports
Related #5006
A test has been added to cover this.

## Do not use undefined for variables generic and parameter
Not using undefined for variables generic fixes the following issue:
`Type 'undefined' does not satisfy the constraint 'Record<string, any>'`

Not using undefined for variables parameter fixes the following issue:
`Argument of type 'undefined' is not assignable to parameter of type 'VariablesParameter<Exact<{ [key: string]: never; }>>'`

Tests have been updated accordingly.

## Improve jsdoc formatting
* Remove newlines before and after the first argument in the example code.
* Add `@param variables` where applicable.