### PR TITLE
Fix typo in base-visitor.ts

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -188,9 +188,9 @@ export interface RawConfig {
    */
   globalNamespace?: boolean;
   /**
-   * @description  Removes fragment duplicants for reducing data transfer.
+   * @description  Removes fragment duplicates for reducing data transfer.
    * It is done by removing sub-fragments imports from fragment definition
-   * Instead - import all of them are imported to the Operation node.
+   * Instead - all of them are imported to the Operation node.
    * @type boolean
    * @default false
    */


### PR DESCRIPTION
## Description

Fixes typo in the `dedupeFragments` config option documentation.

Fixes #6163

## Type of change

Please delete options that are not relevant.

- [X] Documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:
- OS: 
- `@graphql-codegen/...`: 
- NodeJS: 

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
