### PR TITLE
fix: hooks can be functions and need to be normalized

### DIFF
--- a/.changeset/wild-paws-type.md
+++ b/.changeset/wild-paws-type.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+fix hooks as single function

--- a/packages/graphql-codegen-cli/src/hooks.ts
+++ b/packages/graphql-codegen-cli/src/hooks.ts
@@ -28,6 +28,11 @@ function normalizeHooks(
         ...prev,
         [hookName]: [_hooks[hookName]] as string[],
       };
+    } else if (typeof _hooks[hookName] === 'function') {
+      return {
+        ...prev,
+        [hookName]: [_hooks[hookName]],
+      };
     } else if (Array.isArray(_hooks[hookName])) {
       return {
         ...prev,


### PR DESCRIPTION
If a hook is a single function, it is filtered out here, but arrays for
functions would be kept.