### PR TITLE
allow csharp plugin to emit c# 9 record types instead of classes

### DIFF
--- a/.changeset/four-pillows-explain.md
+++ b/.changeset/four-pillows-explain.md
@@ -1,0 +1,20 @@
+---
+'@graphql-codegen/c-sharp': patch
+---
+
+This release adds support to optionally emit c# 9 records instead of classes.
+
+To enable this, add `emitRecords: true` to your codegen yaml or json configuration file. Example:
+
+```yaml
+schema: './types.graphql'
+generates:
+  ./src/types.cs:
+    plugins:
+    - c-sharp
+config:
+    namespaceName: My.Types
+    emitRecords: true
+    scalars:
+      DateTime: DateTime
+```

--- a/.changeset/four-pillows-explain.md
+++ b/.changeset/four-pillows-explain.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-codegen/c-sharp': patch
+'@graphql-codegen/c-sharp': minor
 ---
 
 This release adds support to optionally emit c# 9 records instead of classes.

--- a/packages/plugins/c-sharp/c-sharp/package.json
+++ b/packages/plugins/c-sharp/c-sharp/package.json
@@ -14,7 +14,8 @@
     "@graphql-codegen/visitor-plugin-common": "^1.17.20",
     "strip-indent": "^3.0.0",
     "tslib": "~2.1.0",
-    "unixify": "^1.0.0"
+    "unixify": "^1.0.0",
+    "change-case": "^4.1.2"
   },
   "peerDependencies": {
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"

--- a/packages/plugins/c-sharp/c-sharp/src/config.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/config.ts
@@ -47,7 +47,7 @@ export interface CSharpResolversPluginRawConfig extends RawConfig {
    */
   className?: string;
   /**
-   * @default IEnumberable
+   * @default IEnumerable
    * @description Allow you to customize the list type
    *
    * @exampleMarkdown
@@ -61,4 +61,20 @@ export interface CSharpResolversPluginRawConfig extends RawConfig {
    * ```
    */
   listType?: string;
+
+  /**
+   * @default false
+   * @description Emit C# 9.0+ records instead of classes
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   src/main/c-sharp/my-org/my-app/Types.cs:
+   *     plugins:
+   *       - c-sharp
+   *     config:
+   *       emitRecords: true
+   * ```
+   */
+  emitRecords?: boolean;
 }

--- a/packages/plugins/c-sharp/c-sharp/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/visitor.ts
@@ -368,6 +368,9 @@ ${classMembers}
   }
 
   ObjectTypeDefinition(node: ObjectTypeDefinitionNode): string {
+    if (this.config.emitRecords) {
+      return this.buildRecord(node.name.value, node.description, node.fields, node.interfaces);
+    }
     return this.buildClass(node.name.value, node.description, node.fields, node.interfaces);
   }
 

--- a/packages/plugins/c-sharp/c-sharp/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/visitor.ts
@@ -38,6 +38,7 @@ import {
   wrapFieldType,
   getListTypeField,
 } from '../../common/common';
+import { pascalCase } from 'change-case';
 
 export interface CSharpResolverParsedConfig extends ParsedConfig {
   namespaceName: string;
@@ -254,8 +255,7 @@ export class CSharpResolversVisitor extends BaseVisitor<CSharpResolversPluginRaw
     const recordMembers = inputValueArray
       .map(arg => {
         const fieldType = this.resolveInputFieldType(arg.type);
-        //const fieldHeader = this.getFieldHeader(arg, fieldType);
-        const fieldName = this.convertSafeName(arg.name);
+        const fieldName = pascalCase(this.convertSafeName(arg.name));
         const csharpFieldType = wrapFieldType(fieldType, fieldType.listType, this.config.listType);
         return `${csharpFieldType} ${fieldName}`;
       })
@@ -277,7 +277,7 @@ export class CSharpResolversVisitor extends BaseVisitor<CSharpResolversPluginRaw
       .map(arg => {
         const fieldType = this.resolveInputFieldType(arg.type);
         const fieldHeader = this.getFieldHeader(arg, fieldType);
-        const fieldName = this.convertSafeName(arg.name);
+        const fieldName = pascalCase(this.convertSafeName(arg.name));
         const csharpFieldType = wrapFieldType(fieldType, fieldType.listType, this.config.listType);
         return fieldHeader + indent(`public ${csharpFieldType} ${fieldName} { get; set; }`);
       })

--- a/packages/plugins/c-sharp/c-sharp/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/visitor.ts
@@ -318,9 +318,23 @@ ${classMembers}
       .map(arg => {
         const fieldType = this.resolveInputFieldType(arg.type);
         const fieldHeader = this.getFieldHeader(arg, fieldType);
-        const fieldName = this.convertSafeName(arg.name);
+
+        let fieldName: string;
+        let getterSetter: string;
+
+        if (this.config.emitRecords) {
+          // record
+          fieldName = this.convertSafeName(pascalCase(this.convertName(arg.name)));
+          getterSetter = '{ get; }';
+        } else {
+          // class
+          fieldName = this.convertSafeName(arg.name);
+          getterSetter = '{ get; set; }';
+        }
+
         const csharpFieldType = wrapFieldType(fieldType, fieldType.listType, this.config.listType);
-        return fieldHeader + indent(`public ${csharpFieldType} ${fieldName} { get; set; }`);
+
+        return fieldHeader + indent(`public ${csharpFieldType} ${fieldName} ${getterSetter}`);
       })
       .join('\n\n');
 

--- a/packages/plugins/c-sharp/c-sharp/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/visitor.ts
@@ -255,7 +255,7 @@ export class CSharpResolversVisitor extends BaseVisitor<CSharpResolversPluginRaw
     const recordMembers = inputValueArray
       .map(arg => {
         const fieldType = this.resolveInputFieldType(arg.type);
-        const fieldName = pascalCase(this.convertSafeName(arg.name));
+        const fieldName = this.convertSafeName(pascalCase(this.convertName(arg.name)));
         const csharpFieldType = wrapFieldType(fieldType, fieldType.listType, this.config.listType);
         return `${csharpFieldType} ${fieldName}`;
       })
@@ -277,7 +277,7 @@ export class CSharpResolversVisitor extends BaseVisitor<CSharpResolversPluginRaw
       .map(arg => {
         const fieldType = this.resolveInputFieldType(arg.type);
         const fieldHeader = this.getFieldHeader(arg, fieldType);
-        const fieldName = pascalCase(this.convertSafeName(arg.name));
+        const fieldName = this.convertSafeName(pascalCase(this.convertName(arg.name)));
         const csharpFieldType = wrapFieldType(fieldType, fieldType.listType, this.config.listType);
         return fieldHeader + indent(`public ${csharpFieldType} ${fieldName} { get; set; }`);
       })

--- a/packages/plugins/c-sharp/c-sharp/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/visitor.ts
@@ -292,7 +292,7 @@ ${recordMembers}
       .map(arg => {
         const fieldType = this.resolveInputFieldType(arg.type);
         const fieldHeader = this.getFieldHeader(arg, fieldType);
-        const fieldName = this.convertSafeName(pascalCase(this.convertName(arg.name)));
+        const fieldName = this.convertSafeName(arg.name);
         const csharpFieldType = wrapFieldType(fieldType, fieldType.listType, this.config.listType);
         return fieldHeader + indent(`public ${csharpFieldType} ${fieldName} { get; set; }`);
       })
@@ -386,6 +386,7 @@ ${classMembers}
     if (this.config.emitRecords) {
       return this.buildRecord(node.name.value, node.description, node.fields, node.interfaces);
     }
+
     return this.buildClass(node.name.value, node.description, node.fields, node.interfaces);
   }
 

--- a/packages/plugins/c-sharp/c-sharp/test/c-sharp.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp/test/c-sharp.spec.ts
@@ -248,7 +248,15 @@ describe('C#', () => {
       const result = await plugin(schema, [], {}, { outputFile: '' });
       expect(result).toContain('public class User {');
     });
-
+    it('Should generate C# record for type', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type User {
+          id: Int
+        }
+      `);
+      const result = await plugin(schema, [], { emitRecords: true }, { outputFile: '' });
+      expect(result).toContain('public record User(int? Id) {');
+    });
     it('Should wrap generated classes in Type class', async () => {
       const schema = buildSchema(/* GraphQL */ `
         type User {

--- a/packages/plugins/c-sharp/common/c-sharp-declaration-block.ts
+++ b/packages/plugins/c-sharp/common/c-sharp-declaration-block.ts
@@ -3,7 +3,7 @@ import { StringValueNode, NameNode } from 'graphql';
 import { transformComment } from './utils';
 
 export type Access = 'private' | 'public' | 'protected';
-export type Kind = 'namespace' | 'class' | 'interface' | 'enum';
+export type Kind = 'namespace' | 'class' | 'record' | 'interface' | 'enum';
 
 export class CSharpDeclarationBlock {
   _name: string = null;

--- a/packages/plugins/c-sharp/common/keywords.ts
+++ b/packages/plugins/c-sharp/common/keywords.ts
@@ -54,6 +54,7 @@ export const csharpKeywords = [
   'protected',
   'public',
   'readonly',
+  'record',
   'ref',
   'return',
   'sbyte',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6719,6 +6719,15 @@ capital-case@^1.0.3:
     tslib "^1.10.0"
     upper-case-first "^2.0.1"
 
+capital-case@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
+  integrity sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
+
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
@@ -6794,6 +6803,24 @@ change-case@^4.1.1:
     sentence-case "^3.0.3"
     snake-case "^3.0.3"
     tslib "^1.10.0"
+
+change-case@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"
+  integrity sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
+  dependencies:
+    camel-case "^4.1.2"
+    capital-case "^1.0.4"
+    constant-case "^3.0.4"
+    dot-case "^3.0.4"
+    header-case "^2.0.4"
+    no-case "^3.0.4"
+    param-case "^3.0.4"
+    pascal-case "^3.1.2"
+    path-case "^3.0.4"
+    sentence-case "^3.0.4"
+    snake-case "^3.0.4"
+    tslib "^2.0.3"
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -7332,7 +7359,7 @@ consolidate@^0.16.0:
   dependencies:
     bluebird "^3.7.2"
 
-constant-case@3.0.4:
+constant-case@3.0.4, constant-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.4.tgz#3b84a9aeaf4cf31ec45e6bf5de91bdfb0589faf1"
   integrity sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==
@@ -10409,6 +10436,14 @@ header-case@^2.0.3:
   dependencies:
     capital-case "^1.0.3"
     tslib "^1.10.0"
+
+header-case@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
+  integrity sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==
+  dependencies:
+    capital-case "^1.0.4"
+    tslib "^2.0.3"
 
 hex-color-regex@^1.1.0:
   version "1.1.0"
@@ -14389,7 +14424,7 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
-param-case@3.0.4:
+param-case@3.0.4, param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
   integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
@@ -14542,6 +14577,14 @@ path-case@^3.0.3:
   dependencies:
     dot-case "^3.0.3"
     tslib "^1.10.0"
+
+path-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
+  integrity sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -17011,6 +17054,15 @@ sentence-case@^3.0.3:
     tslib "^1.10.0"
     upper-case-first "^2.0.1"
 
+sentence-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
+  integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
+
 serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
@@ -17243,6 +17295,14 @@ snake-case@^3.0.3:
   dependencies:
     dot-case "^3.0.3"
     tslib "^1.10.0"
+
+snake-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
+  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -18747,6 +18807,13 @@ upper-case-first@^2.0.1:
   integrity sha512-105J8XqQ+9RxW3l9gHZtgve5oaiR9TIwvmZAMAIZWRHe00T21cdvewKORTlOJf/zXW6VukuTshM+HXZNWz7N5w==
   dependencies:
     tslib "^1.10.0"
+
+upper-case-first@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
+  integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
+  dependencies:
+    tslib "^2.0.3"
 
 upper-case@2.0.2, upper-case@^2.0.1, upper-case@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Add an `emitRecords: true` to config, and it will spit out the immutable syntax (init-only) for c# 9 records, e.g. `record MyType(int Age, string Name) : <interfacelist>` etc. Note that the fields/parameters are PascalCased, as they should be in this case since they are exposed as properties.

```yaml
schema:
  - ./types.graphql
  - ./units.graphql
generates:
  ./src/types.cs:
    plugins:
    - c-sharp
config:
    namespaceName: MyNamespace.Types
    emitRecords: true
    scalars:
        ISO8601DateTime: DateTime
```

~~Oh, and I squeaked in a fix for enforcing Pascal Case on C# public properties too. EDIT: which broke tests expecting lower case property names, oops. Will fix tomorrow.~~

input:

```graphql
type Account {
  id: ID!
  login: String!
  lastLogin: ISO8601DateTime
  locations: [Location!]
  disabled: Boolean!
}
```

example output (for records)

```c#
#region Account
    public record Account(string Id, string Login, DateTime LastLogin, List<Location> Locations, bool Disabled) {
      #region members
      [JsonProperty("id")]
      public string Id { get; init; } = Id;
    
      [JsonProperty("login")]
      public string Login { get; init; } = Login;
    
      [JsonProperty("lastLogin")]
      public DateTime LastLogin { get; init; } = LastLogin;
    
      [JsonProperty("locations")]
      public List<Location> Locations { get; init; } = Locations;
    
      [JsonProperty("disabled")]
      public bool Disabled { get; init; } = Disabled;
      #endregion
    }
    #endregion
```
(p.s. I dislike regions, but the class generator uses them already)