### PR TITLE
Implemented first generation skip in watch mode.

### DIFF
--- a/.changeset/odd-colts-grow.md
+++ b/.changeset/odd-colts-grow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': minor
+---
+
+First generation in watch mode can now be skipped.

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -12,6 +12,7 @@ import yaml from 'yaml';
 export type YamlCliFlags = {
   config: string;
   watch: boolean | string | string[];
+  watchSkipFirst: boolean;
   require: string[];
   overwrite: boolean;
   project: string;
@@ -134,7 +135,7 @@ export function buildOptions() {
     w: {
       alias: 'watch',
       describe:
-        'Watch for changes and execute generation automatically. You can also specify a glob expreession for custom watch list.',
+        'Watch for changes and execute generation automatically. You can also specify a glob expression for custom watch list.',
       coerce: (watch: any) => {
         if (watch === 'false') {
           return false;
@@ -144,6 +145,11 @@ export function buildOptions() {
         }
         return !!watch;
       },
+    },
+    watchSkipFirst: {
+      type: 'boolean' as const,
+      describe: 'Skip initial generation in watch mode. Good for previously ran scripts (e.g. pre-script commands).',
+      coerce: (watch: any) => !!watch,
     },
     r: {
       alias: 'require',
@@ -196,6 +202,15 @@ export function updateContextWithCliFlags(context: CodegenContext, cliFlags: Yam
 
   if (cliFlags.watch) {
     config.watch = cliFlags.watch;
+
+    if (cliFlags.watchSkipFirst) {
+      if (!config.watchConfig) {
+        config.watchConfig = {
+          usePolling: false,
+        };
+      }
+      config.watchConfig.skipFirst = cliFlags.watchSkipFirst;
+    }
   }
 
   if (cliFlags.overwrite === true) {

--- a/packages/graphql-codegen-cli/src/utils/watcher.ts
+++ b/packages/graphql-codegen-cli/src/utils/watcher.ts
@@ -142,7 +142,7 @@ export const createWatcher = (
 
   // the promise never resolves to keep process running
   return new Promise<void>((resolve, reject) => {
-    executeCodegen(initalContext)
+    (config.watchConfig?.skipFirst ? Promise.resolve([]) : executeCodegen(initalContext))
       .then(onNext, () => Promise.resolve())
       .then(runWatcher)
       .catch(err => {

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -424,6 +424,7 @@ export namespace Types {
     watchConfig?: {
       usePolling: boolean;
       interval?: number;
+      skipFirst?: boolean;
     };
     /**
      * @description A flag to suppress printing errors when they occur.

--- a/website/docs/getting-started/development-workflow.md
+++ b/website/docs/getting-started/development-workflow.md
@@ -60,6 +60,14 @@ watchConfig:
   interval: 1000
 ```
 
+Be default there is a generation run prior setup watcher (in order to avoid missing files from watcher), however you can opt-out from it with `watchConfig.skipFirst` config flag or via `--watchSkipFirst` CLI argument.
+
+```yml
+watch: true
+watchConfig:
+  skipFirst: true
+```
+
 
 ### Monorepo and Yarn Workspaces
 

--- a/website/static/config.schema.json
+++ b/website/static/config.schema.json
@@ -60,6 +60,9 @@
             },
             "interval": {
               "type": "number"
+            },
+            "skipFirst": {
+              "type": "boolean"
             }
           }
         },


### PR DESCRIPTION
## Description

Implemented possibility to skip first generation whenever some `pre-script` previously can already generate files which result onto unnecessary re-generation on `cold start` of scripts. With this change it's no longer necessary.

Related # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Changed over config values and then manually trigger watcher
- [x] Added `watchSkipFirst` CLI flag and then manually trigger watcher

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
