### PR TITLE
Fixed `include` functionality in `urql-introspection`

### DIFF
--- a/.changeset/sharp-cherries-yell.md
+++ b/.changeset/sharp-cherries-yell.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/urql-introspection': patch
+---
+
+Fixed include functionality in urql-introspection

--- a/packages/plugins/other/urql-introspection/src/index.ts
+++ b/packages/plugins/other/urql-introspection/src/index.ts
@@ -120,14 +120,12 @@ export const plugin: PluginFunction = async (
 
   const ext = extname(info.outputFile).toLowerCase();
 
-  const minifiedData = minifyIntrospectionQuery(
-    minifyIntrospectionQuery(getIntrospectedSchema(schema), {
-      includeDirectives: config.includeDirectives,
-      includeEnums: config.includeEnums,
-      includeInputs: config.includeInputs,
-      includeScalars: config.includeScalars,
-    })
-  );
+  const minifiedData = minifyIntrospectionQuery(getIntrospectedSchema(schema), {
+    includeDirectives: config.includeDirectives,
+    includeEnums: config.includeEnums,
+    includeInputs: config.includeInputs,
+    includeScalars: config.includeScalars,
+  });
 
   const content = JSON.stringify(minifiedData, null, 2);
 

--- a/packages/plugins/other/urql-introspection/tests/urql-introspection.spec.ts
+++ b/packages/plugins/other/urql-introspection/tests/urql-introspection.spec.ts
@@ -225,5 +225,60 @@ export default ${introspection} as unknown as IntrospectionQuery;`;
       expect(tsContent).toBeSimilarStringTo(output);
       expect(tsxContent).toBeSimilarStringTo(output);
     });
+
+    it('Should emit scalars if includeScalars config value is used', async () => {
+      const schema = buildSchema(`
+        scalar MyScalar
+        type Query {
+          myScalar: MyScalar
+        }
+      `);
+      const result = await plugin(schema, [], { includeScalars: true }, { outputFile: 'foo.ts' });
+
+      expect(result).toContain('MyScalar');
+    });
+
+    it('Should emit directives if includeDirectives config value is used', async () => {
+      const schema = buildSchema(`
+        directive @myDirective on FIELD_DEFINITION
+
+        type Query {
+          foo: Int @myDirective
+        }
+      `);
+      const result = await plugin(schema, [], { includeDirectives: true }, { outputFile: 'foo.ts' });
+
+      expect(result).toContain('myDirective');
+    });
+
+    it('Should emit enums if includeEnums config value is used', async () => {
+      const schema = buildSchema(`
+        enum MyEnum {
+          FOO
+        }
+
+        type Query {
+          myEnum: MyEnum
+        }
+      `);
+      const result = await plugin(schema, [], { includeEnums: true }, { outputFile: 'foo.ts' });
+
+      expect(result).toContain('MyEnum');
+    });
+
+    it('Should emit inputs if includeInputs config value is used', async () => {
+      const schema = buildSchema(`
+        input MyInput {
+          foo: Int
+        }
+        
+        type Query {
+          foo(myInput: MyInput): Int
+        }
+      `);
+      const result = await plugin(schema, [], { includeInputs: true }, { outputFile: 'foo.ts' });
+
+      expect(result).toContain('MyInput');
+    });
   });
 });


### PR DESCRIPTION
## Description

Added tests and implemented fix for a bug where `includeScalars` and similar options were not respected

Related #6052 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Added tests to test suite

**Test Environment**:
- OS: 
- `@graphql-codegen/...`: 
- NodeJS: 

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

