### PR TITLE
feat(react-query): expose document for hooks

### DIFF
--- a/.changeset/witty-toes-cross.md
+++ b/.changeset/witty-toes-cross.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': minor
+---
+
+Added an option exposeDocument to expose a document from the hook

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -33,6 +33,17 @@ export interface ReactQueryRawPluginConfig
 
   /**
    * @default false
+   * @description For each generate query hook adds `document` field with a
+   * correspoding GraphQL query. Useful for `queryClient.fetchQuery`. Example:
+   * queryClient.fetchQuery(
+   *   useUserDetailsQuery.getKey(variables),
+   *   () => gqlRequest(useUserDetailsQuery.document, variables),
+   * )
+   */
+  exposeDocument?: boolean;
+
+  /**
+   * @default false
    * @description For each generate query hook adds getKey(variables: QueryVariables) function. Useful for cache updates. Example:
    * const query = useUserDetailsQuery(...);
    * const key = useUserDetailsQuery.getKey({id: theUsersId});

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -19,6 +19,7 @@ import { generateQueryKeyMaker } from './variables-generator';
 
 export interface ReactQueryPluginConfig extends ClientSideBasePluginConfig {
   errorType: string;
+  exposeDocument: boolean;
   exposeQueryKeys: boolean;
 }
 
@@ -58,6 +59,7 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
     super(schema, fragments, rawConfig, {
       documentMode: DocumentMode.string,
       errorType: getConfigValue(rawConfig.errorType, 'unknown'),
+      exposeDocument: getConfigValue(rawConfig.exposeDocument, false),
       exposeQueryKeys: getConfigValue(rawConfig.exposeQueryKeys, false),
     });
     this._externalImportPrefix = this.config.importOperationTypesFrom ? `${this.config.importOperationTypesFrom}.` : '';
@@ -126,6 +128,9 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
         operationVariablesTypes,
         hasRequiredVariables
       );
+      if (this.config.exposeDocument) {
+        query += `\nuse${operationName}.document = ${documentVariableName};\n`;
+      }
       if (this.config.exposeQueryKeys) {
         query += generateQueryKeyMaker(node, operationName, operationVariablesTypes, hasRequiredVariables);
       }

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -467,6 +467,17 @@ describe('React-Query', () => {
     });
   });
 
+  describe('exposeDocument: true', () => {
+    it('Should generate document field for each query', async () => {
+      const config = {
+        fetcher: 'fetch',
+        exposeDocument: true,
+      };
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toBeSimilarStringTo(`useTestQuery.document = TestDocument;`);
+    });
+  });
+
   describe('exposeQueryKeys: true', () => {
     it('Should generate getKey for each query', async () => {
       const config = {


### PR DESCRIPTION
## Description

Adding an option to expose document from hook. See https://github.com/dotansimha/graphql-code-generator/issues/5862

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added tests 

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

