### PR TITLE
feat(typescript-graphql-request): Add enchancements to request middleware function (#5883, #5807)

### DIFF
--- a/.changeset/orange-bugs-impress.md
+++ b/.changeset/orange-bugs-impress.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-graphql-request': minor
+---
+
+feat(typescript-graphql-request): Add enchancements to request middleware function (#5883, #5807) #5884

--- a/.changeset/orange-bugs-impress.md
+++ b/.changeset/orange-bugs-impress.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/typescript-graphql-request': minor
 ---
 
-feat(typescript-graphql-request): Add enchancements to request middleware function (#5883, #5807) #5884
+feat(typescript-graphql-request): Add enhancements to request middleware function (#5883, #5807) #5884

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -268,24 +268,24 @@ export const Feed4Document = \`
 }
     \`;
 
-export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
 
 
-const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<FeedQuery> {
-      return withWrapper(() => client.request<FeedQuery>(FeedDocument, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
     },
     feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed2Query> {
-      return withWrapper(() => client.request<Feed2Query>(Feed2Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
     },
     feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed3Query> {
-      return withWrapper(() => client.request<Feed3Query>(Feed3Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
     },
     feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed4Query> {
-      return withWrapper(() => client.request<Feed4Query>(Feed4Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
     }
   };
 }
@@ -300,7 +300,7 @@ async function test() {
   }
 
   const sdk = getSdk(client, functionWrapper);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -584,24 +584,24 @@ export const Feed4Document = gql\`
 }
     \`;
 
-export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
 
 
-const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<FeedQuery> {
-      return withWrapper(() => client.request<FeedQuery>(FeedDocument, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
     },
     feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed2Query> {
-      return withWrapper(() => client.request<Feed2Query>(Feed2Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
     },
     feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed3Query> {
-      return withWrapper(() => client.request<Feed3Query>(Feed3Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
     },
     feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed4Query> {
-      return withWrapper(() => client.request<Feed4Query>(Feed4Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
     }
   };
 }
@@ -609,7 +609,7 @@ export type Sdk = ReturnType<typeof getSdk>;
 async function test() {
   const client = new GraphQLClient('');
   const sdk = getSdk(client);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -892,24 +892,24 @@ export const Feed4Document = \`
 }
     \`;
 
-export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
 
 
-const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<FeedQuery> {
-      return withWrapper(() => client.request<FeedQuery>(FeedDocument, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
     },
     feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed2Query> {
-      return withWrapper(() => client.request<Feed2Query>(Feed2Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
     },
     feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed3Query> {
-      return withWrapper(() => client.request<Feed3Query>(Feed3Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
     },
     feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed4Query> {
-      return withWrapper(() => client.request<Feed4Query>(Feed4Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
     }
   };
 }
@@ -917,7 +917,7 @@ export type Sdk = ReturnType<typeof getSdk>;
 async function test() {
   const client = new GraphQLClient('');
   const sdk = getSdk(client);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -1203,10 +1203,10 @@ export const Feed4Document = gql\`
 }
     \`;
 
-export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
 
 
-const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 const FeedDocumentString = print(FeedDocument);
 const Feed2DocumentString = print(Feed2Document);
 const Feed3DocumentString = print(Feed3Document);
@@ -1214,16 +1214,16 @@ const Feed4DocumentString = print(Feed4Document);
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: FeedQuery | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
-        return withWrapper(() => client.rawRequest<FeedQuery>(FeedDocumentString, variables, requestHeaders));
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<FeedQuery>(FeedDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
     },
     feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed2Query | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
-        return withWrapper(() => client.rawRequest<Feed2Query>(Feed2DocumentString, variables, requestHeaders));
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed2Query>(Feed2DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
     },
     feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed3Query | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
-        return withWrapper(() => client.rawRequest<Feed3Query>(Feed3DocumentString, variables, requestHeaders));
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed3Query>(Feed3DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
     },
     feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed4Query | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
-        return withWrapper(() => client.rawRequest<Feed4Query>(Feed4DocumentString, variables, requestHeaders));
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed4Query>(Feed4DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
     }
   };
 }
@@ -1232,7 +1232,7 @@ async function test() {
   const Client = require('graphql-request').GraphQLClient;
   const client = new Client('');
   const sdk = getSdk(client);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -1516,24 +1516,24 @@ export const Feed4Document = gql\`
 }
     \`;
 
-export type SdkFunctionWrapper = <T>(action: () => Promise<T>) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
 
 
-const defaultWrapper: SdkFunctionWrapper = sdkFunction => sdkFunction();
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
     feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<FeedQuery> {
-      return withWrapper(() => client.request<FeedQuery>(FeedDocument, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
     },
     feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed2Query> {
-      return withWrapper(() => client.request<Feed2Query>(Feed2Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
     },
     feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed3Query> {
-      return withWrapper(() => client.request<Feed3Query>(Feed3Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
     },
     feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed4Query> {
-      return withWrapper(() => client.request<Feed4Query>(Feed4Document, variables, requestHeaders));
+      return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
     }
   };
 }
@@ -1542,7 +1542,7 @@ async function test() {
   const Client = require('graphql-request').GraphQLClient;
   const client = new Client('');
   const sdk = getSdk(client);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();

--- a/packages/plugins/typescript/graphql-request/tests/graphql-request.spec.ts
+++ b/packages/plugins/typescript/graphql-request/tests/graphql-request.spec.ts
@@ -72,7 +72,7 @@ describe('graphql-request', () => {
 async function test() {
   const client = new GraphQLClient('');
   const sdk = getSdk(client);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -87,7 +87,9 @@ async function test() {
 }`;
       const output = await validate(result, config, docs, schema, usage);
 
-      expect(result.content).toContain(`(FeedDocument, variables, requestHeaders));`);
+      expect(result.content).toContain(
+        `(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');`
+      );
       expect(output).toMatchSnapshot();
     });
 
@@ -102,7 +104,7 @@ async function test() {
 async function test() {
   const client = new GraphQLClient('');
   const sdk = getSdk(client);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -138,7 +140,7 @@ async function test() {
   }
 
   const sdk = getSdk(client, functionWrapper);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -168,7 +170,7 @@ async function test() {
   const Client = require('graphql-request').GraphQLClient;
   const client = new Client('');
   const sdk = getSdk(client);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -198,7 +200,7 @@ async function test() {
   const Client = require('graphql-request').GraphQLClient;
   const client = new Client('');
   const sdk = getSdk(client);
-  
+
   await sdk.feed();
   await sdk.feed3();
   await sdk.feed4();
@@ -246,9 +248,15 @@ async function test() {
       const output = await validate(result, config, docs, schema, '');
 
       expect(output).toContain(`import * as Operations from './operations';`);
-      expect(output).toContain(`(Operations.FeedDocument, variables, requestHeaders));`);
-      expect(output).toContain(`(Operations.Feed2Document, variables, requestHeaders));`);
-      expect(output).toContain(`(Operations.Feed3Document, variables, requestHeaders));`);
+      expect(output).toContain(
+        `(Operations.FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');`
+      );
+      expect(output).toContain(
+        `(Operations.Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');`
+      );
+      expect(output).toContain(
+        `(Operations.Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');`
+      );
     });
   });
 });


### PR DESCRIPTION
Pass operation name to middleware function (#5807)
Add ability to modify request headers from middleware function (#5883)
