### PR TITLE
fix: make lifecycle hooks definition a partial

### DIFF
--- a/.changeset/thirty-nails-wash.md
+++ b/.changeset/thirty-nails-wash.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/plugin-helpers': patch
+---
+
+fix: make lifecycle hooks definition a partial

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -475,7 +475,7 @@ export namespace Types {
      *
      * For more details: https://graphql-code-generator.com/docs/getting-started/lifecycle-hooks
      */
-    hooks?: LifecycleHooksDefinition;
+    hooks?: Partial<LifecycleHooksDefinition>;
   }
 
   export type ComplexPluginOutput = { content: string; prepend?: string[]; append?: string[] };


### PR DESCRIPTION
## Description

As highlighted in the issue, using the cli programmatically should not cause a type error when implementing a single hook.

Related #5904 

## Type of change


- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?


Static analysis is sufficient. Hooks are normalized in runtime code and the normalization process is tested.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


