### PR TITLE
fix(c-sharp): Use `double` instead of `float` 

### DIFF
--- a/.changeset/serious-seas-judge.md
+++ b/.changeset/serious-seas-judge.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/c-sharp': patch
+'@graphql-codegen/c-sharp-operations': patch
+---
+
+Replace float with double

--- a/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
@@ -1028,8 +1028,8 @@ describe('C# Operations', () => {
       expect(result.content).toBeSimilarStringTo(`
         /// <summary>
         /// RunScalarGQL.Request
-        /// <para>Required variables:<br/> { idr=(int), namer=(string), flagr=(bool), fltr=(float)  }</para>
-        /// <para>Optional variables:<br/> { id=(int), name=(string), flag=(bool), flt=(float) }</para>
+        /// <para>Required variables:<br/> { idr=(int), namer=(string), flagr=(bool), fltr=(double)  }</para>
+        /// <para>Optional variables:<br/> { id=(int), name=(string), flag=(bool), flt=(double) }</para>
         /// </summary>
       `);
     });

--- a/packages/plugins/c-sharp/c-sharp/test/c-sharp.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp/test/c-sharp.spec.ts
@@ -422,7 +422,7 @@ describe('C#', () => {
           [JsonRequired]
           public int intReq { get; set; }
           [JsonRequired]
-          public float fltReq { get; set; }
+          public double fltReq { get; set; }
           [JsonRequired]
           public string idReq { get; set; }
           [JsonRequired]
@@ -446,7 +446,7 @@ describe('C#', () => {
 
         expect(result).toBeSimilarStringTo(`
           public int? intOpt { get; set; }
-          public float? fltOpt { get; set; }
+          public double? fltOpt { get; set; }
           public string idOpt { get; set; }
           public string strOpt { get; set; }
           public bool? boolOpt { get; set; }
@@ -494,7 +494,7 @@ describe('C#', () => {
 
         expect(result).toBeSimilarStringTo(`
           public IEnumerable<int> arr1 { get; set; }
-          public IEnumerable<float?> arr2 { get; set; }
+          public IEnumerable<double?> arr2 { get; set; }
           [JsonRequired]
           public IEnumerable<int?> arr3 { get; set; }
           [JsonRequired]
@@ -521,7 +521,7 @@ describe('C#', () => {
         expect(result).toBeSimilarStringTo(`
           public IEnumerable<IEnumerable<int>> arr1 { get; set; }
           [JsonRequired]
-          public IEnumerable<IEnumerable<IEnumerable<float?>>> arr2 { get; set; }
+          public IEnumerable<IEnumerable<IEnumerable<double?>>> arr2 { get; set; }
           [JsonRequired]
           public IEnumerable<IEnumerable<Complex>> arr3 { get; set; }
         `);
@@ -542,7 +542,7 @@ describe('C#', () => {
 
         expect(result).toBeSimilarStringTo(`
           public int? @int { get; set; }
-          public float? @float { get; set; }
+          public double? @float { get; set; }
           public string @string { get; set; }
           public bool? @bool { get; set; }
         `);
@@ -573,7 +573,7 @@ describe('C#', () => {
 
       expect(result).toBeSimilarStringTo(`
         public int? val { get; set; }
-        public float? flt { get; set; }
+        public double? flt { get; set; }
         public string str { get; set; }
         public bool? flag { get; set; }
         public Length? hair { get; set; }

--- a/packages/plugins/c-sharp/common/scalars.ts
+++ b/packages/plugins/c-sharp/common/scalars.ts
@@ -3,7 +3,7 @@ export const C_SHARP_SCALARS = {
   String: 'string',
   Boolean: 'bool',
   Int: 'int',
-  Float: 'float',
+  Float: 'double',
   Date: 'DateTime',
 };
 


### PR DESCRIPTION
## Description

The graphql  type "Float" corresponds to the C# type "double". But it was incorrectly translated to "float" before (which also is a valid C# type, but not the right one).

Related #5815

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I used graphql-codegen cli to generate a .cs-file before and after my changes to verify that graphql  type "Float" is now correctly translated to C# type "double".