### PR TITLE
[typescript-operations] Fix issues with incorrect naming when typesSuffix is used

### DIFF
--- a/.changeset/purple-bikes-call.md
+++ b/.changeset/purple-bikes-call.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Fix issues with incorrect naming of operation and variables when used with typesSuffix

--- a/.changeset/shaggy-brooms-enjoy.md
+++ b/.changeset/shaggy-brooms-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-operations': patch
+---
+
+Fixed issues with incorrect naming when typesSuffix is used

--- a/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
@@ -170,8 +170,9 @@ export class BaseDocumentsVisitor<
     const name = node.name && node.name.value;
 
     if (name) {
-      return this.convertName(node, {
+      return this.convertName(name, {
         useTypesPrefix: false,
+        useTypesSuffix: false,
       });
     }
 
@@ -179,6 +180,7 @@ export class BaseDocumentsVisitor<
       prefix: 'Unnamed_',
       suffix: '_',
       useTypesPrefix: false,
+      useTypesSuffix: false,
     });
   }
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -3788,6 +3788,43 @@ describe('TypeScript Operations Plugin', () => {
   });
 
   describe('Issues', () => {
+    it('#5001 - incorrect output with typeSuffix', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          user(id: ID!): User!
+        }
+
+        type User {
+          id: ID!
+          username: String!
+          email: String!
+        }
+      `);
+
+      const query = parse(/* GraphQL */ `
+        query user {
+          user(id: 1) {
+            id
+            username
+            email
+          }
+        }
+      `);
+
+      const config = {
+        typesSuffix: 'Type',
+      };
+
+      const { content } = await plugin(testSchema, [{ location: '', document: query }], config, {
+        outputFile: 'graphql.ts',
+      });
+
+      expect(content).not.toContain('UserTypeQueryVariablesType');
+      expect(content).not.toContain('UserTypeQueryType');
+      expect(content).toContain('UserQueryVariablesType');
+      expect(content).toContain('UserQueryType');
+    });
+
     it('#3064 - fragments over interfaces causes issues with fields', async () => {
       const testSchema = buildSchema(/* GraphQL */ `
         interface Venue {


### PR DESCRIPTION
Related: https://github.com/dotansimha/graphql-code-generator/issues/5001