### PR TITLE
fixed missing schema property in urql GraphCacheConfig

### DIFF
--- a/.changeset/witty-donkeys-remember.md
+++ b/.changeset/witty-donkeys-remember.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-urql-graphcache': minor
+---
+
+Added missing schema property to GraphCacheConfig

--- a/.changeset/witty-donkeys-remember.md
+++ b/.changeset/witty-donkeys-remember.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-codegen/typescript-urql-graphcache': minor
+'@graphql-codegen/typescript-urql-graphcache': patch
 ---
 
 Added missing schema property to GraphCacheConfig

--- a/.changeset/witty-donkeys-remember.md
+++ b/.changeset/witty-donkeys-remember.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/typescript-urql-graphcache': patch
 ---
 
-Added missing schema property to GraphCacheConfig
+Added missing schema and storage properties to GraphCacheConfig

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -3,6 +3,7 @@ import {
   UpdateResolver as GraphCacheUpdateResolver,
   OptimisticMutationResolver as GraphCacheOptimisticMutationResolver,
 } from '@urql/exchange-graphcache';
+import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
 import gql from 'graphql-tag';
 import * as Urql from 'urql';
 export type Maybe<T> = T | null;
@@ -1064,6 +1065,7 @@ export type GraphCacheUpdaters = {
 };
 
 export type GraphCacheConfig = {
+  schema?: IntrospectionData;
   updates?: GraphCacheUpdaters;
   keys?: GraphCacheKeysConfig;
   optimistic?: GraphCacheOptimisticUpdaters;

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -2,6 +2,7 @@ import {
   Resolver as GraphCacheResolver,
   UpdateResolver as GraphCacheUpdateResolver,
   OptimisticMutationResolver as GraphCacheOptimisticMutationResolver,
+  StorageAdapter as GraphCacheStorageAdapter,
 } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
 import gql from 'graphql-tag';
@@ -1070,4 +1071,5 @@ export type GraphCacheConfig = {
   keys?: GraphCacheKeysConfig;
   optimistic?: GraphCacheOptimisticUpdaters;
   resolvers?: GraphCacheResolvers;
+  storage?: GraphCacheStorageAdapter;
 };

--- a/packages/plugins/typescript/urql-graphcache/src/constants.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/constants.ts
@@ -1,3 +1,3 @@
 export const imports =
-  `import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache'\n` +
-  `import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast'`;
+  `import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';\n` +
+  `import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';`;

--- a/packages/plugins/typescript/urql-graphcache/src/constants.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/constants.ts
@@ -1,1 +1,3 @@
-export const imports = `import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';`;
+export const imports =
+  `import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache'\n` +
+  `import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast'`;

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -234,6 +234,7 @@ export const plugin: PluginFunction<UrqlGraphCacheConfig, Types.ComplexPluginOut
         ',\n};',
 
       'export type GraphCacheConfig = {\n' +
+        '  schema?: IntrospectionData,\n' +
         '  updates?: GraphCacheUpdaters,\n' +
         '  keys?: GraphCacheKeysConfig,\n' +
         '  optimistic?: GraphCacheOptimisticUpdaters,\n' +

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -238,7 +238,8 @@ export const plugin: PluginFunction<UrqlGraphCacheConfig, Types.ComplexPluginOut
         '  updates?: GraphCacheUpdaters,\n' +
         '  keys?: GraphCacheKeysConfig,\n' +
         '  optimistic?: GraphCacheOptimisticUpdaters,\n' +
-        '  resolvers?: GraphCacheResolvers\n' +
+        '  resolvers?: GraphCacheResolvers,\n' +
+        '  storage?: GraphCacheStorageAdapter\n' +
         '};',
     ]
       .filter(Boolean)

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`urql graphcache Should output the cache-generic correctly (with interfaces) 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache'
-import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast'
+"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
+import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
 export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
@@ -49,13 +49,14 @@ export type GraphCacheConfig = {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
-  resolvers?: GraphCacheResolvers
+  resolvers?: GraphCacheResolvers,
+  storage?: GraphCacheStorageAdapter
 };"
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly (with unions) 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache'
-import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast'
+"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
+import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
 export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
@@ -95,13 +96,14 @@ export type GraphCacheConfig = {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
-  resolvers?: GraphCacheResolvers
+  resolvers?: GraphCacheResolvers,
+  storage?: GraphCacheStorageAdapter
 };"
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache'
-import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast'
+"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
+import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
 export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
@@ -151,6 +153,7 @@ export type GraphCacheConfig = {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
-  resolvers?: GraphCacheResolvers
+  resolvers?: GraphCacheResolvers,
+  storage?: GraphCacheStorageAdapter
 };"
 `;

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`urql graphcache Should output the cache-generic correctly (with interfaces) 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
+"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache'
+import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast'
 export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
@@ -44,6 +45,7 @@ export type GraphCacheUpdaters = {
 };
 
 export type GraphCacheConfig = {
+  schema?: IntrospectionData,
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
@@ -52,7 +54,8 @@ export type GraphCacheConfig = {
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly (with unions) 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
+"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache'
+import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast'
 export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
@@ -88,6 +91,7 @@ export type GraphCacheUpdaters = {
 };
 
 export type GraphCacheConfig = {
+  schema?: IntrospectionData,
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
@@ -96,7 +100,8 @@ export type GraphCacheConfig = {
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
+"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache'
+import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast'
 export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
@@ -142,6 +147,7 @@ export type GraphCacheUpdaters = {
 };
 
 export type GraphCacheConfig = {
+  schema?: IntrospectionData,
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,


### PR DESCRIPTION
## Description
This PR adds schema property which is missing in GraphqlCacheConfig.

Related #6228 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] snapshot test
- [x] ran `yarn generate:examples` to make sure the generated file is as expected.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

