### PR TITLE
[typescript-react-apollo] prevent baseOptions from being required when Mutation is used

### DIFF
--- a/.changeset/dirty-flowers-check.md
+++ b/.changeset/dirty-flowers-check.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-apollo': patch
+---
+
+prevent baseOptions from being required when Mutation is used

--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -535,7 +535,7 @@ export type SubmitRepositoryMutationFn = Apollo.MutationFunction<
  * });
  */
 export function useSubmitRepositoryMutation(
-  baseOptions: Apollo.MutationHookOptions<SubmitRepositoryMutationMyOperation, SubmitRepositoryMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<SubmitRepositoryMutationMyOperation, SubmitRepositoryMutationVariables>
 ) {
   return Apollo.useMutation<SubmitRepositoryMutationMyOperation, SubmitRepositoryMutationVariables>(
     SubmitRepositoryDocument,
@@ -580,7 +580,7 @@ export type SubmitCommentMutationFn = Apollo.MutationFunction<
  * });
  */
 export function useSubmitCommentMutation(
-  baseOptions: Apollo.MutationHookOptions<SubmitCommentMutationMyOperation, SubmitCommentMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<SubmitCommentMutationMyOperation, SubmitCommentMutationVariables>
 ) {
   return Apollo.useMutation<SubmitCommentMutationMyOperation, SubmitCommentMutationVariables>(
     SubmitCommentDocument,
@@ -625,7 +625,7 @@ export type VoteMutationFn = Apollo.MutationFunction<VoteMutationMyOperation, Vo
  * });
  */
 export function useVoteMutation(
-  baseOptions: Apollo.MutationHookOptions<VoteMutationMyOperation, VoteMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<VoteMutationMyOperation, VoteMutationVariables>
 ) {
   return Apollo.useMutation<VoteMutationMyOperation, VoteMutationVariables>(VoteDocument, baseOptions);
 }

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -530,7 +530,7 @@ export type SubmitRepositoryMutationFn = Apollo.MutationFunction<
  * });
  */
 export function useSubmitRepositoryMutation(
-  baseOptions: Apollo.MutationHookOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
 ) {
   return Apollo.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(
     SubmitRepositoryDocument,
@@ -572,7 +572,7 @@ export type SubmitCommentMutationFn = Apollo.MutationFunction<SubmitCommentMutat
  * });
  */
 export function useSubmitCommentMutation(
-  baseOptions: Apollo.MutationHookOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
 ) {
   return Apollo.useMutation<SubmitCommentMutation, SubmitCommentMutationVariables>(SubmitCommentDocument, baseOptions);
 }
@@ -613,7 +613,7 @@ export type VoteMutationFn = Apollo.MutationFunction<VoteMutation, VoteMutationV
  *   },
  * });
  */
-export function useVoteMutation(baseOptions: Apollo.MutationHookOptions<VoteMutation, VoteMutationVariables>) {
+export function useVoteMutation(baseOptions?: Apollo.MutationHookOptions<VoteMutation, VoteMutationVariables>) {
   return Apollo.useMutation<VoteMutation, VoteMutationVariables>(VoteDocument, baseOptions);
 }
 export type VoteMutationHookResult = ReturnType<typeof useVoteMutation>;

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -557,7 +557,7 @@ export type SubmitRepositoryMutationFn = Apollo.MutationFunction<
  * });
  */
 export function useSubmitRepositoryMutation(
-  baseOptions: Apollo.MutationHookOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
 ) {
   return Apollo.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(
     SubmitRepositoryDocument,
@@ -599,7 +599,7 @@ export type SubmitCommentMutationFn = Apollo.MutationFunction<SubmitCommentMutat
  * });
  */
 export function useSubmitCommentMutation(
-  baseOptions: Apollo.MutationHookOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
 ) {
   return Apollo.useMutation<SubmitCommentMutation, SubmitCommentMutationVariables>(SubmitCommentDocument, baseOptions);
 }
@@ -640,7 +640,7 @@ export type VoteMutationFn = Apollo.MutationFunction<VoteMutation, VoteMutationV
  *   },
  * });
  */
-export function useVoteMutation(baseOptions: Apollo.MutationHookOptions<VoteMutation, VoteMutationVariables>) {
+export function useVoteMutation(baseOptions?: Apollo.MutationHookOptions<VoteMutation, VoteMutationVariables>) {
   return Apollo.useMutation<VoteMutation, VoteMutationVariables>(VoteDocument, baseOptions);
 }
 export type VoteMutationHookResult = ReturnType<typeof useVoteMutation>;

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -530,7 +530,7 @@ export type SubmitRepositoryMutationFn = Apollo.MutationFunction<
  * });
  */
 export function useSubmitRepositoryMutation(
-  baseOptions: Apollo.MutationHookOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
 ) {
   return Apollo.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(
     SubmitRepositoryDocument,
@@ -572,7 +572,7 @@ export type SubmitCommentMutationFn = Apollo.MutationFunction<SubmitCommentMutat
  * });
  */
 export function useSubmitCommentMutation(
-  baseOptions: Apollo.MutationHookOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
 ) {
   return Apollo.useMutation<SubmitCommentMutation, SubmitCommentMutationVariables>(SubmitCommentDocument, baseOptions);
 }
@@ -613,7 +613,7 @@ export type VoteMutationFn = Apollo.MutationFunction<VoteMutation, VoteMutationV
  *   },
  * });
  */
-export function useVoteMutation(baseOptions: Apollo.MutationHookOptions<VoteMutation, VoteMutationVariables>) {
+export function useVoteMutation(baseOptions?: Apollo.MutationHookOptions<VoteMutation, VoteMutationVariables>) {
   return Apollo.useMutation<VoteMutation, VoteMutationVariables>(VoteDocument, baseOptions);
 }
 export type VoteMutationHookResult = ReturnType<typeof useVoteMutation>;

--- a/dev-test/githunt/types.reactApollo.v2.tsx
+++ b/dev-test/githunt/types.reactApollo.v2.tsx
@@ -533,7 +533,7 @@ export type SubmitRepositoryMutationFn = ApolloReactCommon.MutationFunction<
  * });
  */
 export function useSubmitRepositoryMutation(
-  baseOptions: ApolloReactHooks.MutationHookOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
+  baseOptions?: ApolloReactHooks.MutationHookOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
 ) {
   return ApolloReactHooks.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(
     SubmitRepositoryDocument,
@@ -578,7 +578,7 @@ export type SubmitCommentMutationFn = ApolloReactCommon.MutationFunction<
  * });
  */
 export function useSubmitCommentMutation(
-  baseOptions: ApolloReactHooks.MutationHookOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
+  baseOptions?: ApolloReactHooks.MutationHookOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
 ) {
   return ApolloReactHooks.useMutation<SubmitCommentMutation, SubmitCommentMutationVariables>(
     SubmitCommentDocument,
@@ -623,7 +623,7 @@ export type VoteMutationFn = ApolloReactCommon.MutationFunction<VoteMutation, Vo
  * });
  */
 export function useVoteMutation(
-  baseOptions: ApolloReactHooks.MutationHookOptions<VoteMutation, VoteMutationVariables>
+  baseOptions?: ApolloReactHooks.MutationHookOptions<VoteMutation, VoteMutationVariables>
 ) {
   return ApolloReactHooks.useMutation<VoteMutation, VoteMutationVariables>(VoteDocument, baseOptions);
 }

--- a/dev-test/star-wars/__generated__/CreateReviewForEpisode.tsx
+++ b/dev-test/star-wars/__generated__/CreateReviewForEpisode.tsx
@@ -43,7 +43,7 @@ export type CreateReviewForEpisodeMutationFn = Apollo.MutationFunction<
  * });
  */
 export function useCreateReviewForEpisodeMutation(
-  baseOptions: Apollo.MutationHookOptions<CreateReviewForEpisodeMutation, CreateReviewForEpisodeMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<CreateReviewForEpisodeMutation, CreateReviewForEpisodeMutationVariables>
 ) {
   return Apollo.useMutation<CreateReviewForEpisodeMutation, CreateReviewForEpisodeMutationVariables>(
     CreateReviewForEpisodeDocument,

--- a/dev-test/star-wars/types.refetchFn.tsx
+++ b/dev-test/star-wars/types.refetchFn.tsx
@@ -286,7 +286,7 @@ export type CreateReviewForEpisodeMutationFn = Apollo.MutationFunction<
  * });
  */
 export function useCreateReviewForEpisodeMutation(
-  baseOptions: Apollo.MutationHookOptions<CreateReviewForEpisodeMutation, CreateReviewForEpisodeMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<CreateReviewForEpisodeMutation, CreateReviewForEpisodeMutationVariables>
 ) {
   return Apollo.useMutation<CreateReviewForEpisodeMutation, CreateReviewForEpisodeMutationVariables>(
     CreateReviewForEpisodeDocument,

--- a/dev-test/test-message/types.tsx
+++ b/dev-test/test-message/types.tsx
@@ -141,7 +141,7 @@ export type GetMessagesQueryResult = Apollo.QueryResult<GetMessagesQuery, GetMes
  * });
  */
 export function useCreateMessageMutation(
-  baseOptions: Apollo.MutationHookOptions<CreateMessageMutation, CreateMessageMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<CreateMessageMutation, CreateMessageMutationVariables>
 ) {
   return Apollo.useMutation<CreateMessageMutation, CreateMessageMutationVariables>(
     Operations.CreateMessage,
@@ -173,7 +173,9 @@ export type CreateMessageMutationOptions = Apollo.BaseMutationOptions<
  *   },
  * });
  */
-export function useDeclineMutation(baseOptions: Apollo.MutationHookOptions<DeclineMutation, DeclineMutationVariables>) {
+export function useDeclineMutation(
+  baseOptions?: Apollo.MutationHookOptions<DeclineMutation, DeclineMutationVariables>
+) {
   return Apollo.useMutation<DeclineMutation, DeclineMutationVariables>(Operations.Decline, baseOptions);
 }
 export type DeclineMutationHookResult = ReturnType<typeof useDeclineMutation>;
@@ -197,7 +199,9 @@ export type DeclineMutationOptions = Apollo.BaseMutationOptions<DeclineMutation,
  *   },
  * });
  */
-export function useApproveMutation(baseOptions: Apollo.MutationHookOptions<ApproveMutation, ApproveMutationVariables>) {
+export function useApproveMutation(
+  baseOptions?: Apollo.MutationHookOptions<ApproveMutation, ApproveMutationVariables>
+) {
   return Apollo.useMutation<ApproveMutation, ApproveMutationVariables>(Operations.Approve, baseOptions);
 }
 export type ApproveMutationHookResult = ReturnType<typeof useApproveMutation>;
@@ -222,7 +226,7 @@ export type ApproveMutationOptions = Apollo.BaseMutationOptions<ApproveMutation,
  * });
  */
 export function useEscalateMutation(
-  baseOptions: Apollo.MutationHookOptions<EscalateMutation, EscalateMutationVariables>
+  baseOptions?: Apollo.MutationHookOptions<EscalateMutation, EscalateMutationVariables>
 ) {
   return Apollo.useMutation<EscalateMutation, EscalateMutationVariables>(Operations.Escalate, baseOptions);
 }

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -331,7 +331,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
 
     const hookFns = [
       `export function use${operationName}(baseOptions${
-        hasRequiredVariables ? '' : '?'
+        hasRequiredVariables && operationType !== 'Mutation' ? '' : '?'
       }: ${this.getApolloReactHooksIdentifier()}.${operationType}HookOptions<${operationResultType}, ${operationVariablesTypes}>) {
         return ${this.getApolloReactHooksIdentifier()}.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${this.getDocumentNodeVariable(
         node,

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -129,12 +129,20 @@ describe('React Apollo', () => {
         optionalBaseOptions: true,
       },
       {
+        document: `mutation Feed { feed { ...Feed } } `,
+        optionalBaseOptions: true,
+      },
+      {
         document: `query Feed($something: Boolean) { feed { ...Feed } } `,
         optionalBaseOptions: true,
       },
       {
         document: `query Feed($something: Boolean!) { feed { ...Feed } } `,
         optionalBaseOptions: false,
+      },
+      {
+        document: `mutation Feed($something: Boolean!) { feed { ...Feed } } `,
+        optionalBaseOptions: true,
       },
       {
         document: `query Feed($something: Boolean!, $somethingElse: Boolean!) { feed { ...Feed } } `,
@@ -171,7 +179,7 @@ describe('React Apollo', () => {
           }
         )) as Types.ComplexPluginOutput;
 
-        expect(result.content).toContain(`Query(baseOptions${optionalBaseOptions ? '?' : ''}: Apollo.`);
+        expect(result.content).toContain(`(baseOptions${optionalBaseOptions ? '?' : ''}: Apollo.`);
       }
     );
 


### PR DESCRIPTION
Related: https://github.com/dotansimha/graphql-code-generator/issues/5045