### PR TITLE
Update programmatic-usage.md (#6264) [deploy_website]

### DIFF
--- a/website/docs/getting-started/programmatic-usage.md
+++ b/website/docs/getting-started/programmatic-usage.md
@@ -18,11 +18,14 @@ Then, create a configuration object ([complete signature](https://github.com/dot
 ```ts
 import { buildSchema, printSchema, parse, GraphQLSchema } from 'graphql';
 import * as fs from 'fs';
+import * as path from 'path';
 import * as typescriptPlugin from '@graphql-codegen/typescript';
 
 const schema: GraphQLSchema = buildSchema(`type A { name: String }`);
 const outputFile = 'relative/pathTo/filename.ts';
 const config = {
+  documents: [],
+  config: {},
   // used by a plugin internally, although the 'typescript' plugin currently
   // returns the string output, rather than writing to a file
   filename: outputFile,


### PR DESCRIPTION
## Description

The documentation for programmatic usage doesn't work for typescript/node as is. I think both keys I added should be marked optional and the code should reflect that, but this is the fix to get it working in the first place. I'd love to look into making this work. Path isn't available globally by default in my setup, but I think that's a general issue, so that should be imported too.

Related # (issue)

#6263

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

**Test Environment**:
OS: macOS Big Sur 11.4
"@graphql-codegen/cli": "1.21.6",
"@graphql-codegen/introspection": "1.18.2",
"@graphql-codegen/typescript": "1.22.4",
NodeJS: v15.14.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A, but the issue I linked gives some additional info