### PR TITLE
feat: Adding support for react-query v3

### DIFF
--- a/.changeset/pretty-zoos-listen.md
+++ b/.changeset/pretty-zoos-listen.md
@@ -1,0 +1,7 @@
+---
+'@graphql-codegen/typescript-react-query': major
+---
+
+- Upgraded react-query to v3
+- Modified generated useQuery hooks to allow passing in of data type to be used with query data selectors
+- Reworked the mutations so that variables are passed in at mutate time and not at instantiation

--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -1,4 +1,4 @@
-import { useQuery, QueryConfig, useMutation, MutationConfig } from 'react-query';
+import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
@@ -382,7 +382,7 @@ export const CommentDocument = `
 export const useCommentQuery = (
   dataSource: { endpoint: string; fetchParams?: RequestInit },
   variables: CommentQueryVariables,
-  options?: QueryConfig<CommentQuery>
+  options?: UseQueryOptions<CommentQuery>
 ) =>
   useQuery<CommentQuery>(
     ['Comment', variables],
@@ -405,7 +405,7 @@ export const CurrentUserForProfileDocument = `
 export const useCurrentUserForProfileQuery = (
   dataSource: { endpoint: string; fetchParams?: RequestInit },
   variables?: CurrentUserForProfileQueryVariables,
-  options?: QueryConfig<CurrentUserForProfileQuery>
+  options?: UseQueryOptions<CurrentUserForProfileQuery>
 ) =>
   useQuery<CurrentUserForProfileQuery>(
     ['CurrentUserForProfile', variables],
@@ -430,7 +430,7 @@ export const FeedDocument = `
 export const useFeedQuery = (
   dataSource: { endpoint: string; fetchParams?: RequestInit },
   variables: FeedQueryVariables,
-  options?: QueryConfig<FeedQuery>
+  options?: UseQueryOptions<FeedQuery>
 ) =>
   useQuery<FeedQuery>(
     ['Feed', variables],
@@ -446,16 +446,16 @@ export const SubmitRepositoryDocument = `
     `;
 export const useSubmitRepositoryMutation = (
   dataSource: { endpoint: string; fetchParams?: RequestInit },
-  variables?: SubmitRepositoryMutationVariables,
-  options?: MutationConfig<SubmitRepositoryMutation, unknown, SubmitRepositoryMutationVariables>
+  options?: UseMutationOptions<SubmitRepositoryMutation, unknown, SubmitRepositoryMutationVariables>
 ) =>
   useMutation<SubmitRepositoryMutation, unknown, SubmitRepositoryMutationVariables>(
-    fetcher<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(
-      dataSource.endpoint,
-      dataSource.fetchParams || {},
-      SubmitRepositoryDocument,
-      variables
-    ),
+    (variables?: SubmitRepositoryMutationVariables) =>
+      fetcher<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(
+        dataSource.endpoint,
+        dataSource.fetchParams || {},
+        SubmitRepositoryDocument,
+        variables
+      )(),
     options
   );
 export const SubmitCommentDocument = `
@@ -467,16 +467,16 @@ export const SubmitCommentDocument = `
     ${CommentsPageCommentFragmentDoc}`;
 export const useSubmitCommentMutation = (
   dataSource: { endpoint: string; fetchParams?: RequestInit },
-  variables?: SubmitCommentMutationVariables,
-  options?: MutationConfig<SubmitCommentMutation, unknown, SubmitCommentMutationVariables>
+  options?: UseMutationOptions<SubmitCommentMutation, unknown, SubmitCommentMutationVariables>
 ) =>
   useMutation<SubmitCommentMutation, unknown, SubmitCommentMutationVariables>(
-    fetcher<SubmitCommentMutation, SubmitCommentMutationVariables>(
-      dataSource.endpoint,
-      dataSource.fetchParams || {},
-      SubmitCommentDocument,
-      variables
-    ),
+    (variables?: SubmitCommentMutationVariables) =>
+      fetcher<SubmitCommentMutation, SubmitCommentMutationVariables>(
+        dataSource.endpoint,
+        dataSource.fetchParams || {},
+        SubmitCommentDocument,
+        variables
+      )(),
     options
   );
 export const VoteDocument = `
@@ -492,15 +492,15 @@ export const VoteDocument = `
     `;
 export const useVoteMutation = (
   dataSource: { endpoint: string; fetchParams?: RequestInit },
-  variables?: VoteMutationVariables,
-  options?: MutationConfig<VoteMutation, unknown, VoteMutationVariables>
+  options?: UseMutationOptions<VoteMutation, unknown, VoteMutationVariables>
 ) =>
   useMutation<VoteMutation, unknown, VoteMutationVariables>(
-    fetcher<VoteMutation, VoteMutationVariables>(
-      dataSource.endpoint,
-      dataSource.fetchParams || {},
-      VoteDocument,
-      variables
-    ),
+    (variables?: VoteMutationVariables) =>
+      fetcher<VoteMutation, VoteMutationVariables>(
+        dataSource.endpoint,
+        dataSource.fetchParams || {},
+        VoteDocument,
+        variables
+      )(),
     options
   );

--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -444,11 +444,11 @@ export const SubmitRepositoryDocument = `
   }
 }
     `;
-export const useSubmitRepositoryMutation = (
+export const useSubmitRepositoryMutation = <TError = unknown, TContext = unknown>(
   dataSource: { endpoint: string; fetchParams?: RequestInit },
-  options?: UseMutationOptions<SubmitRepositoryMutation, unknown, SubmitRepositoryMutationVariables>
+  options?: UseMutationOptions<SubmitRepositoryMutation, TError, SubmitRepositoryMutationVariables, TContext>
 ) =>
-  useMutation<SubmitRepositoryMutation, unknown, SubmitRepositoryMutationVariables>(
+  useMutation<SubmitRepositoryMutation, TError, SubmitRepositoryMutationVariables, TContext>(
     (variables?: SubmitRepositoryMutationVariables) =>
       fetcher<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(
         dataSource.endpoint,
@@ -465,11 +465,11 @@ export const SubmitCommentDocument = `
   }
 }
     ${CommentsPageCommentFragmentDoc}`;
-export const useSubmitCommentMutation = (
+export const useSubmitCommentMutation = <TError = unknown, TContext = unknown>(
   dataSource: { endpoint: string; fetchParams?: RequestInit },
-  options?: UseMutationOptions<SubmitCommentMutation, unknown, SubmitCommentMutationVariables>
+  options?: UseMutationOptions<SubmitCommentMutation, TError, SubmitCommentMutationVariables, TContext>
 ) =>
-  useMutation<SubmitCommentMutation, unknown, SubmitCommentMutationVariables>(
+  useMutation<SubmitCommentMutation, TError, SubmitCommentMutationVariables, TContext>(
     (variables?: SubmitCommentMutationVariables) =>
       fetcher<SubmitCommentMutation, SubmitCommentMutationVariables>(
         dataSource.endpoint,
@@ -490,11 +490,11 @@ export const VoteDocument = `
   }
 }
     `;
-export const useVoteMutation = (
+export const useVoteMutation = <TError = unknown, TContext = unknown>(
   dataSource: { endpoint: string; fetchParams?: RequestInit },
-  options?: UseMutationOptions<VoteMutation, unknown, VoteMutationVariables>
+  options?: UseMutationOptions<VoteMutation, TError, VoteMutationVariables, TContext>
 ) =>
-  useMutation<VoteMutation, unknown, VoteMutationVariables>(
+  useMutation<VoteMutation, TError, VoteMutationVariables, TContext>(
     (variables?: VoteMutationVariables) =>
       fetcher<VoteMutation, VoteMutationVariables>(
         dataSource.endpoint,

--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -379,12 +379,12 @@ export const CommentDocument = `
   }
 }
     ${CommentsPageCommentFragmentDoc}`;
-export const useCommentQuery = (
+export const useCommentQuery = <TData = CommentQuery, TError = unknown>(
   dataSource: { endpoint: string; fetchParams?: RequestInit },
   variables: CommentQueryVariables,
-  options?: UseQueryOptions<CommentQuery>
+  options?: UseQueryOptions<CommentQuery, TError, TData>
 ) =>
-  useQuery<CommentQuery>(
+  useQuery<CommentQuery, TError, TData>(
     ['Comment', variables],
     fetcher<CommentQuery, CommentQueryVariables>(
       dataSource.endpoint,
@@ -402,12 +402,12 @@ export const CurrentUserForProfileDocument = `
   }
 }
     `;
-export const useCurrentUserForProfileQuery = (
+export const useCurrentUserForProfileQuery = <TData = CurrentUserForProfileQuery, TError = unknown>(
   dataSource: { endpoint: string; fetchParams?: RequestInit },
   variables?: CurrentUserForProfileQueryVariables,
-  options?: UseQueryOptions<CurrentUserForProfileQuery>
+  options?: UseQueryOptions<CurrentUserForProfileQuery, TError, TData>
 ) =>
-  useQuery<CurrentUserForProfileQuery>(
+  useQuery<CurrentUserForProfileQuery, TError, TData>(
     ['CurrentUserForProfile', variables],
     fetcher<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>(
       dataSource.endpoint,
@@ -427,12 +427,12 @@ export const FeedDocument = `
   }
 }
     ${FeedEntryFragmentDoc}`;
-export const useFeedQuery = (
+export const useFeedQuery = <TData = FeedQuery, TError = unknown>(
   dataSource: { endpoint: string; fetchParams?: RequestInit },
   variables: FeedQueryVariables,
-  options?: UseQueryOptions<FeedQuery>
+  options?: UseQueryOptions<FeedQuery, TError, TData>
 ) =>
-  useQuery<FeedQuery>(
+  useQuery<FeedQuery, TError, TData>(
     ['Feed', variables],
     fetcher<FeedQuery, FeedQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, FeedDocument, variables),
     options

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     ]
   },
   "devDependencies": {
-    "react-query": "2.26.4",
     "@apollo/client": "3.3.6",
     "@babel/preset-typescript": "7.12.7",
     "@changesets/cli": "2.12.0",
@@ -100,6 +99,7 @@
     "npm": "6.14.10",
     "react": "17.0.1",
     "react-dom": "17.0.1",
+    "react-query": "3.2.0",
     "rimraf": "3.0.2",
     "stencil-apollo": "0.1.6",
     "ts-jest": "26.4.4",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "npm": "6.14.10",
     "react": "17.0.1",
     "react-dom": "17.0.1",
-    "react-query": "3.2.0",
+    "react-query": "3.4.0",
     "rimraf": "3.0.2",
     "stencil-apollo": "0.1.6",
     "ts-jest": "26.4.4",

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -29,10 +29,4 @@ export interface ReactQueryRawPluginConfig
    * - `graphql-request`: Will generate each hook with `client` argument, where you should pass your own `GraphQLClient` (created from `graphql-request`).
    */
   fetcher: 'fetch' | HardcodedFetch | 'graphql-request' | string;
-
-  /**
-   * @description Specify the react-query version
-   * @default 3
-   */
-  reactQueryMajorVersion?: number;
 }

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -29,4 +29,10 @@ export interface ReactQueryRawPluginConfig
    * - `graphql-request`: Will generate each hook with `client` argument, where you should pass your own `GraphQLClient` (created from `graphql-request`).
    */
   fetcher: 'fetch' | HardcodedFetch | 'graphql-request' | string;
+
+  /**
+   * @description Specify the react-query version
+   * @default 3
+   */
+  reactQueryMajorVersion?: number;
 }

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -44,10 +44,13 @@ export class CustomMapperFetcher implements FetcherRenderer {
     hasRequiredVariables: boolean
   ): string {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
-    this.visitor.reactQueryIdentifiersInUse.add('useQuery');
-    this.visitor.reactQueryIdentifiersInUse.add('QueryConfig');
+    const hookConfig = this.visitor.getReactQueryHooksMap();
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
 
-    return `export const use${operationName} = (${variables}, options?: QueryConfig<${operationResultType}>) => 
+    return `export const use${operationName} = (${variables}, options?: ${
+      hookConfig.query.options
+    }<${operationResultType}>) => 
   useQuery<${operationResultType}>(
     ['${node.name.value}', variables],
     ${this.getFetcherFnName()}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
@@ -63,10 +66,13 @@ export class CustomMapperFetcher implements FetcherRenderer {
     operationVariablesTypes: string
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
-    this.visitor.reactQueryIdentifiersInUse.add('useMutation');
-    this.visitor.reactQueryIdentifiersInUse.add('MutationConfig');
+    const hookConfig = this.visitor.getReactQueryHooksMap();
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
-    return `export const use${operationName} = (${variables}, options?: MutationConfig<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
+    return `export const use${operationName} = (${variables}, options?: ${
+      hookConfig.mutation.options
+    }<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
     useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
     ${this.getFetcherFnName()}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
     options

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -70,11 +70,11 @@ export class CustomMapperFetcher implements FetcherRenderer {
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
-    return `export const use${operationName} = (${variables}, options?: ${
+    return `export const use${operationName} = (options?: ${
       hookConfig.mutation.options
     }<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
     useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
-    ${this.getFetcherFnName()}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
+    (${variables}) => ${this.getFetcherFnName()}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables)(),
     options
   );`;
   }

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -44,18 +44,24 @@ export class CustomMapperFetcher implements FetcherRenderer {
     hasRequiredVariables: boolean
   ): string {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
-    const hookConfig = this.visitor.getReactQueryHooksMap();
+    const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
 
-    return `export const use${operationName} = (${variables}, options?: ${
-      hookConfig.query.options
-    }<${operationResultType}>) => 
-  useQuery<${operationResultType}>(
-    ['${node.name.value}', variables],
-    ${this.getFetcherFnName()}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
-    options
-  );`;
+    const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
+
+    return `export const use${operationName} = <
+      TData = ${operationResultType},
+      TError = unknown
+    >(
+      ${variables}, 
+      ${options}
+    ) => 
+    ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
+      ['${node.name.value}', variables],
+      ${this.getFetcherFnName()}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
+      options
+    );`;
   }
 
   generateMutationHook(
@@ -66,7 +72,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
     operationVariablesTypes: string
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
-    const hookConfig = this.visitor.getReactQueryHooksMap();
+    const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -82,7 +82,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
       TError = unknown,
       TContext = unknown
     >(${options}) => 
-    useMutation<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
+    ${hookConfig.mutation.hook}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
       (${variables}) => ${this.getFetcherFnName()}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables)(),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -76,12 +76,15 @@ export class CustomMapperFetcher implements FetcherRenderer {
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
-    return `export const use${operationName} = (options?: ${
-      hookConfig.mutation.options
-    }<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
-    useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
-    (${variables}) => ${this.getFetcherFnName()}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables)(),
-    options
-  );`;
+    const options = `options?: ${hookConfig.mutation.options}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>`;
+
+    return `export const use${operationName} = <
+      TError = unknown,
+      TContext = unknown
+    >(${options}) => 
+    useMutation<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
+      (${variables}) => ${this.getFetcherFnName()}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables)(),
+      options
+    );`;
   }
 }

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -61,10 +61,11 @@ ${this.getFetchParams()}
     hasRequiredVariables: boolean
   ): string {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
-    this.visitor.reactQueryIdentifiersInUse.add('useQuery');
-    this.visitor.reactQueryIdentifiersInUse.add('QueryConfig');
+    const hookConfig = this.visitor.getReactQueryHooksMap();
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
 
-    return `export const use${operationName} = (${variables}, options?: QueryConfig<${operationResultType}>) => 
+    return `export const use${operationName} = (${variables}, options?: ${hookConfig.query.options}<${operationResultType}>) => 
   useQuery<${operationResultType}>(
     ['${node.name.value}', variables],
     fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
@@ -80,10 +81,11 @@ ${this.getFetchParams()}
     operationVariablesTypes: string
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
-    this.visitor.reactQueryIdentifiersInUse.add('useMutation');
-    this.visitor.reactQueryIdentifiersInUse.add('MutationConfig');
+    const hookConfig = this.visitor.getReactQueryHooksMap();
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
-    return `export const use${operationName} = (${variables}, options?: MutationConfig<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
+    return `export const use${operationName} = (${variables}, options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
   useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
     fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
     options

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -85,9 +85,9 @@ ${this.getFetchParams()}
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
-    return `export const use${operationName} = (${variables}, options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
+    return `export const use${operationName} = (options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
   useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
-    fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
+    (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables)(),
     options
 );`;
   }

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -99,7 +99,7 @@ ${this.getFetchParams()}
       TError = unknown,
       TContext = unknown
     >(${options}) => 
-    useMutation<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
+    ${hookConfig.mutation.hook}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
       (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables)(),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -93,10 +93,15 @@ ${this.getFetchParams()}
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
-    return `export const use${operationName} = (options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
-  useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
-    (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables)(),
-    options
-);`;
+    const options = `options?: ${hookConfig.mutation.options}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>`;
+
+    return `export const use${operationName} = <
+      TError = unknown,
+      TContext = unknown
+    >(${options}) => 
+    useMutation<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
+      (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables)(),
+      options
+    );`;
   }
 }

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -61,16 +61,24 @@ ${this.getFetchParams()}
     hasRequiredVariables: boolean
   ): string {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
-    const hookConfig = this.visitor.getReactQueryHooksMap();
+    const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
 
-    return `export const use${operationName} = (${variables}, options?: ${hookConfig.query.options}<${operationResultType}>) => 
-  useQuery<${operationResultType}>(
-    ['${node.name.value}', variables],
-    fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
-    options
-  );`;
+    const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
+
+    return `export const use${operationName} = <
+      TData = ${operationResultType},
+      TError = unknown
+    >(
+      ${variables}, 
+      ${options}
+    ) => 
+    ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
+      ['${node.name.value}', variables],
+      fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
+      options
+    );`;
   }
 
   generateMutationHook(
@@ -81,7 +89,7 @@ ${this.getFetchParams()}
     operationVariablesTypes: string
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
-    const hookConfig = this.visitor.getReactQueryHooksMap();
+    const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -61,9 +61,9 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
-    return `export const use${operationName} = (dataSource: { endpoint: string, fetchParams?: RequestInit }, ${variables}, options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
+    return `export const use${operationName} = (dataSource: { endpoint: string, fetchParams?: RequestInit }, options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
   useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
-    fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables),
+    (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables)(),
     options
   );`;
   }

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -51,7 +51,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
       ${variables}, 
       ${options}
     ) => 
-    useQuery<${operationResultType}, TError, TData>(
+    ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
       ['${node.name.value}', variables],
       fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables),
       options
@@ -79,7 +79,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
       dataSource: { endpoint: string, fetchParams?: RequestInit }, 
       ${options}
     ) => 
-    useMutation<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
+    ${hookConfig.mutation.hook}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
       (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables)(),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -37,10 +37,11 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
     hasRequiredVariables: boolean
   ): string {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
-    this.visitor.reactQueryIdentifiersInUse.add('useQuery');
-    this.visitor.reactQueryIdentifiersInUse.add('QueryConfig');
+    const hookConfig = this.visitor.getReactQueryHooksMap();
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
 
-    return `export const use${operationName} = (dataSource: { endpoint: string, fetchParams?: RequestInit }, ${variables}, options?: QueryConfig<${operationResultType}>) => 
+    return `export const use${operationName} = (dataSource: { endpoint: string, fetchParams?: RequestInit }, ${variables}, options?: ${hookConfig.query.options}<${operationResultType}>) => 
   useQuery<${operationResultType}>(
     ['${node.name.value}', variables],
     fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables),
@@ -56,10 +57,11 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
     operationVariablesTypes: string
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
-    this.visitor.reactQueryIdentifiersInUse.add('useMutation');
-    this.visitor.reactQueryIdentifiersInUse.add('MutationConfig');
+    const hookConfig = this.visitor.getReactQueryHooksMap();
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
-    return `export const use${operationName} = (dataSource: { endpoint: string, fetchParams?: RequestInit }, ${variables}, options?: MutationConfig<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
+    return `export const use${operationName} = (dataSource: { endpoint: string, fetchParams?: RequestInit }, ${variables}, options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
   useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
     fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables),
     options

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -37,16 +37,25 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
     hasRequiredVariables: boolean
   ): string {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
-    const hookConfig = this.visitor.getReactQueryHooksMap();
+    const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
 
-    return `export const use${operationName} = (dataSource: { endpoint: string, fetchParams?: RequestInit }, ${variables}, options?: ${hookConfig.query.options}<${operationResultType}>) => 
-  useQuery<${operationResultType}>(
-    ['${node.name.value}', variables],
-    fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables),
-    options
-  );`;
+    const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
+
+    return `export const use${operationName} = <
+      TData = ${operationResultType},
+      TError = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit }, 
+      ${variables}, 
+      ${options}
+    ) => 
+    useQuery<${operationResultType}, TError, TData>(
+      ['${node.name.value}', variables],
+      fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables),
+      options
+    );`;
   }
 
   generateMutationHook(
@@ -57,7 +66,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
     operationVariablesTypes: string
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
-    const hookConfig = this.visitor.getReactQueryHooksMap();
+    const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -70,10 +70,18 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
-    return `export const use${operationName} = (dataSource: { endpoint: string, fetchParams?: RequestInit }, options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
-  useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
-    (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables)(),
-    options
-  );`;
+    const options = `options?: ${hookConfig.mutation.options}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>`;
+
+    return `export const use${operationName} = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit }, 
+      ${options}
+    ) => 
+    useMutation<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
+      (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables)(),
+      options
+    );`;
   }
 }

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -22,16 +22,26 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
   ): string {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
     this.visitor.imports.add(`import { GraphQLClient } from 'graphql-request';`);
-    const hookConfig = this.visitor.getReactQueryHooksMap();
+
+    const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
 
-    return `export const use${operationName} = (client: GraphQLClient, ${variables}, options?: ${hookConfig.query.options}<${operationResultType}>) => 
-  useQuery<${operationResultType}>(
-    ['${node.name.value}', variables],
-    fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables),
-    options
-  );`;
+    const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
+
+    return `export const use${operationName} = <
+      TData = ${operationResultType},
+      TError = unknown
+    >(
+      client: GraphQLClient, 
+      ${variables}, 
+      ${options}
+    ) => 
+    useQuery<${operationResultType}, TError, TData>(
+      ['${node.name.value}', variables],
+      fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables),
+      options
+    );`;
   }
 
   generateMutationHook(
@@ -44,7 +54,7 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     const variables = `variables?: ${operationVariablesTypes}`;
     this.visitor.imports.add(`import { GraphQLClient } from 'graphql-request';`);
 
-    const hookConfig = this.visitor.getReactQueryHooksMap();
+    const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -37,7 +37,7 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
       ${variables}, 
       ${options}
     ) => 
-    useQuery<${operationResultType}, TError, TData>(
+    ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
       ['${node.name.value}', variables],
       fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables),
       options
@@ -67,7 +67,7 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
       client: GraphQLClient, 
       ${options}
     ) => 
-    useMutation<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
+    ${hookConfig.mutation.hook}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
       (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables)(),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -22,10 +22,11 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
   ): string {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
     this.visitor.imports.add(`import { GraphQLClient } from 'graphql-request';`);
-    this.visitor.reactQueryIdentifiersInUse.add('useQuery');
-    this.visitor.reactQueryIdentifiersInUse.add('QueryConfig');
+    const hookConfig = this.visitor.getReactQueryHooksMap();
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
 
-    return `export const use${operationName} = (client: GraphQLClient, ${variables}, options?: QueryConfig<${operationResultType}>) => 
+    return `export const use${operationName} = (client: GraphQLClient, ${variables}, options?: ${hookConfig.query.options}<${operationResultType}>) => 
   useQuery<${operationResultType}>(
     ['${node.name.value}', variables],
     fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables),
@@ -42,10 +43,12 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
     this.visitor.imports.add(`import { GraphQLClient } from 'graphql-request';`);
-    this.visitor.reactQueryIdentifiersInUse.add('useMutation');
-    this.visitor.reactQueryIdentifiersInUse.add('MutationConfig');
 
-    return `export const use${operationName} = (client: GraphQLClient, ${variables}, options?: MutationConfig<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
+    const hookConfig = this.visitor.getReactQueryHooksMap();
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
+    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
+
+    return `export const use${operationName} = (client: GraphQLClient, ${variables}, options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
   useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
     fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables),
     options

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -58,10 +58,18 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
-    return `export const use${operationName} = (client: GraphQLClient, options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
-  useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
-    (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables)(),
-    options
-  );`;
+    const options = `options?: ${hookConfig.mutation.options}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>`;
+
+    return `export const use${operationName} = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      client: GraphQLClient, 
+      ${options}
+    ) => 
+    useMutation<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
+      (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables)(),
+      options
+    );`;
   }
 }

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -48,9 +48,9 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
-    return `export const use${operationName} = (client: GraphQLClient, ${variables}, options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
+    return `export const use${operationName} = (client: GraphQLClient, options?: ${hookConfig.mutation.options}<${operationResultType}, unknown, ${operationVariablesTypes}>) => 
   useMutation<${operationResultType}, unknown, ${operationVariablesTypes}>(
-    fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables),
+    (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables)(),
     options
   );`;
   }

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -17,7 +17,7 @@ import { pascalCase } from 'pascal-case';
 
 export interface ReactQueryPluginConfig extends ClientSideBasePluginConfig {}
 
-export interface ReactQueryVersionMap {
+export interface ReactQueryMethodMap {
   query: {
     hook: string;
     options: string;
@@ -32,28 +32,15 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
   private _externalImportPrefix: string;
   public fetcher: FetcherRenderer;
   public reactQueryIdentifiersInUse = new Set<string>();
-  public reactQueryMajorVersion = 3;
 
-  public queryVersionMap: { [version: number]: ReactQueryVersionMap } = {
-    2: {
-      query: {
-        hook: 'useQuery',
-        options: 'QueryConfig',
-      },
-      mutation: {
-        hook: 'useMutation',
-        options: 'MutationConfig',
-      },
+  public queryMethodMap: ReactQueryMethodMap = {
+    query: {
+      hook: 'useQuery',
+      options: 'UseQueryOptions',
     },
-    3: {
-      query: {
-        hook: 'useQuery',
-        options: 'UseQueryOptions',
-      },
-      mutation: {
-        hook: 'useMutation',
-        options: 'UseMutationOptions',
-      },
+    mutation: {
+      hook: 'useMutation',
+      options: 'UseMutationOptions',
     },
   };
 
@@ -69,9 +56,6 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
     this._externalImportPrefix = this.config.importOperationTypesFrom ? `${this.config.importOperationTypesFrom}.` : '';
     this._documents = documents;
     this.fetcher = this.createFetcher(rawConfig.fetcher || 'fetch');
-
-    const version = rawConfig['reactQueryMajorVersion'];
-    this.reactQueryMajorVersion = version ?? 3;
 
     autoBind(this);
   }
@@ -90,10 +74,6 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
     }
 
     return new CustomMapperFetcher(this, raw as string);
-  }
-
-  public getReactQueryHooksMap() {
-    return this.queryVersionMap[this.reactQueryMajorVersion];
   }
 
   public getImports(): string[] {

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -17,7 +17,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
   useQuery<TTestQuery>(
     ['test', variables],
     myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -30,7 +30,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
     myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
     options
@@ -54,7 +54,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
   useQuery<TTestQuery>(
     ['test', variables],
     myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -67,7 +67,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
     myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
     options
@@ -91,7 +91,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+export const useTestQuery = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
   useQuery<TTestQuery>(
     ['test', variables],
     fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
@@ -104,7 +104,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
     fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
     options
@@ -128,7 +128,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (client: GraphQLClient, variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+export const useTestQuery = (client: GraphQLClient, variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
   useQuery<TTestQuery>(
     ['test', variables],
     fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
@@ -141,7 +141,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (client: GraphQLClient, variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (client: GraphQLClient, variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
     fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables),
     options
@@ -165,7 +165,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
   useQuery<TTestQuery>(
     ['test', variables],
     fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -178,7 +178,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
     fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
     options
@@ -202,7 +202,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
   useQuery<TTestQuery>(
     ['test', variables],
     fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -215,7 +215,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
     fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
     options
@@ -239,7 +239,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
   useQuery<TTestQuery>(
     ['test', variables],
     fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -252,7 +252,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
     fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
     options
@@ -276,7 +276,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
   useQuery<TTestQuery>(
     ['test', variables],
     fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -289,7 +289,7 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
     fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
     options

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -36,11 +36,14 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-    useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
-    options
-  );"
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
+      options
+    );"
 `;
 
 exports[`React-Query fetcher: custom-mapper Should generate query correctly with internal mapper 1`] = `
@@ -79,11 +82,14 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-    useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
-    options
-  );"
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
+      options
+    );"
 `;
 
 exports[`React-Query fetcher: fetch Should generate query and mutation correctly 1`] = `
@@ -123,11 +129,17 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (dataSource: { endpoint: string, fetchParams?: RequestInit }, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-  useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
-    options
-  );"
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit }, 
+      options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
+    ) => 
+    useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
+      options
+    );"
 `;
 
 exports[`React-Query fetcher: graphql-request Should generate query correctly with client 1`] = `
@@ -167,11 +179,17 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (client: GraphQLClient, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-  useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables)(),
-    options
-  );"
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      client: GraphQLClient, 
+      options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
+    ) => 
+    useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables)(),
+      options
+    );"
 `;
 
 exports[`React-Query fetcher: hardcoded-fetch Should generate query correctly with fetch config 1`] = `
@@ -210,11 +228,14 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-  useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
-    options
-);"
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
+      options
+    );"
 `;
 
 exports[`React-Query fetcher: hardcoded-fetch Should generate query correctly with hardcoded endpoint 1`] = `
@@ -253,11 +274,14 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-  useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
-    options
-);"
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
+      options
+    );"
 `;
 
 exports[`React-Query fetcher: hardcoded-fetch Should generate query correctly with hardcoded endpoint from env var 1`] = `
@@ -296,11 +320,14 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-  useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
-    options
-);"
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
+      options
+    );"
 `;
 
 exports[`React-Query fetcher: hardcoded-fetch Should generate query correctly with hardcoded endpoint from just identifier 1`] = `
@@ -339,9 +366,12 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-  useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
-    options
-);"
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
+      options
+    );"
 `;

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -30,9 +30,9 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
+    (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
     options
   );"
 `;
@@ -67,9 +67,9 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
+    (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
     options
   );"
 `;
@@ -104,9 +104,9 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (dataSource: { endpoint: string, fetchParams?: RequestInit }, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
+    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
     options
   );"
 `;
@@ -141,9 +141,9 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (client: GraphQLClient, variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (client: GraphQLClient, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables),
+    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables)(),
     options
   );"
 `;
@@ -178,9 +178,9 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
+    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
     options
 );"
 `;
@@ -215,9 +215,9 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
+    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
     options
 );"
 `;
@@ -252,9 +252,9 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
+    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
     options
 );"
 `;
@@ -289,9 +289,9 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
   useMutation<TTestMutation, unknown, TTestMutationVariables>(
-    fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
+    (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
     options
 );"
 `;

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -17,12 +17,18 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-  useQuery<TTestQuery>(
-    ['test', variables],
-    myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
-    options
-  );
+export const useTestQuery = <
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      variables?: TTestQueryVariables, 
+      options?: UseQueryOptions<TTestQuery, TError, TData>
+    ) => 
+    useQuery<TTestQuery, TError, TData>(
+      ['test', variables],
+      myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
+      options
+    );
 export const TestDocument = \`
     mutation test($name: String) {
   submitRepository(repoFullName: $name) {
@@ -54,12 +60,18 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-  useQuery<TTestQuery>(
-    ['test', variables],
-    myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
-    options
-  );
+export const useTestQuery = <
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      variables?: TTestQueryVariables, 
+      options?: UseQueryOptions<TTestQuery, TError, TData>
+    ) => 
+    useQuery<TTestQuery, TError, TData>(
+      ['test', variables],
+      myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
+      options
+    );
 export const TestDocument = \`
     mutation test($name: String) {
   submitRepository(repoFullName: $name) {
@@ -91,12 +103,19 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-  useQuery<TTestQuery>(
-    ['test', variables],
-    fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
-    options
-  );
+export const useTestQuery = <
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit }, 
+      variables?: TTestQueryVariables, 
+      options?: UseQueryOptions<TTestQuery, TError, TData>
+    ) => 
+    useQuery<TTestQuery, TError, TData>(
+      ['test', variables],
+      fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
+      options
+    );
 export const TestDocument = \`
     mutation test($name: String) {
   submitRepository(repoFullName: $name) {
@@ -128,12 +147,19 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (client: GraphQLClient, variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-  useQuery<TTestQuery>(
-    ['test', variables],
-    fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
-    options
-  );
+export const useTestQuery = <
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      client: GraphQLClient, 
+      variables?: TTestQueryVariables, 
+      options?: UseQueryOptions<TTestQuery, TError, TData>
+    ) => 
+    useQuery<TTestQuery, TError, TData>(
+      ['test', variables],
+      fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
+      options
+    );
 export const TestDocument = \`
     mutation test($name: String) {
   submitRepository(repoFullName: $name) {
@@ -165,12 +191,18 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-  useQuery<TTestQuery>(
-    ['test', variables],
-    fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
-    options
-  );
+export const useTestQuery = <
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      variables?: TTestQueryVariables, 
+      options?: UseQueryOptions<TTestQuery, TError, TData>
+    ) => 
+    useQuery<TTestQuery, TError, TData>(
+      ['test', variables],
+      fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
+      options
+    );
 export const TestDocument = \`
     mutation test($name: String) {
   submitRepository(repoFullName: $name) {
@@ -202,12 +234,18 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-  useQuery<TTestQuery>(
-    ['test', variables],
-    fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
-    options
-  );
+export const useTestQuery = <
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      variables?: TTestQueryVariables, 
+      options?: UseQueryOptions<TTestQuery, TError, TData>
+    ) => 
+    useQuery<TTestQuery, TError, TData>(
+      ['test', variables],
+      fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
+      options
+    );
 export const TestDocument = \`
     mutation test($name: String) {
   submitRepository(repoFullName: $name) {
@@ -239,12 +277,18 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-  useQuery<TTestQuery>(
-    ['test', variables],
-    fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
-    options
-  );
+export const useTestQuery = <
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      variables?: TTestQueryVariables, 
+      options?: UseQueryOptions<TTestQuery, TError, TData>
+    ) => 
+    useQuery<TTestQuery, TError, TData>(
+      ['test', variables],
+      fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
+      options
+    );
 export const TestDocument = \`
     mutation test($name: String) {
   submitRepository(repoFullName: $name) {
@@ -276,12 +320,18 @@ export const TestDocument = \`
   }
 }
     \`;
-export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-  useQuery<TTestQuery>(
-    ['test', variables],
-    fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
-    options
-  );
+export const useTestQuery = <
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      variables?: TTestQueryVariables, 
+      options?: UseQueryOptions<TTestQuery, TError, TData>
+    ) => 
+    useQuery<TTestQuery, TError, TData>(
+      ['test', variables],
+      fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
+      options
+    );
 export const TestDocument = \`
     mutation test($name: String) {
   submitRepository(repoFullName: $name) {

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -78,12 +78,14 @@ describe('React-Query', () => {
           myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
           options
         );`);
-      expect(out.content)
-        .toBeSimilarStringTo(`export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-    useMutation<TTestMutation, unknown, TTestMutationVariables>(
-      (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
-      options
-    );`);
+      expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
+        TError = unknown,
+        TContext = unknown
+      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+      useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+        (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
+        options
+      );`);
 
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config, false);
@@ -113,12 +115,14 @@ describe('React-Query', () => {
         options
       );`);
 
-      expect(out.content)
-        .toBeSimilarStringTo(`export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-    useMutation<TTestMutation, unknown, TTestMutationVariables>(
-      (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
-      options
-    );`);
+      expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
+        TError = unknown,
+        TContext = unknown
+      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+      useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+        (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
+        options
+      );`);
 
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config, false);
@@ -155,12 +159,17 @@ describe('React-Query', () => {
           fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
           options
         );`);
-      expect(out.content)
-        .toBeSimilarStringTo(`    export const useTestMutation = (client: GraphQLClient, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-    useMutation<TTestMutation, unknown, TTestMutationVariables>(
-      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables)(),
-      options
-    );`);
+      expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
+        TError = unknown,
+        TContext = unknown
+      >(
+        client: GraphQLClient, 
+        options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
+      ) => 
+      useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+        (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables)(),
+        options
+      );`);
 
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config, false);
@@ -213,12 +222,14 @@ describe('React-Query', () => {
         options
       );`);
 
-      expect(out.content)
-        .toBeSimilarStringTo(`    export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-    useMutation<TTestMutation, unknown, TTestMutationVariables>(
-      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
-      options
-    );`);
+      expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
+        TError = unknown,
+        TContext = unknown
+      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+      useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+        (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
+        options
+      );`);
 
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config, false);
@@ -240,7 +251,7 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
       expect(out.prepend[1])
-        .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
+        .toBeSimilarStringTo(`function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
         return async (): Promise<TData> => {
           const res = await fetch("http://localhost:3000/graphql", {
             method: "POST",
@@ -275,7 +286,7 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
       expect(out.prepend[1])
-        .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
+        .toBeSimilarStringTo(`function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
         return async (): Promise<TData> => {
           const res = await fetch(process.env.ENDPOINT_URL as string, {
             method: "POST",
@@ -360,12 +371,17 @@ describe('React-Query', () => {
         options
       );`);
 
-      expect(out.content)
-        .toBeSimilarStringTo(`    export const useTestMutation = (dataSource: { endpoint: string, fetchParams?: RequestInit }, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
-      useMutation<TTestMutation, unknown, TTestMutationVariables>(
-        (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
-        options
-      );`);
+      expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
+          TError = unknown,
+          TContext = unknown
+        >(
+          dataSource: { endpoint: string, fetchParams?: RequestInit }, 
+          options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
+        ) => 
+        useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+          (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
+          options
+        );`);
 
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config, false);

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -58,7 +58,6 @@ describe('React-Query', () => {
       const config = {
         fetcher: './my-file#myCustomFetcher',
         typesPrefix: 'T',
-        reactQueryMajorVersion: 3,
       };
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
@@ -67,13 +66,18 @@ describe('React-Query', () => {
         `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
       );
       expect(out.prepend).toContain(`import { myCustomFetcher } from './my-file';`);
-      expect(out.content)
-        .toBeSimilarStringTo(`export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-      useQuery<TTestQuery>(
-        ['test', variables],
-        myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
-        options
-      );`);
+      expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
+          TData = TTestQuery,
+          TError = unknown
+        >(
+          variables?: TTestQueryVariables, 
+          options?: UseQueryOptions<TTestQuery, TError, TData>
+        ) => 
+        useQuery<TTestQuery, TError, TData>(
+          ['test', variables],
+          myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
+          options
+        );`);
       expect(out.content)
         .toBeSimilarStringTo(`export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
@@ -96,9 +100,14 @@ describe('React-Query', () => {
       expect(out.prepend).toContain(
         `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
       );
-      expect(out.content)
-        .toBeSimilarStringTo(`export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-      useQuery<TTestQuery>(
+      expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
+        TData = TTestQuery,
+        TError = unknown
+      >(
+        variables?: TTestQueryVariables, 
+        options?: UseQueryOptions<TTestQuery, TError, TData>
+      ) => 
+      useQuery<TTestQuery, TError, TData>(
         ['test', variables],
         myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
         options
@@ -133,13 +142,19 @@ describe('React-Query', () => {
         .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variables?: TVariables) {
           return async (): Promise<TData> => client.request<TData, TVariables>(query, variables);
         }`);
-      expect(out.content)
-        .toBeSimilarStringTo(`export const useTestQuery = (client: GraphQLClient, variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-      useQuery<TTestQuery>(
-        ['test', variables],
-        fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
-        options
-      );`);
+      expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
+          TData = TTestQuery,
+          TError = unknown
+        >(
+          client: GraphQLClient, 
+          variables?: TTestQueryVariables, 
+          options?: UseQueryOptions<TTestQuery, TError, TData>
+        ) => 
+        useQuery<TTestQuery, TError, TData>(
+          ['test', variables],
+          fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
+          options
+        );`);
       expect(out.content)
         .toBeSimilarStringTo(`    export const useTestMutation = (client: GraphQLClient, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
@@ -185,9 +200,14 @@ describe('React-Query', () => {
           return json.data;
         }
       }`);
-      expect(out.content)
-        .toBeSimilarStringTo(`export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-      useQuery<TTestQuery>(
+      expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
+        TData = TTestQuery,
+        TError = unknown
+      >(
+        variables?: TTestQueryVariables, 
+        options?: UseQueryOptions<TTestQuery, TError, TData>
+      ) => 
+      useQuery<TTestQuery, TError, TData>(
         ['test', variables],
         fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
         options
@@ -326,9 +346,15 @@ describe('React-Query', () => {
         `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
       );
 
-      expect(out.content)
-        .toBeSimilarStringTo(`export const useTestQuery = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
-      useQuery<TTestQuery>(
+      expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
+        TData = TTestQuery,
+        TError = unknown
+      >(
+        dataSource: { endpoint: string, fetchParams?: RequestInit }, 
+        variables?: TTestQueryVariables, 
+        options?: UseQueryOptions<TTestQuery, TError, TData>
+      ) => 
+      useQuery<TTestQuery, TError, TData>(
         ['test', variables],
         fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
         options

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -75,9 +75,9 @@ describe('React-Query', () => {
         options
       );`);
       expect(out.content)
-        .toBeSimilarStringTo(`export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+        .toBeSimilarStringTo(`export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
-      myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
+      (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );`);
 
@@ -105,9 +105,9 @@ describe('React-Query', () => {
       );`);
 
       expect(out.content)
-        .toBeSimilarStringTo(`export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+        .toBeSimilarStringTo(`export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
-      myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
+      (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );`);
 
@@ -141,9 +141,9 @@ describe('React-Query', () => {
         options
       );`);
       expect(out.content)
-        .toBeSimilarStringTo(`    export const useTestMutation = (client: GraphQLClient, variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+        .toBeSimilarStringTo(`    export const useTestMutation = (client: GraphQLClient, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
-      fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables),
+      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables)(),
       options
     );`);
 
@@ -194,9 +194,9 @@ describe('React-Query', () => {
       );`);
 
       expect(out.content)
-        .toBeSimilarStringTo(`    export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+        .toBeSimilarStringTo(`    export const useTestMutation = (options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
-      fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
+      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );`);
 
@@ -335,9 +335,9 @@ describe('React-Query', () => {
       );`);
 
       expect(out.content)
-        .toBeSimilarStringTo(`    export const useTestMutation = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
+        .toBeSimilarStringTo(`    export const useTestMutation = (dataSource: { endpoint: string, fetchParams?: RequestInit }, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
       useMutation<TTestMutation, unknown, TTestMutationVariables>(
-        fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
+        (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
         options
       );`);
 

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -58,23 +58,24 @@ describe('React-Query', () => {
       const config = {
         fetcher: './my-file#myCustomFetcher',
         typesPrefix: 'T',
+        reactQueryMajorVersion: 3,
       };
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
       expect(out.prepend).toContain(
-        `import { useQuery, QueryConfig, useMutation, MutationConfig } from 'react-query';`
+        `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
       );
       expect(out.prepend).toContain(`import { myCustomFetcher } from './my-file';`);
       expect(out.content)
-        .toBeSimilarStringTo(`export const useTestQuery = (variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+        .toBeSimilarStringTo(`export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
       useQuery<TTestQuery>(
         ['test', variables],
         myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
         options
       );`);
       expect(out.content)
-        .toBeSimilarStringTo(`    export const useTestMutation = (variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+        .toBeSimilarStringTo(`export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
       myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
       options
@@ -93,10 +94,10 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
       expect(out.prepend).toContain(
-        `import { useQuery, QueryConfig, useMutation, MutationConfig } from 'react-query';`
+        `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
       );
       expect(out.content)
-        .toBeSimilarStringTo(`export const useTestQuery = (variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+        .toBeSimilarStringTo(`export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
       useQuery<TTestQuery>(
         ['test', variables],
         myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -104,7 +105,7 @@ describe('React-Query', () => {
       );`);
 
       expect(out.content)
-        .toBeSimilarStringTo(`    export const useTestMutation = (variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+        .toBeSimilarStringTo(`export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
       myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
       options
@@ -125,7 +126,7 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
       expect(out.prepend).toContain(
-        `import { useQuery, QueryConfig, useMutation, MutationConfig } from 'react-query';`
+        `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
       );
       expect(out.prepend).toContain(`import { GraphQLClient } from 'graphql-request';`);
       expect(out.prepend[2])
@@ -133,14 +134,14 @@ describe('React-Query', () => {
           return async (): Promise<TData> => client.request<TData, TVariables>(query, variables);
         }`);
       expect(out.content)
-        .toBeSimilarStringTo(`export const useTestQuery = (client: GraphQLClient, variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+        .toBeSimilarStringTo(`export const useTestQuery = (client: GraphQLClient, variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
       useQuery<TTestQuery>(
         ['test', variables],
         fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
         options
       );`);
       expect(out.content)
-        .toBeSimilarStringTo(`    export const useTestMutation = (client: GraphQLClient, variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+        .toBeSimilarStringTo(`    export const useTestMutation = (client: GraphQLClient, variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
       fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables),
       options
@@ -163,7 +164,7 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
       expect(out.prepend).toContain(
-        `import { useQuery, QueryConfig, useMutation, MutationConfig } from 'react-query';`
+        `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
       );
       expect(out.prepend[1])
         .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
@@ -185,7 +186,7 @@ describe('React-Query', () => {
         }
       }`);
       expect(out.content)
-        .toBeSimilarStringTo(`export const useTestQuery = (variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+        .toBeSimilarStringTo(`export const useTestQuery = (variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
       useQuery<TTestQuery>(
         ['test', variables],
         fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -193,7 +194,7 @@ describe('React-Query', () => {
       );`);
 
       expect(out.content)
-        .toBeSimilarStringTo(`    export const useTestMutation = (variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+        .toBeSimilarStringTo(`    export const useTestMutation = (variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
     useMutation<TTestMutation, unknown, TTestMutationVariables>(
       fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables),
       options
@@ -322,11 +323,11 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
       expect(out.prepend).toContain(
-        `import { useQuery, QueryConfig, useMutation, MutationConfig } from 'react-query';`
+        `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
       );
 
       expect(out.content)
-        .toBeSimilarStringTo(`export const useTestQuery = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestQueryVariables, options?: QueryConfig<TTestQuery>) => 
+        .toBeSimilarStringTo(`export const useTestQuery = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestQueryVariables, options?: UseQueryOptions<TTestQuery>) => 
       useQuery<TTestQuery>(
         ['test', variables],
         fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
@@ -334,7 +335,7 @@ describe('React-Query', () => {
       );`);
 
       expect(out.content)
-        .toBeSimilarStringTo(`    export const useTestMutation = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestMutationVariables, options?: MutationConfig<TTestMutation, unknown, TTestMutationVariables>) => 
+        .toBeSimilarStringTo(`    export const useTestMutation = (dataSource: { endpoint: string, fetchParams?: RequestInit }, variables?: TTestMutationVariables, options?: UseMutationOptions<TTestMutation, unknown, TTestMutationVariables>) => 
       useMutation<TTestMutation, unknown, TTestMutationVariables>(
         fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
         options

--- a/yarn.lock
+++ b/yarn.lock
@@ -12619,6 +12619,14 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
+match-sorter@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.0.2.tgz#91bbab14c28a87f4a67755b7a194c0d11dedc080"
+  integrity sha512-SDRLNlWof9GnAUEyhKP0O5525MMGXUGt+ep4MrrqQ2StAh3zjvICVZseiwg7Zijn3GazpJDiwuRr/mFDHd92NQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -13512,7 +13520,6 @@ npm@6.14.10:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -13527,7 +13534,6 @@ npm@6.14.10:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -13546,14 +13552,8 @@ npm@6.14.10:
     libnpx "^10.2.4"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -15652,12 +15652,13 @@ react-monaco-editor@0.41.1:
     monaco-editor "*"
     prop-types "^15.7.2"
 
-react-query@2.26.4:
-  version "2.26.4"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.26.4.tgz#18239b4c0b61d0b744f0d4a91f566b294fa9f752"
-  integrity sha512-sXGG0gh1ah11AcfptYOCRpGDoYMnssq6riQUpQaLSM2EOodVkexp3zNLk1MFDgfRGuXQst40Tnu17oNwni66aA==
+react-query@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.2.0.tgz#c13264941249867c5a5640ec0be8343a55a13158"
+  integrity sha512-P1uErndQIOIhrCLrsw7G3pRPe/S1qL0almPZhYjh/ggRNHwiu8ZRrPh2yTnD8zqDYMvdk+ARJ6VtjukjgX/UZg==
   dependencies:
     "@babel/runtime" "^7.5.5"
+    match-sorter "^6.0.2"
 
 react-router-config@^5.1.1:
   version "5.1.1"
@@ -16180,6 +16181,11 @@ remedial@^1.0.7:
   version "1.0.8"
   resolved "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz#a5e4fd52a0e4956adbaf62da63a5a46a78c578a0"
   integrity sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==
+
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7385,7 +7385,7 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -10302,7 +10302,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -12158,11 +12158,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -12171,32 +12166,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -12362,11 +12335,6 @@ lodash.reject@^4.4.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
   integrity sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -15652,10 +15620,10 @@ react-monaco-editor@0.41.1:
     monaco-editor "*"
     prop-types "^15.7.2"
 
-react-query@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.2.0.tgz#c13264941249867c5a5640ec0be8343a55a13158"
-  integrity sha512-P1uErndQIOIhrCLrsw7G3pRPe/S1qL0almPZhYjh/ggRNHwiu8ZRrPh2yTnD8zqDYMvdk+ARJ6VtjukjgX/UZg==
+react-query@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.4.0.tgz#98d0b05761e9526190e59b650841a03d57b853d1"
+  integrity sha512-Hsyru21BCjM6W5hcLS+AprUlfPnp0nANWMrmqxlSC5YWs8FZOXyxBGKaIBjtnoEQxVjTlUKEmGgqZBnhAz7hCw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     match-sorter "^6.0.2"


### PR DESCRIPTION
Related #5271

Description:
* Upgraded react-query to v3
* Modified generated useQuery hooks to allow passing in of data type to be used with [query data selectors](https://react-query.tanstack.com/guides/migrating-to-react-query-3#query-data-selectors)
* Reworked the mutations so that variables are passed in at mutate time and not at instantiation

Example new useQuery hook
```js
export const useListPostsQuery = <TData = ListPostsQuery, TError = unknown,>(
    variables: ListPostsQueryVariables,
    options?: UseQueryOptions<ListPostsQuery, TError, TData>
  ) =>
  useQuery<ListPostsQuery, TError, TData>(
    ["ListPosts", variables],
    fetcher<ListPostsQuery, ListPostsQueryVariables>(
      ListPostsDocument,
      variables
    ),
    options
  );
```

Example new useMutation hook
```js
export const useCreatePostMutation = <TError = unknown, TContext = unknown>(
  options?: UseMutationOptions<CreatePostMutation, TError, CreatePostMutationVariables, TContext>
) =>
  useMutation<CreatePostMutation, TError, CreatePostMutationVariables, TContext>(
    (variables?: CreatePostMutationVariables) => fetcher<CreatePostMutation, CreatePostMutationVariables>(
      CreatePostDocument,
      variables
    )(),
    options
  );
```

Used in demo [here](https://github.com/kcwinner/cdk-appsync-react-demo/blob/v3_demo/frontend/src/lib/api.ts)