### PR TITLE
fix: Fix passing paths with empty space

### DIFF
--- a/packages/graphql-codegen-cli/src/hooks.ts
+++ b/packages/graphql-codegen-cli/src/hooks.ts
@@ -70,7 +70,7 @@ async function executeHooks(
   for (const script of scripts) {
     if (typeof script === 'string') {
       debugLog(`Running lifecycle hook "${hookName}" script: ${script} with args: ${args.join(' ')}...`);
-      await execShellCommand(`${script} ${args.join(' ')}`);
+      await execShellCommand(`${script} "${args.join(' ')}"`);
     } else {
       debugLog(`Running lifecycle hook "${hookName}" script: ${script.name} with args: ${args.join(' ')}...`);
       await script(...args);


### PR DESCRIPTION
Small fix that prevents commands in hooks from breaking when passing a path with a whitespace to the command, such as `prettier --write /Users/johndoe/my project/index.ts`.