### PR TITLE
Fix missing imports on dedupeFragments with near-operation-file

### DIFF
--- a/.changeset/rotten-pets-notice.md
+++ b/.changeset/rotten-pets-notice.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/near-operation-file-preset': patch
+---
+
+fix missing imports on dedupeFragments on near-operation-file

--- a/packages/presets/near-operation-file/src/fragment-resolver.ts
+++ b/packages/presets/near-operation-file/src/fragment-resolver.ts
@@ -128,14 +128,15 @@ function buildFragmentRegistry(
 export default function buildFragmentResolver<T>(
   collectorOptions: DocumentImportResolverOptions,
   presetOptions: Types.PresetFnArgs<T>,
-  schemaObject: GraphQLSchema
+  schemaObject: GraphQLSchema,
+  dedupeFragments = false
 ) {
   const fragmentRegistry = buildFragmentRegistry(collectorOptions, presetOptions, schemaObject);
   const { baseOutputDir } = presetOptions;
   const { baseDir, typesImport } = collectorOptions;
 
   function resolveFragments(generatedFilePath: string, documentFileContent: DocumentNode) {
-    const fragmentsInUse = extractExternalFragmentsInUse(documentFileContent, fragmentRegistry);
+    const fragmentsInUse = extractExternalFragmentsInUse(documentFileContent, fragmentRegistry, dedupeFragments);
 
     const externalFragments: LoadedFragment<{ level: number }>[] = [];
     // fragment files to import names

--- a/packages/presets/near-operation-file/src/resolve-document-imports.ts
+++ b/packages/presets/near-operation-file/src/resolve-document-imports.ts
@@ -50,9 +50,10 @@ interface ResolveDocumentImportResult {
 export function resolveDocumentImports<T>(
   presetOptions: Types.PresetFnArgs<T>,
   schemaObject: GraphQLSchema,
-  importResolverOptions: DocumentImportResolverOptions
+  importResolverOptions: DocumentImportResolverOptions,
+  dedupeFragments = false
 ): Array<ResolveDocumentImportResult> {
-  const resolveFragments = buildFragmentResolver(importResolverOptions, presetOptions, schemaObject);
+  const resolveFragments = buildFragmentResolver(importResolverOptions, presetOptions, schemaObject, dedupeFragments);
   const { baseOutputDir, documents } = presetOptions;
   const { generateFilePath, schemaTypesSource, baseDir, typesImport } = importResolverOptions;
 

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -17,6 +17,7 @@ export function appendExtensionToFilePath(baseFilePath: string, extension: strin
 export function extractExternalFragmentsInUse(
   documentNode: DocumentNode | FragmentDefinitionNode,
   fragmentNameToFile: FragmentRegistry,
+  dedupeFragments = false,
   result: { [fragmentName: string]: number } = {},
   level = 0
 ): { [fragmentName: string]: number } {
@@ -46,8 +47,9 @@ export function extractExternalFragmentsInUse(
               extractExternalFragmentsInUse(
                 fragmentNameToFile[node.name.value].node,
                 fragmentNameToFile,
+                dedupeFragments,
                 result,
-                level + 1
+                level + (documentNode.kind === 'Document' && dedupeFragments ? 0 : 1)
               );
             }
           }


### PR DESCRIPTION
## Description
Fix missing imports on dedupeFragments with near-operation-file
Related #6217 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)