### PR TITLE
Add generation of __typename for typed-document-node plugin

### DIFF
--- a/.changeset/yellow-eggs-lie.md
+++ b/.changeset/yellow-eggs-lie.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typed-document-node': minor
+---
+
+Generation of \_\_typename for SelectionSet by addTypenameToSelectionSets parametr

--- a/packages/plugins/typescript/typed-document-node/src/config.ts
+++ b/packages/plugins/typescript/typed-document-node/src/config.ts
@@ -17,4 +17,21 @@ export interface TypeScriptTypedDocumentNodesConfig extends RawClientSideBasePlu
    * ```
    */
   flattenGeneratedTypes?: boolean;
+
+  /**
+   * @description Add __typename to selection set
+   * @default false
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript-operations
+   *    - typed-document-node
+   *  config:
+   *    addTypenameToSelectionSets: true
+   * ```
+   */
+  addTypenameToSelectionSets?: boolean;
 }

--- a/packages/plugins/typescript/typed-document-node/src/visitor.ts
+++ b/packages/plugins/typescript/typed-document-node/src/visitor.ts
@@ -9,14 +9,20 @@ import {
 } from '@graphql-codegen/visitor-plugin-common';
 import { GraphQLSchema } from 'graphql';
 
+interface TypeScriptDocumentNodesVisitorPluginConfig extends RawClientSideBasePluginConfig {
+  addTypenameToSelectionSets?: boolean;
+}
+
 export class TypeScriptDocumentNodesVisitor extends ClientSideBaseVisitor<
-  RawClientSideBasePluginConfig,
+  TypeScriptDocumentNodesVisitorPluginConfig,
   ClientSideBasePluginConfig
 > {
+  private pluginConfig: TypeScriptDocumentNodesVisitorPluginConfig;
+
   constructor(
     schema: GraphQLSchema,
     fragments: LoadedFragment[],
-    rawConfig: RawClientSideBasePluginConfig,
+    config: TypeScriptDocumentNodesVisitorPluginConfig,
     documents: Types.DocumentFile[]
   ) {
     super(
@@ -25,11 +31,13 @@ export class TypeScriptDocumentNodesVisitor extends ClientSideBaseVisitor<
       {
         documentMode: DocumentMode.documentNodeImportFragments,
         documentNodeImport: '@graphql-typed-document-node/core#TypedDocumentNode',
-        ...rawConfig,
+        ...config,
       },
       {},
       documents
     );
+
+    this.pluginConfig = config;
 
     autoBind(this);
 
@@ -39,6 +47,47 @@ export class TypeScriptDocumentNodesVisitor extends ClientSideBaseVisitor<
       const tagImport = this._generateImport(documentNodeImport, 'DocumentNode', true);
       this._imports.add(tagImport);
     }
+  }
+
+  public SelectionSet(node, _, parent) {
+    if (!this.pluginConfig.addTypenameToSelectionSets) {
+      return;
+    }
+
+    // Don't add __typename to OperationDefinitions.
+    if (parent && parent.kind === 'OperationDefinition') {
+      return;
+    }
+
+    // No changes if no selections.
+    const { selections } = node;
+    if (!selections) {
+      return;
+    }
+
+    // If selections already have a __typename or is introspection do nothing.
+    const hasTypename = selections.some(
+      selection =>
+        selection.kind === 'Field' &&
+        (selection.name.value === '__typename' || selection.name.value.lastIndexOf('__', 0) === 0)
+    );
+    if (hasTypename) {
+      return;
+    }
+
+    return {
+      ...node,
+      selections: [
+        ...selections,
+        {
+          kind: 'Field',
+          name: {
+            kind: 'Name',
+            value: '__typename',
+          },
+        },
+      ],
+    };
   }
 
   protected getDocumentNodeSignature(resultType: string, variablesTypes: string, node) {

--- a/packages/plugins/typescript/typed-document-node/tests/typed-document-node.spec.ts
+++ b/packages/plugins/typescript/typed-document-node/tests/typed-document-node.spec.ts
@@ -167,4 +167,73 @@ describe('TypedDocumentNode', () => {
 
     expect((res.content.match(/JobSimpleRecruiterDataFragmentDoc.definitions/g) || []).length).toBe(2);
   });
+
+  describe('addTypenameToSelectionSets', () => {
+    it('Check is add __typename to typed document', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        schema {
+          query: Query
+        }
+
+        type Query {
+          job: Job
+        }
+
+        type Job {
+          id: ID!
+        }
+      `);
+
+      const ast = parse(/* GraphQL */ `
+        query {
+          job {
+            id
+          }
+        }
+      `);
+
+      const res = (await plugin(
+        schema,
+        [{ location: '', document: ast }],
+        { addTypenameToSelectionSets: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect((res.content.match(/__typename/g) || []).length).toBe(1);
+    });
+
+    it('Check with __typename in selection set', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        schema {
+          query: Query
+        }
+
+        type Query {
+          job: Job
+        }
+
+        type Job {
+          id: ID!
+        }
+      `);
+
+      const ast = parse(/* GraphQL */ `
+        query {
+          job {
+            id
+            __typename
+          }
+        }
+      `);
+
+      const res = (await plugin(
+        schema,
+        [{ location: '', document: ast }],
+        { addTypenameToSelectionSets: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect((res.content.match(/__typename/g) || []).length).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
## Description
Added automatic appending __typename field to typed-document-node plugin by config parameter

### Motivation
In our project(based on NextJS) we use apollo client for graphql layer. As you know apollo automatically adds __typename to query in runtime.
Such functionality is performance overhead for us, and we want to move __typename adding to generation time.

Related # (issue)

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Unit test + in our project localy