### PR TITLE
feat: configuration of default scalar type

### DIFF
--- a/.changeset/wild-rules-press.md
+++ b/.changeset/wild-rules-press.md
@@ -1,0 +1,14 @@
+---
+'@graphql-codegen/c-sharp': minor
+'@graphql-codegen/c-sharp-operations': minor
+'@graphql-codegen/java': minor
+'@graphql-codegen/kotlin': minor
+'@graphql-codegen/java-resolvers': minor
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-compatibility': minor
+'@graphql-codegen/typescript-mongodb': minor
+'@graphql-codegen/typescript': minor
+'@graphql-codegen/near-operation-file-preset': minor
+---
+
+Added new configuration settings for scalars: `strictScalars` and `defaultScalarType`

--- a/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
@@ -5,8 +5,8 @@ import {
   LoadedFragment,
   indentMultiline,
   getBaseTypeNode,
-  buildScalars,
   indent,
+  buildScalarsFromConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import autoBind from 'auto-bind';
 import {
@@ -88,7 +88,7 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
         querySuffix: rawConfig.querySuffix || defaultSuffix,
         mutationSuffix: rawConfig.mutationSuffix || defaultSuffix,
         subscriptionSuffix: rawConfig.subscriptionSuffix || defaultSuffix,
-        scalars: buildScalars(schema, rawConfig.scalars, C_SHARP_SCALARS),
+        scalars: buildScalarsFromConfig(schema, rawConfig, C_SHARP_SCALARS),
         typesafeOperation: rawConfig.typesafeOperation || false,
       },
       documents

--- a/packages/plugins/c-sharp/c-sharp/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/visitor.ts
@@ -4,8 +4,8 @@ import {
   EnumValuesMap,
   indentMultiline,
   indent,
-  buildScalars,
   getBaseTypeNode,
+  buildScalarsFromConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import { CSharpResolversPluginRawConfig } from './config';
 import {
@@ -58,7 +58,7 @@ export class CSharpResolversVisitor extends BaseVisitor<CSharpResolversPluginRaw
       namespaceName: rawConfig.namespaceName || 'GraphQLCodeGen',
       className: rawConfig.className || 'Types',
       emitRecords: rawConfig.emitRecords || false,
-      scalars: buildScalars(_schema, rawConfig.scalars, C_SHARP_SCALARS),
+      scalars: buildScalarsFromConfig(_schema, rawConfig, C_SHARP_SCALARS),
     });
   }
 

--- a/packages/plugins/java/java/src/visitor.ts
+++ b/packages/plugins/java/java/src/visitor.ts
@@ -4,8 +4,8 @@ import {
   EnumValuesMap,
   indentMultiline,
   indent,
-  buildScalars,
   getBaseTypeNode,
+  buildScalarsFromConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import { JavaResolversPluginRawConfig } from './config';
 import {
@@ -44,7 +44,7 @@ export class JavaResolversVisitor extends BaseVisitor<JavaResolversPluginRawConf
       className: rawConfig.className || 'Types',
       classMembersPrefix: rawConfig.classMembersPrefix || '',
       package: rawConfig.package || defaultPackageName,
-      scalars: buildScalars(_schema, rawConfig.scalars, JAVA_SCALARS, 'Object'),
+      scalars: buildScalarsFromConfig(_schema, rawConfig, JAVA_SCALARS, 'Object'),
     });
   }
 

--- a/packages/plugins/java/kotlin/src/visitor.ts
+++ b/packages/plugins/java/kotlin/src/visitor.ts
@@ -1,12 +1,12 @@
 import {
   BaseVisitor,
-  buildScalars,
   EnumValuesMap,
   indent,
   indentMultiline,
   ParsedConfig,
   transformComment,
   getBaseTypeNode,
+  buildScalarsFromConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import { KotlinResolversPluginRawConfig } from './config';
 import {
@@ -54,7 +54,7 @@ export class KotlinResolversVisitor extends BaseVisitor<KotlinResolversPluginRaw
       listType: rawConfig.listType || 'Iterable',
       withTypes: rawConfig.withTypes || false,
       package: rawConfig.package || defaultPackageName,
-      scalars: buildScalars(_schema, rawConfig.scalars, KOTLIN_SCALARS),
+      scalars: buildScalarsFromConfig(_schema, rawConfig, KOTLIN_SCALARS),
     });
   }
 

--- a/packages/plugins/java/resolvers/src/visitor.ts
+++ b/packages/plugins/java/resolvers/src/visitor.ts
@@ -7,8 +7,8 @@ import {
   indent,
   indentMultiline,
   getBaseTypeNode,
-  buildScalars,
   ExternalParsedMapper,
+  buildScalarsFromConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import { JavaResolversPluginRawConfig } from './config';
 import { JAVA_SCALARS, JavaDeclarationBlock, wrapTypeWithModifiers } from '@graphql-codegen/java-common';
@@ -39,7 +39,7 @@ export class JavaResolversVisitor extends BaseVisitor<JavaResolversPluginRawConf
       defaultMapper: parseMapper(rawConfig.defaultMapper || 'Object'),
       className: rawConfig.className || 'Resolvers',
       listType: rawConfig.listType || 'Iterable',
-      scalars: buildScalars(_schema, rawConfig.scalars, JAVA_SCALARS, 'Object'),
+      scalars: buildScalarsFromConfig(_schema, rawConfig, JAVA_SCALARS, 'Object'),
     });
   }
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
@@ -1,7 +1,7 @@
 import { NormalizedScalarsMap } from './types';
 import autoBind from 'auto-bind';
 import { DEFAULT_SCALARS } from './scalars';
-import { DeclarationBlock, DeclarationBlockConfig, buildScalars, getConfigValue } from './utils';
+import { DeclarationBlock, DeclarationBlockConfig, getConfigValue, buildScalarsFromConfig } from './utils';
 import {
   GraphQLSchema,
   FragmentDefinitionNode,
@@ -136,7 +136,7 @@ export class BaseDocumentsVisitor<
       addTypename: !rawConfig.skipTypename,
       globalNamespace: !!rawConfig.globalNamespace,
       operationResultSuffix: getConfigValue(rawConfig.operationResultSuffix, ''),
-      scalars: buildScalars(_schema, rawConfig.scalars, defaultScalars),
+      scalars: buildScalarsFromConfig(_schema, rawConfig, defaultScalars),
       ...((additionalConfig || {}) as any),
     });
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -14,13 +14,13 @@ import {
   DeclarationBlockConfig,
   indent,
   getBaseTypeNode,
-  buildScalars,
   getConfigValue,
   getRootTypeNames,
   stripMapperTypeInterpolation,
   OMIT_TYPE,
   REQUIRE_FIELDS_TYPE,
   wrapTypeWithModifiers,
+  buildScalarsFromConfig,
 } from './utils';
 import {
   NameNode,
@@ -385,7 +385,7 @@ export class BaseResolversVisitor<
         ? parseMapper(rawConfig.defaultMapper || 'any', 'DefaultMapperType')
         : null,
       mappers: transformMappers(rawConfig.mappers || {}, rawConfig.mapperTypeSuffix),
-      scalars: buildScalars(_schema, rawConfig.scalars, defaultScalars),
+      scalars: buildScalarsFromConfig(_schema, rawConfig, defaultScalars),
       internalResolversPrefix: getConfigValue(rawConfig.internalResolversPrefix, '__'),
       ...(additionalConfig || {}),
     } as TPluginConfig);

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -33,12 +33,12 @@ import {
 } from './types';
 import {
   transformComment,
-  buildScalars,
   DeclarationBlock,
   DeclarationBlockConfig,
   indent,
   wrapWithSingleQuotes,
   getConfigValue,
+  buildScalarsFromConfig,
 } from './utils';
 import { OperationVariablesToObject } from './variables-to-object';
 import { parseEnumValues } from './enum-values';
@@ -215,7 +215,7 @@ export class BaseTypesVisitor<
         ignoreEnumValuesFromSchema: rawConfig.ignoreEnumValuesFromSchema,
       }),
       declarationKind: normalizeDeclarationKind(rawConfig.declarationKind),
-      scalars: buildScalars(_schema, rawConfig.scalars, defaultScalars),
+      scalars: buildScalarsFromConfig(_schema, rawConfig, defaultScalars),
       fieldWrapperValue: getConfigValue(rawConfig.fieldWrapperValue, 'T'),
       wrapFieldDefinitions: getConfigValue(rawConfig.wrapFieldDefinitions, false),
       ignoreEnumValuesFromSchema: getConfigValue(rawConfig.ignoreEnumValuesFromSchema, false),

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -34,6 +34,32 @@ export interface ParsedConfig {
 
 export interface RawConfig {
   /**
+   * @description Makes scalars strict.
+   *
+   * If scalars are found in the schema that are not defined in `scalars`
+   * an error will be thrown during codegen.
+   * @default false
+   *
+   * @exampleMarkdown
+   * ```yml
+   * config:
+   *   strictScalars: true
+   * ```
+   */
+  strictScalars?: boolean;
+  /**
+   * @description Allows you to override the type that unknown scalars will have.
+   *
+   * @default any
+   *
+   * @exampleMarkdown
+   * ```yml
+   * config:
+   *   defaultScalarType: unknown
+   * ```
+   */
+  defaultScalarType?: string;
+  /**
    * @description Extends or overrides the built-in scalars and custom GraphQL scalars to a custom type.
    *
    * @exampleMarkdown

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -49,7 +49,6 @@ export interface RawConfig {
   strictScalars?: boolean;
   /**
    * @description Allows you to override the type that unknown scalars will have.
-   *
    * @default any
    *
    * @exampleMarkdown

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -12,10 +12,9 @@ import {
 import { DepGraph } from 'dependency-graph';
 import gqlTag from 'graphql-tag';
 import { Types } from '@graphql-codegen/plugin-helpers';
-import { getConfigValue, buildScalars } from './utils';
+import { getConfigValue, buildScalarsFromConfig } from './utils';
 import { LoadedFragment, ParsedImport } from './types';
 import { basename, extname } from 'path';
-import { DEFAULT_SCALARS } from './scalars';
 import { pascalCase } from 'change-case-all';
 import { generateFragmentImportStatement } from './imports';
 import { optimizeDocumentNode } from '@graphql-tools/optimize';
@@ -197,7 +196,7 @@ export class ClientSideBaseVisitor<
     documents?: Types.DocumentFile[]
   ) {
     super(rawConfig, {
-      scalars: buildScalars(_schema, rawConfig.scalars, DEFAULT_SCALARS),
+      scalars: buildScalarsFromConfig(_schema, rawConfig),
       dedupeOperationSuffix: getConfigValue(rawConfig.dedupeOperationSuffix, false),
       optimizeDocumentNode: getConfigValue(rawConfig.optimizeDocumentNode, true),
       omitOperationSuffix: getConfigValue(rawConfig.omitOperationSuffix, false),

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -266,13 +266,13 @@ export function buildScalarsFromConfig(
   schema: GraphQLSchema | undefined,
   config: RawConfig,
   defaultScalarsMapping: NormalizedScalarsMap = DEFAULT_SCALARS,
-  defaultScalarType: string | undefined = 'any'
+  defaultScalarType = 'any'
 ): ParsedScalarsMap {
   return buildScalars(
     schema,
     config.scalars,
     defaultScalarsMapping,
-    config.strictScalars ? undefined : config.defaultScalarType || defaultScalarType
+    config.strictScalars ? null : config.defaultScalarType || defaultScalarType
   );
 }
 
@@ -280,7 +280,7 @@ export function buildScalars(
   schema: GraphQLSchema | undefined,
   scalarsMapping: ScalarsMap,
   defaultScalarsMapping: NormalizedScalarsMap = DEFAULT_SCALARS,
-  defaultScalarType: string | undefined = 'any'
+  defaultScalarType: string | null = 'any'
 ): ParsedScalarsMap {
   const result: ParsedScalarsMap = {};
 
@@ -308,7 +308,7 @@ export function buildScalars(
             type: JSON.stringify(scalarsMapping[name]),
           };
         } else if (!defaultScalarsMapping[name]) {
-          if (defaultScalarType === undefined) {
+          if (defaultScalarType === null) {
             throw new Error(`Unknown scalar type ${name}. Please override it using the "scalars" configuration field!`);
           }
           result[name] = {

--- a/packages/plugins/typescript/compatibility/src/visitor.ts
+++ b/packages/plugins/typescript/compatibility/src/visitor.ts
@@ -4,8 +4,8 @@ import {
   DeclarationBlock,
   indent,
   getConfigValue,
-  buildScalars,
   ParsedConfig,
+  buildScalarsFromConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import { GraphQLSchema, OperationDefinitionNode, OperationTypeNode, FragmentDefinitionNode } from 'graphql';
 
@@ -26,7 +26,7 @@ export class CompatibilityPluginVisitor extends BaseVisitor<CompatibilityPluginR
       noNamespaces: getConfigValue<boolean>(rawConfig.noNamespaces, false),
       preResolveTypes: getConfigValue<boolean>(rawConfig.preResolveTypes, false),
       strict: getConfigValue<boolean>(rawConfig.strict, false),
-      scalars: buildScalars(_schema, rawConfig.scalars),
+      scalars: buildScalarsFromConfig(_schema, rawConfig),
     } as any);
   }
 

--- a/packages/plugins/typescript/mongodb/src/visitor.ts
+++ b/packages/plugins/typescript/mongodb/src/visitor.ts
@@ -5,8 +5,7 @@ import {
   getConfigValue,
   ParsedConfig,
   BaseVisitor,
-  buildScalars,
-  DEFAULT_SCALARS,
+  buildScalarsFromConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import autoBind from 'auto-bind';
 import { Directives, TypeScriptMongoPluginConfig } from './config';
@@ -64,7 +63,7 @@ export class TsMongoVisitor extends BaseVisitor<TypeScriptMongoPluginConfig, Typ
       idFieldName: pluginConfig.idFieldName || '_id',
       enumsAsString: getConfigValue<boolean>(pluginConfig.enumsAsString, true),
       avoidOptionals: getConfigValue<boolean>(pluginConfig.avoidOptionals, false),
-      scalars: buildScalars(_schema, pluginConfig.scalars, DEFAULT_SCALARS),
+      scalars: buildScalarsFromConfig(_schema, pluginConfig),
     } as Partial<TypeScriptMongoPluginParsedConfig>) as any);
     autoBind(this);
   }

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1797,6 +1797,54 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
+    it('Should correctly throw an error when an unknown scalar is detected while using `strictScalars`', async () => {
+      const schema = buildSchema(`
+      scalar MyScalar
+
+      type MyType {
+        foo: String
+        bar: MyScalar!
+      }`);
+
+      expect(() => {
+        plugin(schema, [], { strictScalars: true }, { outputFile: '' });
+      }).toThrow('Unknown scalar type MyScalar');
+    });
+
+    it('Should allow overriding default scalar type', async () => {
+      const schema = buildSchema(`
+      scalar MyScalar
+
+      type MyType {
+        foo: String
+        bar: MyScalar!
+      }`);
+      const result = (await plugin(
+        schema,
+        [],
+        { defaultScalarType: 'unknown' },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect(result.content).toBeSimilarStringTo(`
+      export type Scalars = {
+        ID: string;
+        String: string;
+        Boolean: boolean;
+        Int: number;
+        Float: number;
+        MyScalar: unknown;
+      };`);
+
+      expect(result.content).toBeSimilarStringTo(`
+      export type MyType = {
+        __typename?: 'MyType';
+        foo?: Maybe<Scalars['String']>;
+        bar: Scalars['MyScalar'];
+      };`);
+      validateTs(result);
+    });
+
     it('Should add FieldWrapper when field definition wrapping is enabled', async () => {
       const schema = buildSchema(`
       scalar A

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1797,7 +1797,7 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
-    it('Should correctly throw an error when an unknown scalar is detected while using `strictScalars`', async () => {
+    it('Should correctly throw an error when an unknown scalar is detected while using `strictScalars`', () => {
       const schema = buildSchema(`
       scalar MyScalar
 

--- a/packages/presets/near-operation-file/src/fragment-resolver.ts
+++ b/packages/presets/near-operation-file/src/fragment-resolver.ts
@@ -1,7 +1,6 @@
 import { Types } from '@graphql-codegen/plugin-helpers';
 import {
   BaseVisitor,
-  buildScalars,
   FragmentImport,
   getConfigValue,
   getPossibleTypes,
@@ -9,6 +8,7 @@ import {
   ParsedConfig,
   RawConfig,
   ImportDeclaration,
+  buildScalarsFromConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import { DocumentNode, FragmentDefinitionNode, GraphQLSchema, Kind, print } from 'graphql';
 import { DocumentImportResolverOptions } from './resolve-document-imports';
@@ -40,7 +40,7 @@ function buildFragmentRegistry(
   schemaObject: GraphQLSchema
 ): FragmentRegistry {
   const baseVisitor = new BaseVisitor<RawConfig, NearOperationFileParsedConfig>(config, {
-    scalars: buildScalars(schemaObject, config.scalars),
+    scalars: buildScalarsFromConfig(schemaObject, config),
     dedupeOperationSuffix: getConfigValue(config.dedupeOperationSuffix, false),
     omitOperationSuffix: getConfigValue(config.omitOperationSuffix, false),
     fragmentVariablePrefix: getConfigValue(config.fragmentVariablePrefix, ''),


### PR DESCRIPTION
## Description

Allows defining the scalar type to use for unknown scalars, instead of `any`.

Additionally, allows setting a config value `strictScalars: true`, which will result in the generator throwing an error if it encounters a scalar that wasn't defined in the `scalars` config field.

Related #5274

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

Added unit tests.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I chose to create a new wrapper method for `buildScalars` and keep the changes minimal. The reason for the new method is to ensure that there are no breaking changes. I wasn't sure if `buildScalars` is exported and used by other external plugins.