### PR TITLE
fix(style): docusaurus admonition dark mode color (#5310) [deploy_website]

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -11,6 +11,7 @@
 
 .admonition-shell {
   --ra-admonition-background-color: rgb(41, 45, 62) !important;
+  --ra-admonition-color: #ffffff;
 }
 
 .admonition a {


### PR DESCRIPTION
Overwrites docusaurus' admonition color and keeps it white for both `dark` and `light` modes.

Fixes #5308.

_Light mode:_

![image](https://user-images.githubusercontent.com/40426996/103031903-6eee6f80-4567-11eb-8777-6e9ddc3c8f1f.png)

_Dark mode:_

![image](https://user-images.githubusercontent.com/40426996/103031918-77df4100-4567-11eb-86fe-6c2044949fd5.png)