### PR TITLE
Expose query keys for react-query (#5334)

### DIFF
--- a/.changeset/spotty-flowers-rush.md
+++ b/.changeset/spotty-flowers-rush.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': minor
+---
+
+Exposed query keys for each generated qurey hook

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -29,4 +29,13 @@ export interface ReactQueryRawPluginConfig
    * - `graphql-request`: Will generate each hook with `client` argument, where you should pass your own `GraphQLClient` (created from `graphql-request`).
    */
   fetcher: 'fetch' | HardcodedFetch | 'graphql-request' | string;
+
+  /**
+   * @default false
+   * @description For each generate query hook adds getKey(variables: QueryVariables) function. Useful for cache updates. Example:
+   * const query = useUserDetailsQuery(...);
+   * const key = useUserDetailsQuery.getKey({id: theUsersId});
+   * // use key in a cache update after a mutation
+   */
+  exposeQueryKeys?: boolean;
 }

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -3,6 +3,7 @@ import { ReactQueryVisitor } from './visitor';
 import { FetcherRenderer } from './fetcher';
 import { HardcodedFetch } from './config';
 import { URL } from 'url';
+import { generateQueryKey, generateQueryVariablesSignature } from './variables-generator';
 
 export class HardcodedFetchFetcher implements FetcherRenderer {
   constructor(private visitor: ReactQueryVisitor, private config: HardcodedFetch) {}
@@ -60,7 +61,7 @@ ${this.getFetchParams()}
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
@@ -75,7 +76,7 @@ ${this.getFetchParams()}
       ${options}
     ) => 
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ['${node.name.value}', variables],
+      ${generateQueryKey(node)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -1,6 +1,7 @@
 import { OperationDefinitionNode } from 'graphql';
 import { ReactQueryVisitor } from './visitor';
 import { FetcherRenderer } from './fetcher';
+import { generateQueryKey, generateQueryVariablesSignature } from './variables-generator';
 
 export class FetchFetcher implements FetcherRenderer {
   constructor(private visitor: ReactQueryVisitor) {}
@@ -36,7 +37,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
@@ -52,7 +53,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
       ${options}
     ) => 
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ['${node.name.value}', variables],
+      ${generateQueryKey(node)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -1,6 +1,7 @@
 import { OperationDefinitionNode } from 'graphql';
 import { ReactQueryVisitor } from './visitor';
 import { FetcherRenderer } from './fetcher';
+import { generateQueryKey, generateQueryVariablesSignature } from './variables-generator';
 
 export class GraphQLRequestClientFetcher implements FetcherRenderer {
   constructor(private visitor: ReactQueryVisitor) {}
@@ -20,7 +21,7 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     this.visitor.imports.add(`import { GraphQLClient } from 'graphql-request';`);
 
     const hookConfig = this.visitor.queryMethodMap;
@@ -38,7 +39,7 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
       ${options}
     ) => 
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ['${node.name.value}', variables],
+      ${generateQueryKey(node)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -1,0 +1,22 @@
+import { OperationDefinitionNode } from 'graphql';
+
+export function generateQueryVariablesSignature(
+  hasRequiredVariables: boolean,
+  operationVariablesTypes: string
+): string {
+  return `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
+}
+
+export function generateQueryKey(node: OperationDefinitionNode): string {
+  return `['${node.name.value}', variables]`;
+}
+
+export function generateQueryKeyMaker(
+  node: OperationDefinitionNode,
+  operationName: string,
+  operationVariablesTypes: string,
+  hasRequiredVariables: boolean
+) {
+  const signature = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+  return `\nuse${operationName}.getKey = (${signature}) => ${generateQueryKey(node)};\n`;
+}

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -14,6 +14,7 @@ import { HardcodedFetchFetcher } from './fetcher-fetch-hardcoded';
 import { GraphQLRequestClientFetcher } from './fetcher-graphql-request';
 import { CustomMapperFetcher } from './fetcher-custom-mapper';
 import { pascalCase } from 'pascal-case';
+import { generateQueryKeyMaker } from './variables-generator';
 
 export interface ReactQueryPluginConfig extends ClientSideBasePluginConfig {}
 
@@ -108,7 +109,7 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
     operationVariablesTypes = this._externalImportPrefix + operationVariablesTypes;
 
     if (operationType === 'Query') {
-      return this.fetcher.generateQueryHook(
+      let query = this.fetcher.generateQueryHook(
         node,
         documentVariableName,
         operationName,
@@ -116,6 +117,10 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
         operationVariablesTypes,
         hasRequiredVariables
       );
+      if (this.rawConfig.exposeQueryKeys) {
+        query += generateQueryKeyMaker(node, operationName, operationVariablesTypes, hasRequiredVariables);
+      }
+      return query;
     } else if (operationType === 'Mutation') {
       return this.fetcher.generateMutationHook(
         node,

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -387,4 +387,17 @@ describe('React-Query', () => {
       await validateTypeScript(mergeOutputs(out), schema, docs, config, false);
     });
   });
+
+  describe('exposeQueryKeys: true', () => {
+    it('Should generate getKey for each query', async () => {
+      const config = {
+        fetcher: 'fetch',
+        exposeQueryKeys: true,
+      };
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toBeSimilarStringTo(
+        `useTestQuery.getKey = (variables?: TestQueryVariables) => ['test', variables];`
+      );
+    });
+  });
 });


### PR DESCRIPTION
As suggested in https://github.com/dotansimha/graphql-code-generator/issues/5334

for each `useTestQuery` you'll get an ```useTestQuery.getKey = (variables: TestQueryVariables) => ['test', variables];```
This option can be turned on by setting `exposeQueryKeys: true` in config