### PR TITLE
Introduce replaceKinds to use graphql.Kind instead of strings

### DIFF
--- a/.changeset/brown-terms-confess.md
+++ b/.changeset/brown-terms-confess.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+---
+
+Introduce replaceKinds option to replace kinds as strings with Kind of graphql-js

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -462,7 +462,7 @@ export class ClientSideBaseVisitor<
         const tagImport = this._generateImport(documentNodeImport, 'DocumentNode', true);
 
         if (this.config.replaceKinds) {
-          const kindImport = this._parseImport('graphql/language/kinds#Kind');
+          const kindImport = this._parseImport('graphql#Kind');
           this._imports.add(this._generateImport(kindImport, 'Kind', false));
         }
 

--- a/packages/plugins/typescript/document-nodes/tests/graphql-document-nodes.spec.ts
+++ b/packages/plugins/typescript/document-nodes/tests/graphql-document-nodes.spec.ts
@@ -406,7 +406,7 @@ describe('graphql-codegen typescript-graphql-document-nodes', () => {
 
     expect(content).toMatch(`"kind": Kind.DOCUMENT`);
     expect(content).not.toMatch(`"kind": "`);
-    expect(result.prepend).toContainEqual(`import { Kind } from 'graphql/language/kinds';`);
+    expect(result.prepend).toContainEqual(`import { Kind } from 'graphql';`);
     validateTs(content);
   });
 });


### PR DESCRIPTION
```diff
- {"kind" : "Document", definitions: []}
+ {"kind" : Kind.DOCUMENT, definitions: []}
```

It should save up some bundle size