### PR TITLE
Fix missing use of type import when using custom apollo hooks import

### DIFF
--- a/.changeset/flat-tables-clap.md
+++ b/.changeset/flat-tables-clap.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-apollo': patch
+---
+
+Fix missing use of type import when using custom apollo hooks import

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -110,11 +110,23 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     return GROUPED_APOLLO_CLIENT_3_IDENTIFIER;
   }
 
+  private usesExternalHooksOnly(): boolean {
+    const apolloReactCommonIdentifier = this.getApolloReactCommonIdentifier();
+    return (
+      apolloReactCommonIdentifier === GROUPED_APOLLO_CLIENT_3_IDENTIFIER &&
+      this.config.apolloReactHooksImportFrom !== APOLLO_CLIENT_3_UNIFIED_PACKAGE &&
+      this.config.withHooks &&
+      !this.config.withComponent &&
+      !this.config.withHOC
+    );
+  }
+
   private getApolloReactCommonImport(isTypeImport: boolean): string {
     const apolloReactCommonIdentifier = this.getApolloReactCommonIdentifier();
 
     return `${this.getImportStatement(
-      isTypeImport && apolloReactCommonIdentifier !== GROUPED_APOLLO_CLIENT_3_IDENTIFIER
+      isTypeImport &&
+        (apolloReactCommonIdentifier !== GROUPED_APOLLO_CLIENT_3_IDENTIFIER || this.usesExternalHooksOnly())
     )} * as ${apolloReactCommonIdentifier} from '${this.config.apolloReactCommonImportFrom}';`;
   }
 


### PR DESCRIPTION
## Description

As described in the linked issue. When using a combination of the `near-operations-file` preset, only generating hooks, and using a custom apollo hooks import, the "common" import is generated like this:
```ts
import * as Apollo from '@apollo/client';
```
While it is expected to be generated like this, since only types are used from the import:
```ts
import type * as Apollo from '@apollo/client';
```

In combination with the tsconfig setting `importsNotUsedAsValues: true` this causes errors.

This fix is a pretty naive approach, that may only fix this specific scenario, but the change should be pretty harmless overall.

Fixes #5633

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Checked it against our code base

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
While this should probably have a test associated, to prevent regression. I'm not familiar enough with this code base to write a test that involves the necessary moving parts (`near-operations-file` in particular)