### PR TITLE
feat(typescript): adds a `defaultValue` flag to all `avoidOptionals` configs

### DIFF
--- a/.changeset/chilled-cows-fry.md
+++ b/.changeset/chilled-cows-fry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript': minor
+---
+
+See https://github.com/dotansimha/graphql-code-generator/issues/5112

--- a/.changeset/short-monkeys-return.md
+++ b/.changeset/short-monkeys-return.md
@@ -2,4 +2,5 @@
 '@graphql-codegen/typescript': minor
 ---
 
+Added a "defaultValue" option in the "avoidOptionals" config
 See https://github.com/dotansimha/graphql-code-generator/issues/5112

--- a/packages/plugins/other/visitor-plugin-common/src/avoid-optionals.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/avoid-optionals.ts
@@ -13,6 +13,7 @@ export function normalizeAvoidOptionals(avoidOptionals?: boolean | AvoidOptional
       object: avoidOptionals,
       inputValue: avoidOptionals,
       field: avoidOptionals,
+      defaultValue: avoidOptionals,
     };
   }
 

--- a/packages/plugins/other/visitor-plugin-common/src/avoid-optionals.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/avoid-optionals.ts
@@ -4,6 +4,7 @@ export const DEFAULT_AVOID_OPTIONALS: AvoidOptionalsConfig = {
   object: false,
   inputValue: false,
   field: false,
+  defaultValue: false,
 };
 
 export function normalizeAvoidOptionals(avoidOptionals?: boolean | AvoidOptionalsConfig): AvoidOptionalsConfig {

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -82,6 +82,7 @@ export interface AvoidOptionalsConfig {
   field?: boolean;
   object?: boolean;
   inputValue?: boolean;
+  defaultValue?: boolean;
 }
 
 export interface ParsedImport {

--- a/packages/plugins/typescript/operations/src/config.ts
+++ b/packages/plugins/typescript/operations/src/config.ts
@@ -36,6 +36,7 @@ export interface TypeScriptDocumentsPluginConfig extends RawDocumentsConfig {
    *      field: true
    *      inputValue: true
    *      object: true
+   *      defaultValue: true
    * ```
    */
   avoidOptionals?: boolean | AvoidOptionalsConfig;

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -53,14 +53,7 @@ interface Type {
 }
 
 function escapeString(str: string) {
-  return (
-    "'" +
-    str
-      .replace(/\\/g, '\\\\')
-      .replace(/\n/g, '\\n')
-      .replace(/'/g, "\\'") +
-    "'"
-  );
+  return "'" + str.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, "\\'") + "'";
 }
 
 type DecoratorOptions = { [key: string]: string };
@@ -137,7 +130,7 @@ export class TypeGraphQLVisitor<
       new TypeScriptOperationVariablesToObject(
         this.scalars,
         this.convertName,
-        this.config.avoidOptionals.object,
+        this.config.avoidOptionals,
         this.config.immutableTypes,
         null,
         enumNames,

--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -34,6 +34,7 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    *      field: true
    *      inputValue: true
    *      object: true
+   *      defaultValue: true
    * ```
    */
   avoidOptionals?: boolean | AvoidOptionalsConfig;
@@ -173,7 +174,7 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    */
   maybeValue?: string;
   /**
-   * @description Set the to `true` in order to generate output without `export` modifier.
+   * @description Set to `true` in order to generate output without `export` modifier.
    * This is useful if you are generating `.d.ts` file and want it to be globally available.
    * @default false
    *

--- a/packages/plugins/typescript/typescript/src/typescript-variables-to-object.ts
+++ b/packages/plugins/typescript/typescript/src/typescript-variables-to-object.ts
@@ -3,6 +3,8 @@ import {
   OperationVariablesToObject,
   NormalizedScalarsMap,
   ConvertNameFn,
+  AvoidOptionalsConfig,
+  normalizeAvoidOptionals,
 } from '@graphql-codegen/visitor-plugin-common';
 import { TypeNode, Kind } from 'graphql';
 
@@ -10,7 +12,7 @@ export class TypeScriptOperationVariablesToObject extends OperationVariablesToOb
   constructor(
     _scalars: NormalizedScalarsMap,
     _convertName: ConvertNameFn,
-    private _avoidOptionals: boolean,
+    private _avoidOptionals: boolean | AvoidOptionalsConfig,
     private _immutableTypes: boolean,
     _namespacedImportName: string | null = null,
     _enumNames: string[] = [],
@@ -21,8 +23,7 @@ export class TypeScriptOperationVariablesToObject extends OperationVariablesToOb
   }
 
   private clearOptional(str: string): string {
-    const prefix = this._namespacedImportName ? `${this._namespacedImportName}.` : '';
-    const rgx = new RegExp(`^${prefix}Maybe<(.*?)>$`, 'i');
+    const rgx = new RegExp(`^${this.wrapMaybe(`(.*?)`)}$`, 'i');
 
     if (str.startsWith(`${this._namespacedImportName ? `${this._namespacedImportName}.` : ''}Maybe`)) {
       return str.replace(rgx, '$1');
@@ -32,8 +33,6 @@ export class TypeScriptOperationVariablesToObject extends OperationVariablesToOb
   }
 
   public wrapAstTypeWithModifiers(baseType: string, typeNode: TypeNode): string {
-    const prefix = this._namespacedImportName ? `${this._namespacedImportName}.` : '';
-
     if (typeNode.kind === Kind.NON_NULL_TYPE) {
       const type = this.wrapAstTypeWithModifiers(baseType, typeNode.type);
 
@@ -41,17 +40,14 @@ export class TypeScriptOperationVariablesToObject extends OperationVariablesToOb
     } else if (typeNode.kind === Kind.LIST_TYPE) {
       const innerType = this.wrapAstTypeWithModifiers(baseType, typeNode.type);
 
-      return `${prefix}Maybe<${this._immutableTypes ? 'ReadonlyArray' : 'Array'}<${innerType}>>`;
+      return this.wrapMaybe(`${this._immutableTypes ? 'ReadonlyArray' : 'Array'}<${innerType}>`);
     } else {
-      return `${prefix}Maybe<${baseType}>`;
+      return this.wrapMaybe(baseType);
     }
   }
 
   protected formatFieldString(fieldName: string, isNonNullType: boolean, hasDefaultValue: boolean): string {
-    if (!hasDefaultValue && (this._avoidOptionals || isNonNullType)) {
-      return fieldName;
-    }
-    return `${fieldName}?`;
+    return `${fieldName}${this.getAvoidOption(isNonNullType, hasDefaultValue) ? '?' : ''}`;
   }
 
   protected formatTypeString(fieldType: string, isNonNullType: boolean, hasDefaultValue: boolean): string {
@@ -60,6 +56,16 @@ export class TypeScriptOperationVariablesToObject extends OperationVariablesToOb
     }
 
     return fieldType;
+  }
+
+  protected wrapMaybe(type?: string) {
+    const prefix = this._namespacedImportName ? `${this._namespacedImportName}.` : '';
+    return `${prefix}Maybe${type ? `<${type}>` : ''}`;
+  }
+
+  protected getAvoidOption(isNonNullType: boolean, hasDefaultValue: boolean) {
+    const options = normalizeAvoidOptionals(this._avoidOptionals);
+    return ((options.object || !options.defaultValue) && hasDefaultValue) || (!options.object && !isNonNullType);
   }
 
   protected getPunctuation(): string {

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -153,8 +153,7 @@ export class TsVisitor<
   InputValueDefinition(node: InputValueDefinitionNode, key?: number | string, parent?: any): string {
     const originalFieldNode = parent[key] as FieldDefinitionNode;
     const addOptionalSign =
-      !this.config.avoidOptionals.inputValue &&
-      (originalFieldNode.type.kind !== Kind.NON_NULL_TYPE || node.defaultValue !== undefined);
+      !this.config.avoidOptionals.inputValue && originalFieldNode.type.kind !== Kind.NON_NULL_TYPE;
     const comment = transformComment((node.description as any) as string, 1);
     const { type } = this.config.declarationKind;
     return (

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -153,7 +153,9 @@ export class TsVisitor<
   InputValueDefinition(node: InputValueDefinitionNode, key?: number | string, parent?: any): string {
     const originalFieldNode = parent[key] as FieldDefinitionNode;
     const addOptionalSign =
-      !this.config.avoidOptionals.inputValue && originalFieldNode.type.kind !== Kind.NON_NULL_TYPE;
+      !this.config.avoidOptionals.inputValue &&
+      (originalFieldNode.type.kind !== Kind.NON_NULL_TYPE ||
+        (!this.config.avoidOptionals.defaultValue && node.defaultValue !== undefined));
     const comment = transformComment((node.description as any) as string, 1);
     const { type } = this.config.declarationKind;
     return (

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -67,7 +67,7 @@ export class TsVisitor<
       new TypeScriptOperationVariablesToObject(
         this.scalars,
         this.convertName,
-        this.config.avoidOptionals.object,
+        this.config.avoidOptionals,
         this.config.immutableTypes,
         null,
         enumNames,

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2349,6 +2349,29 @@ describe('TypeScript', () => {
 
       validateTs(result);
     });
+
+    it('Should generate correctly types for field arguments with default value and avoidOptionals.defaultValue option set to true - #5112', async () => {
+      const schema = buildSchema(
+        `type MyType { foo(a: String = "default", b: String! = "default", c: String, d: String!): String }`
+      );
+      const result = (await plugin(
+        schema,
+        [],
+        { avoidOptionals: { defaultValue: true } },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type MyTypeFooArgs = {
+          a?: Maybe<Scalars['String']>;
+          b: Scalars['String'];
+          c?: Maybe<Scalars['String']>;
+          d: Scalars['String'];
+        };
+    `);
+
+      validateTs(result);
+    });
   });
 
   describe('Enum', () => {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2244,29 +2244,6 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
-    it('Should generate correctly types for field arguments - with default value and avoidOptionals.defaultValue option set to true', async () => {
-      const schema = buildSchema(
-        `type MyType { foo(a: String = "default", b: String! = "default", c: String, d: String!): String }`
-      );
-      const result = (await plugin(
-        schema,
-        [],
-        { avoidOptionals: true },
-        { outputFile: '' }
-      )) as Types.ComplexPluginOutput;
-
-      expect(result.content).toBeSimilarStringTo(`
-        export type MyTypeFooArgs = {
-          a?: Maybe<Scalars['String']>;
-          b?: Scalars['String'];
-          c: Maybe<Scalars['String']>;
-          d: Scalars['String'];
-      };
-    `);
-
-      validateTs(result);
-    });
-
     it('Should generate correctly types for field arguments - with input type', async () => {
       const schema = buildSchema(
         `input MyInput { f: String } type MyType { foo(a: MyInput, b: MyInput!, c: [MyInput], d: [MyInput]!, e: [MyInput!]!): String }`

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2244,6 +2244,29 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
+    it('Should generate correctly types for field arguments - with default value and avoidOptionals.defaultValue option set to true', async () => {
+      const schema = buildSchema(
+        `type MyType { foo(a: String = "default", b: String! = "default", c: String, d: String!): String }`
+      );
+      const result = (await plugin(
+        schema,
+        [],
+        { avoidOptionals: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type MyTypeFooArgs = {
+          a?: Maybe<Scalars['String']>;
+          b?: Scalars['String'];
+          c: Maybe<Scalars['String']>;
+          d: Scalars['String'];
+      };
+    `);
+
+      validateTs(result);
+    });
+
     it('Should generate correctly types for field arguments - with input type', async () => {
       const schema = buildSchema(
         `input MyInput { f: String } type MyType { foo(a: MyInput, b: MyInput!, c: [MyInput], d: [MyInput]!, e: [MyInput!]!): String }`
@@ -2319,6 +2342,24 @@ describe('TypeScript', () => {
         `input MyInput { a: String = "default", b: String! = "default", c: String, d: String! }`
       );
       const result = await plugin(schema, [], {}, { outputFile: '' });
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type MyInput = {
+          a?: Maybe<Scalars['String']>;
+          b?: Scalars['String'];
+          c?: Maybe<Scalars['String']>;
+          d: Scalars['String'];
+        };
+    `);
+
+      validateTs(result);
+    });
+
+    it('Should generate correctly types for inputs with default value and avoidOptionals.defaultValue set to true - #5112', async () => {
+      const schema = buildSchema(
+        `input MyInput { a: String = "default", b: String! = "default", c: String, d: String! }`
+      );
+      const result = await plugin(schema, [], { avoidOptionals: { defaultValue: true } }, { outputFile: '' });
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyInput = {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2323,7 +2323,7 @@ describe('TypeScript', () => {
       expect(result.content).toBeSimilarStringTo(`
         export type MyInput = {
           a?: Maybe<Scalars['String']>;
-          b?: Scalars['String'];
+          b: Scalars['String'];
           c?: Maybe<Scalars['String']>;
           d: Scalars['String'];
         };


### PR DESCRIPTION
This PR adds a `defaultValue` flag to the `avoidOptionals` configuration in all plugins. The behavior is as follows:
- Upon turning on the flag, all defaulted fields (in `input`s or arguments) will strictly obey the type of that field.
   - e.g. `input TestInput { test: String! = "test" }` will transpile to `type TestInput { test: Scalars['String'] }`.
- For `input`s, if the `inputValue` flag in `avoidOptionals` is on, then `defaultValue` is not necessary.
- For arguments, if the `objectValue` is `true`, then `defaultValue` is ignored. (to keep with current behavior)

Related #5112 