### PR TITLE
[React Query] Allow the custom fetcher to lazily receive mutation variables

### DIFF
--- a/.changeset/wicked-onions-complain.md
+++ b/.changeset/wicked-onions-complain.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': minor
+---
+
+Allow fetcher to receive variables lazily so it can use react hooks

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -1,7 +1,7 @@
 import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-common';
 
 export type HardcodedFetch = { endpoint: string; fetchParams?: Record<string, any> };
-export type CustomFetch = { func: string; lazyVariables?: boolean } | string;
+export type CustomFetch = { func: string; isReactHook?: boolean } | string;
 
 /**
  * @description This plugin generates `React-Query` Hooks with TypeScript typings.

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -1,6 +1,7 @@
 import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-common';
 
 export type HardcodedFetch = { endpoint: string; fetchParams?: Record<string, any> };
+export type CustomFetch = { func: string; lazyVariables?: boolean } | string;
 
 /**
  * @description This plugin generates `React-Query` Hooks with TypeScript typings.
@@ -28,7 +29,7 @@ export interface ReactQueryRawPluginConfig
    * - `file#identifier` - You can use custom fetcher method that should implement the exported `ReactQueryFetcher` interface. Example: `./my-fetcher#myCustomFetcher`.
    * - `graphql-request`: Will generate each hook with `client` argument, where you should pass your own `GraphQLClient` (created from `graphql-request`).
    */
-  fetcher?: 'fetch' | HardcodedFetch | 'graphql-request' | string;
+  fetcher?: 'fetch' | HardcodedFetch | 'graphql-request' | CustomFetch;
 
   /**
    * @default false

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -6,14 +6,14 @@ import { CustomFetch } from './config';
 
 export class CustomMapperFetcher implements FetcherRenderer {
   private _mapper: ParsedMapper;
-  private _lazyVariables: boolean;
+  private _isReactHook: boolean;
 
   constructor(private visitor: ReactQueryVisitor, customFetcher: CustomFetch) {
     if (typeof customFetcher === 'string') {
       customFetcher = { func: customFetcher };
     }
     this._mapper = parseMapper(customFetcher.func);
-    this._lazyVariables = customFetcher.lazyVariables;
+    this._isReactHook = customFetcher.isReactHook;
   }
 
   private getFetcherFnName(operationResultType: string, operationVariablesTypes: string): string {
@@ -53,7 +53,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
     const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
 
     const typedFetcher = this.getFetcherFnName(operationResultType, operationVariablesTypes);
-    const impl = this._lazyVariables
+    const impl = this._isReactHook
       ? `${typedFetcher}(${documentVariableName}).bind(null, variables)`
       : `${typedFetcher}(${documentVariableName}, variables)`;
 
@@ -85,7 +85,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
 
     const options = `options?: ${hookConfig.mutation.options}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>`;
     const typedFetcher = this.getFetcherFnName(operationResultType, operationVariablesTypes);
-    const impl = this._lazyVariables
+    const impl = this._isReactHook
       ? `${typedFetcher}(${documentVariableName})`
       : `(${variables}) => ${typedFetcher}(${documentVariableName}, variables)()`;
 

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -2,20 +2,22 @@ import { OperationDefinitionNode } from 'graphql';
 import { ReactQueryVisitor } from './visitor';
 import { FetcherRenderer } from './fetcher';
 import { parseMapper, ParsedMapper, buildMapperImport } from '@graphql-codegen/visitor-plugin-common';
+import { CustomFetch } from './config';
 
 export class CustomMapperFetcher implements FetcherRenderer {
   private _mapper: ParsedMapper;
+  private _lazyVariables: boolean;
 
-  constructor(private visitor: ReactQueryVisitor, fetcherStr: string) {
-    this._mapper = parseMapper(fetcherStr);
+  constructor(private visitor: ReactQueryVisitor, customFetcher: CustomFetch) {
+    if (typeof customFetcher === 'string') {
+      customFetcher = { func: customFetcher };
+    }
+    this._mapper = parseMapper(customFetcher.func);
+    this._lazyVariables = customFetcher.lazyVariables;
   }
 
-  getFetcherFnName(): string {
-    if (this._mapper.isExternal) {
-      return this._mapper.type;
-    }
-
-    return this._mapper.type;
+  private getFetcherFnName(operationResultType: string, operationVariablesTypes: string): string {
+    return `${this._mapper.type}<${operationResultType}, ${operationVariablesTypes}>`;
   }
 
   generateFetcherImplementaion(): string {
@@ -50,6 +52,11 @@ export class CustomMapperFetcher implements FetcherRenderer {
 
     const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
 
+    const typedFetcher = this.getFetcherFnName(operationResultType, operationVariablesTypes);
+    const impl = this._lazyVariables
+      ? `${typedFetcher}(${documentVariableName}).bind(null, variables)`
+      : `${typedFetcher}(${documentVariableName}, variables)`;
+
     return `export const use${operationName} = <
       TData = ${operationResultType},
       TError = ${this.visitor.config.errorType}
@@ -59,7 +66,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
     ) => 
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
       ['${node.name.value}', variables],
-      ${this.getFetcherFnName()}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
+      ${impl},
       options
     );`;
   }
@@ -77,13 +84,17 @@ export class CustomMapperFetcher implements FetcherRenderer {
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
 
     const options = `options?: ${hookConfig.mutation.options}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>`;
+    const typedFetcher = this.getFetcherFnName(operationResultType, operationVariablesTypes);
+    const impl = this._lazyVariables
+      ? `${typedFetcher}(${documentVariableName})`
+      : `(${variables}) => ${typedFetcher}(${documentVariableName}, variables)()`;
 
     return `export const use${operationName} = <
       TError = ${this.visitor.config.errorType},
       TContext = unknown
     >(${options}) => 
     ${hookConfig.mutation.hook}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
-      (${variables}) => ${this.getFetcherFnName()}<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables)(),
+      ${impl},
       options
     );`;
   }

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -74,13 +74,13 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
   private createFetcher(raw: ReactQueryRawPluginConfig['fetcher']): FetcherRenderer {
     if (raw === 'fetch') {
       return new FetchFetcher(this);
-    } else if (typeof raw === 'object' && raw.endpoint) {
+    } else if (typeof raw === 'object' && 'endpoint' in raw) {
       return new HardcodedFetchFetcher(this, raw);
     } else if (raw === 'graphql-request') {
       return new GraphQLRequestClientFetcher(this);
     }
 
-    return new CustomMapperFetcher(this, raw as string);
+    return new CustomMapperFetcher(this, raw);
   }
 
   public getImports(): string[] {

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`React-Query fetcher: custom-mapper Should generate mutation correctly with lazy variables 1`] = `
+"
+export const TestDocument = \`
+    query test {
+  feed {
+    id
+    commentCount
+    repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+export const useTestQuery = <
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      variables?: TTestQueryVariables, 
+      options?: UseQueryOptions<TTestQuery, TError, TData>
+    ) => 
+    useQuery<TTestQuery, TError, TData>(
+      ['test', variables],
+      useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
+      options
+    );
+export const TestDocument = \`
+    mutation test($name: String) {
+  submitRepository(repoFullName: $name) {
+    id
+  }
+}
+    \`;
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      useCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument),
+      options
+    );"
+`;
+
 exports[`React-Query fetcher: custom-mapper Should generate query correctly with external mapper 1`] = `
 "
 export const TestDocument = \`

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -137,6 +137,46 @@ describe('React-Query', () => {
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config, false);
     });
+
+    it('Should generate mutation correctly with lazy variables', async () => {
+      const config = {
+        fetcher: {
+          func: './my-file#useCustomFetcher',
+          lazyVariables: true,
+        },
+        typesPrefix: 'T',
+      };
+
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+
+      expect(out.prepend).toContain(
+        `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
+      );
+      expect(out.prepend).toContain(`import { useCustomFetcher } from './my-file';`);
+      expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
+          TData = TTestQuery,
+          TError = unknown
+        >(
+          variables?: TTestQueryVariables, 
+          options?: UseQueryOptions<TTestQuery, TError, TData>
+        ) => 
+        useQuery<TTestQuery, TError, TData>(
+          ['test', variables],
+          useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
+          options
+        );`);
+      expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
+        TError = unknown,
+        TContext = unknown
+      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+      useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+        useCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument),
+        options
+      );`);
+
+      expect(out.content).toMatchSnapshot();
+      await validateTypeScript(mergeOutputs(out), schema, docs, config, false);
+    });
   });
 
   describe('fetcher: graphql-request', () => {

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -142,7 +142,7 @@ describe('React-Query', () => {
       const config = {
         fetcher: {
           func: './my-file#useCustomFetcher',
-          lazyVariables: true,
+          isReactHook: true,
         },
         typesPrefix: 'T',
       };

--- a/website/docs/plugins/typescript-react-query.md
+++ b/website/docs/plugins/typescript-react-query.md
@@ -141,7 +141,7 @@ export const MyComponent = () => {
 
 ### Using Custom Fetcher
 
-If you wish to create a custom fetcher, you can provide a Mapper string (`file#identifier`). Codegen will take care of importing it and use it as a fetcher.
+If you wish to create a custom fetcher, you can provide your own function as a Mapper string (`file#identifier`). Codegen will take care of importing it and use it as a fetcher.
 
 ```yml
 schema: MY_SCHEMA_PATH
@@ -153,7 +153,16 @@ generates:
       - typescript-operations
       - typescript-react-query
     config:
-      fetcher: './my-file#myFetcher'
+      fetcher:
+        func: './my-file#myFetcher'
+        lazyVariables: false # optional, defaults to false, controls the function's signature. Read below
+```
+
+As a shortcut, the `fetcher` property may also directly contain the function as a mapper string:
+```yml
+    #...
+    config:
+      fetcher: './my-file#myFetcher' # lazyVariables is false here (the default version)
 ```
 
 Codegen will use `myFetcher`, and you can just use the hook directly:
@@ -166,13 +175,17 @@ export const MyComponent = () => {
 };
 ```
 
-Your `myFetcher` should be in the following signature:
+Depending on the `lazyVariables` property, your `myFetcher` should be in the following signature:
+* `lazyVariables: false`
+  ```ts
+  type MyFetcher<TData, TVariables> = (operation: string, variables?: TVariables): (() => Promise<TData>)
+  ```
+* `lazyVariables: true`
+  ```ts
+  type MyFetcher<TData, TVariables> = (operation: string): ((variables?: TVariables) => Promise<TData>)
+  ```
 
-```ts
-type MyFetcher<TData, TVariables> = (operation: string, variables?: TVariables): (() => Promise<TData>)
-```
-
-#### Usage example
+#### Usage example (`lazyVariables: false`)
 ```tsx
 export const fetchData = <TData, TVariables>(query: string, variables?: TVariables): (() => Promise<TData>) => {
   return async () => {
@@ -180,6 +193,36 @@ export const fetchData = <TData, TVariables>(query: string, variables?: TVariabl
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query,
+        variables,
+      }),
+    });
+
+    const json = await res.json();
+
+    if (json.errors) {
+      const { message } = json.errors[0] || 'Error..';
+      throw new Error(message);
+    }
+
+    return json.data;
+  };
+};
+```
+
+#### Usage example (`lazyVariables: true`)
+```tsx
+export const fetchData = <TData, TVariables>(query: string): (() => Promise<TData>) => {
+  // it is safe to call React Hooks here.
+  const {url, headers} = React.useContext(FetchParamsContext);
+  return async (variables?: TVariables) => {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers
       },
       body: JSON.stringify({
         query,

--- a/website/docs/plugins/typescript-react-query.md
+++ b/website/docs/plugins/typescript-react-query.md
@@ -155,14 +155,14 @@ generates:
     config:
       fetcher:
         func: './my-file#myFetcher'
-        lazyVariables: false # optional, defaults to false, controls the function's signature. Read below
+        isReactHook: false # optional, defaults to false, controls the function's signature. Read below
 ```
 
 As a shortcut, the `fetcher` property may also directly contain the function as a mapper string:
 ```yml
     #...
     config:
-      fetcher: './my-file#myFetcher' # lazyVariables is false here (the default version)
+      fetcher: './my-file#myFetcher' # isReactHook is false here (the default version)
 ```
 
 Codegen will use `myFetcher`, and you can just use the hook directly:
@@ -175,17 +175,17 @@ export const MyComponent = () => {
 };
 ```
 
-Depending on the `lazyVariables` property, your `myFetcher` should be in the following signature:
-* `lazyVariables: false`
+Depending on the `isReactHook` property, your `myFetcher` should be in the following signature:
+* `isReactHook: false`
   ```ts
   type MyFetcher<TData, TVariables> = (operation: string, variables?: TVariables): (() => Promise<TData>)
   ```
-* `lazyVariables: true`
+* `isReactHook: true`
   ```ts
   type MyFetcher<TData, TVariables> = (operation: string): ((variables?: TVariables) => Promise<TData>)
   ```
 
-#### Usage example (`lazyVariables: false`)
+#### Usage example (`isReactHook: false`)
 ```tsx
 export const fetchData = <TData, TVariables>(query: string, variables?: TVariables): (() => Promise<TData>) => {
   return async () => {
@@ -212,9 +212,9 @@ export const fetchData = <TData, TVariables>(query: string, variables?: TVariabl
 };
 ```
 
-#### Usage example (`lazyVariables: true`)
+#### Usage example (`isReactHook: true`)
 ```tsx
-export const fetchData = <TData, TVariables>(query: string): (() => Promise<TData>) => {
+export const useFetchData = <TData, TVariables>(query: string): (() => Promise<TData>) => {
   // it is safe to call React Hooks here.
   const {url, headers} = React.useContext(FetchParamsContext);
   return async (variables?: TVariables) => {


### PR DESCRIPTION
Currently the generated hooks use the custom fetcher in the following way:

query hooks: They invoke the fetcher inline. I.e you could **use react hooks in your fetcher**
mutation hooks: They create a lambda function that will invoke your fetcher at a later time, when react query performs your mutation. i.e you cannot use react hooks in your fetcher.

**Wait, why would you want to use react hooks in your fetcher?**
My usecase is rather simple: I have to inject some headers and the fetch url at runtime. So in order to not pass them to the queries and mutations everywhere in the code, I could keep them in a `ReactContext` and retrieve them through `useContext` in the fetcher.

**The solution**
This PR extends the `fetcher` option and allows one to pass an object with the following interface:
```
{
   func: string; // this is the custom identifier eg ./myFile#useMyFetcher
   lazyVariables?: bool // this specifies that useMyFetcher will not receive the query variables itself. *The async function it returns will receive those variables instead*
}
```
Omitting `lazyVariables` is equivalent to just passing the custom fetcher string and getting the old functionality.

If `lazyVariables` is `true`, then fetcher should look like this:

```
function useMyFetcher<TData, TVariables>(document: string) {
  // it's now safe to call any react hook here
  // ex:
  // const url = useContext(URLContext);
   return async (variables?: TVariables) {
      await fetch(...);
   }
}
```
