### PR TITLE
feat(visitor-plugin-common): add ignoreEnumValuesFromSchema to ignore enum values from GraphQLSchema

### DIFF
--- a/.changeset/popular-icons-tap.md
+++ b/.changeset/popular-icons-tap.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/visitor-plugin-common': minor
 ---
 
-feat(visitor-plugin-common): add respectEnumValuesFromSchema to disable this functionality
+feat(visitor-plugin-common): add ignoreEnumValuesFromSchema to ignore enum values from GraphQLSchema

--- a/.changeset/popular-icons-tap.md
+++ b/.changeset/popular-icons-tap.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+---
+
+feat(visitor-plugin-common): add respectEnumValuesFromSchema to disable this functionality

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -339,7 +339,10 @@ export class BaseResolversVisitor<
       enumPrefix: getConfigValue(rawConfig.enumPrefix, true),
       federation: getConfigValue(rawConfig.federation, false),
       resolverTypeWrapperSignature: getConfigValue(rawConfig.resolverTypeWrapperSignature, 'Promise<T> | T'),
-      enumValues: parseEnumValues(_schema, rawConfig.enumValues),
+      enumValues: parseEnumValues({
+        schema: _schema,
+        mapOrStr: rawConfig.enumValues,
+      }),
       addUnderscoreToArgsType: getConfigValue(rawConfig.addUnderscoreToArgsType, false),
       contextType: parseMapper(rawConfig.contextType || 'any', 'ContextType'),
       fieldContextTypes: getConfigValue(rawConfig.fieldContextTypes, []),

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -174,6 +174,22 @@ export interface RawTypesConfig extends RawConfig {
    * ```
    */
   onlyOperationTypes?: boolean;
+  /**
+   * @description This will cause the generator to respect enum values defined in GraphQLSchema
+   * @default true
+   *
+   * @exampleMarkdown
+   * ## Obtain enum values from schema
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    respectEnumValuesFromSchema: true
+   * ```
+   */
+  respectEnumValuesFromSchema?: boolean;
 }
 
 export class BaseTypesVisitor<
@@ -192,7 +208,11 @@ export class BaseTypesVisitor<
       enumPrefix: getConfigValue(rawConfig.enumPrefix, true),
       onlyOperationTypes: getConfigValue(rawConfig.onlyOperationTypes, false),
       addUnderscoreToArgsType: getConfigValue(rawConfig.addUnderscoreToArgsType, false),
-      enumValues: parseEnumValues(_schema, rawConfig.enumValues),
+      enumValues: parseEnumValues({
+        schema: _schema,
+        mapOrStr: rawConfig.enumValues,
+        respectEnumValuesFromSchema: getConfigValue(rawConfig.respectEnumValuesFromSchema, true),
+      }),
       declarationKind: normalizeDeclarationKind(rawConfig.declarationKind),
       scalars: buildScalars(_schema, rawConfig.scalars, defaultScalars),
       fieldWrapperValue: getConfigValue(rawConfig.fieldWrapperValue, 'T'),

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -51,6 +51,7 @@ export interface ParsedTypesConfig extends ParsedConfig {
   enumPrefix: boolean;
   fieldWrapperValue: string;
   wrapFieldDefinitions: boolean;
+  ignoreEnumValuesFromSchema: boolean;
 }
 
 export interface RawTypesConfig extends RawConfig {
@@ -211,12 +212,13 @@ export class BaseTypesVisitor<
       enumValues: parseEnumValues({
         schema: _schema,
         mapOrStr: rawConfig.enumValues,
-        ignoreEnumValuesFromSchema: getConfigValue(rawConfig.ignoreEnumValuesFromSchema, false),
+        ignoreEnumValuesFromSchema: rawConfig.ignoreEnumValuesFromSchema,
       }),
       declarationKind: normalizeDeclarationKind(rawConfig.declarationKind),
       scalars: buildScalars(_schema, rawConfig.scalars, defaultScalars),
       fieldWrapperValue: getConfigValue(rawConfig.fieldWrapperValue, 'T'),
       wrapFieldDefinitions: getConfigValue(rawConfig.wrapFieldDefinitions, false),
+      ignoreEnumValuesFromSchema: getConfigValue(rawConfig.ignoreEnumValuesFromSchema, false),
       ...additionalConfig,
     });
 
@@ -514,7 +516,10 @@ export class BaseTypesVisitor<
           this.convertName(enumOption, { useTypesPrefix: false, transformUnderscore: true })
         );
         const comment = transformComment((enumOption.description as any) as string, 1);
-        const schemaEnumValue = schemaEnumType ? schemaEnumType.getValue(enumOption.name as any).value : undefined;
+        const schemaEnumValue =
+          schemaEnumType && !this.config.ignoreEnumValuesFromSchema
+            ? schemaEnumType.getValue(enumOption.name as any).value
+            : undefined;
         let enumValue: string | number =
           typeof schemaEnumValue !== 'undefined' ? schemaEnumValue : (enumOption.name as any);
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -175,21 +175,21 @@ export interface RawTypesConfig extends RawConfig {
    */
   onlyOperationTypes?: boolean;
   /**
-   * @description This will cause the generator to respect enum values defined in GraphQLSchema
-   * @default true
+   * @description This will cause the generator to ignore enum values defined in GraphQLSchema
+   * @default false
    *
    * @exampleMarkdown
-   * ## Obtain enum values from schema
+   * ## Ignore enum values from schema
    * ```yml
    * generates:
    * path/to/file.ts:
    *  plugins:
    *    - typescript
    *  config:
-   *    respectEnumValuesFromSchema: true
+   *    ignoreEnumValuesFromSchema: true
    * ```
    */
-  respectEnumValuesFromSchema?: boolean;
+  ignoreEnumValuesFromSchema?: boolean;
 }
 
 export class BaseTypesVisitor<
@@ -211,7 +211,7 @@ export class BaseTypesVisitor<
       enumValues: parseEnumValues({
         schema: _schema,
         mapOrStr: rawConfig.enumValues,
-        respectEnumValuesFromSchema: getConfigValue(rawConfig.respectEnumValuesFromSchema, true),
+        ignoreEnumValuesFromSchema: getConfigValue(rawConfig.ignoreEnumValuesFromSchema, false),
       }),
       declarationKind: normalizeDeclarationKind(rawConfig.declarationKind),
       scalars: buildScalars(_schema, rawConfig.scalars, defaultScalars),

--- a/packages/plugins/other/visitor-plugin-common/src/enum-values.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/enum-values.ts
@@ -16,7 +16,7 @@ export function parseEnumValues({
   const allEnums = Object.keys(allTypes).filter(t => isEnumType(allTypes[t]));
 
   if (typeof mapOrStr === 'object') {
-    if (ignoreEnumValuesFromSchema) {
+    if (!ignoreEnumValuesFromSchema) {
       for (const enumTypeName of allEnums) {
         const enumType = schema.getType(enumTypeName) as GraphQLEnumType;
         for (const { name, value } of enumType.getValues()) {

--- a/packages/plugins/other/visitor-plugin-common/src/enum-values.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/enum-values.ts
@@ -6,17 +6,17 @@ import { parseMapper } from './mappers';
 export function parseEnumValues({
   schema,
   mapOrStr = {},
-  respectEnumValuesFromSchema = true,
+  ignoreEnumValuesFromSchema,
 }: {
   schema: GraphQLSchema;
   mapOrStr: EnumValuesMap;
-  respectEnumValuesFromSchema?: boolean;
+  ignoreEnumValuesFromSchema?: boolean;
 }): ParsedEnumValuesMap {
   const allTypes = schema.getTypeMap();
   const allEnums = Object.keys(allTypes).filter(t => isEnumType(allTypes[t]));
 
   if (typeof mapOrStr === 'object') {
-    if (respectEnumValuesFromSchema) {
+    if (ignoreEnumValuesFromSchema) {
       for (const enumTypeName of allEnums) {
         const enumType = schema.getType(enumTypeName) as GraphQLEnumType;
         for (const { name, value } of enumType.getValues()) {

--- a/packages/plugins/other/visitor-plugin-common/src/enum-values.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/enum-values.ts
@@ -3,18 +3,28 @@ import { GraphQLSchema, isEnumType, GraphQLEnumType } from 'graphql';
 import { DetailedError } from '@graphql-codegen/plugin-helpers';
 import { parseMapper } from './mappers';
 
-export function parseEnumValues(schema: GraphQLSchema, mapOrStr: EnumValuesMap = {}): ParsedEnumValuesMap {
+export function parseEnumValues({
+  schema,
+  mapOrStr = {},
+  respectEnumValuesFromSchema = true,
+}: {
+  schema: GraphQLSchema;
+  mapOrStr: EnumValuesMap;
+  respectEnumValuesFromSchema?: boolean;
+}): ParsedEnumValuesMap {
   const allTypes = schema.getTypeMap();
   const allEnums = Object.keys(allTypes).filter(t => isEnumType(allTypes[t]));
 
   if (typeof mapOrStr === 'object') {
-    for (const enumTypeName of allEnums) {
-      const enumType = schema.getType(enumTypeName) as GraphQLEnumType;
-      for (const { name, value } of enumType.getValues()) {
-        if (value && value !== name) {
-          mapOrStr[enumTypeName] = mapOrStr[enumTypeName] || {};
-          if (typeof mapOrStr[enumTypeName] !== 'string' && !mapOrStr[enumTypeName][name]) {
-            mapOrStr[enumTypeName][name] = value;
+    if (respectEnumValuesFromSchema) {
+      for (const enumTypeName of allEnums) {
+        const enumType = schema.getType(enumTypeName) as GraphQLEnumType;
+        for (const { name, value } of enumType.getValues()) {
+          if (value && value !== name) {
+            mapOrStr[enumTypeName] = mapOrStr[enumTypeName] || {};
+            if (typeof mapOrStr[enumTypeName] !== 'string' && !mapOrStr[enumTypeName][name]) {
+              mapOrStr[enumTypeName][name] = value;
+            }
           }
         }
       }

--- a/packages/plugins/other/visitor-plugin-common/tests/enum-values.spec.ts
+++ b/packages/plugins/other/visitor-plugin-common/tests/enum-values.spec.ts
@@ -15,8 +15,11 @@ describe('enumValues', () => {
   `);
 
   it('should work with namespaces', () => {
-    const result = parseEnumValues(schema, {
-      Test: `my-file#SomeNamespace.ETest`,
+    const result = parseEnumValues({
+      schema,
+      mapOrStr: {
+        Test: `my-file#SomeNamespace.ETest`,
+      },
     });
 
     expect(result).toEqual({
@@ -32,8 +35,11 @@ describe('enumValues', () => {
   });
 
   it('should work with regular type', () => {
-    const result = parseEnumValues(schema, {
-      Test: `my-file#ETest`,
+    const result = parseEnumValues({
+      schema,
+      mapOrStr: {
+        Test: `my-file#ETest`,
+      },
     });
 
     expect(result).toEqual({
@@ -49,8 +55,11 @@ describe('enumValues', () => {
   });
 
   it('should work with aliased type', () => {
-    const result = parseEnumValues(schema, {
-      Test: `my-file#ETest as Something`,
+    const result = parseEnumValues({
+      schema,
+      mapOrStr: {
+        Test: `my-file#ETest as Something`,
+      },
     });
 
     expect(result).toEqual({

--- a/packages/plugins/other/visitor-plugin-common/tests/enum-values.spec.ts
+++ b/packages/plugins/other/visitor-plugin-common/tests/enum-values.spec.ts
@@ -100,7 +100,7 @@ describe('enumValues', () => {
     const result = parseEnumValues({
       schema: schemaWithEnumValues,
       mapOrStr: {},
-      respectEnumValuesFromSchema: true,
+      ignoreEnumValuesFromSchema: false,
     });
 
     expect(result).toEqual({
@@ -123,7 +123,7 @@ describe('enumValues', () => {
     const result = parseEnumValues({
       schema: schemaWithEnumValues,
       mapOrStr: {},
-      respectEnumValuesFromSchema: false,
+      ignoreEnumValuesFromSchema: true,
     });
 
     expect(result).not.toEqual({

--- a/packages/plugins/other/visitor-plugin-common/tests/enum-values.spec.ts
+++ b/packages/plugins/other/visitor-plugin-common/tests/enum-values.spec.ts
@@ -1,4 +1,4 @@
-import { buildSchema } from 'graphql';
+import { buildSchema, GraphQLEnumType, GraphQLObjectType, GraphQLSchema } from 'graphql';
 import { parseEnumValues } from '../src/enum-values';
 
 describe('enumValues', () => {
@@ -70,6 +70,74 @@ describe('enumValues', () => {
         sourceIdentifier: 'Something',
         importIdentifier: 'ETest as Something',
         mappedValues: null,
+      },
+    });
+  });
+  const schemaWithEnumValues = new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        test: {
+          type: new GraphQLEnumType({
+            name: 'Test',
+            values: {
+              A: {
+                value: 'a',
+              },
+              B: {
+                value: 'b',
+              },
+              C: {
+                value: 'c',
+              },
+            },
+          }),
+        },
+      },
+    }),
+  });
+  it('should respect enum values from schema', () => {
+    const result = parseEnumValues({
+      schema: schemaWithEnumValues,
+      mapOrStr: {},
+      respectEnumValuesFromSchema: true,
+    });
+
+    expect(result).toEqual({
+      Test: {
+        isDefault: false,
+        typeIdentifier: 'Test',
+        sourceFile: null,
+        importIdentifier: null,
+        sourceIdentifier: null,
+        mappedValues: {
+          A: 'a',
+          B: 'b',
+          C: 'c',
+        },
+      },
+    });
+  });
+
+  it('should ignore enum values from schema', () => {
+    const result = parseEnumValues({
+      schema: schemaWithEnumValues,
+      mapOrStr: {},
+      respectEnumValuesFromSchema: false,
+    });
+
+    expect(result).not.toEqual({
+      Test: {
+        isDefault: false,
+        typeIdentifier: 'Test',
+        sourceFile: null,
+        importIdentifier: null,
+        sourceIdentifier: null,
+        mappedValues: {
+          A: 'a',
+          B: 'b',
+          C: 'c',
+        },
       },
     });
   });


### PR DESCRIPTION
By default, `enumValues` is taken from `GraphQLSchema` but this doesn't work well with client side stuff because client side libraries doesn't expect the value from the server side. I think this functionality is already problematic. We should never use server-side values for client-side stuff.
Anyway, this PR adds an option `ignoreEnumValuesFromSchema` which is false by default, and users can disable it to fix this. For example, I'll use this on Mesh.