### PR TITLE
[Angular] Add additionalDI config for add custom dependency injections

### DIFF
--- a/.changeset/ninety-teachers-protect.md
+++ b/.changeset/ninety-teachers-protect.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-apollo-angular': minor
+---
+
+Add additionalDI config for add custom dependency injections

--- a/packages/plugins/typescript/apollo-angular/src/config.ts
+++ b/packages/plugins/typescript/apollo-angular/src/config.ts
@@ -114,4 +114,17 @@ export interface ApolloAngularRawPluginConfig extends RawClientSideBasePluginCon
    * @default 'apollo-angular'
    */
   apolloAngularPackage?: 'apollo-angular' | string;
+  /**
+   * @description Add additional dependency injections for generated services
+   * @default []
+   *
+   * @exampleMarkdown
+   * ```yml
+   * config:
+   *   additionalDI
+   *      - 'testService: TestService'
+   *      - 'testService1': TestService1'
+   * ```
+   */
+  additionalDI?: string[];
 }

--- a/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
+++ b/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
@@ -107,6 +107,28 @@ describe('Apollo Angular', () => {
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it(`should add additional DI for constructor & super call`, async () => {
+      const docs = [{ location: '', document: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          additionalDI: ['testService: TestService', 'testService1: TestService1'],
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`
+          constructor(apollo: Apollo.Apollo, testService: TestService, testService1: TestService1) {
+            super(apollo, testService, testService1);
+          }
+        }
+      `);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it(`should add the correct angular imports with override`, async () => {
       const docs = [{ location: '', document: basicDoc }];
       const content = (await plugin(


### PR DESCRIPTION
Due to PR #4508 feature will overwrite the params for the constructor of the basic Query service to makes injected service lose.
Add the `additionalDI ` and config to add custom dependency injections
For the case see https://github.com/dotansimha/graphql-code-generator/issues/4366#issuecomment-759314958