### PR TITLE
fix(vue-apollo): regression, respect omitOperationSuffix even with dedupeOperationSuffix enabled

### DIFF
--- a/.changeset/empty-dragons-teach.md
+++ b/.changeset/empty-dragons-teach.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-vue-apollo': minor
+---
+
+Fix regression so omitOperationSuffix is respected again

--- a/.changeset/empty-dragons-teach.md
+++ b/.changeset/empty-dragons-teach.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-codegen/typescript-vue-apollo': minor
+'@graphql-codegen/typescript-vue-apollo': patch
 ---
 
 Fix regression so omitOperationSuffix is respected again

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -130,7 +130,7 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
 
   private getCompositionFunctionSuffix(name: string, operationType: string) {
     if (!this.config.dedupeOperationSuffix) {
-      return pascalCase(operationType);
+      return this.config.omitOperationSuffix ? '' : pascalCase(operationType);
     }
     if (name.includes('Query') || name.includes('Mutation') || name.includes('Subscription')) {
       return '';


### PR DESCRIPTION
related #5014 
omitOperationSuffix was not respected because of dedupeOperationSuffix
@packages/plugins/typescript/vue-apollo/src/visitor.ts:133