### PR TITLE
fix(naming-convention): revert and pin change-case-all dependency back to 1.0.12 for workaround #3256

### DIFF
--- a/.changeset/heavy-peaches-arrive.md
+++ b/.changeset/heavy-peaches-arrive.md
@@ -1,0 +1,22 @@
+---
+'@graphql-codegen/cli': patch
+'@graphql-codegen/c-sharp': patch
+'@graphql-codegen/c-sharp-operations': patch
+'@graphql-codegen/java-apollo-android': patch
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-apollo-angular': patch
+'@graphql-codegen/typescript-apollo-client-helpers': patch
+'@graphql-codegen/typescript-compatibility': patch
+'@graphql-codegen/named-operations-object': patch
+'@graphql-codegen/typescript-react-apollo': patch
+'@graphql-codegen/typescript-react-offix': patch
+'@graphql-codegen/typescript-react-query': patch
+'@graphql-codegen/typescript-stencil-apollo': patch
+'@graphql-codegen/typed-document-node': patch
+'@graphql-codegen/typescript-urql': patch
+'@graphql-codegen/typescript-vue-apollo': patch
+'@graphql-codegen/graphql-modules-preset': patch
+'@graphql-codegen/plugin-helpers': patch
+---
+
+fix(naming-convention): revert and pin change-case-all dependency for workaround #3256

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -54,7 +54,7 @@
     "@graphql-tools/utils": "^7.0.0",
     "ansi-escapes": "^4.3.1",
     "chalk": "^4.1.0",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "chokidar": "^3.4.3",
     "common-tags": "^1.8.0",
     "cosmiconfig": "^7.0.0",

--- a/packages/plugins/c-sharp/c-sharp-operations/package.json
+++ b/packages/plugins/c-sharp/c-sharp-operations/package.json
@@ -17,7 +17,7 @@
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "auto-bind": "~4.0.0",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "tslib": "~2.1.0"
   },
   "sideEffects": false,

--- a/packages/plugins/c-sharp/c-sharp/package.json
+++ b/packages/plugins/c-sharp/c-sharp/package.json
@@ -15,7 +15,7 @@
     "strip-indent": "^3.0.0",
     "tslib": "~2.1.0",
     "unixify": "^1.0.0",
-    "change-case-all": "^1.0.12"
+    "change-case-all": "1.0.12"
   },
   "peerDependencies": {
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"

--- a/packages/plugins/java/apollo-android/package.json
+++ b/packages/plugins/java/apollo-android/package.json
@@ -18,7 +18,7 @@
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "auto-bind": "~4.0.0",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "pluralize": "^8.0.0",
     "tslib": "~2.1.0"
   },

--- a/packages/plugins/other/visitor-plugin-common/package.json
+++ b/packages/plugins/other/visitor-plugin-common/package.json
@@ -21,7 +21,7 @@
     "dependency-graph": "^0.11.0",
     "graphql-tag": "^2.11.0",
     "parse-filepath": "^1.0.2",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "tslib": "~2.1.0"
   },
   "peerDependencies": {

--- a/packages/plugins/typescript/apollo-angular/package.json
+++ b/packages/plugins/typescript/apollo-angular/package.json
@@ -21,7 +21,7 @@
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "auto-bind": "~4.0.0",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "tslib": "~2.1.0"
   },
   "main": "dist/index.cjs.js",

--- a/packages/plugins/typescript/apollo-client-helpers/package.json
+++ b/packages/plugins/typescript/apollo-client-helpers/package.json
@@ -20,7 +20,7 @@
     "@apollo/client": "3.3.11"
   },
   "dependencies": {
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "auto-bind": "~4.0.0",

--- a/packages/plugins/typescript/compatibility/package.json
+++ b/packages/plugins/typescript/compatibility/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "tslib": "~2.1.0"
   },
   "peerDependencies": {

--- a/packages/plugins/typescript/named-operations-object/package.json
+++ b/packages/plugins/typescript/named-operations-object/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^1.18.3",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "tslib": "~2.1.0"
   },
   "main": "dist/index.cjs.js",

--- a/packages/plugins/typescript/react-apollo-offix/package.json
+++ b/packages/plugins/typescript/react-apollo-offix/package.json
@@ -15,7 +15,7 @@
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "auto-bind": "~4.0.0",
-    "change-case-all": "^1.0.12"
+    "change-case-all": "1.0.12"
   },
   "peerDependencies": {
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0",

--- a/packages/plugins/typescript/react-apollo/package.json
+++ b/packages/plugins/typescript/react-apollo/package.json
@@ -17,7 +17,7 @@
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "auto-bind": "~4.0.0",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "tslib": "~2.1.0"
   },
   "peerDependencies": {

--- a/packages/plugins/typescript/react-query/package.json
+++ b/packages/plugins/typescript/react-query/package.json
@@ -17,7 +17,7 @@
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "auto-bind": "~4.0.0",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "tslib": "~2.1.0"
   },
   "peerDependencies": {

--- a/packages/plugins/typescript/stencil-apollo/package.json
+++ b/packages/plugins/typescript/stencil-apollo/package.json
@@ -17,7 +17,7 @@
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "auto-bind": "~4.0.0",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "tslib": "~2.1.0"
   },
   "peerDependencies": {

--- a/packages/plugins/typescript/typed-document-node/package.json
+++ b/packages/plugins/typescript/typed-document-node/package.json
@@ -17,7 +17,7 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "dependencies": {
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "auto-bind": "~4.0.0",

--- a/packages/plugins/typescript/urql/package.json
+++ b/packages/plugins/typescript/urql/package.json
@@ -17,7 +17,7 @@
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "auto-bind": "~4.0.0",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "tslib": "~2.1.0"
   },
   "peerDependencies": {

--- a/packages/plugins/typescript/vue-apollo/package.json
+++ b/packages/plugins/typescript/vue-apollo/package.json
@@ -17,7 +17,7 @@
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "auto-bind": "~4.0.0",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "tslib": "~2.1.0"
   },
   "peerDependencies": {

--- a/packages/presets/graphql-modules/package.json
+++ b/packages/presets/graphql-modules/package.json
@@ -18,7 +18,7 @@
     "@graphql-codegen/plugin-helpers": "^1.18.3",
     "@graphql-codegen/visitor-plugin-common": "^1.19.0",
     "parse-filepath": "^1.0.2",
-    "change-case-all": "^1.0.12",
+    "change-case-all": "1.0.12",
     "tslib": "~2.1.0"
   },
   "peerDependencies": {

--- a/packages/utils/plugins-helpers/src/resolve-external-module-and-fn.ts
+++ b/packages/utils/plugins-helpers/src/resolve-external-module-and-fn.ts
@@ -1,10 +1,10 @@
 export function resolveExternalModuleAndFn(pointer: any): any {
-  // eslint-disable-next-line no-eval
-  const importExternally = (moduleName: string) => eval(`require('${moduleName}')`);
-
   if (typeof pointer === 'function') {
     return pointer;
   }
+
+  // eslint-disable-next-line no-eval
+  const importExternally = (moduleName: string) => eval(`require('${moduleName}')`);
 
   // eslint-disable-next-line prefer-const
   let [moduleName, functionName] = pointer.split('#');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6903,7 +6903,7 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-change-case-all@^1.0.12:
+change-case-all@1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/change-case-all/-/change-case-all-1.0.12.tgz#ae3e0faf5e610e8e25c5d5eaa4a6d5c2f1d68797"
   integrity sha512-zdQus7R0lkprF99lrWUC5bFj6Nog4Xt4YCEjQ/vM4vbc6b5JHFBQMxRPAjfx+HJH8WxMzH0E+lQ8yQJLgmPCBg==


### PR DESCRIPTION
Related https://github.com/dotansimha/graphql-code-generator/issues/3256#issuecomment-799338073 and https://github.com/btxtiger/change-case-all/issues/2