### PR TITLE
fix(visitor-plugin-common): guards possible runtime type error

### DIFF
--- a/.changeset/chilly-donuts-breathe.md
+++ b/.changeset/chilly-donuts-breathe.md
@@ -1,0 +1,39 @@
+---
+'@graphql-cli/codegen': patch
+'@graphql-codegen/cli': patch
+'@graphql-codegen/c-sharp': patch
+'@graphql-codegen/c-sharp-operations': patch
+'@graphql-codegen/flow': patch
+'@graphql-codegen/flow-operations': patch
+'@graphql-codegen/java-apollo-android': patch
+'@graphql-codegen/introspection': patch
+'@graphql-codegen/schema-ast': patch
+'@graphql-codegen/urql-introspection': patch
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-apollo-angular': patch
+'@graphql-codegen/typescript-apollo-client-helpers': patch
+'@graphql-codegen/typescript-compatibility': patch
+'@graphql-codegen/typescript-document-nodes': patch
+'@graphql-codegen/typescript-generic-sdk': patch
+'@graphql-codegen/typescript-graphql-request': patch
+'@graphql-codegen/typescript-mongodb': patch
+'@graphql-codegen/named-operations-object': patch
+'@graphql-codegen/typescript-operations': patch
+'@graphql-codegen/typescript-react-apollo': patch
+'@graphql-codegen/typescript-react-offix': patch
+'@graphql-codegen/typescript-react-query': patch
+'@graphql-codegen/typescript-resolvers': patch
+'@graphql-codegen/typescript-stencil-apollo': patch
+'@graphql-codegen/typescript-type-graphql': patch
+'@graphql-codegen/typed-document-node': patch
+'@graphql-codegen/typescript': patch
+'@graphql-codegen/typescript-urql': patch
+'@graphql-codegen/typescript-vue-apollo': patch
+'@graphql-codegen/graphql-modules-preset': patch
+'@graphql-codegen/config-schema': patch
+'@graphql-codegen/testing': patch
+'@graphql-codegen/plugin-helpers': patch
+'@graphql-codegen/website': patch
+---
+
+fix(visitor-plugin-common): guard for a runtime type error

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -372,7 +372,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     for (const { field, selectedFieldType } of linkFieldSelectionSets.values()) {
       const realSelectedFieldType = getBaseType(selectedFieldType as any);
       const selectionSet = this.createNext(realSelectedFieldType, field.selectionSet);
-      const isConditional = hasConditionalDirectives(field.directives);
+      const isConditional = hasConditionalDirectives(field);
 
       linkFields.push({
         alias: field.alias ? this._processor.config.formatNamedField(field.alias.value, selectedFieldType) : undefined,
@@ -397,7 +397,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       ...this._processor.transformPrimitiveFields(
         parentSchemaType,
         Array.from(primitiveFields.values()).map(field => ({
-          isConditional: hasConditionalDirectives(field.directives),
+          isConditional: hasConditionalDirectives(field),
           fieldName: field.name.value,
         }))
       ),

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -20,7 +20,6 @@ import {
   isListType,
   isAbstractType,
   GraphQLOutputType,
-  DirectiveNode,
 } from 'graphql';
 import { ScalarsMap, NormalizedScalarsMap, ParsedScalarsMap } from './types';
 import { DEFAULT_SCALARS } from './scalars';

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -403,7 +403,9 @@ export function getPossibleTypes(schema: GraphQLSchema, type: GraphQLNamedType):
   return [];
 }
 
-export function hasConditionalDirectives(directives: readonly DirectiveNode[]): boolean {
+export function hasConditionalDirectives(directives: readonly DirectiveNode[] | null | undefined): boolean {
+  if (!directives) return false;
+
   if (directives.length === 0) return false;
 
   for (const directive of directives) {

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -403,17 +403,9 @@ export function getPossibleTypes(schema: GraphQLSchema, type: GraphQLNamedType):
   return [];
 }
 
-export function hasConditionalDirectives(directives: readonly DirectiveNode[] | null | undefined): boolean {
-  if (!directives) return false;
-
-  if (directives.length === 0) return false;
-
-  for (const directive of directives) {
-    if (['skip', 'include'].includes(directive.name.value)) {
-      return true;
-    }
-  }
-  return false;
+export function hasConditionalDirectives(field: FieldNode): boolean {
+  const CONDITIONAL_DIRECTIVES = ['skip', 'include'];
+  return field.directives?.some(directive => CONDITIONAL_DIRECTIVES.includes(directive.name.value));
 }
 
 type WrapModifiersOptions = {


### PR DESCRIPTION
There is type error on run `graphql-mesh generate-sdk`.

```
TypeError: Cannot read property 'length' of undefined
    at hasConditionalDirectives (/Users/tim/Workspace/tmp/graphql-mesh-test/node_modules/@graphql-codegen/visitor-plugin-common/index.cjs.js:479:20)
```

![image](https://user-images.githubusercontent.com/9696352/111580200-82be1080-87fa-11eb-8699-5cffee156419.png)

The line 479:
![image](https://user-images.githubusercontent.com/9696352/111580095-6326e800-87fa-11eb-8e65-e6362a31634e.png)

I think we shouldn't trust TypeScript that much :/