### PR TITLE
feat: allow returning string literal types for resolvers returning enum values

### DIFF
--- a/.changeset/swift-fishes-draw.md
+++ b/.changeset/swift-fishes-draw.md
@@ -1,0 +1,7 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-resolvers': minor
+'@graphql-codegen/typescript': minor
+---
+
+add `allowEnumStringTypes` option for allowing string literals as valid return types from resolvers in addition to enum values.\_

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -31,6 +31,7 @@ export interface ParsedConfig {
   immutableTypes: boolean;
   useTypeImports: boolean;
   dedupeFragments: boolean;
+  allowEnumStringTypes: boolean;
 }
 
 export interface RawConfig {
@@ -195,6 +196,10 @@ export interface RawConfig {
    * @default false
    */
   dedupeFragments?: boolean;
+  /**
+   * @ignore
+   */
+  allowEnumStringTypes?: boolean;
 }
 
 export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig extends ParsedConfig = ParsedConfig> {
@@ -213,6 +218,7 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
       nonOptionalTypename: !!rawConfig.nonOptionalTypename,
       useTypeImports: !!rawConfig.useTypeImports,
       dedupeFragments: !!rawConfig.dedupeFragments,
+      allowEnumStringTypes: !!rawConfig.allowEnumStringTypes,
       ...((additionalConfig || {}) as any),
     };
 

--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -276,4 +276,14 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    * ```
    */
   entireFieldWrapperValue?: string;
+  /**
+   * @description Allow using enum string values directly.
+   *
+   * @exampleMarkdown
+   * ```yml
+   *   config:
+   *     allowEnumStringTypes: true
+   * ```
+   */
+  allowEnumStringTypes?: boolean;
 }

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2908,6 +2908,29 @@ describe('TypeScript', () => {
 
       validateTs(result);
     });
+
+    it('allowEnumStringTypes', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        enum MyEnum {
+          A
+          B
+          C
+        }
+        type Query {
+          a: MyEnum
+        }
+      `);
+      const result = (await plugin(
+        schema,
+        [],
+        { allowEnumStringTypes: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      validateTs(result);
+
+      expect(result.content).toBeSimilarStringTo('a?: Maybe<MyEnum | `${MyEnum}`>;');
+    });
   });
 
   it('should not have [object Object]', async () => {


### PR DESCRIPTION
## Description

Sometimes you already have const strings returned from your Database layer. Having to map them to the corresponding GraphQL Enum type can be an annoying task.

Often we simply cast them instead of doing a more error-prone mapping using a mapper function based on switch statements (e.g. `moodTags: (record) => record.moodTags as Array<AudioAnalysisV6MoodTags>,`). However, doing so can cause unnoticed bugs when one of the taxonomies changes.

WIth TypeScript literal types we can now map TypeScript enum types to literal union types easily.

```ts
enum AEnum {
  A = "A"
  B = "B"
  C = "C"
}

type ValuesOfA = `${AEnum}` // "A" | "B" | "C"
const value1: ValuesOfA = "A" // ok
const value2: AEnum = "A" // error, we can only assign AEnum.A :/

```

Related # (none)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

-

## How Has This Been Tested?

I added a unit test and tested it in a production codebase.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

-
