### PR TITLE
Added support for multi-search

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -31,3 +31,9 @@ jobs:
           FOLDER: website/build
           CLEAN: true
           SINGLE_COMMIT: true
+      - name: Index Docs
+        uses: darrenjennings/algolia-docsearch-action@master
+        with:
+          algolia_api_key: ${{ secrets.ALGOLIA_API_KEY }}
+          algolia_application_id: ${{ secrets.ALGOLIA_APPLICATION_ID }}
+          file: algolia/config.json

--- a/algolia/config.json
+++ b/algolia/config.json
@@ -1,0 +1,48 @@
+{
+  "index_name": "theguild",
+  "start_urls": [
+    "https://graphql-mesh.com/docs/",
+    "https://graphql-mesh.com/docs/getting-started/introduction",
+    "https://www.graphql-tools.com/docs/",
+    "https://www.graphql-tools.com/docs/introduction",
+    "https://graphql-config.com/",
+    "https://graphql-inspector.com/docs/",
+    "https://graphql-inspector.com/docs/index",
+    "https://graphql-modules.com/docs/",
+    "https://graphql-cli.com/introduction",
+    "https://the-guild.dev/"
+  ],
+  "sitemap_urls": [
+    "https://graphql-mesh.com/sitemap.xml",
+    "https://graphql-tools.com/sitemap.xml",
+    "https://graphql-config.com/sitemap.xml",
+    "https://graphql-inspector.com/sitemap.xml",
+    "https://graphql-modules.com/sitemap.xml",
+    "https://graphql-cli.com/sitemap.xml",
+    "https://the-guild.dev/sitemap.xml"
+  ],
+  "sitemap_alternate_links": true,
+  "stop_urls": [],
+  "selectors": {
+    "lvl0": {
+      "selector": ".menu__link--sublist.menu__link--active",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5",
+    "lvl6": "article h6",
+    "text": "article p, article li"
+  },
+  "strip_chars": " .,;:#",
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": ["language", "version", "type"],
+    "attributesToRetrieve": ["hierarchy", "content", "anchor", "url", "url_without_anchor", "type"]
+  },
+  "conversation_id": ["1138947400"],
+  "nb_hits": 3036
+}

--- a/packages/presets/graphql-modules/src/utils.ts
+++ b/packages/presets/graphql-modules/src/utils.ts
@@ -1,12 +1,12 @@
 import {
-  DocumentNode,
-  Kind,
   DefinitionNode,
+  DocumentNode,
   FieldDefinitionNode,
   InputValueDefinitionNode,
+  Kind,
   NamedTypeNode,
-  TypeNode,
   Source,
+  TypeNode,
 } from 'graphql';
 import parse from 'parse-filepath';
 

--- a/packages/presets/graphql-modules/src/utils.ts
+++ b/packages/presets/graphql-modules/src/utils.ts
@@ -139,16 +139,14 @@ export function groupSourcesByModule(sources: Source[], basePath: string): Recor
   const grouped: Record<string, Source[]> = {};
 
   sources.forEach(source => {
-    if (source.name.indexOf(basePath) !== -1) {
-      // PERF: we could guess the module by matching source.location with a list of already resolved paths
-      const mod = extractModuleDirectory(source.name, basePath);
+    // PERF: we could guess the module by matching source.location with a list of already resolved paths
+    const mod = extractModuleDirectory(source.name, basePath);
 
-      if (!grouped[mod]) {
-        grouped[mod] = [];
-      }
-
-      grouped[mod].push(source);
+    if (!grouped[mod]) {
+      grouped[mod] = [];
     }
+
+    grouped[mod].push(source);
   });
 
   return grouped;

--- a/patches/@docsearch+react+3.0.0-alpha.32.patch
+++ b/patches/@docsearch+react+3.0.0-alpha.32.patch
@@ -1,0 +1,44 @@
+diff --git a/node_modules/@docsearch/react/dist/esm/DocSearchModal.js b/node_modules/@docsearch/react/dist/esm/DocSearchModal.js
+index 12c8367..41e9bec 100644
+--- a/node_modules/@docsearch/react/dist/esm/DocSearchModal.js
++++ b/node_modules/@docsearch/react/dist/esm/DocSearchModal.js
+@@ -230,7 +230,7 @@ export function DocSearchModal(_ref) {
+               getItems: function getItems() {
+                 return Object.values(groupBy(items, function (item) {
+                   return item.hierarchy.lvl1;
+-                })).map(transformItems).map(function (hits) {
++                })).map(function (hits) {
+                   return hits.map(function (item) {
+                     return _objectSpread(_objectSpread({}, item), {}, {
+                       // eslint-disable-next-line @typescript-eslint/camelcase
+diff --git a/node_modules/@docsearch/react/dist/esm/Results.js b/node_modules/@docsearch/react/dist/esm/Results.js
+index 2b3096c..ca6da66 100644
+--- a/node_modules/@docsearch/react/dist/esm/Results.js
++++ b/node_modules/@docsearch/react/dist/esm/Results.js
+@@ -91,7 +91,7 @@ function Result(_ref) {
+     className: "DocSearch-Hit-title",
+     hit: item,
+     attribute: "hierarchy.lvl1"
+-  }), item.content && /*#__PURE__*/React.createElement(Snippet, {
++  }),/*#__PURE__*/React.createElement('div', {style: {fontSize: "10px"}}, `${item.url}`), item.content && /*#__PURE__*/React.createElement(Snippet, {
+     className: "DocSearch-Hit-path",
+     hit: item,
+     attribute: "content"
+@@ -101,7 +101,7 @@ function Result(_ref) {
+     className: "DocSearch-Hit-title",
+     hit: item,
+     attribute: "hierarchy.".concat(item.type)
+-  }), /*#__PURE__*/React.createElement(Snippet, {
++  }),/*#__PURE__*/React.createElement('div', {style: {fontSize: "10px"}}, `${item.url}`), /*#__PURE__*/React.createElement(Snippet, {
+     className: "DocSearch-Hit-path",
+     hit: item,
+     attribute: "hierarchy.lvl1"
+@@ -111,7 +111,7 @@ function Result(_ref) {
+     className: "DocSearch-Hit-title",
+     hit: item,
+     attribute: "content"
+-  }), /*#__PURE__*/React.createElement(Snippet, {
++  }),/*#__PURE__*/React.createElement('div', {style: {fontSize: "10px"}}, `${item.url}`), /*#__PURE__*/React.createElement(Snippet, {
+     className: "DocSearch-Hit-path",
+     hit: item,
+     attribute: "hierarchy.lvl1"

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,23 @@
+# Website
+
+This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
+
+## Installation
+
+Run `yarn` from the root directory
+
+## Building the plugins
+
+You will need to build the plugins before firing up the development server.
+
+Run `yarn build` from the root directory
+
+## Local Development
+
+`$ yarn start`
+
+This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
+
+## Generate a static version of the website
+
+Run `yarn build:website` from the website directory to build the static website

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -16,9 +16,10 @@ module.exports = {
       trackingID: 'UA-128969121-3',
     },
     algolia: {
-      apiKey: 'dc81d9e0ead1aecb5e776d262181ceeb',
-      indexName: 'graphql-code-generator',
-      searchParameters: {},
+      appId: 'ANRJKXZTRW',
+      apiKey: '811d453fc7f80306044dd5cc4b87e064',
+      indexName: 'theguild',
+      algoliaOptions: {},
     },
     navbar: {
       title: 'GraphQL Code Generator',


### PR DESCRIPTION
@Urigo @ardatan Only a very small change is needed to be made to enable multi-search on the client side. 

Have added the client side changes to this PR which works across multiple Guild websites.

In addition to it, I have also added a README to the website folder to document running the website locally

**NOTE:** [The indexer](https://github.com/tvvignesh/algolia-docsearch-indexer) has to be run manually or on schedule after setting it up in a server for updating the search results in  the index as the docs on the relevant websites are changed.