### PR TITLE
Add `entireFieldWrapperValue` configuration option, to wrap arrays.

### DIFF
--- a/.changeset/warm-candles-teach.md
+++ b/.changeset/warm-candles-teach.md
@@ -1,0 +1,7 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript': minor
+'@graphql-codegen/flow': minor
+---
+
+Add entireFieldWrapperValue configuration option, to wrap arrays

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -51,6 +51,8 @@ export interface ParsedTypesConfig extends ParsedConfig {
   enumPrefix: boolean;
   fieldWrapperValue: string;
   wrapFieldDefinitions: boolean;
+  entireFieldWrapperValue: string;
+  wrapEntireDefinitions: boolean;
   ignoreEnumValuesFromSchema: boolean;
 }
 
@@ -191,6 +193,44 @@ export interface RawTypesConfig extends RawConfig {
    * ```
    */
   ignoreEnumValuesFromSchema?: boolean;
+  /**
+   * @name wrapEntireFieldDefinitions
+   * @type boolean
+   * @description Set the to `true` in order to wrap field definitions with `EntireFieldWrapper`.
+   * This is useful to allow return types such as Promises and functions for fields.
+   * Differs from `wrapFieldDefinitions` in that this wraps the entire field definition if ie. the field is an Array, while
+   * `wrapFieldDefinitions` will wrap every single value inside the array.
+   * @default true
+   *
+   * @example Enable wrapping entire fields
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    wrapEntireFieldDefinitions: false
+   * ```
+   */
+  wrapEntireFieldDefinitions?: boolean;
+  /**
+   * @name entireFieldWrapperValue
+   * @type string
+   * @description Allow to override the type value of `EntireFieldWrapper`. This wrapper applies outside of Array and Maybe
+   * unlike `fieldWrapperValue`, that will wrap the inner type.
+   * @default T | Promise<T> | (() => T | Promise<T>)
+   *
+   * @example Only allow values
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    entireFieldWrapperValue: T
+   * ```
+   */
+  entireFieldWrapperValue?: string;
 }
 
 export class BaseTypesVisitor<
@@ -218,6 +258,8 @@ export class BaseTypesVisitor<
       scalars: buildScalars(_schema, rawConfig.scalars, defaultScalars),
       fieldWrapperValue: getConfigValue(rawConfig.fieldWrapperValue, 'T'),
       wrapFieldDefinitions: getConfigValue(rawConfig.wrapFieldDefinitions, false),
+      entireFieldWrapperValue: getConfigValue(rawConfig.entireFieldWrapperValue, 'T'),
+      wrapEntireDefinitions: getConfigValue(rawConfig.wrapEntireFieldDefinitions, false),
       ignoreEnumValuesFromSchema: getConfigValue(rawConfig.ignoreEnumValuesFromSchema, false),
       ...additionalConfig,
     });
@@ -232,6 +274,14 @@ export class BaseTypesVisitor<
   public getFieldWrapperValue(): string {
     if (this.config.fieldWrapperValue) {
       return `${this.getExportPrefix()}type FieldWrapper<T> = ${this.config.fieldWrapperValue};`;
+    }
+
+    return '';
+  }
+
+  public getEntireFieldWrapperValue(): string {
+    if (this.config.entireFieldWrapperValue) {
+      return `${this.getExportPrefix()}type EntireFieldWrapper<T> = ${this.config.entireFieldWrapperValue};`;
     }
 
     return '';

--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -238,4 +238,42 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    * ```
    */
   useImplementingTypes?: boolean;
+  /**
+   * @name wrapEntireFieldDefinitions
+   * @type boolean
+   * @description Set the to `true` in order to wrap field definitions with `EntireFieldWrapper`.
+   * This is useful to allow return types such as Promises and functions for fields.
+   * Differs from `wrapFieldDefinitions` in that this wraps the entire field definition if ie. the field is an Array, while
+   * `wrapFieldDefinitions` will wrap every single value inside the array.
+   * @default true
+   *
+   * @example Enable wrapping entire fields
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    wrapEntireFieldDefinitions: false
+   * ```
+   */
+  wrapEntireFieldDefinitions?: boolean
+  /**
+   * @name entireFieldWrapperValue
+   * @type string
+   * @description Allow to override the type value of `EntireFieldWrapper`. This wrapper applies outside of Array and Maybe
+   * unlike `fieldWrapperValue`, that will wrap the inner type.
+   * @default T | Promise<T> | (() => T | Promise<T>)
+   *
+   * @example Only allow values
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *  config:
+   *    entireFieldWrapperValue: T
+   * ```
+   */;
+  entireFieldWrapperValue?: string;
 }

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -64,6 +64,8 @@ export class TsVisitor<
       onlyOperationTypes: getConfigValue(pluginConfig.onlyOperationTypes, false),
       immutableTypes: getConfigValue(pluginConfig.immutableTypes, false),
       useImplementingTypes: getConfigValue(pluginConfig.useImplementingTypes, false),
+      entireFieldWrapperValue: getConfigValue(pluginConfig.entireFieldWrapperValue, 'T'),
+      wrapEntireDefinitions: getConfigValue(pluginConfig.wrapEntireFieldDefinitions, false),
       ...(additionalConfig || {}),
     } as TParsedConfig);
 
@@ -125,6 +127,9 @@ export class TsVisitor<
 
     if (this.config.wrapFieldDefinitions) {
       definitions.push(this.getFieldWrapperValue());
+    }
+    if (this.config.wrapEntireDefinitions) {
+      definitions.push(this.getEntireFieldWrapperValue());
     }
 
     return definitions;
@@ -204,7 +209,9 @@ export class TsVisitor<
   }
 
   FieldDefinition(node: FieldDefinitionNode, key?: number | string, parent?: any): string {
-    const typeString = (node.type as any) as string;
+    const typeString = this.config.wrapEntireDefinitions
+      ? `EntireFieldWrapper<${node.type}>`
+      : ((node.type as any) as string);
     const originalFieldNode = parent[key] as FieldDefinitionNode;
     const addOptionalSign = !this.config.avoidOptionals.field && originalFieldNode.type.kind !== Kind.NON_NULL_TYPE;
     const comment = this.getFieldComment(node);

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2059,6 +2059,40 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
+    it('Should build list type correctly when wrapping both field definitions and entire field definitions', async () => {
+      const schema = buildSchema(`
+        type ListOfStrings {
+          foo: [String!]!
+        }
+
+        type ListOfMaybeStrings {
+          foo: [String]!
+        }
+      `);
+      const result = (await plugin(
+        schema,
+        [],
+        { wrapEntireFieldDefinitions: true, wrapFieldDefinitions: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type ListOfStrings = {
+          __typename?: 'ListOfStrings';
+          foo: EntireFieldWrapper<Array<FieldWrapper<Scalars['String']>>>;
+        };
+      `);
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type ListOfMaybeStrings = {
+          __typename?: 'ListOfMaybeStrings';
+          foo: EntireFieldWrapper<Array<Maybe<FieldWrapper<Scalars['String']>>>>;
+        };
+      `);
+
+      validateTs(result);
+    });
+
     it('Should not wrap input type fields', async () => {
       const schema = buildSchema(`
         input MyInput {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2025,6 +2025,40 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
+    it('Should build list type correctly when wrapping entire field definitions', async () => {
+      const schema = buildSchema(`
+        type ListOfStrings {
+          foo: [String!]!
+        }
+
+        type ListOfMaybeStrings {
+          foo: [String]!
+        }
+      `);
+      const result = (await plugin(
+        schema,
+        [],
+        { entireWrapFieldDefinitions: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type ListOfStrings = {
+          __typename?: 'ListOfStrings';
+          foo: EntireFieldWrapper<Array<Scalars['String']>>;
+        };
+      `);
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type ListOfMaybeStrings = {
+          __typename?: 'ListOfMaybeStrings';
+          foo: EntireFieldWrapper<Array<Maybe<Scalars['String']>>>;
+        };
+      `);
+
+      validateTs(result);
+    });
+
     it('Should not wrap input type fields', async () => {
       const schema = buildSchema(`
         input MyInput {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2038,7 +2038,7 @@ describe('TypeScript', () => {
       const result = (await plugin(
         schema,
         [],
-        { entireWrapFieldDefinitions: true },
+        { wrapEntireFieldDefinitions: true },
         { outputFile: '' }
       )) as Types.ComplexPluginOutput;
 


### PR DESCRIPTION
## Description

Fixes regression introduced in: #3938, fixes feature requested in: #5227  and #4614 (issue can be discussed ether in these issues, or here).


### The problem
The change made in issue #3938 changed how `fieldWrapper` worked, so that it is no longer possible to wrap an entire array using `FieldWrapper`, rather the values INSIDE the array are wrapped.

@nebbles summed this up well in #5227:

When adding to config:

    wrapFieldDefinitions: true
    fieldWrapperValue: T | Promise<T> | (() => T) | (() => Promise<T>)

Then I'd expect this wrapper to be applied to the Type of the field

A type like this:

    images: Array<GqlImageData>;

Should turn into: 

     images: FieldWrapper<Array<GqlImageData>>;

However as mentioned, the above change (#3938) means that Arrays cannot be given a custom wrapper. The result of using the config returns

    images: Array<FieldWrapper<GqlImageData>>;

### The fix

This adds two new configuration options: `wrapEntireFieldDefinitions` and `entireFieldWrapperValue` that fixes this. So when adding to config:

    wrapEntireFieldDefinitions: true
    entireFieldWrapperValue: T | Promise<T> | (() => T) | (() => Promise<T>)

A type like this:

    images: Array<GqlImageData>;

Turns into:

     images: EntireFieldWrapper<Array<GqlImageData>>;


This can also be nested with `wrapFieldDefinitions` so that 

    wrapFieldDefinitions: true
    fieldWrapperValue: T | Promise<T> | (() => T) | (() => Promise<T>)
    wrapEntireFieldDefinitions: true
    entireFieldWrapperValue: T | Promise<T> | (() => T) | (() => Promise<T>)

Will make it so a type like this:

    images: Array<GqlImageData>;

Turns into:

     images: EntireFieldWrapper<Array<FieldWrapper<GqlImageData>>>;

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Added a new test case for these new configuration option(s).

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

It can also be considered, that this should be added to `flow` generator also. But I'm not an expert there, so requires assistance.