### PR TITLE
feat(apollo-client-helpers): Add TypePolicies merge field

### DIFF
--- a/.changeset/twelve-papayas-scream.md
+++ b/.changeset/twelve-papayas-scream.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-apollo-client-helpers': patch
+---
+
+Extend TypePolicy for types in TypedTypePolicies

--- a/packages/plugins/typescript/apollo-client-helpers/src/index.ts
+++ b/packages/plugins/typescript/apollo-client-helpers/src/index.ts
@@ -45,13 +45,10 @@ ${fieldsNames.map(fieldName => `\t${fieldName}?: FieldPolicy<any> | FieldReadFun
 
       return {
         ...prev,
-        [typeName]: `{
+        [typeName]: `Omit<TypePolicy, "fields" | "keyFields"> & {
 \t\tkeyFields${
           config.requireKeyFields ? '' : '?'
         }: false | ${keySpecifierVarName} | (() => undefined | ${keySpecifierVarName}),
-\t\tqueryType?: true,
-\t\tmutationType?: true,
-\t\tsubscriptionType?: true,
 \t\tfields?: ${fieldPolicyVarName},
 \t}`,
       };
@@ -78,7 +75,7 @@ ${fieldsNames.map(fieldName => `\t${fieldName}?: FieldPolicy<any> | FieldReadFun
     prepend: [
       `import ${
         config.useTypeImports ? 'type ' : ''
-      }{ FieldPolicy, FieldReadFunction, TypePolicies } from '@apollo/client/cache';`,
+      }{ FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';`,
     ],
     content: [...perTypePolicies, rootContent].join('\n'),
   };

--- a/packages/plugins/typescript/apollo-client-helpers/tests/__snapshots__/apollo-client-helpers.spec.ts.snap
+++ b/packages/plugins/typescript/apollo-client-helpers/tests/__snapshots__/apollo-client-helpers.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`apollo-client-helpers Should output typePolicies object correctly 1`] = `
-"import { FieldPolicy, FieldReadFunction, TypePolicies } from '@apollo/client/cache';
+"import { FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';
 export type QueryKeySpecifier = ('user' | QueryKeySpecifier)[];
 export type QueryFieldPolicy = {
 	user?: FieldPolicy<any> | FieldReadFunction<any>
@@ -12,25 +12,19 @@ export type UserFieldPolicy = {
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type TypedTypePolicies = TypePolicies & {
-	Query?: {
+	Query?: Omit<TypePolicy, \\"fields\\" | \\"keyFields\\"> & {
 		keyFields?: false | QueryKeySpecifier | (() => undefined | QueryKeySpecifier),
-		queryType?: true,
-		mutationType?: true,
-		subscriptionType?: true,
 		fields?: QueryFieldPolicy,
 	},
-	User?: {
+	User?: Omit<TypePolicy, \\"fields\\" | \\"keyFields\\"> & {
 		keyFields?: false | UserKeySpecifier | (() => undefined | UserKeySpecifier),
-		queryType?: true,
-		mutationType?: true,
-		subscriptionType?: true,
 		fields?: UserFieldPolicy,
 	}
 };"
 `;
 
 exports[`apollo-client-helpers Should output typePolicies object with requireKeyFields: true 1`] = `
-"import { FieldPolicy, FieldReadFunction, TypePolicies } from '@apollo/client/cache';
+"import { FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';
 export type QueryKeySpecifier = ('user' | QueryKeySpecifier)[];
 export type QueryFieldPolicy = {
 	user?: FieldPolicy<any> | FieldReadFunction<any>
@@ -41,25 +35,19 @@ export type UserFieldPolicy = {
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type TypedTypePolicies = TypePolicies & {
-	Query?: {
+	Query?: Omit<TypePolicy, \\"fields\\" | \\"keyFields\\"> & {
 		keyFields: false | QueryKeySpecifier | (() => undefined | QueryKeySpecifier),
-		queryType?: true,
-		mutationType?: true,
-		subscriptionType?: true,
 		fields?: QueryFieldPolicy,
 	},
-	User?: {
+	User?: Omit<TypePolicy, \\"fields\\" | \\"keyFields\\"> & {
 		keyFields: false | UserKeySpecifier | (() => undefined | UserKeySpecifier),
-		queryType?: true,
-		mutationType?: true,
-		subscriptionType?: true,
 		fields?: UserFieldPolicy,
 	}
 };"
 `;
 
 exports[`apollo-client-helpers Should output typePolicies object with requirePoliciesForAllTypes: true 1`] = `
-"import { FieldPolicy, FieldReadFunction, TypePolicies } from '@apollo/client/cache';
+"import { FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';
 export type QueryKeySpecifier = ('user' | QueryKeySpecifier)[];
 export type QueryFieldPolicy = {
 	user?: FieldPolicy<any> | FieldReadFunction<any>
@@ -70,18 +58,12 @@ export type UserFieldPolicy = {
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type TypedTypePolicies = TypePolicies & {
-	Query?: {
+	Query?: Omit<TypePolicy, \\"fields\\" | \\"keyFields\\"> & {
 		keyFields?: false | QueryKeySpecifier | (() => undefined | QueryKeySpecifier),
-		queryType?: true,
-		mutationType?: true,
-		subscriptionType?: true,
 		fields?: QueryFieldPolicy,
 	},
-	User: {
+	User: Omit<TypePolicy, \\"fields\\" | \\"keyFields\\"> & {
 		keyFields?: false | UserKeySpecifier | (() => undefined | UserKeySpecifier),
-		queryType?: true,
-		mutationType?: true,
-		subscriptionType?: true,
 		fields?: UserFieldPolicy,
 	}
 };"


### PR DESCRIPTION
Adds the merge field ([see API](https://www.apollographql.com/docs/react/caching/cache-field-behavior/#fieldpolicy-api-reference)) for generated TypePolicies.

We could also, instead, use something like `Omit<FieldPolicy, "fields" | "keyFields"> & { fields?: ..., keyFields?: ... }>`, that way, when Apollo adds other fields, we still only override the ones that we type specifically.

wdyt?