### PR TITLE
map directive on FIELD_DEFINITION to custom field resolver type

### DIFF
--- a/.changeset/weak-plums-reflect.md
+++ b/.changeset/weak-plums-reflect.md
@@ -38,7 +38,7 @@ export type UnauthenticatedResolver<TResult, TParent, _TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => Promise<TResult> | TResult;
 
-export type AUthenticatedResolver<TResult, TParent, _TContext, TArgs> = (
+export type AuthenticatedResolver<TResult, TParent, _TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: AuthenticatedContext,

--- a/.changeset/weak-plums-reflect.md
+++ b/.changeset/weak-plums-reflect.md
@@ -9,6 +9,8 @@ Allow overwriting the resolver type signature based on directive usages.
 
 For actually ensuring that a type is correct at runtime you will have to use schema transforms (e.g. with [@graphql-tools/utils mapSchema](https://www.graphql-tools.com/docs/schema-directives)) that apply those rules! Otherwise, you might end up with a runtime type mismatch which could cause unnoticed bugs or runtime errors.
 
+Example configuration:
+
 ```yml
 config:
   # This was possible before
@@ -16,6 +18,32 @@ config:
   # This is new
   directiveResolverMappings:
     authenticated: ../resolvers-types.ts#AuthenticatedResolver
+```
+
+Example mapping file (`resolver-types.ts`):
+
+```ts
+export type UnauthenticatedContext = {
+  user: null;
+};
+
+export type AuthenticatedContext = {
+  user: { id: string };
+};
+
+export type UnauthenticatedResolver<TResult, TParent, _TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: UnauthenticatedContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type AUthenticatedResolver<TResult, TParent, _TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: AuthenticatedContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
 ```
 
 Example Schema:

--- a/.changeset/weak-plums-reflect.md
+++ b/.changeset/weak-plums-reflect.md
@@ -1,0 +1,30 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-resolvers': minor
+---
+
+Allow overwriting the resolver type signature based on directive usages.
+
+**WARNING:** Using this option does only change the generated type definitions.
+
+For actually ensuring that a type is correct at runtime you will have to use schema transforms (e.g. with [@graphql-tools/utils mapSchema](https://www.graphql-tools.com/docs/schema-directives)) that apply those rules! Otherwise, you might end up with a runtime type mismatch which could cause unnoticed bugs or runtime errors.
+
+```yml
+config:
+  # This was possible before
+  customResolverFn: ../resolver-types.ts#UnauthenticatedResolver
+  # This is new
+  directiveResolverMappings:
+    authenticated: ../resolvers-types.ts#AuthenticatedResolver
+```
+
+Example Schema:
+
+```graphql
+directive @authenticated on FIELD_DEFINITION
+
+type Query {
+  yee: String
+  foo: String @authenticated
+}
+```

--- a/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
+++ b/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
@@ -103,6 +103,10 @@ export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
+export type AuthenticatedDirectiveArgs = {  };
+
+export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
 export type MyTypeResolvers<ContextType = any, ParentType = $ElementType<ResolversParentTypes, 'MyType'>> = {
   foo?: Resolver<$ElementType<ResolversTypes, 'String'>, ParentType, ContextType>,
   otherType?: Resolver<?$ElementType<ResolversTypes, 'MyOtherType'>, ParentType, ContextType>,
@@ -168,6 +172,7 @@ export type Resolvers<ContextType = any> = {
 
 export type DirectiveResolvers<ContextType = any> = {
   myDirective?: MyDirectiveDirectiveResolver<any, any, ContextType>,
+  authenticated?: AuthenticatedDirectiveResolver<any, any, ContextType>,
 };
 ",
   "prepend": Array [

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -72,7 +72,7 @@ export interface ParsedResolversConfig extends ParsedConfig {
   allResolversTypeName: string;
   internalResolversPrefix: string;
   onlyResolveTypeForInterfaces: boolean;
-  directiveResolverMappings: Map<string, string>;
+  directiveResolverMappings: Record<string, string>;
 }
 
 export interface RawResolversConfig extends RawConfig {
@@ -334,7 +334,7 @@ export interface RawResolversConfig extends RawConfig {
   /**
    * @ignore
    */
-  directiveResolverMappings?: Map<string, string>;
+  directiveResolverMappings?: Record<string, string>;
 }
 
 export type ResolverTypes = { [gqlType: string]: string };
@@ -360,7 +360,7 @@ export class BaseResolversVisitor<
   protected _hasScalars = false;
   protected _hasFederation = false;
   protected _fieldContextTypeMap: FieldContextTypeMap;
-  private _directiveResolverMappings: Map<string, string>;
+  private _directiveResolverMappings: Record<string, string>;
 
   constructor(
     rawConfig: TRawConfig,
@@ -416,7 +416,7 @@ export class BaseResolversVisitor<
       namedType => !isEnumType(namedType)
     );
     this._fieldContextTypeMap = this.createFieldContextTypeMap();
-    this._directiveResolverMappings = rawConfig.directiveResolverMappings ?? new Map<string, string>();
+    this._directiveResolverMappings = rawConfig.directiveResolverMappings ?? {};
   }
 
   public getResolverTypeWrapperSignature(): string {
@@ -956,7 +956,7 @@ export class BaseResolversVisitor<
 
       const directiveMappings =
         node.directives
-          ?.map(directive => this._directiveResolverMappings.get(directive.name as any))
+          ?.map(directive => this._directiveResolverMappings[directive.name as any])
           .filter(Boolean)
           .reverse() ?? [];
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -72,7 +72,7 @@ export interface ParsedResolversConfig extends ParsedConfig {
   allResolversTypeName: string;
   internalResolversPrefix: string;
   onlyResolveTypeForInterfaces: boolean;
-  customDirectiveToResolverTypeNameMapping: Map<string, string>;
+  directiveResolverMappings: Map<string, string>;
 }
 
 export interface RawResolversConfig extends RawConfig {
@@ -334,7 +334,7 @@ export interface RawResolversConfig extends RawConfig {
   /**
    * @ignore
    */
-  customDirectiveToResolverTypeNameMappings?: Map<string, string>;
+  directiveResolverMappings?: Map<string, string>;
 }
 
 export type ResolverTypes = { [gqlType: string]: string };
@@ -360,7 +360,7 @@ export class BaseResolversVisitor<
   protected _hasScalars = false;
   protected _hasFederation = false;
   protected _fieldContextTypeMap: FieldContextTypeMap;
-  private _customDirectiveToResolverTypeNameMappings: Map<string, string>;
+  private _directiveResolverMappings: Map<string, string>;
 
   constructor(
     rawConfig: TRawConfig,
@@ -416,8 +416,7 @@ export class BaseResolversVisitor<
       namedType => !isEnumType(namedType)
     );
     this._fieldContextTypeMap = this.createFieldContextTypeMap();
-    this._customDirectiveToResolverTypeNameMappings =
-      rawConfig.customDirectiveToResolverTypeNameMappings ?? new Map<string, string>();
+    this._directiveResolverMappings = rawConfig.directiveResolverMappings ?? new Map<string, string>();
   }
 
   public getResolverTypeWrapperSignature(): string {
@@ -957,8 +956,9 @@ export class BaseResolversVisitor<
 
       const directiveMappings =
         node.directives
-          ?.map(directive => this._customDirectiveToResolverTypeNameMappings.get(directive.name as any))
-          .filter(Boolean) ?? [];
+          ?.map(directive => this._directiveResolverMappings.get(directive.name as any))
+          .filter(Boolean)
+          .reverse() ?? [];
 
       const resolverType = isSubscriptionType ? 'SubscriptionResolver' : directiveMappings[0] ?? 'Resolver';
 

--- a/packages/plugins/typescript/resolvers/src/config.ts
+++ b/packages/plugins/typescript/resolvers/src/config.ts
@@ -102,6 +102,17 @@ export interface TypeScriptResolversPluginConfig extends RawResolversConfig {
    */
   customResolverFn?: string;
   /**
+   * @description Map the usage of a directive into using a specific resolver
+   * @exampleMarkdown
+   * ```yml
+   *   config:
+   *     customResolverFn: ../resolver-types.ts#UnauthenticatedResolver
+   *     customDirectiveToResolverFnMapping:
+   *       authenticated: ../resolvers-types.ts#AuthenticatedResolver
+   * ```
+   */
+  customDirectiveToResolverFnMapping?: Record<string, string>;
+  /**
    * @description Allow you to override the `ParentType` generic in each resolver, by avoid enforcing the base type of the generated generic type.
    *
    * This will generate `ParentType = Type` instead of `ParentType extends Type = Type` in each resolver.

--- a/packages/plugins/typescript/resolvers/src/config.ts
+++ b/packages/plugins/typescript/resolvers/src/config.ts
@@ -102,16 +102,16 @@ export interface TypeScriptResolversPluginConfig extends RawResolversConfig {
    */
   customResolverFn?: string;
   /**
-   * @description Map the usage of a directive into using a specific resolver
+   * @description Map the usage of a directive into using a specific resolver.
    * @exampleMarkdown
    * ```yml
    *   config:
    *     customResolverFn: ../resolver-types.ts#UnauthenticatedResolver
-   *     customDirectiveToResolverFnMapping:
+   *     directiveResolverMappings:
    *       authenticated: ../resolvers-types.ts#AuthenticatedResolver
    * ```
    */
-  customDirectiveToResolverFnMapping?: Record<string, string>;
+  directiveResolverMappings?: Record<string, string>;
   /**
    * @description Allow you to override the `ParentType` generic in each resolver, by avoid enforcing the base type of the generated generic type.
    *

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -32,7 +32,7 @@ export const plugin: PluginFunction<TypeScriptResolversPluginConfig, Types.Compl
   const importType = config.useTypeImports ? 'import type' : 'import';
   const prepend: string[] = [];
   const defsToInclude: string[] = [];
-  const directiveResolverMappings = new Map<string, string>();
+  const directiveResolverMappings = {} as Record<string, string>;
 
   if (config.directiveResolverMappings) {
     for (const [directiveName, mapper] of Object.entries(config.directiveResolverMappings)) {
@@ -64,7 +64,7 @@ export type Resolver${capitalizedDirectiveName}WithResolve<TResult, TParent, TCo
       }
       defsToInclude.push(resolverWithResolve);
       defsToInclude.push(`${resolverType} ${resolverFnUsage} | ${resolverWithResolveUsage};`);
-      directiveResolverMappings.set(directiveName, resolverTypeName);
+      directiveResolverMappings[directiveName] = resolverTypeName;
     }
   }
 

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -32,10 +32,10 @@ export const plugin: PluginFunction<TypeScriptResolversPluginConfig, Types.Compl
   const importType = config.useTypeImports ? 'import type' : 'import';
   const prepend: string[] = [];
   const defsToInclude: string[] = [];
-  const customDirectiveToResolverTypeNameMappings = new Map<string, string>();
+  const directiveResolverMappings = new Map<string, string>();
 
-  if (config.customDirectiveToResolverFnMapping) {
-    for (const [directiveName, mapper] of Object.entries(config.customDirectiveToResolverFnMapping)) {
+  if (config.directiveResolverMappings) {
+    for (const [directiveName, mapper] of Object.entries(config.directiveResolverMappings)) {
       const parsedMapper = parseMapper(mapper);
       const capitalizedDirectiveName = capitalize(directiveName);
       const resolverFnName = `ResolverFn${capitalizedDirectiveName}`;
@@ -64,13 +64,13 @@ export type Resolver${capitalizedDirectiveName}WithResolve<TResult, TParent, TCo
       }
       defsToInclude.push(resolverWithResolve);
       defsToInclude.push(`${resolverType} ${resolverFnUsage} | ${resolverWithResolveUsage};`);
-      customDirectiveToResolverTypeNameMappings.set(directiveName, resolverTypeName);
+      directiveResolverMappings.set(directiveName, resolverTypeName);
     }
   }
 
   const transformedSchema = config.federation ? addFederationReferencesToSchema(schema) : schema;
   const visitor = new TypeScriptResolversVisitor(
-    { ...config, customDirectiveToResolverTypeNameMappings },
+    { ...config, directiveResolverMappings: directiveResolverMappings },
     transformedSchema
   );
   const namespacedImportPrefix = visitor.config.namespacedImportName ? `${visitor.config.namespacedImportName}.` : '';

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -175,6 +175,10 @@ export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
+export type AuthenticatedDirectiveArgs = {  };
+
+export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
 export type MyTypeResolvers<ContextType = any, ParentType = ResolversParentTypes['MyType']> = ResolversObject<{
   foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
@@ -239,6 +243,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
 
 export type DirectiveResolvers<ContextType = any> = ResolversObject<{
   myDirective?: MyDirectiveDirectiveResolver<any, any, ContextType>;
+  authenticated?: AuthenticatedDirectiveResolver<any, any, ContextType>;
 }>;
 
         export const myTypeResolvers: MyTypeResolvers<{}, { parentOverride: boolean }> = {
@@ -365,6 +370,10 @@ export type MyDirectiveDirectiveArgs = {   arg: Types.Scalars['Int'];
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
+export type AuthenticatedDirectiveArgs = {  };
+
+export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
 export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = ResolversObject<{
   foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   otherType?: Resolver<Types.Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
@@ -429,6 +438,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
 
 export type DirectiveResolvers<ContextType = any> = ResolversObject<{
   myDirective?: MyDirectiveDirectiveResolver<any, any, ContextType>;
+  authenticated?: AuthenticatedDirectiveResolver<any, any, ContextType>;
 }>;
 "
 `;
@@ -608,6 +618,10 @@ export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
+export type AuthenticatedDirectiveArgs = {  };
+
+export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
 export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = ResolversObject<{
   foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
@@ -672,6 +686,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
 
 export type DirectiveResolvers<ContextType = any> = ResolversObject<{
   myDirective?: MyDirectiveDirectiveResolver<any, any, ContextType>;
+  authenticated?: AuthenticatedDirectiveResolver<any, any, ContextType>;
 }>;
 "
 `;

--- a/packages/plugins/typescript/resolvers/tests/common.ts
+++ b/packages/plugins/typescript/resolvers/tests/common.ts
@@ -5,7 +5,7 @@ import { plugin as tsPlugin } from '@graphql-codegen/typescript';
 
 export const schema = buildSchema(/* GraphQL */ `
   type MyType {
-    foo: String!
+    foo: String! @authenticated
     otherType: MyOtherType
     withArgs(arg: String, arg2: String!): String
     unionChild: ChildUnion
@@ -43,6 +43,7 @@ export const schema = buildSchema(/* GraphQL */ `
   scalar MyScalar
 
   directive @myDirective(arg: Int!, arg2: String!, arg3: Boolean!) on FIELD
+  directive @authenticated on FIELD_DEFINITION
 `);
 
 export const validate = async (

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -153,10 +153,10 @@ describe('TypeScript Resolvers Plugin', () => {
       expect(content).toMatchSnapshot();
     });
 
-    it('customDirectiveToResolverFnMapping - should generate correct types', async () => {
+    it('directiveResolverMappings - should generate correct types', async () => {
       const config = {
         noSchemaStitching: true,
-        customDirectiveToResolverFnMapping: {
+        directiveResolverMappings: {
           authenticated: `
 (
   parent: TParent,
@@ -168,7 +168,7 @@ describe('TypeScript Resolvers Plugin', () => {
       };
       const result = await plugin(schema, [], config, { outputFile: '' });
       expect(result.content).toBeSimilarStringTo(`
-export type ResolverFnAuthenticated<TResult, TParent, TContext, TArgs> = 
+export type ResolverFnAuthenticated<TResult, TParent, TContext, TArgs> =
 (
   parent: TParent,
   args: TArgs,


### PR DESCRIPTION
This can be handy for automatically having the correct type when using directives for authorization as it allows providing a custom context, without having to manually type it.