### PR TITLE
docs: remove back tick from description

### DIFF
--- a/website/docs/generated-config/typescript-operations.md
+++ b/website/docs/generated-config/typescript-operations.md
@@ -1,7 +1,7 @@
 This plugin generates TypeScript types based on your GraphQLSchema *and* your GraphQL operations and fragments.
 It generates types for your GraphQL documents: Query, Mutation, Subscription and Fragment.
 
-Note: In most configurations, this plugin requires you to use `typescript as well, because it depends on its base types.
+Note: In most configurations, this plugin requires you to use typescript as well, because it depends on its base types.
 
 ## Installation
 


### PR DESCRIPTION
I'm not sure if the intention was to link somewhere else.