### PR TITLE
fix(typed-document-node): avoid printing imports when there are no operations

### DIFF
--- a/.changeset/olive-owls-chew.md
+++ b/.changeset/olive-owls-chew.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typed-document-node': patch
+---
+
+Avoid printing imports when there are no operations

--- a/packages/plugins/typescript/typed-document-node/src/index.ts
+++ b/packages/plugins/typescript/typed-document-node/src/index.ts
@@ -27,7 +27,7 @@ export const plugin: PluginFunction<RawClientSideBasePluginConfig> = (
   const visitorResult = visit(allAst, { leave: visitor });
 
   return {
-    prepend: visitor.getImports(),
+    prepend: allAst.definitions.length === 0 ? [] : visitor.getImports(),
     content: [visitor.fragments, ...visitorResult.definitions.filter(t => typeof t === 'string')].join('\n'),
   };
 };

--- a/packages/plugins/typescript/typed-document-node/tests/typed-document-node.spec.ts
+++ b/packages/plugins/typescript/typed-document-node/tests/typed-document-node.spec.ts
@@ -1,0 +1,10 @@
+import { Types } from '@graphql-codegen/plugin-helpers';
+import { plugin } from '../src';
+
+describe('TypeDocumentNode', () => {
+  it('Should not output imports when there are no operations at all', async () => {
+    const result = (await plugin(null as any, [], {})) as Types.ComplexPluginOutput;
+    expect(result.content).toBe('');
+    expect(result.prepend.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Realted: https://github.com/dotansimha/graphql-code-generator/issues/4989