### PR TITLE
Add generates.preset

### DIFF
--- a/website/docs/getting-started/codegen-config.md
+++ b/website/docs/getting-started/codegen-config.md
@@ -48,6 +48,8 @@ Here are the supported options that you can define in the config file (see [sour
 - **`generates` (required)** - A map where the key represents an output path for the generated code and the value represents a set of options which are relevant for that specific file. Below are the possible options that can be specified:
 
   - **`generates.plugins` (required)** - A list of plugins to use when generating the file. Templates are also considered as plugins and they can be specified in this section. A full list of supported plugins can be found [here](../plugins/index.md). You can also point to a custom plugin in a local file (see [Custom Plugins](../custom-codegen/index.md)).
+  
+  - [**`generates.preset`**](../presets/index.md) - A list of available presets for generated files. Such as [`near-operation-file`](../presets/near-operation-file.md#example), which generates files alongside your documents.
 
   - [**`generates.schema`**](schema-field.md#output-file-level) - Same as root `schema`, but applies only for the specific output file.
 


### PR DESCRIPTION
Adds `generates.preset` documentation to highlight some of the presets available such as near-operation-file.

When I was setting up for the first pass it wasn't clear to me that all the documents no matter where in the repo would just end up in a single file.
We might want to look into adding a step in the cli tool to offer presets as an option. Not sure how that would work though.