### PR TITLE
fix(plugin: graphql-requests): Fix argument types in auto-generated methods

### DIFF
--- a/.changeset/swift-rules-do.md
+++ b/.changeset/swift-rules-do.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-graphql-request': patch
+---
+
+fix(plugin: graphql-requests): Fix argument types in auto-generated methods

--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -47,7 +47,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
 
     if (this.config.rawRequest) {
       this._additionalImports.push(`${typeImport} { GraphQLError } from 'graphql-request/dist/types';`);
-      this._additionalImports.push(`${typeImport} { Headers } from 'graphql-request/dist/types.dom';`);
+      this._additionalImports.push(`${typeImport} { Headers, HeadersInit } from 'graphql-request/dist/types.dom';`);
     }
   }
 
@@ -87,7 +87,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
         if (this.config.rawRequest) {
           return `${o.node.name.value}(variables${optionalVariables ? '?' : ''}: ${
             o.operationVariablesTypes
-          }, requestHeaders?: Headers): Promise<{ data?: ${
+          }, requestHeaders?: HeadersInit): Promise<{ data?: ${
             o.operationResultType
           } | undefined; extensions?: any; headers: Headers; status: number; errors?: GraphQLError[] | undefined; }> {
     return withWrapper(() => client.rawRequest<${o.operationResultType}>(${doc}, variables, requestHeaders));
@@ -95,7 +95,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
         } else {
           return `${o.node.name.value}(variables${optionalVariables ? '?' : ''}: ${
             o.operationVariablesTypes
-          }, requestHeaders?: Headers): Promise<${o.operationResultType}> {
+          }, requestHeaders?: HeadersInit): Promise<${o.operationResultType}> {
   return withWrapper(() => client.request<${o.operationResultType}>(${doc}, variables, requestHeaders));
 }`;
         }

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -273,16 +273,16 @@ export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
 const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Headers): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: HeadersInit): Promise<FeedQuery> {
       return withWrapper(() => client.request<FeedQuery>(FeedDocument, variables, requestHeaders));
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Headers): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: HeadersInit): Promise<Feed2Query> {
       return withWrapper(() => client.request<Feed2Query>(Feed2Document, variables, requestHeaders));
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Headers): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: HeadersInit): Promise<Feed3Query> {
       return withWrapper(() => client.request<Feed3Query>(Feed3Document, variables, requestHeaders));
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Headers): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: HeadersInit): Promise<Feed4Query> {
       return withWrapper(() => client.request<Feed4Query>(Feed4Document, variables, requestHeaders));
     }
   };
@@ -588,16 +588,16 @@ export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
 const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Headers): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: HeadersInit): Promise<FeedQuery> {
       return withWrapper(() => client.request<FeedQuery>(print(FeedDocument), variables, requestHeaders));
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Headers): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: HeadersInit): Promise<Feed2Query> {
       return withWrapper(() => client.request<Feed2Query>(print(Feed2Document), variables, requestHeaders));
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Headers): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: HeadersInit): Promise<Feed3Query> {
       return withWrapper(() => client.request<Feed3Query>(print(Feed3Document), variables, requestHeaders));
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Headers): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: HeadersInit): Promise<Feed4Query> {
       return withWrapper(() => client.request<Feed4Query>(print(Feed4Document), variables, requestHeaders));
     }
   };
@@ -894,16 +894,16 @@ export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
 const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Headers): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: HeadersInit): Promise<FeedQuery> {
       return withWrapper(() => client.request<FeedQuery>(FeedDocument, variables, requestHeaders));
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Headers): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: HeadersInit): Promise<Feed2Query> {
       return withWrapper(() => client.request<Feed2Query>(Feed2Document, variables, requestHeaders));
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Headers): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: HeadersInit): Promise<Feed3Query> {
       return withWrapper(() => client.request<Feed3Query>(Feed3Document, variables, requestHeaders));
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Headers): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: HeadersInit): Promise<Feed4Query> {
       return withWrapper(() => client.request<Feed4Query>(Feed4Document, variables, requestHeaders));
     }
   };
@@ -1202,16 +1202,16 @@ export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
 const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Headers): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: HeadersInit): Promise<FeedQuery> {
       return withWrapper(() => client.request<FeedQuery>(print(FeedDocument), variables, requestHeaders));
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Headers): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: HeadersInit): Promise<Feed2Query> {
       return withWrapper(() => client.request<Feed2Query>(print(Feed2Document), variables, requestHeaders));
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Headers): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: HeadersInit): Promise<Feed3Query> {
       return withWrapper(() => client.request<Feed3Query>(print(Feed3Document), variables, requestHeaders));
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Headers): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: HeadersInit): Promise<Feed4Query> {
       return withWrapper(() => client.request<Feed4Query>(print(Feed4Document), variables, requestHeaders));
     }
   };


### PR DESCRIPTION
`GraphQLClient`'s `request` method accepts `Dom.RequestInit['headers']` parameter (it is same as `HeadersInit`).
but auto-generated methods accept `Headers` parameter only.
so I can not pass an object to that methods.
I fixed it.
