### PR TITLE
(urql-graphcache) - default to empty object just like urql itself does

### DIFF
--- a/.changeset/silent-beers-act.md
+++ b/.changeset/silent-beers-act.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-urql-graphcache": patch
+---
+
+Default resolver-args to empty object just like urql itself does

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -998,42 +998,42 @@ export type GraphCacheResolvers = {
   Query?: {
     feed?: GraphCacheResolver<WithTypename<Query>, QueryFeedArgs, Array<WithTypename<Entry> | string>>;
     entry?: GraphCacheResolver<WithTypename<Query>, QueryEntryArgs, WithTypename<Entry> | string>;
-    currentUser?: GraphCacheResolver<WithTypename<Query>, null, WithTypename<User> | string>;
+    currentUser?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, WithTypename<User> | string>;
   };
   Comment?: {
-    id?: GraphCacheResolver<WithTypename<Comment>, null, Scalars['Int'] | string>;
-    postedBy?: GraphCacheResolver<WithTypename<Comment>, null, WithTypename<User> | string>;
-    createdAt?: GraphCacheResolver<WithTypename<Comment>, null, Scalars['Float'] | string>;
-    content?: GraphCacheResolver<WithTypename<Comment>, null, Scalars['String'] | string>;
-    repoName?: GraphCacheResolver<WithTypename<Comment>, null, Scalars['String'] | string>;
+    id?: GraphCacheResolver<WithTypename<Comment>, Record<string, never>, Scalars['Int'] | string>;
+    postedBy?: GraphCacheResolver<WithTypename<Comment>, Record<string, never>, WithTypename<User> | string>;
+    createdAt?: GraphCacheResolver<WithTypename<Comment>, Record<string, never>, Scalars['Float'] | string>;
+    content?: GraphCacheResolver<WithTypename<Comment>, Record<string, never>, Scalars['String'] | string>;
+    repoName?: GraphCacheResolver<WithTypename<Comment>, Record<string, never>, Scalars['String'] | string>;
   };
   Entry?: {
-    repository?: GraphCacheResolver<WithTypename<Entry>, null, WithTypename<Repository> | string>;
-    postedBy?: GraphCacheResolver<WithTypename<Entry>, null, WithTypename<User> | string>;
-    createdAt?: GraphCacheResolver<WithTypename<Entry>, null, Scalars['Float'] | string>;
-    score?: GraphCacheResolver<WithTypename<Entry>, null, Scalars['Int'] | string>;
-    hotScore?: GraphCacheResolver<WithTypename<Entry>, null, Scalars['Float'] | string>;
+    repository?: GraphCacheResolver<WithTypename<Entry>, Record<string, never>, WithTypename<Repository> | string>;
+    postedBy?: GraphCacheResolver<WithTypename<Entry>, Record<string, never>, WithTypename<User> | string>;
+    createdAt?: GraphCacheResolver<WithTypename<Entry>, Record<string, never>, Scalars['Float'] | string>;
+    score?: GraphCacheResolver<WithTypename<Entry>, Record<string, never>, Scalars['Int'] | string>;
+    hotScore?: GraphCacheResolver<WithTypename<Entry>, Record<string, never>, Scalars['Float'] | string>;
     comments?: GraphCacheResolver<WithTypename<Entry>, EntryCommentsArgs, Array<WithTypename<Comment> | string>>;
-    commentCount?: GraphCacheResolver<WithTypename<Entry>, null, Scalars['Int'] | string>;
-    id?: GraphCacheResolver<WithTypename<Entry>, null, Scalars['Int'] | string>;
-    vote?: GraphCacheResolver<WithTypename<Entry>, null, WithTypename<Vote> | string>;
+    commentCount?: GraphCacheResolver<WithTypename<Entry>, Record<string, never>, Scalars['Int'] | string>;
+    id?: GraphCacheResolver<WithTypename<Entry>, Record<string, never>, Scalars['Int'] | string>;
+    vote?: GraphCacheResolver<WithTypename<Entry>, Record<string, never>, WithTypename<Vote> | string>;
   };
   Repository?: {
-    name?: GraphCacheResolver<WithTypename<Repository>, null, Scalars['String'] | string>;
-    full_name?: GraphCacheResolver<WithTypename<Repository>, null, Scalars['String'] | string>;
-    description?: GraphCacheResolver<WithTypename<Repository>, null, Scalars['String'] | string>;
-    html_url?: GraphCacheResolver<WithTypename<Repository>, null, Scalars['String'] | string>;
-    stargazers_count?: GraphCacheResolver<WithTypename<Repository>, null, Scalars['Int'] | string>;
-    open_issues_count?: GraphCacheResolver<WithTypename<Repository>, null, Scalars['Int'] | string>;
-    owner?: GraphCacheResolver<WithTypename<Repository>, null, WithTypename<User> | string>;
+    name?: GraphCacheResolver<WithTypename<Repository>, Record<string, never>, Scalars['String'] | string>;
+    full_name?: GraphCacheResolver<WithTypename<Repository>, Record<string, never>, Scalars['String'] | string>;
+    description?: GraphCacheResolver<WithTypename<Repository>, Record<string, never>, Scalars['String'] | string>;
+    html_url?: GraphCacheResolver<WithTypename<Repository>, Record<string, never>, Scalars['String'] | string>;
+    stargazers_count?: GraphCacheResolver<WithTypename<Repository>, Record<string, never>, Scalars['Int'] | string>;
+    open_issues_count?: GraphCacheResolver<WithTypename<Repository>, Record<string, never>, Scalars['Int'] | string>;
+    owner?: GraphCacheResolver<WithTypename<Repository>, Record<string, never>, WithTypename<User> | string>;
   };
   User?: {
-    login?: GraphCacheResolver<WithTypename<User>, null, Scalars['String'] | string>;
-    avatar_url?: GraphCacheResolver<WithTypename<User>, null, Scalars['String'] | string>;
-    html_url?: GraphCacheResolver<WithTypename<User>, null, Scalars['String'] | string>;
+    login?: GraphCacheResolver<WithTypename<User>, Record<string, never>, Scalars['String'] | string>;
+    avatar_url?: GraphCacheResolver<WithTypename<User>, Record<string, never>, Scalars['String'] | string>;
+    html_url?: GraphCacheResolver<WithTypename<User>, Record<string, never>, Scalars['String'] | string>;
   };
   Vote?: {
-    vote_value?: GraphCacheResolver<WithTypename<Vote>, null, Scalars['Int'] | string>;
+    vote_value?: GraphCacheResolver<WithTypename<Vote>, Record<string, never>, Scalars['Int'] | string>;
   };
 };
 

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -124,7 +124,7 @@ function getResolversConfig(schema: GraphQLSchema, convertName: ConvertFn) {
     const fields = parentType.astNode.fields.reduce((fields, field) => {
       const argsName = field.arguments?.length
         ? convertName(`${parentType.name}${capitalize(field.name.value)}Args`)
-        : 'null';
+        : 'Record<string, never>';
       const type = unwrapType(field.type);
 
       fields.push(
@@ -154,7 +154,8 @@ function getRootUpdatersConfig(schema: GraphQLSchema, convertName: ConvertFn) {
         fields.forEach(fieldNode => {
           const argsName = fieldNode.arguments?.length
             ? convertName(`${rootType.name}${capitalize(fieldNode.name.value)}Args`)
-            : '{}';
+            : 'Record<string, never>';
+
           const type = unwrapType(fieldNode.type);
           updaters.push(
             `${fieldNode.name.value}?: GraphCacheUpdateResolver<{ ${fieldNode.name.value}: ${constructType(
@@ -186,7 +187,7 @@ function getOptimisticUpdatersConfig(schema: GraphQLSchema, convertName: Convert
     fields.forEach(fieldNode => {
       const argsName = fieldNode.arguments?.length
         ? convertName(`Mutation${capitalize(fieldNode.name.value)}Args`)
-        : '{}';
+        : 'Record<string, never>';
       const type = unwrapType(fieldNode.type);
       const outputType = constructType(type, schema, convertName);
       optimistic.push(

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -12,25 +12,25 @@ export type GraphCacheKeysConfig = {
 
 export type GraphCacheResolvers = {
   Query?: {
-    schoolBooks?: GraphCacheResolver<WithTypename<Query>, null, Array<WithTypename<Textbook> | string>>
+    schoolBooks?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, Array<WithTypename<Textbook> | string>>
   },
   Author?: {
-    id?: GraphCacheResolver<WithTypename<Author>, null, Scalars['ID'] | string>,
-    name?: GraphCacheResolver<WithTypename<Author>, null, Scalars['String'] | string>,
-    friends?: GraphCacheResolver<WithTypename<Author>, null, Array<WithTypename<Author> | string>>,
+    id?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['ID'] | string>,
+    name?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['String'] | string>,
+    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<WithTypename<Author> | string>>,
     friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<WithTypename<Author> | string>>
   },
   Todo?: {
-    id?: GraphCacheResolver<WithTypename<Todo>, null, Scalars['ID'] | string>,
-    text?: GraphCacheResolver<WithTypename<Todo>, null, Scalars['String'] | string>,
-    complete?: GraphCacheResolver<WithTypename<Todo>, null, Scalars['Boolean'] | string>,
-    author?: GraphCacheResolver<WithTypename<Todo>, null, WithTypename<Author> | string>
+    id?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['ID'] | string>,
+    text?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['String'] | string>,
+    complete?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['Boolean'] | string>,
+    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, WithTypename<Author> | string>
   },
   Textbook?: {
-    id?: GraphCacheResolver<WithTypename<Textbook>, null, Scalars['ID'] | string>,
-    title?: GraphCacheResolver<WithTypename<Textbook>, null, Scalars['String'] | string>,
-    author?: GraphCacheResolver<WithTypename<Textbook>, null, WithTypename<Author> | string>,
-    todo?: GraphCacheResolver<WithTypename<Textbook>, null, WithTypename<Todo> | string>
+    id?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, Scalars['ID'] | string>,
+    title?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, Scalars['String'] | string>,
+    author?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, WithTypename<Author> | string>,
+    todo?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, WithTypename<Todo> | string>
   }
 };
 
@@ -62,17 +62,17 @@ export type GraphCacheKeysConfig = {
 
 export type GraphCacheResolvers = {
   Query?: {
-    media?: GraphCacheResolver<WithTypename<Query>, null, Array<WithTypename<Media> | string>>
+    media?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, Array<WithTypename<Media> | string>>
   },
   Book?: {
-    id?: GraphCacheResolver<WithTypename<Book>, null, Scalars['ID'] | string>,
-    title?: GraphCacheResolver<WithTypename<Book>, null, Scalars['String'] | string>,
-    pages?: GraphCacheResolver<WithTypename<Book>, null, Scalars['Int'] | string>
+    id?: GraphCacheResolver<WithTypename<Book>, Record<string, never>, Scalars['ID'] | string>,
+    title?: GraphCacheResolver<WithTypename<Book>, Record<string, never>, Scalars['String'] | string>,
+    pages?: GraphCacheResolver<WithTypename<Book>, Record<string, never>, Scalars['Int'] | string>
   },
   Movie?: {
-    id?: GraphCacheResolver<WithTypename<Movie>, null, Scalars['ID'] | string>,
-    title?: GraphCacheResolver<WithTypename<Movie>, null, Scalars['String'] | string>,
-    duration?: GraphCacheResolver<WithTypename<Movie>, null, Scalars['Int'] | string>
+    id?: GraphCacheResolver<WithTypename<Movie>, Record<string, never>, Scalars['ID'] | string>,
+    title?: GraphCacheResolver<WithTypename<Movie>, Record<string, never>, Scalars['String'] | string>,
+    duration?: GraphCacheResolver<WithTypename<Movie>, Record<string, never>, Scalars['Int'] | string>
   }
 };
 
@@ -106,19 +106,19 @@ export type GraphCacheKeysConfig = {
 
 export type GraphCacheResolvers = {
   Query?: {
-    todos?: GraphCacheResolver<WithTypename<Query>, null, Array<WithTypename<Todo> | string>>
+    todos?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, Array<WithTypename<Todo> | string>>
   },
   Author?: {
-    id?: GraphCacheResolver<WithTypename<Author>, null, Scalars['ID'] | string>,
-    name?: GraphCacheResolver<WithTypename<Author>, null, Scalars['String'] | string>,
-    friends?: GraphCacheResolver<WithTypename<Author>, null, Array<WithTypename<Author> | string>>,
+    id?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['ID'] | string>,
+    name?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['String'] | string>,
+    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<WithTypename<Author> | string>>,
     friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<WithTypename<Author> | string>>
   },
   Todo?: {
-    id?: GraphCacheResolver<WithTypename<Todo>, null, Scalars['ID'] | string>,
-    text?: GraphCacheResolver<WithTypename<Todo>, null, Scalars['String'] | string>,
-    complete?: GraphCacheResolver<WithTypename<Todo>, null, Scalars['Boolean'] | string>,
-    author?: GraphCacheResolver<WithTypename<Todo>, null, WithTypename<Author> | string>
+    id?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['ID'] | string>,
+    text?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['String'] | string>,
+    complete?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['Boolean'] | string>,
+    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, WithTypename<Author> | string>
   }
 };
 


### PR DESCRIPTION
## Description

This brings the types up to speed, urql defaults variables to an empty object.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Test Environment**:
- OS:  Windows 10
- `@graphql-codegen/...`: urql-graphcache
- NodeJS: 14.15.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
