### PR TITLE
Consider DateTime as builtin C# value type

### DIFF
--- a/.changeset/tasty-ravens-doubt.md
+++ b/.changeset/tasty-ravens-doubt.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/c-sharp': major
+---
+
+Consider DateTime as builtin C# value type

--- a/packages/plugins/c-sharp/c-sharp/test/c-sharp.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp/test/c-sharp.spec.ts
@@ -452,6 +452,25 @@ describe('C#', () => {
           public bool? boolOpt { get; set; }
         `);
       });
+
+      it('Should properly treat DateTime nullability', async () => {
+        const schema = buildSchema(/* GraphQL */ `
+          type Test {
+            dateOptional: Date
+            dateMandatory: Date!
+          }
+
+          scalar Date
+        `);
+        const result = await plugin(schema, [], {}, { outputFile: '' });
+
+        expect(result).toBeSimilarStringTo(`
+          [JsonProperty("dateOptional")]
+          public DateTime? dateOptional { get; set; }
+          [JsonProperty("dateMandatory")]
+          public DateTime dateMandatory { get; set; }
+        `);
+      });
     });
 
     describe('Array', () => {

--- a/packages/plugins/c-sharp/common/scalars.ts
+++ b/packages/plugins/c-sharp/common/scalars.ts
@@ -7,9 +7,7 @@ export const C_SHARP_SCALARS = {
   Date: 'DateTime',
 };
 
-// All native C# built-in value types
-// See https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types
-export const csharpNativeValueTypes = [
+export const csharpValueTypes = [
   'bool',
   'byte',
   'sbyte',
@@ -23,4 +21,5 @@ export const csharpNativeValueTypes = [
   'ulong',
   'short',
   'ushort',
+  'DateTime',
 ];

--- a/packages/plugins/c-sharp/common/utils.ts
+++ b/packages/plugins/c-sharp/common/utils.ts
@@ -1,6 +1,6 @@
 import { Kind, TypeNode, StringValueNode } from 'graphql';
 import { indent } from '@graphql-codegen/visitor-plugin-common';
-import { csharpNativeValueTypes } from './scalars';
+import { csharpValueTypes } from './scalars';
 import { ListTypeField, CSharpFieldType } from './c-sharp-field-types';
 
 export function transformComment(comment: string | StringValueNode, indentLevel = 0): string {
@@ -26,7 +26,7 @@ function isStringValueNode(node: any): node is StringValueNode {
 export function isValueType(type: string): boolean {
   // Limitation: only checks the list of known built in value types
   // Eg .NET types and struct types won't be detected correctly
-  return csharpNativeValueTypes.includes(type);
+  return csharpValueTypes.includes(type);
 }
 
 export function getListTypeField(typeNode: TypeNode): ListTypeField | undefined {


### PR DESCRIPTION
This code causes issues with nullability of value types. Task #5859 

```
export function isValueType(type: string): boolean {
  // Limitation: only checks the list of known built in value types
  // Eg .NET types and struct types won't be detected correctly
  return csharpValueTypes.includes(type);
}
```

I do not eliminate that limitation completly:
```
  // Limitation: only checks the list of known built in value types
  // Eg .NET types and struct types won't be detected correctly
```

But with this fix - generator more or less usable in C# projects. It is quite major blocker - if code does not support DateTime nullability.

In general DateTime - is not language primitive like ```int, bool, float``` but it is built-in value type. For CRL - there is no much difference in DateTime and Int32 (int is an alias for Int32): 
*  https://github.com/microsoft/referencesource/blob/master/mscorlib/system/datetime.cs
* https://github.com/microsoft/referencesource/blob/master/mscorlib/system/int32.cs
