### PR TITLE
fix: make plugins optional for preset

### DIFF
--- a/.changeset/loud-toys-draw.md
+++ b/.changeset/loud-toys-draw.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/cli': patch
+'@graphql-codegen/plugin-helpers': patch
+---
+
+don't require plugins for for config if preset provides plugin. Instead the preset should throw if no plugins were provided.

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -124,9 +124,9 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
     }
 
     for (const filename of generateKeys) {
-      generates[filename] = normalizeOutputParam(config.generates[filename]);
+      const output = (generates[filename] = normalizeOutputParam(config.generates[filename]));
 
-      if (generates[filename].plugins.length === 0) {
+      if (!output.preset && (!output.plugins || output.plugins.length === 0)) {
         throw new DetailedError(
           'Invalid Codegen Configuration!',
           `

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -152,6 +152,10 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
 
     const shouldAbsolute = !baseTypesPath.startsWith('~');
 
+    if (Object.keys(options.pluginMap).length === 0) {
+      throw new Error(`Preset "near-operation-file" requires you to specify plugins, that generate code.`);
+    }
+
     const pluginMap: { [name: string]: CodegenPlugin } = {
       ...options.pluginMap,
       add: addPlugin,

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -152,10 +152,6 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
 
     const shouldAbsolute = !baseTypesPath.startsWith('~');
 
-    if (Object.keys(options.pluginMap).length === 0) {
-      throw new Error(`Preset "near-operation-file" requires you to specify plugins, that generate code.`);
-    }
-
     const pluginMap: { [name: string]: CodegenPlugin } = {
       ...options.pluginMap,
       add: addPlugin,

--- a/packages/utils/plugins-helpers/src/helpers.ts
+++ b/packages/utils/plugins-helpers/src/helpers.ts
@@ -25,7 +25,7 @@ export function isOutputConfigArray(type: any): type is Types.OutputConfig[] {
 }
 
 export function isConfiguredOutput(type: any): type is Types.ConfiguredOutput {
-  return typeof type === 'object' && type.plugins;
+  return (typeof type === 'object' && type.plugins) || type.preset;
 }
 
 export function normalizeOutputParam(config: Types.OutputConfig | Types.ConfiguredOutput): Types.ConfiguredOutput {


### PR DESCRIPTION
I think it is totally legit for a preset to not require any additional plugins, having them required can be confusing. Instead the presets should throw if plugins are mandatory