### PR TITLE
feat(graphql-codegen-cli): adds YAML `merge` (`<<`) syntax for configuration files

### DIFF
--- a/.changeset/chatty-buttons-greet.md
+++ b/.changeset/chatty-buttons-greet.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': minor
+---
+
+Add `merge` (`<<`) syntax for `yaml` configurations

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -83,6 +83,7 @@
     "upper-case": "^2.0.1",
     "valid-url": "^1.0.9",
     "wrap-ansi": "^7.0.0",
+    "yaml": "^1.10.0",
     "yargs": "^16.1.1"
   },
   "devDependencies": {

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -7,6 +7,7 @@ import { GraphQLConfig } from 'graphql-config';
 import { findAndLoadGraphQLConfig } from './graphql-config';
 import { loadSchema, loadDocuments, defaultSchemaLoadOptions, defaultDocumentsLoadOptions } from './load';
 import { GraphQLSchema } from 'graphql';
+import yaml from 'yaml';
 
 export type YamlCliFlags = {
   config: string;
@@ -39,7 +40,13 @@ function customLoader(ext: 'json' | 'yaml' | 'js') {
     }
 
     if (ext === 'yaml') {
-      return defaultLoaders['.yaml'](filepath, content);
+      try {
+        const result = yaml.parse(content, { prettyErrors: true, merge: true });
+        return result;
+      } catch (error) {
+        error.message = `YAML Error in ${filepath}:\n${error.message}`;
+        throw error;
+      }
     }
 
     if (ext === 'js') {


### PR DESCRIPTION
This PR allows users to use `<<` syntax (see [here](https://yaml.org/type/merge.html)) for use in configuration files since `<<` as a key has no conflict for this package or its dependents.