### PR TITLE
test(typescript-react-apollo): Implement fix for #6001

### DIFF
--- a/.changeset/shaggy-bees-drum.md
+++ b/.changeset/shaggy-bees-drum.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-apollo': patch
+---
+
+No longer use TypesSuffix on function names.

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -330,6 +330,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<ReactApolloRawPlug
     const operationName: string = this.convertName(nodeName, {
       suffix,
       useTypesPrefix: false,
+      useTypesSuffix: false,
     });
 
     this.imports.add(this.getApolloReactCommonImport(true));

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -470,44 +470,36 @@ describe('React Apollo', () => {
         ((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })) as any).content
       ).toContain('Apollo.QueryResult<NotificationsQueryQuery, NotificationsQueryQueryVariables>;');
       expect(
-        (
-          (await plugin(
-            schema,
-            [{ location: 'test-file.ts', document: ast }],
-            { dedupeOperationSuffix: false },
-            { outputFile: '' }
-          )) as any
-        ).content
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: false },
+          { outputFile: '' }
+        )) as any).content
       ).toContain('Apollo.QueryResult<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
       expect(
-        (
-          (await plugin(
-            schema,
-            [{ location: 'test-file.ts', document: ast }],
-            { dedupeOperationSuffix: true },
-            { outputFile: '' }
-          )) as any
-        ).content
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: true },
+          { outputFile: '' }
+        )) as any).content
       ).toContain('Apollo.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
       expect(
-        (
-          (await plugin(
-            schema,
-            [{ location: 'test-file.ts', document: ast2 }],
-            { dedupeOperationSuffix: true },
-            { outputFile: '' }
-          )) as any
-        ).content
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: true },
+          { outputFile: '' }
+        )) as any).content
       ).toContain('Apollo.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
       expect(
-        (
-          (await plugin(
-            schema,
-            [{ location: 'test-file.ts', document: ast2 }],
-            { dedupeOperationSuffix: false },
-            { outputFile: '' }
-          )) as any
-        ).content
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: false },
+          { outputFile: '' }
+        )) as any).content
       ).toContain('Apollo.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
     });
 
@@ -531,44 +523,36 @@ describe('React Apollo', () => {
         ((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })) as any).content
       ).toContain('Apollo.QueryResult<NotificationsQueryQuery, NotificationsQueryQueryVariables>;');
       expect(
-        (
-          (await plugin(
-            schema,
-            [{ location: 'test-file.ts', document: ast }],
-            { omitOperationSuffix: false },
-            { outputFile: '' }
-          )) as any
-        ).content
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { omitOperationSuffix: false },
+          { outputFile: '' }
+        )) as any).content
       ).toContain('Apollo.QueryResult<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
       expect(
-        (
-          (await plugin(
-            schema,
-            [{ location: 'test-file.ts', document: ast }],
-            { omitOperationSuffix: true },
-            { outputFile: '' }
-          )) as any
-        ).content
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { omitOperationSuffix: true },
+          { outputFile: '' }
+        )) as any).content
       ).toContain('Apollo.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
       expect(
-        (
-          (await plugin(
-            schema,
-            [{ location: 'test-file.ts', document: ast2 }],
-            { omitOperationSuffix: true },
-            { outputFile: '' }
-          )) as any
-        ).content
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { omitOperationSuffix: true },
+          { outputFile: '' }
+        )) as any).content
       ).toContain('Apollo.QueryResult<Notifications, NotificationsVariables>');
       expect(
-        (
-          (await plugin(
-            schema,
-            [{ location: 'test-file.ts', document: ast2 }],
-            { omitOperationSuffix: false },
-            { outputFile: '' }
-          )) as any
-        ).content
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { omitOperationSuffix: false },
+          { outputFile: '' }
+        )) as any).content
       ).toContain('Apollo.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
     });
 

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -370,6 +370,29 @@ describe('React Apollo', () => {
         content.content.split('{"kind":"FragmentDefinition","name":{"kind":"Name","value":"RepositoryFields"}').length
       ).toBe(3);
     });
+
+    it('#6001 - Should not use TypesSuffix on function names', async () => {
+      const docs = [
+        {
+          location: '',
+          document: parse(/* GraphQL */ `
+            query user {
+              user(id: 1) {
+                id
+                username
+                email
+              }
+            }
+          `),
+        },
+      ];
+
+      const content = await plugin(schema, docs, { typesSuffix: 'Type' });
+
+      expect(content.content).toEqual(expect.stringMatching(/UserQueryType/));
+      // String matching `useUserQuery` but not `useUserQueryType`.
+      expect(content.content).toEqual(expect.stringMatching(/(?=.useUserQuery)(?!.useUserQueryType)(.+)/));
+    });
   });
 
   describe('Imports', () => {
@@ -447,36 +470,44 @@ describe('React Apollo', () => {
         ((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })) as any).content
       ).toContain('Apollo.QueryResult<NotificationsQueryQuery, NotificationsQueryQueryVariables>;');
       expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast }],
-          { dedupeOperationSuffix: false },
-          { outputFile: '' }
-        )) as any).content
+        (
+          (await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast }],
+            { dedupeOperationSuffix: false },
+            { outputFile: '' }
+          )) as any
+        ).content
       ).toContain('Apollo.QueryResult<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
       expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast }],
-          { dedupeOperationSuffix: true },
-          { outputFile: '' }
-        )) as any).content
+        (
+          (await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast }],
+            { dedupeOperationSuffix: true },
+            { outputFile: '' }
+          )) as any
+        ).content
       ).toContain('Apollo.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
       expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast2 }],
-          { dedupeOperationSuffix: true },
-          { outputFile: '' }
-        )) as any).content
+        (
+          (await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast2 }],
+            { dedupeOperationSuffix: true },
+            { outputFile: '' }
+          )) as any
+        ).content
       ).toContain('Apollo.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
       expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast2 }],
-          { dedupeOperationSuffix: false },
-          { outputFile: '' }
-        )) as any).content
+        (
+          (await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast2 }],
+            { dedupeOperationSuffix: false },
+            { outputFile: '' }
+          )) as any
+        ).content
       ).toContain('Apollo.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
     });
 
@@ -500,36 +531,44 @@ describe('React Apollo', () => {
         ((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, { outputFile: '' })) as any).content
       ).toContain('Apollo.QueryResult<NotificationsQueryQuery, NotificationsQueryQueryVariables>;');
       expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast }],
-          { omitOperationSuffix: false },
-          { outputFile: '' }
-        )) as any).content
+        (
+          (await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast }],
+            { omitOperationSuffix: false },
+            { outputFile: '' }
+          )) as any
+        ).content
       ).toContain('Apollo.QueryResult<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
       expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast }],
-          { omitOperationSuffix: true },
-          { outputFile: '' }
-        )) as any).content
+        (
+          (await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast }],
+            { omitOperationSuffix: true },
+            { outputFile: '' }
+          )) as any
+        ).content
       ).toContain('Apollo.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
       expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast2 }],
-          { omitOperationSuffix: true },
-          { outputFile: '' }
-        )) as any).content
+        (
+          (await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast2 }],
+            { omitOperationSuffix: true },
+            { outputFile: '' }
+          )) as any
+        ).content
       ).toContain('Apollo.QueryResult<Notifications, NotificationsVariables>');
       expect(
-        ((await plugin(
-          schema,
-          [{ location: 'test-file.ts', document: ast2 }],
-          { omitOperationSuffix: false },
-          { outputFile: '' }
-        )) as any).content
+        (
+          (await plugin(
+            schema,
+            [{ location: 'test-file.ts', document: ast2 }],
+            { omitOperationSuffix: false },
+            { outputFile: '' }
+          )) as any
+        ).content
       ).toContain('Apollo.QueryResult<NotificationsQuery, NotificationsQueryVariables>');
     });
 


### PR DESCRIPTION
## Description

Implement a fix for #6001, `typescript-react-apollo` should use `typesSuffix` on type names but not on operation names.

Related #6001 

## Type of change

- [x] Breaking change: The generated output would be slightly changed after this issue is fixed.

## How Has This Been Tested?

- [x] A failing automated test has been added for `typescript-react-apollo`.
- [x] Tested manually on an existing project. 

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
