### PR TITLE
Expose fetcher (with `exposeFetcher` config) in `typescript-react-query` plugin 

### DIFF
--- a/.changeset/ninety-months-deny.md
+++ b/.changeset/ninety-months-deny.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': minor
+---
+
+Added new flag for `exposeFetcher` for exporting the fetcher

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -34,7 +34,7 @@ export interface ReactQueryRawPluginConfig
   /**
    * @default false
    * @description For each generate query hook adds `document` field with a
-   * correspoding GraphQL query. Useful for `queryClient.fetchQuery`. Example:
+   * corresponding GraphQL query. Useful for `queryClient.fetchQuery`. Example:
    * queryClient.fetchQuery(
    *   useUserDetailsQuery.getKey(variables),
    *   () => gqlRequest(useUserDetailsQuery.document, variables),

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -52,6 +52,17 @@ export interface ReactQueryRawPluginConfig
   exposeQueryKeys?: boolean;
 
   /**
+   * @default false
+   * @description For each generate query hook addds `fetcher` field with a corresponding GraphQL query using the fetcher.
+   * It is useful for `queryClient.fetchQuery` and `queryClient.prefetchQuery`.
+   * @exampleMarkdown
+   * ```ts
+   *  await queryClient.prefetchQuery(userQuery.getKey(), () => userQuery.fetcher())
+   * ```
+   */
+  exposeFetcher?: boolean;
+
+  /**
    * @default unknown
    * @description Changes the default "TError" generic type.
    */

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -98,4 +98,24 @@ export class CustomMapperFetcher implements FetcherRenderer {
       options
     );`;
   }
+
+  generateFetcherFetch(
+    node: OperationDefinitionNode,
+    documentVariableName: string,
+    operationName: string,
+    operationResultType: string,
+    operationVariablesTypes: string,
+    hasRequiredVariables: boolean
+  ): string {
+    // We can't generate a fetcher field since we can't call react hooks outside of a React Fucntion Component
+    // Related: https://reactjs.org/docs/hooks-rules.html
+    if (this._isReactHook) return '';
+
+    const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
+
+    const typedFetcher = this.getFetcherFnName(operationResultType, operationVariablesTypes);
+    const impl = `${typedFetcher}(${documentVariableName}, variables)`;
+
+    return `\nuse${operationName}.fetcher = (${variables}) => ${impl};`;
+  }
 }

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -104,4 +104,17 @@ ${this.getFetchParams()}
       options
     );`;
   }
+
+  generateFetcherFetch(
+    node: OperationDefinitionNode,
+    documentVariableName: string,
+    operationName: string,
+    operationResultType: string,
+    operationVariablesTypes: string,
+    hasRequiredVariables: boolean
+  ): string {
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+
+    return `\nuse${operationName}.fetcher = (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables);`;
+  }
 }

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -85,4 +85,17 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
       options
     );`;
   }
+
+  generateFetcherFetch(
+    node: OperationDefinitionNode,
+    documentVariableName: string,
+    operationName: string,
+    operationResultType: string,
+    operationVariablesTypes: string,
+    hasRequiredVariables: boolean
+  ): string {
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+
+    return `\nuse${operationName}.fetcher = (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables);`;
+  }
 }

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -75,4 +75,17 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
       options
     );`;
   }
+
+  generateFetcherFetch(
+    node: OperationDefinitionNode,
+    documentVariableName: string,
+    operationName: string,
+    operationResultType: string,
+    operationVariablesTypes: string,
+    hasRequiredVariables: boolean
+  ): string {
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+
+    return `\nuse${operationName}.fetcher = (client: GraphQLClient, ${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables);`;
+  }
 }

--- a/packages/plugins/typescript/react-query/src/fetcher.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher.ts
@@ -17,4 +17,12 @@ export interface FetcherRenderer {
     operationResultType: string,
     operationVariablesTypes: string
   ) => string;
+  generateFetcherFetch: (
+    node: OperationDefinitionNode,
+    documentVariableName: string,
+    operationName: string,
+    operationResultType: string,
+    operationVariablesTypes: string,
+    hasRequiredVariables: boolean
+  ) => string;
 }

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -196,6 +196,33 @@ describe('React-Query', () => {
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config);
     });
+
+    it("Should generate fetcher field when exposeFetcher is true and the fetcher isn't a react hook", async () => {
+      const config = {
+        fetcher: {
+          func: './my-file#customFetcher',
+        },
+        exposeFetcher: true,
+      };
+
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toBeSimilarStringTo(
+        `useTestQuery.fetcher = (variables?: TestQueryVariables) => customFetcher<TestQuery, TestQueryVariables>(TestDocument, variables);`
+      );
+    });
+
+    it('Should NOT generate fetcher field when exposeFetcher is true and the fetcher IS a react hook', async () => {
+      const config = {
+        fetcher: {
+          func: './my-file#useCustomFetcher',
+          isReactHook: true,
+        },
+        exposeFetcher: true,
+      };
+
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).not.toBeSimilarStringTo(`useTestQuery.fetcher`);
+    });
   });
 
   describe('fetcher: graphql-request', () => {
@@ -252,6 +279,17 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
       expect(out.prepend).toContain(`import type { GraphQLClient } from 'graphql-request';`);
+    });
+    it('Should generate fetcher field when exposeFetcher is true', async () => {
+      const config = {
+        fetcher: 'graphql-request',
+        exposeFetcher: true,
+      };
+
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toBeSimilarStringTo(
+        `useTestQuery.fetcher = (client: GraphQLClient, variables?: TestQueryVariables) => fetcher<TestQuery, TestQueryVariables>(client, TestDocument, variables);`
+      );
     });
   });
 
@@ -421,6 +459,20 @@ describe('React-Query', () => {
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config);
     });
+
+    it('Should generate fetcher field when exposeFetcher is true', async () => {
+      const config = {
+        fetcher: {
+          endpoint: 'myEndpoint',
+        },
+        exposeFetcher: true,
+      };
+
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toBeSimilarStringTo(
+        `useTestQuery.fetcher = (variables?: TestQueryVariables) => fetcher<TestQuery, TestQueryVariables>(TestDocument, variables);`
+      );
+    });
   });
 
   describe('fetcher: fetch', () => {
@@ -464,6 +516,17 @@ describe('React-Query', () => {
 
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config);
+    });
+
+    it.only('Should generate fetcher field when exposeFetcher is true', async () => {
+      const config = {
+        exposeFetcher: true,
+      };
+
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toBeSimilarStringTo(
+        `useTestQuery.fetcher = (variables?: TestQueryVariables) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables);`
+      );
     });
   });
 

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -518,7 +518,7 @@ describe('React-Query', () => {
       await validateTypeScript(mergeOutputs(out), schema, docs, config);
     });
 
-    it.only('Should generate fetcher field when exposeFetcher is true', async () => {
+    it('Should generate fetcher field when exposeFetcher is true', async () => {
       const config = {
         exposeFetcher: true,
       };


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description
This pull request adds an option to export each query's fetcher.

Related # (issue)
 #5526

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit test
- [x] Local Manula test

**Test Environment**:
- OS: Ubuntu-20.04 (WSL2)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules