### PR TITLE
Fixes mistaken MODULE_NOT_FOUND error for missing dependency

### DIFF
--- a/.changeset/loud-clouds-lick.md
+++ b/.changeset/loud-clouds-lick.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Fix wrong MODULE_NOT_FOUND for missing dependencies

--- a/packages/graphql-codegen-cli/src/plugins.ts
+++ b/packages/graphql-codegen-cli/src/plugins.ts
@@ -22,7 +22,7 @@ export async function getPluginByName(
     try {
       return await pluginLoader(moduleName);
     } catch (err) {
-      if (err.code !== 'MODULE_NOT_FOUND') {
+      if (err.code !== 'MODULE_NOT_FOUND' || !err.message.includes(moduleName)) {
         throw new DetailedError(
           `Unable to load template plugin matching ${name}`,
           `

--- a/packages/graphql-codegen-cli/src/presets.ts
+++ b/packages/graphql-codegen-cli/src/presets.ts
@@ -18,7 +18,7 @@ export async function getPresetByName(
 
       return loaded as Types.OutputPreset;
     } catch (err) {
-      if (err.code !== 'MODULE_NOT_FOUND') {
+      if (err.code !== 'MODULE_NOT_FOUND' || !err.message.includes(moduleName)) {
         throw new DetailedError(
           `Unable to load preset matching ${name}`,
           `


### PR DESCRIPTION
When the referenced plugin/preset throws a `MODULE_NOT_FOUND` error within itself, `@graphql-codegen/cli` mistakenly assumes the plugin/preset itself wasn't found, resulting in a very misleading error message.

This shouldn't happen when using external packages as plugins/presets, but I hit this issue when using a local file, within which I had forgotten to install a dependency - in my case, `ramda`.