### PR TITLE
Added new config for `typescript-resolvers`: `externalMappersFrom`

### DIFF
--- a/.changeset/heavy-windows-remain.md
+++ b/.changeset/heavy-windows-remain.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Added support for externalMappersFrom flag

--- a/.changeset/twelve-poems-stare.md
+++ b/.changeset/twelve-poems-stare.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-resolvers': minor
+---
+
+Added support for using `mappers` with an external TypeScript type, and use type inference for type-checking. (`externalMappersFrom`)

--- a/dev-test/codegen.yml
+++ b/dev-test/codegen.yml
@@ -30,7 +30,7 @@ generates:
       - typescript
       - typescript-resolvers
   ./dev-test/test-schema/typings-external-mappers.ts:
-    schema: ./dev-test/test-schema/schema.json
+    schema: ./dev-test/test-schema/schema-with-root.graphql
     config:
       externalMappersFrom: './external-mappers#Mappers'
     plugins:

--- a/dev-test/codegen.yml
+++ b/dev-test/codegen.yml
@@ -29,6 +29,13 @@ generates:
     plugins:
       - typescript
       - typescript-resolvers
+  ./dev-test/test-schema/typings-external-mappers.ts:
+    schema: ./dev-test/test-schema/schema.json
+    config:
+      externalMappersFrom: './external-mappers#Mappers'
+    plugins:
+      - typescript
+      - typescript-resolvers
   ./dev-test/test-schema/typings.avoidOptionals.ts:
     schema: ./dev-test/test-schema/schema.json
     config:

--- a/dev-test/test-schema/external-mappers.ts
+++ b/dev-test/test-schema/external-mappers.ts
@@ -1,0 +1,3 @@
+export type Mappers = {
+  User: string;
+};

--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -14,6 +14,11 @@ export type Scalars = {
   Float: number;
 };
 
+export type Profile = {
+  __typename?: 'Profile';
+  age: Scalars['Int'];
+};
+
 export type Query = {
   __typename?: 'Query';
   someDummyField: Scalars['Int'];
@@ -40,6 +45,7 @@ export type User = {
   id: Scalars['Int'];
   name: Scalars['String'];
   email: Scalars['String'];
+  profile: Profile;
 };
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
@@ -128,8 +134,9 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
-  Query: ResolverTypeWrapper<{}>;
+  Profile: ResolverTypeWrapper<Profile>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
+  Query: ResolverTypeWrapper<{}>;
   QueryRoot: ResolverTypeWrapper<QueryRoot>;
   SubscriptionRoot: ResolverTypeWrapper<{}>;
   User: ResolverTypeWrapper<User>;
@@ -139,13 +146,22 @@ export type ResolversTypes = {
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
-  Query: {};
+  Profile: Profile;
   Int: Scalars['Int'];
+  Query: {};
   QueryRoot: QueryRoot;
   SubscriptionRoot: {};
   User: User;
   String: Scalars['String'];
   Boolean: Scalars['Boolean'];
+};
+
+export type ProfileResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Profile'] = ResolversParentTypes['Profile']
+> = {
+  age?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type QueryResolvers<
@@ -184,10 +200,12 @@ export type UserResolvers<
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  profile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type Resolvers<ContextType = any> = {
+  Profile?: ProfileResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   QueryRoot?: QueryRootResolvers<ContextType>;
   SubscriptionRoot?: SubscriptionRootResolvers<ContextType>;

--- a/dev-test/test-schema/schema-with-root.graphql
+++ b/dev-test/test-schema/schema-with-root.graphql
@@ -19,6 +19,11 @@ type User {
   id: Int!
   name: String!
   email: String!
+  profile: Profile!
+}
+
+type Profile {
+  age: Int!
 }
 
 type SubscriptionRoot {

--- a/dev-test/test-schema/typings-external-mappers.ts
+++ b/dev-test/test-schema/typings-external-mappers.ts
@@ -1,0 +1,164 @@
+import { GraphQLResolveInfo } from 'graphql';
+import { Mappers } from './external-mappers';
+export type Maybe<T> = T | null;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+type UseExternalMapper<
+  TDictinary extends Record<string, unknown>,
+  TTypeName extends string,
+  TFallback
+> = TTypeName extends keyof TDictinary ? TDictinary[TTypeName] : TFallback;
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } &
+  { [P in K]-?: NonNullable<T[P]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  allUsers: Array<Maybe<User>>;
+  userById?: Maybe<User>;
+};
+
+export type QueryUserByIdArgs = {
+  id: Scalars['Int'];
+};
+
+export type User = {
+  __typename?: 'User';
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  email: Scalars['String'];
+};
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  fragment: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+
+export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  selectionSet: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | StitchingResolver<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
+  obj: T,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  Query: ResolverTypeWrapper<{}>;
+  Int: ResolverTypeWrapper<Scalars['Int']>;
+  User: ResolverTypeWrapper<UseExternalMapper<Mappers, 'User', User>>;
+  String: ResolverTypeWrapper<Scalars['String']>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+};
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  Query: {};
+  Int: Scalars['Int'];
+  User: UseExternalMapper<Mappers, 'User', User>;
+  String: Scalars['String'];
+  Boolean: Scalars['Boolean'];
+};
+
+export type QueryResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+> = {
+  allUsers?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, ContextType>;
+  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserByIdArgs, 'id'>>;
+};
+
+export type UserResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
+> = {
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type Resolvers<ContextType = any> = {
+  Query?: QueryResolvers<ContextType>;
+  User?: UserResolvers<ContextType>;
+};
+
+/**
+ * @deprecated
+ * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
+ */
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;

--- a/dev-test/test-schema/typings-external-mappers.ts
+++ b/dev-test/test-schema/typings-external-mappers.ts
@@ -146,12 +146,14 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   QueryRoot: ResolverTypeWrapper<
     Omit<QueryRoot, 'allUsers' | 'userById'> & {
-      allUsers: Array<Maybe<ResolversTypes['User']>>;
-      userById?: Maybe<ResolversTypes['User']>;
+      allUsers: Array<Maybe<UseExternalMapper<Mappers, 'User', ResolversTypes['User']>>>;
+      userById?: Maybe<UseExternalMapper<Mappers, 'User', ResolversTypes['User']>>;
     }
   >;
   SubscriptionRoot: ResolverTypeWrapper<{}>;
-  User: ResolverTypeWrapper<Omit<User, 'profile'> & { profile: ResolversTypes['Profile'] }>;
+  User: ResolverTypeWrapper<
+    Omit<User, 'profile'> & { profile: UseExternalMapper<Mappers, 'Profile', ResolversTypes['Profile']> }
+  >;
   String: ResolverTypeWrapper<Scalars['String']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
 };
@@ -162,11 +164,11 @@ export type ResolversParentTypes = {
   Int: Scalars['Int'];
   Query: {};
   QueryRoot: Omit<QueryRoot, 'allUsers' | 'userById'> & {
-    allUsers: Array<Maybe<ResolversParentTypes['User']>>;
-    userById?: Maybe<ResolversParentTypes['User']>;
+    allUsers: Array<Maybe<UseExternalMapper<Mappers, 'User', ResolversParentTypes['User']>>>;
+    userById?: Maybe<UseExternalMapper<Mappers, 'User', ResolversParentTypes['User']>>;
   };
   SubscriptionRoot: {};
-  User: Omit<User, 'profile'> & { profile: ResolversParentTypes['Profile'] };
+  User: Omit<User, 'profile'> & { profile: UseExternalMapper<Mappers, 'Profile', ResolversParentTypes['Profile']> };
   String: Scalars['String'];
   Boolean: Scalars['Boolean'];
 };

--- a/dev-test/test-schema/typings-external-mappers.ts
+++ b/dev-test/test-schema/typings-external-mappers.ts
@@ -9,6 +9,7 @@ type UseExternalMapper<
   TTypeName extends string,
   TFallback
 > = TTypeName extends keyof TDictinary ? TDictinary[TTypeName] : TFallback;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } &
   { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
@@ -143,9 +144,14 @@ export type ResolversTypes = {
   Profile: ResolverTypeWrapper<UseExternalMapper<Mappers, 'Profile', Profile>>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
   Query: ResolverTypeWrapper<{}>;
-  QueryRoot: ResolverTypeWrapper<UseExternalMapper<Mappers, 'QueryRoot', QueryRoot>>;
+  QueryRoot: ResolverTypeWrapper<
+    Omit<QueryRoot, 'allUsers' | 'userById'> & {
+      allUsers: Array<Maybe<ResolversTypes['User']>>;
+      userById?: Maybe<ResolversTypes['User']>;
+    }
+  >;
   SubscriptionRoot: ResolverTypeWrapper<{}>;
-  User: ResolverTypeWrapper<UseExternalMapper<Mappers, 'User', User>>;
+  User: ResolverTypeWrapper<Omit<User, 'profile'> & { profile: ResolversTypes['Profile'] }>;
   String: ResolverTypeWrapper<Scalars['String']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
 };
@@ -155,9 +161,12 @@ export type ResolversParentTypes = {
   Profile: UseExternalMapper<Mappers, 'Profile', Profile>;
   Int: Scalars['Int'];
   Query: {};
-  QueryRoot: UseExternalMapper<Mappers, 'QueryRoot', QueryRoot>;
+  QueryRoot: Omit<QueryRoot, 'allUsers' | 'userById'> & {
+    allUsers: Array<Maybe<ResolversParentTypes['User']>>;
+    userById?: Maybe<ResolversParentTypes['User']>;
+  };
   SubscriptionRoot: {};
-  User: UseExternalMapper<Mappers, 'User', User>;
+  User: Omit<User, 'profile'> & { profile: ResolversParentTypes['Profile'] };
   String: Scalars['String'];
   Boolean: Scalars['Boolean'];
 };

--- a/dev-test/test-schema/typings-external-mappers.ts
+++ b/dev-test/test-schema/typings-external-mappers.ts
@@ -20,14 +20,30 @@ export type Scalars = {
   Float: number;
 };
 
-export type Query = {
-  __typename?: 'Query';
-  allUsers: Array<Maybe<User>>;
-  userById?: Maybe<User>;
+export type Profile = {
+  __typename?: 'Profile';
+  age: Scalars['Int'];
 };
 
-export type QueryUserByIdArgs = {
+export type Query = {
+  __typename?: 'Query';
+  someDummyField: Scalars['Int'];
+};
+
+export type QueryRoot = {
+  __typename?: 'QueryRoot';
+  allUsers: Array<Maybe<User>>;
+  userById?: Maybe<User>;
+  answer: Array<Scalars['Int']>;
+};
+
+export type QueryRootUserByIdArgs = {
   id: Scalars['Int'];
+};
+
+export type SubscriptionRoot = {
+  __typename?: 'SubscriptionRoot';
+  newUser?: Maybe<User>;
 };
 
 export type User = {
@@ -35,9 +51,14 @@ export type User = {
   id: Scalars['Int'];
   name: Scalars['String'];
   email: Scalars['String'];
+  profile: Profile;
 };
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
 
 export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
   fragment: string;
@@ -53,6 +74,7 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> =
   | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
+  | ResolverWithResolve<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
@@ -118,8 +140,11 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
-  Query: ResolverTypeWrapper<{}>;
+  Profile: ResolverTypeWrapper<UseExternalMapper<Mappers, 'Profile', Profile>>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
+  Query: ResolverTypeWrapper<{}>;
+  QueryRoot: ResolverTypeWrapper<UseExternalMapper<Mappers, 'QueryRoot', QueryRoot>>;
+  SubscriptionRoot: ResolverTypeWrapper<{}>;
   User: ResolverTypeWrapper<UseExternalMapper<Mappers, 'User', User>>;
   String: ResolverTypeWrapper<Scalars['String']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -127,19 +152,51 @@ export type ResolversTypes = {
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
-  Query: {};
+  Profile: UseExternalMapper<Mappers, 'Profile', Profile>;
   Int: Scalars['Int'];
+  Query: {};
+  QueryRoot: UseExternalMapper<Mappers, 'QueryRoot', QueryRoot>;
+  SubscriptionRoot: {};
   User: UseExternalMapper<Mappers, 'User', User>;
   String: Scalars['String'];
   Boolean: Scalars['Boolean'];
+};
+
+export type ProfileResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Profile'] = ResolversParentTypes['Profile']
+> = {
+  age?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type QueryResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
 > = {
+  someDummyField?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+};
+
+export type QueryRootResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['QueryRoot'] = ResolversParentTypes['QueryRoot']
+> = {
   allUsers?: Resolver<Array<Maybe<ResolversTypes['User']>>, ParentType, ContextType>;
-  userById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserByIdArgs, 'id'>>;
+  userById?: Resolver<
+    Maybe<ResolversTypes['User']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryRootUserByIdArgs, 'id'>
+  >;
+  answer?: Resolver<Array<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type SubscriptionRootResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['SubscriptionRoot'] = ResolversParentTypes['SubscriptionRoot']
+> = {
+  newUser?: SubscriptionResolver<Maybe<ResolversTypes['User']>, 'newUser', ParentType, ContextType>;
 };
 
 export type UserResolvers<
@@ -149,11 +206,15 @@ export type UserResolvers<
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  profile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type Resolvers<ContextType = any> = {
+  Profile?: ProfileResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  QueryRoot?: QueryRootResolvers<ContextType>;
+  SubscriptionRoot?: SubscriptionRootResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
 };
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -565,7 +565,6 @@ export class BaseResolversVisitor<
           .map(type => getTypeToUse(type.name))
           .join(' | ');
       } else if (this.config.externalMappersFrom) {
-        shouldApplyOmit = true;
         prev[typeName] = applyWrapper(this.applyUseExternalMappers(typeName));
       } else {
         shouldApplyOmit = true;

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -565,6 +565,7 @@ export class BaseResolversVisitor<
           .map(type => getTypeToUse(type.name))
           .join(' | ');
       } else if (this.config.externalMappersFrom) {
+        shouldApplyOmit = true;
         prev[typeName] = applyWrapper(this.applyUseExternalMappers(typeName));
       } else {
         shouldApplyOmit = true;

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -443,7 +443,7 @@ export class BaseResolversVisitor<
     // In case we are using external mappers that are inferred using TypeScript, we don't want to map them manually
     // And we can safely assume that using `UseExtermalMapper` will return the correct type, so the fallback is done there
     // instead of during during code-generation
-    if (this.config.externalMappersFrom) {
+    if (this.config.externalMappersFrom && (isObjectType(type) || isInterfaceType(type))) {
       return true;
     }
 
@@ -564,7 +564,7 @@ export class BaseResolversVisitor<
           .getTypes()
           .map(type => getTypeToUse(type.name))
           .join(' | ');
-      } else if (this.config.externalMappersFrom) {
+      } else if (this.config.externalMappersFrom && nestedMapping[typeName]) {
         prev[typeName] = this.applyUseExternalMappers(typeName);
         shouldApplyOmit = true;
       } else {

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -597,7 +597,7 @@ export class BaseResolversVisitor<
               replaceWithType: wrapTypeWithModifiers(
                 nestedMapping[baseType.name] && this.config.externalMappersFrom
                   ? this.applyUseExternalMappers(
-                      this.convertName(typeName, { useTypesPrefix: this.config.enumPrefix }, true)
+                      this.convertName(baseType.name, { useTypesPrefix: this.config.enumPrefix }, true)
                     )
                   : getTypeToUse(baseType.name),
                 field.type,

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -564,6 +564,9 @@ export class BaseResolversVisitor<
           .getTypes()
           .map(type => getTypeToUse(type.name))
           .join(' | ');
+      } else if (this.config.externalMappersFrom) {
+        prev[typeName] = this.applyUseExternalMappers(typeName);
+        shouldApplyOmit = true;
       } else {
         shouldApplyOmit = true;
         prev[typeName] = this.convertName(typeName, { useTypesPrefix: this.config.enumPrefix }, true);
@@ -601,7 +604,14 @@ export class BaseResolversVisitor<
 
         if (relevantFields.length > 0) {
           // Puts ResolverTypeWrapper on top of an entire type
-          prev[typeName] = applyWrapper(this.replaceFieldsInType(prev[typeName], relevantFields));
+          prev[typeName] = applyWrapper(
+            this.replaceFieldsInType(
+              this.config.externalMappersFrom
+                ? this.convertName(typeName, { useTypesPrefix: this.config.enumPrefix }, true)
+                : prev[typeName],
+              relevantFields
+            )
+          );
         } else {
           // We still want to use ResolverTypeWrapper, even if we don't touch any fields
           prev[typeName] = applyWrapper(prev[typeName]);

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -438,7 +438,7 @@ export class BaseResolversVisitor<
       return false;
     }
 
-    if (this.config.externalMappersFrom && isObjectType(type)) {
+    if (this.config.externalMappersFrom && (isObjectType(type) || isInterfaceType(type))) {
       return true;
     }
 
@@ -578,7 +578,8 @@ export class BaseResolversVisitor<
             const isUnion = isUnionType(baseType);
 
             if (
-              (!this.config.mappers[baseType.name] || !this.config.externalMappersFrom) &&
+              !this.config.externalMappersFrom &&
+              !this.config.mappers[baseType.name] &&
               !isUnion &&
               !nestedMapping[baseType.name]
             ) {

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -577,7 +577,11 @@ export class BaseResolversVisitor<
             const baseType = getBaseType(field.type);
             const isUnion = isUnionType(baseType);
 
-            if (!this.config.mappers[baseType.name] && !isUnion && !nestedMapping[baseType.name]) {
+            if (
+              (!this.config.mappers[baseType.name] || !this.config.externalMappersFrom) &&
+              !isUnion &&
+              !nestedMapping[baseType.name]
+            ) {
               return null;
             }
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -564,9 +564,6 @@ export class BaseResolversVisitor<
           .getTypes()
           .map(type => getTypeToUse(type.name))
           .join(' | ');
-      } else if (this.config.externalMappersFrom) {
-        shouldApplyOmit = true;
-        prev[typeName] = applyWrapper(this.applyUseExternalMappers(typeName));
       } else {
         shouldApplyOmit = true;
         prev[typeName] = this.convertName(typeName, { useTypesPrefix: this.config.enumPrefix }, true);

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -444,7 +444,7 @@ export class BaseResolversVisitor<
     // And we can safely assume that using `UseExtermalMapper` will return the correct type, so the fallback is done there
     // instead of during during code-generation
     if (this.config.externalMappersFrom) {
-      return false;
+      return true;
     }
 
     // In case we are using `mappers` configuration, we need to mark the GraphQL type

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -596,7 +596,9 @@ export class BaseResolversVisitor<
               fieldName,
               replaceWithType: wrapTypeWithModifiers(
                 nestedMapping[baseType.name] && this.config.externalMappersFrom
-                  ? this.applyUseExternalMappers(baseType.name, getTypeToUse(baseType.name))
+                  ? this.applyUseExternalMappers(
+                      this.convertName(typeName, { useTypesPrefix: this.config.enumPrefix }, true)
+                    )
                   : getTypeToUse(baseType.name),
                 field.type,
                 {

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -594,10 +594,16 @@ export class BaseResolversVisitor<
             return {
               addOptionalSign,
               fieldName,
-              replaceWithType: wrapTypeWithModifiers(getTypeToUse(baseType.name), field.type, {
-                wrapOptional: this.applyMaybe,
-                wrapArray: this.wrapWithArray,
-              }),
+              replaceWithType: wrapTypeWithModifiers(
+                nestedMapping[baseType.name] && this.config.externalMappersFrom
+                  ? this.applyUseExternalMappers(baseType.name, getTypeToUse(baseType.name))
+                  : getTypeToUse(baseType.name),
+                field.type,
+                {
+                  wrapOptional: this.applyMaybe,
+                  wrapArray: this.wrapWithArray,
+                }
+              ),
             };
           })
           .filter(a => a);
@@ -1045,10 +1051,10 @@ export type IDirectiveResolvers${contextType} = ${name}<ContextType>;`
     };
   }
 
-  protected applyUseExternalMappers(typeName: string): string {
+  protected applyUseExternalMappers(typeName: string, fallbackType: string = typeName): string {
     this._globalDeclarations.add(USE_EXTERNAL_MAPPERS_TYPE);
 
-    return `UseExternalMapper<${this.config.externalMappersFrom.type}, '${typeName}', ${typeName}>`;
+    return `UseExternalMapper<${this.config.externalMappersFrom.type}, '${typeName}', ${fallbackType}>`;
   }
 
   protected applyRequireFields(argsType: string, fields: InputValueDefinitionNode[]): string {

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -360,6 +360,7 @@ export function stripMapperTypeInterpolation(identifier: string): string {
 
 export const OMIT_TYPE = 'export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;';
 export const REQUIRE_FIELDS_TYPE = `export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };`;
+export const USE_EXTERNAL_MAPPERS_TYPE = `type UseExternalMapper<TDictinary extends Record<string, unknown>, TTypeName extends string, TFallback> = TTypeName extends keyof TDictinary ? TDictinary[TTypeName]: TFallback;`;
 
 export function mergeSelectionSets(selectionSet1: SelectionSetNode, selectionSet2: SelectionSetNode): void {
   const newSelections = [...selectionSet1.selections];
@@ -398,9 +399,11 @@ export const getFieldNodeNameValue = (node: FieldNode): string => {
   return (node.alias || node.name).value;
 };
 
-export function separateSelectionSet(
-  selections: ReadonlyArray<SelectionNode>
-): { fields: FieldNode[]; spreads: FragmentSpreadNode[]; inlines: InlineFragmentNode[] } {
+export function separateSelectionSet(selections: ReadonlyArray<SelectionNode>): {
+  fields: FieldNode[];
+  spreads: FragmentSpreadNode[];
+  inlines: InlineFragmentNode[];
+} {
   return {
     fields: selections.filter(s => s.kind === Kind.FIELD) as FieldNode[],
     inlines: selections.filter(s => s.kind === Kind.INLINE_FRAGMENT) as InlineFragmentNode[],

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -715,3 +715,137 @@ export type DirectiveResolvers<ContextType = any> = ResolversObject<{
  */
 export type IDirectiveResolvers<ContextType = any> = DirectiveResolvers<ContextType>;"
 `;
+
+exports[`TypeScript Resolvers Plugin External TS Mapper should generate nested types correctly 1`] = `
+"
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+
+export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  fragment: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+
+export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
+  selectionSet: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | ResolverWithResolve<TResult, TParent, TContext, TArgs>
+  | StitchingResolver<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  Query: ResolverTypeWrapper<{}>;
+  ProductsCollection: ResolverTypeWrapper<Omit<ProductsCollection, 'products'> & { products: Array<ResolversTypes['Product']> }>;
+  TestEnum: TestEnum;
+  Product: ResolverTypeWrapper<UseExternalMapper<Mappers, 'Product', Product>>;
+  ID: ResolverTypeWrapper<Scalars['ID']>;
+  String: ResolverTypeWrapper<Scalars['String']>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+};
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  Query: {};
+  ProductsCollection: Omit<ProductsCollection, 'products'> & { products: Array<ResolversParentTypes['Product']> };
+  Product: UseExternalMapper<Mappers, 'Product', Product>;
+  ID: Scalars['ID'];
+  String: Scalars['String'];
+  Boolean: Scalars['Boolean'];
+};
+
+export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  products?: Resolver<ResolversTypes['ProductsCollection'], ParentType, ContextType>;
+};
+
+export type ProductsCollectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['ProductsCollection'] = ResolversParentTypes['ProductsCollection']> = {
+  products?: Resolver<Array<ResolversTypes['Product']>, ParentType, ContextType>;
+  testEnum?: Resolver<Maybe<ResolversTypes['TestEnum']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ProductResolvers<ContextType = any, ParentType extends ResolversParentTypes['Product'] = ResolversParentTypes['Product']> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type Resolvers<ContextType = any> = {
+  Query?: QueryResolvers<ContextType>;
+  ProductsCollection?: ProductsCollectionResolvers<ContextType>;
+  Product?: ProductResolvers<ContextType>;
+};
+
+
+/**
+ * @deprecated
+ * Use \\"Resolvers\\" root object instead. If you wish to get \\"IResolvers\\", add \\"typesPrefix: I\\" to your config.
+ */
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;
+"
+`;

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -801,7 +801,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
-  ProductsCollection: ResolverTypeWrapper<Omit<ProductsCollection, 'products'> & { products: Array<UseExternalMapper<Mappers, 'Product', ResolversTypes['Product']>> }>;
+  ProductsCollection: ResolverTypeWrapper<Omit<ProductsCollection, 'products'> & { products: Array<UseExternalMapper<Mappers, 'Product', Product>> }>;
   TestEnum: TestEnum;
   Product: ResolverTypeWrapper<UseExternalMapper<Mappers, 'Product', Product>>;
   ID: ResolverTypeWrapper<Scalars['ID']>;
@@ -812,7 +812,7 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   Query: {};
-  ProductsCollection: Omit<ProductsCollection, 'products'> & { products: Array<UseExternalMapper<Mappers, 'Product', ResolversParentTypes['Product']>> };
+  ProductsCollection: Omit<ProductsCollection, 'products'> & { products: Array<UseExternalMapper<Mappers, 'Product', Product>> };
   Product: UseExternalMapper<Mappers, 'Product', Product>;
   ID: Scalars['ID'];
   String: Scalars['String'];

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -801,7 +801,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
-  ProductsCollection: ResolverTypeWrapper<Omit<ProductsCollection, 'products'> & { products: Array<ResolversTypes['Product']> }>;
+  ProductsCollection: ResolverTypeWrapper<Omit<ProductsCollection, 'products'> & { products: Array<UseExternalMapper<Mappers, 'Product', ResolversTypes['Product']>> }>;
   TestEnum: TestEnum;
   Product: ResolverTypeWrapper<UseExternalMapper<Mappers, 'Product', Product>>;
   ID: ResolverTypeWrapper<Scalars['ID']>;
@@ -812,7 +812,7 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   Query: {};
-  ProductsCollection: Omit<ProductsCollection, 'products'> & { products: Array<ResolversParentTypes['Product']> };
+  ProductsCollection: Omit<ProductsCollection, 'products'> & { products: Array<UseExternalMapper<Mappers, 'Product', ResolversParentTypes['Product']>> };
   Product: UseExternalMapper<Mappers, 'Product', Product>;
   ID: Scalars['ID'];
   String: Scalars['String'];

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -7,6 +7,40 @@ import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 import { ENUM_RESOLVERS_SIGNATURE } from '../src/visitor';
 
 describe('TypeScript Resolvers Plugin', () => {
+  describe('External TS Mapper', () => {
+    it('should generate nested types correctly', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          products: ProductsCollection!
+        }
+
+        type ProductsCollection {
+          products: [Product!]!
+          testEnum: TestEnum
+        }
+
+        enum TestEnum {
+          VALUE
+        }
+
+        type Product {
+          id: ID!
+          name: String!
+        }
+      `);
+      const result = await plugin(
+        testSchema,
+        [],
+        {
+          externalMappersFrom: './mappers#Mappers',
+        },
+        { outputFile: '' }
+      );
+
+      expect(result.content).toMatchSnapshot();
+    });
+  });
+
   describe('Backward Compatability', () => {
     it('Should generate IDirectiveResolvers by default', async () => {
       const result = await plugin(schema, [], {}, { outputFile: '' });

--- a/website/docs/plugins/typescript-resolvers.md
+++ b/website/docs/plugins/typescript-resolvers.md
@@ -76,6 +76,34 @@ generates:
       - typescript-resolvers
 ```
 
+If you wish to leverage TypeScript type-system and TypeScript type-inference (and you are using TS > 4), you can use `externalMappersFrom` config flag for defining your GraphQL resolvers mappers in a TypeScript file, instead in the codegen YAML config file.
+
+You can point to an external TS `type` identifier as a general mapper:
+
+```yaml
+schema: schema.graphql
+generates:
+  ./resolvers-types.ts:
+    config:
+      externalMappersFrom: "./my-mappers#TypeMapping"
+    plugins:
+      - typescript
+      - typescript-resolvers
+```
+
+And then in `my-mappers.ts` file, export an identifier called `TypeMapping` with a custom type mapping:
+
+```ts
+import { UserModel, UserProfile } from "./models";
+
+export type TypeMapping = {
+  User: UserModel,
+  Profile: UserProfile,
+}
+```
+
+Now, the generated TypeScript code will check if `TypeMapping` has a key with the GraphQL type name, and if so, it will use the type specified instead of the default type.
+
 ## Enum Resolvers
 
 [Apollo-Server](https://www.apollographql.com/docs/apollo-server/) and schemas built with [`graphql-tools`](https://www.graphql-tools.com/) supports creating resolvers for GraphQL `enum`s. 


### PR DESCRIPTION
This PR adds a new config flag for `typescript-resolvers`. If you wish to leverage TypeScript type-system and TypeScript type-inference (and you are using TS > 4), you can use `externalMappersFrom` config flag for defining your GraphQL resolvers mappers in a TypeScript file, instead in the codegen YAML config file.

You can point to an external TS `type` identifier as a general mapper:

```yaml
schema: schema.graphql
generates:
  ./resolvers-types.ts:
    config:
      externalMappersFrom: "./my-mappers#TypeMapping"
    plugins:
      - typescript
      - typescript-resolvers
```

And then in `my-mappers.ts` file, export an identifier called `TypeMapping` with a custom type mapping:

```ts
import { UserModel, UserProfile } from "./models";

export type TypeMapping = {
  User: UserModel,
  Profile: UserProfile,
}
```