### PR TITLE
react-query: dedupe operation names in hook names

### DIFF
--- a/.changeset/healthy-walls-provide.md
+++ b/.changeset/healthy-walls-provide.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+Make typescript-react-query respect the dedupeOperationSuffix option for hook names

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -105,6 +105,19 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
     return this.fetcher.generateFetcherImplementaion();
   }
 
+  private _getHookSuffix(name: string, operationType: string) {
+    if (this.config.omitOperationSuffix) {
+      return '';
+    }
+    if (!this.config.dedupeOperationSuffix) {
+      return pascalCase(operationType);
+    }
+    if (name.includes('Query') || name.includes('Mutation') || name.includes('Subscription')) {
+      return '';
+    }
+    return pascalCase(operationType);
+  }
+
   protected buildOperation(
     node: OperationDefinitionNode,
     documentVariableName: string,
@@ -113,9 +126,12 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const operationName: string = this.convertName(node.name?.value ?? '', {
-      suffix: this.config.omitOperationSuffix ? '' : pascalCase(operationType),
+    const nodeName = node.name?.value ?? '';
+    const suffix = this._getHookSuffix(nodeName, operationType);
+    const operationName: string = this.convertName(nodeName, {
+      suffix,
       useTypesPrefix: false,
+      useTypesSuffix: false,
     });
 
     operationResultType = this._externalImportPrefix + operationResultType;

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -99,9 +99,9 @@ describe('React-Query', () => {
           TData = TTestQuery,
           TError = unknown
         >(
-          variables?: TTestQueryVariables, 
+          variables?: TTestQueryVariables,
           options?: UseQueryOptions<TTestQuery, TError, TData>
-        ) => 
+        ) =>
         useQuery<TTestQuery, TError, TData>(
           ['test', variables],
           myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -110,7 +110,7 @@ describe('React-Query', () => {
       expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
         TError = unknown,
         TContext = unknown
-      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
         (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
         options
@@ -135,9 +135,9 @@ describe('React-Query', () => {
         TData = TTestQuery,
         TError = unknown
       >(
-        variables?: TTestQueryVariables, 
+        variables?: TTestQueryVariables,
         options?: UseQueryOptions<TTestQuery, TError, TData>
-      ) => 
+      ) =>
       useQuery<TTestQuery, TError, TData>(
         ['test', variables],
         myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -147,7 +147,7 @@ describe('React-Query', () => {
       expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
         TError = unknown,
         TContext = unknown
-      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
         (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
         options
@@ -176,9 +176,9 @@ describe('React-Query', () => {
           TData = TTestQuery,
           TError = unknown
         >(
-          variables?: TTestQueryVariables, 
+          variables?: TTestQueryVariables,
           options?: UseQueryOptions<TTestQuery, TError, TData>
-        ) => 
+        ) =>
         useQuery<TTestQuery, TError, TData>(
           ['test', variables],
           useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
@@ -187,7 +187,7 @@ describe('React-Query', () => {
       expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
         TError = unknown,
         TContext = unknown
-      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
         useCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument),
         options
@@ -223,6 +223,96 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).not.toBeSimilarStringTo(`useTestQuery.fetcher`);
     });
+
+    it(`tests for dedupeOperationSuffix`, async () => {
+      const ast = parse(/* GraphQL */ `
+        query notificationsQuery {
+          notifications {
+            id
+          }
+        }
+      `);
+      const ast2 = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            id
+          }
+        }
+      `);
+      const config = {
+        fetcher: 'myCustomFetcher',
+        typesPrefix: 'T',
+        outputFile: '',
+      };
+
+      expect(
+        ((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, config)) as any).content
+      ).toContain('fetcher<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQueryQuery = ');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
+    });
   });
 
   describe('fetcher: graphql-request', () => {
@@ -246,10 +336,10 @@ describe('React-Query', () => {
           TData = TTestQuery,
           TError = unknown
         >(
-          client: GraphQLClient, 
-          variables?: TTestQueryVariables, 
+          client: GraphQLClient,
+          variables?: TTestQueryVariables,
           options?: UseQueryOptions<TTestQuery, TError, TData>
-        ) => 
+        ) =>
         useQuery<TTestQuery, TError, TData>(
           ['test', variables],
           fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
@@ -259,9 +349,9 @@ describe('React-Query', () => {
         TError = unknown,
         TContext = unknown
       >(
-        client: GraphQLClient, 
+        client: GraphQLClient,
         options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
-      ) => 
+      ) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
         (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables)(),
         options
@@ -291,6 +381,94 @@ describe('React-Query', () => {
         `useTestQuery.fetcher = (client: GraphQLClient, variables?: TestQueryVariables) => fetcher<TestQuery, TestQueryVariables>(client, TestDocument, variables);`
       );
     });
+    it(`tests for dedupeOperationSuffix`, async () => {
+      const ast = parse(/* GraphQL */ `
+        query notificationsQuery {
+          notifications {
+            id
+          }
+        }
+      `);
+      const ast2 = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            id
+          }
+        }
+      `);
+      const config = {
+        fetcher: 'graphql-request',
+        typesPrefix: 'T',
+      };
+
+      expect(
+        ((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, config)) as any).content
+      ).toContain('fetcher<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQueryQuery = ');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
+    });
   });
 
   describe('fetcher: hardcoded-fetch', () => {
@@ -314,15 +492,15 @@ describe('React-Query', () => {
             method: "POST",
             body: JSON.stringify({ query, variables }),
           });
-      
+
           const json = await res.json();
-      
+
           if (json.errors) {
             const { message } = json.errors[0];
-      
+
             throw new Error(message);
           }
-      
+
           return json.data;
         }
       }`);
@@ -330,9 +508,9 @@ describe('React-Query', () => {
         TData = TTestQuery,
         TError = unknown
       >(
-        variables?: TTestQueryVariables, 
+        variables?: TTestQueryVariables,
         options?: UseQueryOptions<TTestQuery, TError, TData>
-      ) => 
+      ) =>
       useQuery<TTestQuery, TError, TData>(
         ['test', variables],
         fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -342,7 +520,7 @@ describe('React-Query', () => {
       expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
         TError = unknown,
         TContext = unknown
-      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
         (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
         options
@@ -375,15 +553,15 @@ describe('React-Query', () => {
             headers: {"Authorization":"Bearer XYZ"},
             body: JSON.stringify({ query, variables }),
           });
-      
+
           const json = await res.json();
-      
+
           if (json.errors) {
             const { message } = json.errors[0];
-      
+
             throw new Error(message);
           }
-      
+
           return json.data;
         }
       }`);
@@ -409,15 +587,15 @@ describe('React-Query', () => {
             method: "POST",
             body: JSON.stringify({ query, variables }),
           });
-      
+
           const json = await res.json();
-      
+
           if (json.errors) {
             const { message } = json.errors[0];
-      
+
             throw new Error(message);
           }
-      
+
           return json.data;
         }
       }`);
@@ -443,15 +621,15 @@ describe('React-Query', () => {
             method: "POST",
             body: JSON.stringify({ query, variables }),
           });
-      
+
           const json = await res.json();
-      
+
           if (json.errors) {
             const { message } = json.errors[0];
-      
+
             throw new Error(message);
           }
-      
+
           return json.data;
         }
       }`);
@@ -473,6 +651,97 @@ describe('React-Query', () => {
         `useTestQuery.fetcher = (variables?: TestQueryVariables) => fetcher<TestQuery, TestQueryVariables>(TestDocument, variables);`
       );
     });
+
+    it(`tests for dedupeOperationSuffix`, async () => {
+      const ast = parse(/* GraphQL */ `
+        query notificationsQuery {
+          notifications {
+            id
+          }
+        }
+      `);
+      const ast2 = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            id
+          }
+        }
+      `);
+      const config = {
+        fetcher: {
+          endpoint: 'http://localhost:3000/graphql',
+        },
+        typesPrefix: 'T',
+      };
+
+      expect(
+        ((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, config)) as any).content
+      ).toContain('fetcher<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQueryQuery = ');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
+    });
   });
 
   describe('fetcher: fetch', () => {
@@ -492,10 +761,10 @@ describe('React-Query', () => {
         TData = TTestQuery,
         TError = unknown
       >(
-        dataSource: { endpoint: string, fetchParams?: RequestInit }, 
-        variables?: TTestQueryVariables, 
+        dataSource: { endpoint: string, fetchParams?: RequestInit },
+        variables?: TTestQueryVariables,
         options?: UseQueryOptions<TTestQuery, TError, TData>
-      ) => 
+      ) =>
       useQuery<TTestQuery, TError, TData>(
         ['test', variables],
         fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
@@ -506,9 +775,9 @@ describe('React-Query', () => {
           TError = unknown,
           TContext = unknown
         >(
-          dataSource: { endpoint: string, fetchParams?: RequestInit }, 
+          dataSource: { endpoint: string, fetchParams?: RequestInit },
           options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
-        ) => 
+        ) =>
         useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
           (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
           options
@@ -527,6 +796,95 @@ describe('React-Query', () => {
       expect(out.content).toBeSimilarStringTo(
         `useTestQuery.fetcher = (variables?: TestQueryVariables) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables);`
       );
+    });
+
+    it(`tests for dedupeOperationSuffix`, async () => {
+      const ast = parse(/* GraphQL */ `
+        query notificationsQuery {
+          notifications {
+            id
+          }
+        }
+      `);
+      const ast2 = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            id
+          }
+        }
+      `);
+      const config = {
+        fetcher: 'fetch',
+        typesPrefix: 'T',
+      };
+
+      expect(
+        ((await plugin(schema, [{ location: 'test-file.ts', document: ast }], {}, config)) as any).content
+      ).toContain('fetcher<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQueryQuery, NotificationsQueryQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQueryQuery = ');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: true },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('fetcher<NotificationsQuery, NotificationsQueryVariables>');
+      expect(
+        ((await plugin(
+          schema,
+          [{ location: 'test-file.ts', document: ast2 }],
+          { dedupeOperationSuffix: false },
+          config
+        )) as any).content
+      ).toContain('export const useNotificationsQuery =');
     });
   });
 


### PR DESCRIPTION
## Description

This PR gets the `typescript-react-query` plugin to respect the `dedupeOperationSuffix` parameter when generating hook names.

Related #6368.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

https://codesandbox.io/s/react-query-operation-suffix-deduping-bug-repro-c8r58

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ported the relevant tests from the `typescript-react-apollo` test suite and made sure they pass
- [x] Ran my modified version of the plugin against my in-development app and verified that the hook names were deduplicated correctly

**Test Environment**:
- OS: macOS 11.5.1
- `@graphql-codegen/typescript-react-query`: 1.3.5
- NodeJS: 14.16.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A)

## Further comments

I more or less just copied and modified a bunch of code from `typescript-react-apollo` for this (both in the plugin itself and the corresponding test suite).  It might or might not be the best possible implementation for the `typescript-react-query` plugin, but it does make it work in the way the docs say it should.