### PR TITLE
Umbrella PR - federation resolvers plugin refactor

### DIFF
--- a/.changeset/giant-ravens-return.md
+++ b/.changeset/giant-ravens-return.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-resolvers': minor
+---
+
+Some fixes and attempts to make it better

--- a/packages/utils/graphql-codegen-testing/src/typescript.ts
+++ b/packages/utils/graphql-codegen-testing/src/typescript.ts
@@ -1,6 +1,6 @@
 import { Types } from '@graphql-codegen/plugin-helpers';
 import { resolve, join, dirname } from 'path';
-import * as lzString from 'lz-string';
+// import * as lzString from 'lz-string';
 
 import type { CompilerOptions, ScriptTarget as ScriptTargetType } from 'typescript';
 
@@ -18,9 +18,9 @@ import {
   getPreEmitDiagnostics,
 } from 'typescript';
 
-import open from 'open';
+// import open from 'open';
 
-const { compressToEncodedURIComponent } = lzString;
+// const { compressToEncodedURIComponent } = lzString;
 
 export function validateTs(
   pluginOutput: Types.PluginOutput,
@@ -243,8 +243,8 @@ export function compileTs(
     }
   } catch (e) {
     if (openPlayground) {
-      const compressedCode = compressToEncodedURIComponent(contents);
-      open('http://www.typescriptlang.org/play/#code/' + compressedCode);
+      // const compressedCode = compressToEncodedURIComponent(contents);
+      // open('http://www.typescriptlang.org/play/#code/' + compressedCode);
     }
 
     throw e;


### PR DESCRIPTION
Yes we already support Federation in `typescript-resolvers` but it kind of broken... and we want to fix it!

## Umbrella PR

Treat this PR as a base for smaller, atomic PRs. Here's a [doc on Notion](https://www.notion.so/Federation-typescript-resolvers-3b47e825ff9a43b7a970c28e8784a6f70) explaining what, how and why.

## We need help!

We want to get there quickly and if there's a chance someone from the community can help us, it would be awesome! 😎 

A list of tasks is available as jest tests (or todos) in `packages/plugins/typescript/resolvers/tests/federation.spec.ts` file but also here:

- [x] should add `__resolveReference` to objects with `@key`
- [x] `__resolveReference` should use a union of `@key` directives
- [ ] only fields specified by `@requires` should be available in parent object
- [x] do not create resolvers for `@external` fields
- [ ] should accept a `reference`
- [ ] should accept a `reference` based on union of `@key` directives
- [x] should NOT accept a `reference` on an external type without `@key`
- [x] should NOT accept a `reference` on an external type (with `@extends`) without `@key`
- [x] should NOT accept a `reference` on a local (non-external) type
- [ ] support `__resolveObject`
- [ ] should mapper apply to `__resolveReference` as output?
- [ ] should mapper apply to `__resolveReference` as input?
- [ ] mappers should not collide with references - both accepted
- [ ] check if Federation allows to resolve a custom object and if so then what data goes to other services - is it the custom object or an object matching GraphQL type.


## How to help

You can help in two ways:
- create a test to make sure we follow federation spec
- implement a part of Federation into typescript-resolvers plugin
- discuss with us the implementation and tests
- make sure we follow Federation spec

if you eager to help, please mention @kamilkisiela (me) or @dotansimha in a comment and let's get things done!
