### PR TITLE
Allow to generate only __resolveType for interfaces resolvers

### DIFF
--- a/.changeset/pretty-bananas-destroy.md
+++ b/.changeset/pretty-bananas-destroy.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-resolvers': minor
+---
+
+NEW CONFIG (`onlyResolveTypeForInterfaces`): Allow to generate only \_\_resolveType for interfaces

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -136,6 +136,19 @@ describe('TypeScript Resolvers Plugin', () => {
   });
 
   describe('Config', () => {
+    it('onlyResolveTypeForInterfaces - should allow to have only resolveType for interfaces', async () => {
+      const config = {
+        onlyResolveTypeForInterfaces: true,
+      };
+      const result = await plugin(schema, [], config, { outputFile: '' });
+      const content = await validate(result, config, schema);
+
+      expect(content).toBeSimilarStringTo(`
+      export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
+        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+      };`);
+    });
+
     it('optionalInfoArgument - should allow to have optional info argument', async () => {
       const config = {
         noSchemaStitching: true,


### PR DESCRIPTION
Related: https://github.com/dotansimha/graphql-code-generator/issues/5648