### PR TITLE
Experiment: `tsgql`

### DIFF
--- a/dev-test/codegen.yml
+++ b/dev-test/codegen.yml
@@ -2,394 +2,408 @@ hooks:
   afterAllFileWrite:
     - prettier --write
 generates:
-  ./dev-test/test-schema/resolvers-types.ts:
-    schema: ./dev-test/test-schema/schema-text.js
-    plugins:
-      - typescript
-      - typescript-resolvers
-  ./dev-test/test-schema/flow-types.flow.js:
-    schema: ./dev-test/test-schema/schema.json
-    plugins:
-      - flow
-      - flow-resolvers
-  ./dev-test/test-schema/resolvers-root.ts:
-    schema: ./dev-test/test-schema/schema-with-root.graphql
-    plugins:
-      - typescript
-      - typescript-resolvers
-  ./dev-test/test-schema/resolvers-federation.ts:
-    schema: ./dev-test/test-schema/schema-federation.graphql
-    config:
-      federation: true
-    plugins:
-      - typescript
-      - typescript-resolvers
-  ./dev-test/test-schema/typings.ts:
-    schema: ./dev-test/test-schema/schema.json
-    plugins:
-      - typescript
-      - typescript-resolvers
-  ./dev-test/test-schema/typings.avoidOptionals.ts:
-    schema: ./dev-test/test-schema/schema.json
-    config:
-      avoidOptionals: true
-    plugins:
-      - typescript
-  ./dev-test/test-schema/typings.wrapped.ts:
-    schema: ./dev-test/test-schema/schema.json
+  ./dev-test/test-schema/tsql.d.ts:
+    schema:
+      - ./dev-test/test-schema/tsgql-test.ts:
+          noRequire: true
     plugins:
       - add:
-          content: 'declare namespace GraphQL {'
+          content: "declare module 'tsgql' {"
+          placement: prepend
+      - typescript
+      - typescript-resolvers
       - add:
-          placement: append
           content: '}'
-      - typescript
-      - typescript-operations
-  ./dev-test/test-schema/env.types.ts:
-    schema: ${SCHEMA_PATH}
-    plugins:
-      - typescript
-  ./dev-test/test-schema/typings.immutableTypes.ts:
-    schema: ./dev-test/test-schema/schema.json
-    config:
-      imutableTypes: true
-    plugins:
-      - typescript
-  ./dev-test/test-schema/typings.enum.ts:
-    schema: ./dev-test/test-schema/schema-object.js
-    plugins:
-      - typescript
-  ./dev-test/githunt/graphql-declared-modules.d.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - typescript-graphql-files-modules
-  ./dev-test/githunt/typed-document-nodes.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-      - typed-document-node
-  ./dev-test/githunt/flow.flow.js:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - flow
-      - flow-operations
-  ./dev-test/githunt/types.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/githunt/types.preResolveTypes.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      preResolveTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/githunt/types.preResolveTypes.onlyOperationTypes.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      preResolveTypes: true
-      onlyOperationTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/githunt/types.flatten.preResolveTypes.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      preResolveTypes: true
-      flattenGeneratedTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/githunt/types.preResolveTypes.compatibility.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      preResolveTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-compatibility
-  ./dev-test/githunt/types.enumsAsTypes.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      enumsAsTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/githunt/types.d.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      enumsAsTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/githunt/types.avoidOptionals.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      avoidOptionals: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/githunt/types.immutableTypes.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      immutableTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/githunt/types.reactApollo.tsx:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-react-apollo
-  ./dev-test/githunt/types.reactApollo.v2.tsx:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      reactApolloVersion: 2
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-react-apollo
-  ./dev-test/githunt/types.reactApollo.customSuffix.tsx:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      operationResultSuffix: MyOperation
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-react-apollo
-  ./dev-test/githunt/types.reactApollo.preResolveTypes.tsx:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      preResolveTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-react-apollo
-  ./dev-test/githunt/types.reactApollo.hooks.tsx:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-react-apollo
-  ./dev-test/githunt/types.react-query.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-react-query
-  ./dev-test/githunt/types.rtk-query.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - add:
-          content: 'module.hot?.accept();'
-      - typescript
-      - typescript-operations
-      - typescript-rtk-query:
-          importBaseApiFrom: '../../packages/plugins/typescript/rtk-query/tests/baseApi'
-          exportHooks: true
-          overrideExisting: 'module.hot?.status() === "apply"'
+          placement: content
+      - tsgql
+  # ./dev-test/test-schema/resolvers-types.ts:
+  #   schema: ./dev-test/test-schema/schema-text.js
+  #   plugins:
+  #     - typescript
+  #     - typescript-resolvers
+  # ./dev-test/test-schema/flow-types.flow.js:
+  #   schema: ./dev-test/test-schema/schema.json
+  #   plugins:
+  #     - flow
+  #     - flow-resolvers
+  # ./dev-test/test-schema/resolvers-root.ts:
+  #   schema: ./dev-test/test-schema/schema-with-root.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-resolvers
+  # ./dev-test/test-schema/resolvers-federation.ts:
+  #   schema: ./dev-test/test-schema/schema-federation.graphql
+  #   config:
+  #     federation: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-resolvers
+  # ./dev-test/test-schema/typings.ts:
+  #   schema: ./dev-test/test-schema/schema.json
+  #   plugins:
+  #     - typescript
+  #     - typescript-resolvers
+  # ./dev-test/test-schema/typings.avoidOptionals.ts:
+  #   schema: ./dev-test/test-schema/schema.json
+  #   config:
+  #     avoidOptionals: true
+  #   plugins:
+  #     - typescript
+  # ./dev-test/test-schema/typings.wrapped.ts:
+  #   schema: ./dev-test/test-schema/schema.json
+  #   plugins:
+  #     - add:
+  #         content: 'declare namespace GraphQL {'
+  #     - add:
+  #         placement: append
+  #         content: '}'
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/test-schema/env.types.ts:
+  #   schema: ${SCHEMA_PATH}
+  #   plugins:
+  #     - typescript
+  # ./dev-test/test-schema/typings.immutableTypes.ts:
+  #   schema: ./dev-test/test-schema/schema.json
+  #   config:
+  #     imutableTypes: true
+  #   plugins:
+  #     - typescript
+  # ./dev-test/test-schema/typings.enum.ts:
+  #   schema: ./dev-test/test-schema/schema-object.js
+  #   plugins:
+  #     - typescript
+  # ./dev-test/githunt/graphql-declared-modules.d.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - typescript-graphql-files-modules
+  # ./dev-test/githunt/typed-document-nodes.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typed-document-node
+  # ./dev-test/githunt/flow.flow.js:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - flow
+  #     - flow-operations
+  # ./dev-test/githunt/types.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/githunt/types.preResolveTypes.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     preResolveTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/githunt/types.preResolveTypes.onlyOperationTypes.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     preResolveTypes: true
+  #     onlyOperationTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/githunt/types.flatten.preResolveTypes.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     preResolveTypes: true
+  #     flattenGeneratedTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/githunt/types.preResolveTypes.compatibility.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     preResolveTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-compatibility
+  # ./dev-test/githunt/types.enumsAsTypes.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     enumsAsTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/githunt/types.d.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     enumsAsTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/githunt/types.avoidOptionals.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     avoidOptionals: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/githunt/types.immutableTypes.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     immutableTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/githunt/types.reactApollo.tsx:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-react-apollo
+  # ./dev-test/githunt/types.reactApollo.v2.tsx:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     reactApolloVersion: 2
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-react-apollo
+  # ./dev-test/githunt/types.reactApollo.customSuffix.tsx:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     operationResultSuffix: MyOperation
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-react-apollo
+  # ./dev-test/githunt/types.reactApollo.preResolveTypes.tsx:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     preResolveTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-react-apollo
+  # ./dev-test/githunt/types.reactApollo.hooks.tsx:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-react-apollo
+  # ./dev-test/githunt/types.react-query.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-react-query
+  # ./dev-test/githunt/types.rtk-query.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - add:
+  #         content: 'module.hot?.accept();'
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-rtk-query:
+  #         importBaseApiFrom: '../../packages/plugins/typescript/rtk-query/tests/baseApi'
+  #         exportHooks: true
+  #         overrideExisting: 'module.hot?.status() === "apply"'
 
-  ./dev-test/githunt/types.apolloAngular.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-apollo-angular
-  ./dev-test/githunt/types.apolloAngular.sdk.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    config:
-      sdkClass: true
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-apollo-angular
-  ./dev-test/githunt/types.stencilApollo.tsx:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-stencil-apollo
-  ./dev-test/githunt/types.urql.tsx:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-urql
-      - urql-introspection
-      - typescript-urql-graphcache
-  ./dev-test/githunt:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    preset: near-operation-file
-    presetConfig:
-      extension: .stencil-component.tsx
-      folder: __generated__
-      baseTypesPath: types.d.ts
-    plugins:
-      - typescript-operations
-      - typescript-stencil-apollo
-    config:
-      componentType: class
-      globalNamespace: true
-  ./dev-test/githunt/types.vueApollo.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-vue-apollo
-  ./dev-test/githunt/types.vueApolloSmartOps.ts:
-    schema: ./dev-test/githunt/schema.json
-    documents: ./dev-test/githunt/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-vue-apollo-smart-ops
-  ./dev-test/star-wars/types.ts:
-    schema: ./dev-test/star-wars/schema.json
-    documents: ./dev-test/star-wars/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/star-wars/types.preResolveTypes.ts:
-    schema: ./dev-test/star-wars/schema.json
-    documents: ./dev-test/star-wars/**/*.graphql
-    config:
-      preResolveTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts:
-    schema: ./dev-test/star-wars/schema.json
-    documents: ./dev-test/star-wars/**/*.graphql
-    config:
-      preResolveTypes: true
-      onlyOperationTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/test-schema/types.preResolveTypes.ts:
-    schema: ./dev-test/test-schema/schema.graphql
-    documents:
-      - 'query test { testArr1 testArr2 testArr3 }'
-    config:
-      preResolveTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/test-schema/types.preResolveTypes.onlyOperationTypes.ts:
-    schema: ./dev-test/test-schema/schema.graphql
-    documents:
-      - 'query test { testArr1 testArr2 testArr3 }'
-    config:
-      preResolveTypes: true
-      onlyOperationTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/star-wars/types.d.ts:
-    schema: ./dev-test/star-wars/schema.json
-    config:
-      enumsAsTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/star-wars:
-    schema: ./dev-test/star-wars/schema.json
-    documents: ./dev-test/star-wars/**/*.graphql
-    preset: near-operation-file
-    presetConfig:
-      extension: .tsx
-      folder: __generated__
-      baseTypesPath: types.d.ts
-    plugins:
-      - typescript-operations
-      - typescript-react-apollo
-  ./dev-test/modules/:
-    schema: ./dev-test/modules/*/types/*.graphql
-    preset: graphql-modules
-    presetConfig:
-      baseTypesPath: types.ts
-      filename: generated.ts
-    plugins:
-      - typescript
-      - typescript-resolvers
-  ./dev-test/star-wars/types.globallyAvailable.d.ts:
-    schema: ./dev-test/star-wars/schema.json
-    documents: ./dev-test/star-wars/**/*.graphql
-    config:
-      enumsAsTypes: true
-      noExport: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/star-wars/types.avoidOptionals.ts:
-    schema: ./dev-test/star-wars/schema.json
-    documents: ./dev-test/star-wars/**/*.graphql
-    config:
-      avoidOptionals: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/star-wars/types.immutableTypes.ts:
-    schema: ./dev-test/star-wars/schema.json
-    documents: ./dev-test/star-wars/**/*.graphql
-    config:
-      immutableTypes: true
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/star-wars/types.skipSchema.ts:
-    schema: ./dev-test/star-wars/schema.json
-    documents: ./dev-test/star-wars/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-operations
-  ./dev-test/star-wars/types.refetchFn.tsx:
-    schema: ./dev-test/star-wars/schema.json
-    documents: ./dev-test/star-wars/**/*.graphql
-    plugins:
-      - typescript
-      - typescript-react-apollo
-    config:
-      withRefetchFn: true
-  ./dev-test/test-message/types.tsx:
-    schema: ./dev-test/test-message/schema.graphql
-    documents: ./dev-test/test-message/documents.ts
-    plugins:
-      - typescript
-      - typescript-operations
-      - typescript-react-apollo
-    config:
-      documentMode: external
-      importDocumentNodeExternallyFrom: './documents.ts'
-      reactApolloVersion: 3
-      gqlImport: graphql-tag
-      hooksImportFrom: '@apollo/react-hooks'
-      withMutationFn: false
+  # ./dev-test/githunt/types.apolloAngular.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-apollo-angular
+  # ./dev-test/githunt/types.apolloAngular.sdk.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   config:
+  #     sdkClass: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-apollo-angular
+  # ./dev-test/githunt/types.stencilApollo.tsx:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-stencil-apollo
+  # ./dev-test/githunt/types.urql.tsx:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-urql
+  #     - urql-introspection
+  #     - typescript-urql-graphcache
+  # ./dev-test/githunt:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   preset: near-operation-file
+  #   presetConfig:
+  #     extension: .stencil-component.tsx
+  #     folder: __generated__
+  #     baseTypesPath: types.d.ts
+  #   plugins:
+  #     - typescript-operations
+  #     - typescript-stencil-apollo
+  #   config:
+  #     componentType: class
+  #     globalNamespace: true
+  # ./dev-test/githunt/types.vueApollo.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-vue-apollo
+  # ./dev-test/githunt/types.vueApolloSmartOps.ts:
+  #   schema: ./dev-test/githunt/schema.json
+  #   documents: ./dev-test/githunt/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-vue-apollo-smart-ops
+  # ./dev-test/star-wars/types.ts:
+  #   schema: ./dev-test/star-wars/schema.json
+  #   documents: ./dev-test/star-wars/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/star-wars/types.preResolveTypes.ts:
+  #   schema: ./dev-test/star-wars/schema.json
+  #   documents: ./dev-test/star-wars/**/*.graphql
+  #   config:
+  #     preResolveTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts:
+  #   schema: ./dev-test/star-wars/schema.json
+  #   documents: ./dev-test/star-wars/**/*.graphql
+  #   config:
+  #     preResolveTypes: true
+  #     onlyOperationTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/test-schema/types.preResolveTypes.ts:
+  #   schema: ./dev-test/test-schema/schema.graphql
+  #   documents:
+  #     - 'query test { testArr1 testArr2 testArr3 }'
+  #   config:
+  #     preResolveTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/test-schema/types.preResolveTypes.onlyOperationTypes.ts:
+  #   schema: ./dev-test/test-schema/schema.graphql
+  #   documents:
+  #     - 'query test { testArr1 testArr2 testArr3 }'
+  #   config:
+  #     preResolveTypes: true
+  #     onlyOperationTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/star-wars/types.d.ts:
+  #   schema: ./dev-test/star-wars/schema.json
+  #   config:
+  #     enumsAsTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/star-wars:
+  #   schema: ./dev-test/star-wars/schema.json
+  #   documents: ./dev-test/star-wars/**/*.graphql
+  #   preset: near-operation-file
+  #   presetConfig:
+  #     extension: .tsx
+  #     folder: __generated__
+  #     baseTypesPath: types.d.ts
+  #   plugins:
+  #     - typescript-operations
+  #     - typescript-react-apollo
+  # ./dev-test/modules/:
+  #   schema: ./dev-test/modules/*/types/*.graphql
+  #   preset: graphql-modules
+  #   presetConfig:
+  #     baseTypesPath: types.ts
+  #     filename: generated.ts
+  #   plugins:
+  #     - typescript
+  #     - typescript-resolvers
+  # ./dev-test/star-wars/types.globallyAvailable.d.ts:
+  #   schema: ./dev-test/star-wars/schema.json
+  #   documents: ./dev-test/star-wars/**/*.graphql
+  #   config:
+  #     enumsAsTypes: true
+  #     noExport: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/star-wars/types.avoidOptionals.ts:
+  #   schema: ./dev-test/star-wars/schema.json
+  #   documents: ./dev-test/star-wars/**/*.graphql
+  #   config:
+  #     avoidOptionals: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/star-wars/types.immutableTypes.ts:
+  #   schema: ./dev-test/star-wars/schema.json
+  #   documents: ./dev-test/star-wars/**/*.graphql
+  #   config:
+  #     immutableTypes: true
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/star-wars/types.skipSchema.ts:
+  #   schema: ./dev-test/star-wars/schema.json
+  #   documents: ./dev-test/star-wars/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  # ./dev-test/star-wars/types.refetchFn.tsx:
+  #   schema: ./dev-test/star-wars/schema.json
+  #   documents: ./dev-test/star-wars/**/*.graphql
+  #   plugins:
+  #     - typescript
+  #     - typescript-react-apollo
+  #   config:
+  #     withRefetchFn: true
+  # ./dev-test/test-message/types.tsx:
+  #   schema: ./dev-test/test-message/schema.graphql
+  #   documents: ./dev-test/test-message/documents.ts
+  #   plugins:
+  #     - typescript
+  #     - typescript-operations
+  #     - typescript-react-apollo
+  #   config:
+  #     documentMode: external
+  #     importDocumentNodeExternallyFrom: './documents.ts'
+  #     reactApolloVersion: 3
+  #     gqlImport: graphql-tag
+  #     hooksImportFrom: '@apollo/react-hooks'
+  #     withMutationFn: false

--- a/dev-test/test-schema/tsgql-test.ts
+++ b/dev-test/test-schema/tsgql-test.ts
@@ -1,0 +1,13 @@
+import { typeDefs } from 'tsgql';
+
+const sdl = typeDefs(/* GraphQL */ `
+  type Query {
+    foo: String!
+  }
+`);
+
+export const resolvers: typeof sdl = {
+  Query: {
+    foo: () => 'test',
+  },
+};

--- a/dev-test/test-schema/tsql.d.ts
+++ b/dev-test/test-schema/tsql.d.ts
@@ -1,0 +1,143 @@
+declare module 'tsgql' {
+  export type Maybe<T> = T | null;
+  export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+  export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+  export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+  import { GraphQLResolveInfo } from 'graphql';
+  /** All built-in and custom scalars, mapped to their actual values */
+  export type Scalars = {
+    ID: string;
+    String: string;
+    Boolean: boolean;
+    Int: number;
+    Float: number;
+  };
+
+  export type Query = {
+    __typename?: 'Query';
+    foo: Scalars['String'];
+  };
+
+  export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+  export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+    resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+  };
+
+  export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
+    fragment: string;
+    resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+  };
+
+  export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
+    selectionSet: string;
+    resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+  };
+  export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+    | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+    | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+  export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+    | ResolverFn<TResult, TParent, TContext, TArgs>
+    | ResolverWithResolve<TResult, TParent, TContext, TArgs>
+    | StitchingResolver<TResult, TParent, TContext, TArgs>;
+
+  export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+    parent: TParent,
+    args: TArgs,
+    context: TContext,
+    info: GraphQLResolveInfo
+  ) => Promise<TResult> | TResult;
+
+  export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+    parent: TParent,
+    args: TArgs,
+    context: TContext,
+    info: GraphQLResolveInfo
+  ) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
+
+  export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+    parent: TParent,
+    args: TArgs,
+    context: TContext,
+    info: GraphQLResolveInfo
+  ) => TResult | Promise<TResult>;
+
+  export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+    subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+    resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+  }
+
+  export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+    subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+    resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+  }
+
+  export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+    | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+    | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+  export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+    | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+    | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+  export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+    parent: TParent,
+    context: TContext,
+    info: GraphQLResolveInfo
+  ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+  export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
+    obj: T,
+    context: TContext,
+    info: GraphQLResolveInfo
+  ) => boolean | Promise<boolean>;
+
+  export type NextResolverFn<T> = () => Promise<T>;
+
+  export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+    next: NextResolverFn<TResult>,
+    parent: TParent,
+    args: TArgs,
+    context: TContext,
+    info: GraphQLResolveInfo
+  ) => TResult | Promise<TResult>;
+
+  /** Mapping between all available schema types and the resolvers types */
+  export type ResolversTypes = {
+    Query: ResolverTypeWrapper<{}>;
+    String: ResolverTypeWrapper<Scalars['String']>;
+    Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+  };
+
+  /** Mapping between all available schema types and the resolvers parents */
+  export type ResolversParentTypes = {
+    Query: {};
+    String: Scalars['String'];
+    Boolean: Scalars['Boolean'];
+  };
+
+  export type QueryResolvers<
+    ContextType = any,
+    ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+  > = {
+    foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  };
+
+  export type Resolvers<ContextType = any> = {
+    Query?: QueryResolvers<ContextType>;
+  };
+
+  /**
+   * @deprecated
+   * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
+   */
+  export type IResolvers<ContextType = any> = Resolvers<ContextType>;
+}
+declare module 'tsgql' {
+  import { DocumentNode, parse } from 'graphql';
+  export type Resolvers = {};
+
+  export function typeDefs<TDocumentString extends string>(sources: TDocumentString): Resolvers {
+    return parse(sources);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prerelease": "yarn build",
     "release": "changeset publish",
     "release:canary": "(node scripts/canary-release.js && yarn build && yarn changeset publish --tag alpha) || echo Skipping Canary...",
-    "generate:examples": "node packages/graphql-codegen-cli/dist/bin.js --require dotenv/config --config ./dev-test/codegen.yml dotenv_config_path=dev-test/.env"
+    "generate:examples": "node packages/graphql-codegen-cli/dist/bin.js --require dotenv/config --require ts-node/register/transpile-only --config ./dev-test/codegen.yml dotenv_config_path=dev-test/.env"
   },
   "workspaces": {
     "packages": [

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -144,9 +144,7 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
     })
   );
 
-  return [...sortPrependValues(Array.from(prepend.values())), ...output, ...Array.from(append.values())]
-    .filter(Boolean)
-    .join('\n');
+  return [...Array.from(prepend.values()), ...output, ...Array.from(append.values())].filter(Boolean).join('\n');
 }
 
 function resolveCompareValue(a: string) {

--- a/packages/graphql-codegen-core/src/execute-plugin.ts
+++ b/packages/graphql-codegen-core/src/execute-plugin.ts
@@ -5,8 +5,8 @@ export interface ExecutePluginOptions {
   name: string;
   config: Types.PluginConfig;
   parentConfig: Types.PluginConfig;
-  schema: DocumentNode;
-  schemaAst?: GraphQLSchema;
+  schema: DocumentNode; // This is a mixup we should address when refactoring v2
+  schemaAst?: GraphQLSchema; // This is a mixup we should address when refactoring v2
   documents: Types.DocumentFile[];
   outputFilename: string;
   allPlugins: Types.ConfiguredPlugin[];

--- a/packages/plugins/typescript/tsgql/jest.config.js
+++ b/packages/plugins/typescript/tsgql/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../../jest.project')({	dirname: __dirname });

--- a/packages/plugins/typescript/tsgql/package.json
+++ b/packages/plugins/typescript/tsgql/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@graphql-codegen/tsgql",
+  "version": "0.0.0",
+  "description": "GraphQL Code Generator plugin for generating TypeScript types for resolvers signature based on TypeScript string literals",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dotansimha/graphql-code-generator.git",
+    "directory": "packages/plugins/typescript/tsgql"
+  },
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint **/*.ts",
+    "test": "jest --no-watchman --config ../../../../jest.config.js",
+    "prepack": "bob prepack"
+  },
+  "dependencies": {
+    "@graphql-codegen/plugin-helpers": "^1.18.8",
+    "@graphql-tools/utils": "^7.9.1",
+    "tslib": "~2.3.0"
+  },
+  "peerDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+  },
+  "devDependencies": {
+    "graphql-subscriptions": "1.2.1"
+  },
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "buildOptions": {
+    "input": "./src/index.ts"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  }
+}

--- a/packages/plugins/typescript/tsgql/src/index.ts
+++ b/packages/plugins/typescript/tsgql/src/index.ts
@@ -1,0 +1,19 @@
+import { Types, PluginFunction } from '@graphql-codegen/plugin-helpers';
+import { GraphQLSchema } from 'graphql';
+
+export const plugin: PluginFunction = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: {}, info) => {
+  const moduleDeclaration = `declare module 'tsgql' {
+  import { DocumentNode, parse } from 'graphql';
+  export type Resolvers = {};
+
+  export function typeDefs<TDocumentString extends string>(sources: TDocumentString): Resolvers {
+    return parse(sources);
+  }
+}
+`;
+
+  return {
+    prepend: [],
+    content: [moduleDeclaration].join('\n'),
+  };
+};


### PR DESCRIPTION
Check `dev-test/test-schema/tsgql-test.ts` with TS autocomplete. 
It creates a fake TS module for making the typeDefs typed. We can later do matching based on SDL and filter only the specific relevant resolvers.

![Uploading image.png…]()
 