### PR TITLE
docs: fix typescript-type-graphql plugin name

### DIFF
--- a/website/docs/generated-config/typescript-type-graphql.md
+++ b/website/docs/generated-config/typescript-type-graphql.md
@@ -43,7 +43,7 @@ instead of `myField?: Maybe<string>`.
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    avoidOptionals: true
 ```
@@ -53,7 +53,7 @@ path/to/file.ts:
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    avoidOptionals:
      field: true
@@ -75,7 +75,7 @@ Will prefix every generated `enum` with `const`, you can read more about const e
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    constEnums: true
 ```
@@ -93,7 +93,7 @@ Generates enum as TypeScript `type` instead of `enum`. Useful it you wish to gen
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    enumsAsTypes: true
 ```
@@ -111,7 +111,7 @@ Controls whether to preserve typescript enum values as numbers
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    numericEnums: true
 ```
@@ -130,7 +130,7 @@ This is useful if you are using `relay`.
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    enumsAsTypes: true
    futureProofEnums: true
@@ -149,7 +149,7 @@ Generates enum as TypeScript `const assertions` instead of `enum`. This can even
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    enumsAsConst: true
 ```
@@ -168,10 +168,10 @@ Override all definition types
 ```yml
 generates:
 path/to/file.ts:
-plugins:
-- typescript
-config:
-onlyOperationTypes: true
+  plugins:
+    - typescript-type-graphql
+  config:
+    onlyOperationTypes: true
 ```
 
 ### `immutableTypes`
@@ -187,7 +187,7 @@ Generates immutable types by adding `readonly` to properties and uses `ReadonlyA
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    immutableTypes: true
 ```
@@ -206,7 +206,7 @@ Allow to override the type value of `Maybe`.
 generates:
  path/to/file.ts:
    plugins:
-     - typescript
+     - typescript-type-graphql
    config:
      maybeValue: T | null | undefined
 ```
@@ -216,7 +216,7 @@ generates:
 generates:
  path/to/file.ts:
    plugins:
-     - typescript
+     - typescript-type-graphql
      - typescript-resolvers
    config:
      maybeValue: 'T extends PromiseLike<infer U> ? Promise<U | null> : T | null'
@@ -237,7 +237,7 @@ This is useful if you are generating `.d.ts` file and want it to be globally ava
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    noExport: true
 ```
@@ -256,7 +256,7 @@ When a GraphQL interface is used for a field, this flag will use the implementin
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    useImplementingTypes: true
 ```
@@ -357,7 +357,7 @@ Allow you to add wrapper for field type, use T as the generic value. Make sure t
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    wrapFieldDefinitions: true
    fieldWrapperValue: T | Promise<T>
@@ -378,7 +378,7 @@ This is useful to allow return types such as Promises and functions.
 generates:
 path/to/file.ts:
  plugins:
-   - typescript
+   - typescript-type-graphql
  config:
    wrapFieldDefinitions: true
 ```


### PR DESCRIPTION
fix plugin name so that we can generating `type-graphql` codes.