### PR TITLE
declare a peer dependency on graphql-request

### DIFF
--- a/.changeset/four-pots-suffer.md
+++ b/.changeset/four-pots-suffer.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-graphql-request': patch
+---
+
+fix(typescript-graphql-request): declare a peer dependency on graphql-request

--- a/.changeset/smooth-tools-trade.md
+++ b/.changeset/smooth-tools-trade.md
@@ -1,5 +1,0 @@
----
-"@graphql-codegen/typescript-graphql-request": patch
----
-
-declare a peer dependency on graphql-request

--- a/.changeset/smooth-tools-trade.md
+++ b/.changeset/smooth-tools-trade.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-graphql-request": patch
+---
+
+declare a peer dependency on graphql-request

--- a/packages/plugins/typescript/graphql-request/package.json
+++ b/packages/plugins/typescript/graphql-request/package.json
@@ -21,6 +21,7 @@
   },
   "peerDependencies": {
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0",
+    "graphql-request": "^3.4.0",
     "graphql-tag": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I had graphql-request 3.3.0 installed and the types weren't working out. I had to look at the changelog to figure out what version of graphql-request I needed.