### PR TITLE
Add support for useTypeImports when using fetcher: graphql-request

### DIFF
--- a/.changeset/heavy-gifts-ring.md
+++ b/.changeset/heavy-gifts-ring.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': major
+---
+
+Add support for useTypeImports when using fetcher: graphql-request

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -22,7 +22,9 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     hasRequiredVariables: boolean
   ): string {
     const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
-    this.visitor.imports.add(`import { GraphQLClient } from 'graphql-request';`);
+
+    const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
+    this.visitor.imports.add(`${typeImport} { GraphQLClient } from 'graphql-request';`);
 
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -224,6 +224,16 @@ describe('React-Query', () => {
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config, false);
     });
+    it('Should support useTypeImports', async () => {
+      const config = {
+        fetcher: 'graphql-request',
+        useTypeImports: true,
+      };
+
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+
+      expect(out.prepend).toContain(`import type { GraphQLClient } from 'graphql-request';`);
+    });
   });
 
   describe('fetcher: hardcoded-fetch', () => {


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

Add support for useTypeImports when using fetcher: graphql-request.

Related https://github.com/dotansimha/graphql-code-generator/issues/5478

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

`yarn build && yarn test`

- [x] Added new unit test

**Test Environment**:
- OS: macOS 10.15.7
- `@graphql-codegen/...`: 
- NodeJS: 15.6.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules

## Further comments

It would be awesome if this fix could be applied as a patch to version `0.1` in addition to version `1`