### PR TITLE
Update schema-field.md

### DIFF
--- a/website/docs/getting-started/schema-field.md
+++ b/website/docs/getting-started/schema-field.md
@@ -288,9 +288,9 @@ If your schema has a different or complicated way of loading, you can point to a
 ```yml
 schema:
   - http://localhost:3000/graphql:
-      loader: my-url-loader.js
+      loader: ./my-url-loader.js
   - schema.graphql:
-      loader: my-file-loader.js
+      loader: ./my-file-loader.js
 ```
 
 Your custom loader should export a default function that returns `GraphQLSchema` object, or an identifier called `schema`. For example:


### PR DESCRIPTION
If the loader file is in the root of the project (so alongside package.json) it should have `./` otherwise it will fail with an error that is not very helpful to immediately debug it. So it's better to fix this example usage :)