### PR TITLE
Fix a typo in custom-codegen contributing.md file

### DIFF
--- a/website/docs/custom-codegen/contributing.md
+++ b/website/docs/custom-codegen/contributing.md
@@ -198,7 +198,7 @@ export type MyPluginConfig = {
 };
 ```
 
-Now, open `./website/generate-config.js` and add a record to the mapping in that filee, point the file with the configuration annotation, and the output file:
+Now, open `./website/generate-config.js` and add a record to the mapping in that file, point the file with the configuration annotation, and the output file:
 
 ```js
 const mapping = {


### PR DESCRIPTION
## Description

There is no such word as `filee` and the sentence makes sense with just `file` , so I assume it's a typo.

## Type of change

- n/a Bug fix (non-breaking change which fixes an issue)
- n/a New feature (non-breaking change which adds functionality)
- n/a Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

https://www.graphql-code-generator.com/docs/custom-codegen/contributing

![Screenshot 2021-07-07 at 20 51 43](https://user-images.githubusercontent.com/2437969/124814060-d600ce00-df65-11eb-91aa-f51f98eea4b7.jpeg)


## How Has This Been Tested?

1. Start website
```
yarn workspace @graphql-codegen/website run start
```

2. Visit http://localhost:3000/docs/custom-codegen/contributing


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- n/a I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- n/a I have added tests that prove my fix is effective or that my feature works
- n/a New and existing unit tests pass locally with my changes
- n/a Any dependent changes have been merged and published in downstream modules
