### PR TITLE
Enable flattening typed document nodes

### DIFF
--- a/.changeset/happy-kids-walk.md
+++ b/.changeset/happy-kids-walk.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typed-document-node': patch
+---
+
+Enable flattening typed document nodes

--- a/packages/plugins/typescript/typed-document-node/src/config.ts
+++ b/packages/plugins/typescript/typed-document-node/src/config.ts
@@ -1,0 +1,20 @@
+import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-common';
+
+export interface TypeScriptTypedDocumentNodesConfig extends RawClientSideBasePluginConfig {
+  /**
+   * @description Flatten fragment spread and inline fragments into a simple selection set before generating.
+   * @default false
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *  config:
+   *    flattenGeneratedTypes: true
+   * ```
+   */
+  flattenGeneratedTypes?: boolean;
+}

--- a/packages/plugins/typescript/typed-document-node/src/index.ts
+++ b/packages/plugins/typescript/typed-document-node/src/index.ts
@@ -1,14 +1,16 @@
 import { Types, PluginValidateFn, PluginFunction } from '@graphql-codegen/plugin-helpers';
 import { visit, concatAST, GraphQLSchema, Kind, FragmentDefinitionNode } from 'graphql';
+import { TypeScriptTypedDocumentNodesConfig } from 'packages/plugins/typescript/typed-document-node/src/config';
 import { extname } from 'path';
-import { LoadedFragment, RawClientSideBasePluginConfig, DocumentMode } from '@graphql-codegen/visitor-plugin-common';
+import { LoadedFragment, RawClientSideBasePluginConfig, DocumentMode, optimizeOperations } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptDocumentNodesVisitor } from './visitor';
 
-export const plugin: PluginFunction<RawClientSideBasePluginConfig> = (
+export const plugin: PluginFunction<TypeScriptTypedDocumentNodesConfig> = (
   schema: GraphQLSchema,
-  documents: Types.DocumentFile[],
-  config: RawClientSideBasePluginConfig
+  rawDocuments: Types.DocumentFile[],
+  config: TypeScriptTypedDocumentNodesConfig
 ) => {
+  const documents = config.flattenGeneratedTypes ? optimizeOperations(schema, rawDocuments) : rawDocuments;
   const allAst = concatAST(documents.map(v => v.document));
 
   const allFragments: LoadedFragment[] = [


### PR DESCRIPTION
I wanted to completely flatten fragments.