### PR TITLE
Feat/directive typing

### DIFF
--- a/dev-test/githunt/typed-document-nodes.ts
+++ b/dev-test/githunt/typed-document-nodes.ts
@@ -12,6 +12,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.apolloAngular.sdk.ts
+++ b/dev-test/githunt/types.apolloAngular.sdk.ts
@@ -15,6 +15,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.apolloAngular.ts
+++ b/dev-test/githunt/types.apolloAngular.ts
@@ -14,6 +14,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.avoidOptionals.ts
+++ b/dev-test/githunt/types.avoidOptionals.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.d.ts
+++ b/dev-test/githunt/types.d.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.enumsAsTypes.ts
+++ b/dev-test/githunt/types.enumsAsTypes.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.flatten.preResolveTypes.ts
+++ b/dev-test/githunt/types.flatten.preResolveTypes.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.immutableTypes.ts
+++ b/dev-test/githunt/types.immutableTypes.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   readonly __typename?: 'Comment';

--- a/dev-test/githunt/types.preResolveTypes.onlyOperationTypes.ts
+++ b/dev-test/githunt/types.preResolveTypes.onlyOperationTypes.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A list of options for the sort order of the feed */
 export enum FeedType {
   /** Sort by a combination of freshness and score, using Reddit's algorithm */

--- a/dev-test/githunt/types.preResolveTypes.ts
+++ b/dev-test/githunt/types.preResolveTypes.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -32,6 +32,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -14,6 +14,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -14,6 +14,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -14,6 +14,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -14,6 +14,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.reactApollo.v2.tsx
+++ b/dev-test/githunt/types.reactApollo.v2.tsx
@@ -15,6 +15,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.rtk-query.ts
+++ b/dev-test/githunt/types.rtk-query.ts
@@ -13,6 +13,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.stencilApollo.tsx
+++ b/dev-test/githunt/types.stencilApollo.tsx
@@ -14,6 +14,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.ts
+++ b/dev-test/githunt/types.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -21,6 +21,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.vueApollo.ts
+++ b/dev-test/githunt/types.vueApollo.ts
@@ -15,6 +15,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/githunt/types.vueApolloSmartOps.ts
+++ b/dev-test/githunt/types.vueApolloSmartOps.ts
@@ -18,6 +18,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A comment about an entry, submitted by a user */
 export type Comment = {
   __typename?: 'Comment';

--- a/dev-test/gql-tag-operations/gql/graphql.ts
+++ b/dev-test/gql-tag-operations/gql/graphql.ts
@@ -15,6 +15,9 @@ export type Scalars = {
   Url: any;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Meta = {
   __typename?: 'Meta';
   count?: Maybe<Scalars['Int']>;

--- a/dev-test/modules/types.ts
+++ b/dev-test/modules/types.ts
@@ -15,6 +15,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Article = {
   __typename?: 'Article';
   id: Scalars['ID'];

--- a/dev-test/star-wars/types.avoidOptionals.ts
+++ b/dev-test/star-wars/types.avoidOptionals.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A character from the Star Wars universe */
 export type Character = {
   /** The ID of the character */

--- a/dev-test/star-wars/types.d.ts
+++ b/dev-test/star-wars/types.d.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A character from the Star Wars universe */
 export type Character = {
   /** The ID of the character */

--- a/dev-test/star-wars/types.globallyAvailable.d.ts
+++ b/dev-test/star-wars/types.globallyAvailable.d.ts
@@ -11,6 +11,9 @@ type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+type Directives = {};
+
 /** A character from the Star Wars universe */
 type Character = {
   /** The ID of the character */

--- a/dev-test/star-wars/types.immutableTypes.ts
+++ b/dev-test/star-wars/types.immutableTypes.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A character from the Star Wars universe */
 export type Character = {
   /** The ID of the character */

--- a/dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts
+++ b/dev-test/star-wars/types.preResolveTypes.onlyOperationTypes.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** The input object sent when passing a color */
 export type ColorInput = {
   red: Scalars['Int'];

--- a/dev-test/star-wars/types.preResolveTypes.ts
+++ b/dev-test/star-wars/types.preResolveTypes.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A character from the Star Wars universe */
 export type Character = {
   /** The ID of the character */

--- a/dev-test/star-wars/types.refetchFn.tsx
+++ b/dev-test/star-wars/types.refetchFn.tsx
@@ -14,6 +14,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A character from the Star Wars universe */
 export type Character = {
   /** The ID of the character */

--- a/dev-test/star-wars/types.skipSchema.ts
+++ b/dev-test/star-wars/types.skipSchema.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A character from the Star Wars universe */
 export type Character = {
   /** The ID of the character */

--- a/dev-test/star-wars/types.ts
+++ b/dev-test/star-wars/types.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 /** A character from the Star Wars universe */
 export type Character = {
   /** The ID of the character */

--- a/dev-test/test-message/types.tsx
+++ b/dev-test/test-message/types.tsx
@@ -14,6 +14,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type CreateMessageInput = {
   description: Scalars['String'];
 };

--- a/dev-test/test-schema/env.types.ts
+++ b/dev-test/test-schema/env.types.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   allUsers: Array<Maybe<User>>;

--- a/dev-test/test-schema/resolvers-federation.ts
+++ b/dev-test/test-schema/resolvers-federation.ts
@@ -13,6 +13,9 @@ export type Scalars = {
   _FieldSet: any;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Address = {
   __typename?: 'Address';
   lines: Lines;

--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -14,6 +14,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   someDummyField: Scalars['Int'];

--- a/dev-test/test-schema/resolvers-types.ts
+++ b/dev-test/test-schema/resolvers-types.ts
@@ -14,6 +14,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   allUsers: Array<Maybe<User>>;

--- a/dev-test/test-schema/types.preResolveTypes.onlyOperationTypes.ts
+++ b/dev-test/test-schema/types.preResolveTypes.onlyOperationTypes.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type TestQueryVariables = Exact<{ [key: string]: never }>;
 
 export type TestQuery = {

--- a/dev-test/test-schema/types.preResolveTypes.ts
+++ b/dev-test/test-schema/types.preResolveTypes.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   allUsers: Array<Maybe<User>>;

--- a/dev-test/test-schema/typings.avoidOptionals.ts
+++ b/dev-test/test-schema/typings.avoidOptionals.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   allUsers: Array<Maybe<User>>;

--- a/dev-test/test-schema/typings.enum.ts
+++ b/dev-test/test-schema/typings.enum.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export enum Foo {
   Bar = 'QUX',
 }

--- a/dev-test/test-schema/typings.immutableTypes.ts
+++ b/dev-test/test-schema/typings.immutableTypes.ts
@@ -11,6 +11,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   allUsers: Array<Maybe<User>>;

--- a/dev-test/test-schema/typings.ts
+++ b/dev-test/test-schema/typings.ts
@@ -14,6 +14,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   allUsers: Array<Maybe<User>>;

--- a/dev-test/test-schema/typings.wrapped.ts
+++ b/dev-test/test-schema/typings.wrapped.ts
@@ -12,6 +12,9 @@ declare namespace GraphQL {
     Float: number;
   };
 
+  /** Type overrides using directives */
+  export type Directives = {};
+
   export type Query = {
     __typename?: 'Query';
     allUsers: Array<Maybe<User>>;

--- a/packages/plugins/other/schema-ast/src/index.ts
+++ b/packages/plugins/other/schema-ast/src/index.ts
@@ -85,7 +85,13 @@ export const validate: PluginValidateFn<any> = async (
 };
 
 export function transformSchemaAST(schema: GraphQLSchema, config: { [key: string]: any }) {
-  const printedSchema = printSchema(schema);
+  let printedSchema: string;
+  if (config.includeDirectives) {
+    printedSchema = printSchemaWithDirectives(schema);
+  } else {
+    printedSchema = printSchema(schema);
+  }
+
   const astNode = parseSchema(printedSchema);
 
   const transformedAST = config.disableDescriptions

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -345,7 +345,7 @@ export class BaseResolversVisitor<
   protected _declarationBlockConfig: DeclarationBlockConfig = {};
   protected _collectedResolvers: { [key: string]: string } = {};
   protected _collectedDirectiveResolvers: { [key: string]: string } = {};
-  protected _variablesTransfomer: OperationVariablesToObject;
+  protected _variablesTransformer: OperationVariablesToObject;
   protected _usedMappers: { [key: string]: boolean } = {};
   protected _resolversTypes: ResolverTypes = {};
   protected _resolversParentTypes: ResolverParentTypes = {};
@@ -393,7 +393,7 @@ export class BaseResolversVisitor<
     autoBind(this);
     this._federation = new ApolloFederation({ enabled: this.config.federation, schema: this.schema });
     this._rootTypeNames = getRootTypeNames(_schema);
-    this._variablesTransfomer = new OperationVariablesToObject(
+    this._variablesTransformer = new OperationVariablesToObject(
       this.scalars,
       this.convertName,
       this.config.namespacedImportName
@@ -774,7 +774,7 @@ export class BaseResolversVisitor<
   }
 
   setVariablesTransformer(variablesTransfomer: OperationVariablesToObject): void {
-    this._variablesTransfomer = variablesTransfomer;
+    this._variablesTransformer = variablesTransfomer;
   }
 
   public hasScalars(): boolean {
@@ -908,7 +908,7 @@ export class BaseResolversVisitor<
       }
 
       const typeToUse = this.getTypeToUse(realType);
-      const mappedType = this._variablesTransfomer.wrapAstTypeWithModifiers(typeToUse, original.type);
+      const mappedType = this._variablesTransformer.wrapAstTypeWithModifiers(typeToUse, original.type);
       const subscriptionType = this._schema.getSubscriptionType();
       const isSubscriptionType = subscriptionType && subscriptionType.name === parentName;
 
@@ -1113,7 +1113,7 @@ export class BaseResolversVisitor<
         .withName(directiveArgsTypeName)
         .withContent(
           `{ ${
-            hasArguments ? this._variablesTransfomer.transform<InputValueDefinitionNode>(sourceNode.arguments) : ''
+            hasArguments ? this._variablesTransformer.transform<InputValueDefinitionNode>(sourceNode.arguments) : ''
           } }`
         ).string,
       new DeclarationBlock({

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -30,6 +30,8 @@ import {
   DeclarationKindConfig,
   DeclarationKind,
   ParsedEnumValuesMap,
+  DirectivesMap,
+  ParsedDirectivesMap,
 } from './types';
 import {
   transformComment,
@@ -42,6 +44,7 @@ import {
 } from './utils';
 import { OperationVariablesToObject } from './variables-to-object';
 import { parseEnumValues } from './enum-values';
+import { transformDirectiveMappers } from './mappers';
 
 export interface ParsedTypesConfig extends ParsedConfig {
   enumValues: ParsedEnumValuesMap;
@@ -54,6 +57,7 @@ export interface ParsedTypesConfig extends ParsedConfig {
   entireFieldWrapperValue: string;
   wrapEntireDefinitions: boolean;
   ignoreEnumValuesFromSchema: boolean;
+  directiveMappers: ParsedDirectivesMap;
 }
 
 export interface RawTypesConfig extends RawConfig {
@@ -231,6 +235,34 @@ export interface RawTypesConfig extends RawConfig {
    * ```
    */
   entireFieldWrapperValue?: string;
+  /**
+   * @description Replaces a GraphQL scalar with a custom type, allowing you to modify the scalar typing in certain cases.
+   * You can use both `module#type` and `module#namespace#type` syntax.
+   * Will NOT work with introspected schemas since directives are not exported.
+   * Only works with directives on ARGUMENT_DEFINITION or INPUT_FIELD_DEFINITION.
+   *
+   * @exampleMarkdown
+   * ## Custom Context Type
+   * ```yml
+   * plugins
+   *   config:
+   *     directiveMappers:
+   *       AsNumber: number
+   *       AsComplex: ./my-models#Complex
+   * ```
+   */
+  directiveMappers?: DirectivesMap;
+  /**
+   * @description Adds a suffix to the imported names to prevent name clashes.
+   *
+   * @exampleMarkdown
+   * ```yml
+   * plugins
+   *   config:
+   *     directiveMapperTypeSuffix: Model
+   * ```
+   */
+  directiveMapperTypeSuffix?: string;
 }
 
 export class BaseTypesVisitor<
@@ -261,9 +293,14 @@ export class BaseTypesVisitor<
       entireFieldWrapperValue: getConfigValue(rawConfig.entireFieldWrapperValue, 'T'),
       wrapEntireDefinitions: getConfigValue(rawConfig.wrapEntireFieldDefinitions, false),
       ignoreEnumValuesFromSchema: getConfigValue(rawConfig.ignoreEnumValuesFromSchema, false),
+      directiveMappers: transformDirectiveMappers(
+        rawConfig.directiveMappers || {},
+        rawConfig.directiveMapperTypeSuffix
+      ),
       ...additionalConfig,
     });
 
+    // Note: Missing directive mappers but not a problem since always overriden by implementors
     this._argumentsTransformer = new OperationVariablesToObject(this.scalars, this.convertName);
   }
 
@@ -301,6 +338,20 @@ export class BaseTypesVisitor<
       .filter(a => a);
   }
 
+  public getDirectiveMappersImports(): string[] {
+    return Object.keys(this.config.directiveMappers)
+      .map(directive => {
+        const mappedValue = this.config.directiveMappers[directive];
+
+        if (mappedValue.isExternal) {
+          return this._buildTypeImport(mappedValue.import, mappedValue.source, mappedValue.default);
+        }
+
+        return null;
+      })
+      .filter(a => a);
+  }
+
   public get scalarsDefinition(): string {
     const allScalars = Object.keys(this.config.scalars).map(scalarName => {
       const scalarValue = this.config.scalars[scalarName].type;
@@ -320,6 +371,27 @@ export class BaseTypesVisitor<
       .withBlock(allScalars.join('\n')).string;
   }
 
+  public get directiveMappersDefinition(): string {
+    const allDirectives = Object.keys(this.config.directiveMappers).map(directiveName => {
+      const directiveValue = this.config.directiveMappers[directiveName].type;
+      const directiveType = this._schema.getDirective(directiveName);
+      const comment =
+        directiveType && directiveType.astNode && directiveType.description
+          ? transformComment(directiveType.description, 1)
+          : '';
+      const { directive } = this._parsedConfig.declarationKind;
+
+      return comment + indent(`${directiveName}: ${directiveValue}${this.getPunctuation(directive)}`);
+    });
+
+    return new DeclarationBlock(this._declarationBlockConfig)
+      .export()
+      .asKind(this._parsedConfig.declarationKind.directive)
+      .withName('Directives')
+      .withComment('Type overrides using directives')
+      .withBlock(allDirectives.join('\n')).string;
+  }
+
   setDeclarationBlockConfig(config: DeclarationBlockConfig): void {
     this._declarationBlockConfig = config;
   }
@@ -329,7 +401,7 @@ export class BaseTypesVisitor<
   }
 
   NonNullType(node: NonNullTypeNode): string {
-    const asString = (node.type as any) as string;
+    const asString = node.type as any as string;
 
     return asString;
   }
@@ -339,7 +411,7 @@ export class BaseTypesVisitor<
       .export()
       .asKind(this._parsedConfig.declarationKind.input)
       .withName(this.convertName(node))
-      .withComment((node.description as any) as string)
+      .withComment(node.description as any as string)
       .withBlock(node.fields.join('\n'));
   }
 
@@ -348,10 +420,15 @@ export class BaseTypesVisitor<
   }
 
   InputValueDefinition(node: InputValueDefinitionNode): string {
-    const comment = transformComment((node.description as any) as string, 1);
+    const comment = transformComment(node.description as any as string, 1);
     const { input } = this._parsedConfig.declarationKind;
 
-    return comment + indent(`${node.name}: ${node.type}${this.getPunctuation(input)}`);
+    let type: string = node.type as any as string;
+    if (node.directives && this.config.directiveMappers) {
+      type = this._getDirectiveOverrideType(node.directives) || type;
+    }
+
+    return comment + indent(`${node.name}: ${type}${this.getPunctuation(input)}`);
   }
 
   Name(node: NameNode): string {
@@ -359,7 +436,7 @@ export class BaseTypesVisitor<
   }
 
   FieldDefinition(node: FieldDefinitionNode): string {
-    const typeString = (node.type as any) as string;
+    const typeString = node.type as any as string;
     const { type } = this._parsedConfig.declarationKind;
     const comment = this.getFieldComment(node);
 
@@ -377,7 +454,7 @@ export class BaseTypesVisitor<
       .export()
       .asKind('type')
       .withName(this.convertName(node))
-      .withComment((node.description as any) as string)
+      .withComment(node.description as any as string)
       .withContent(possibleTypes).string;
   }
 
@@ -414,7 +491,7 @@ export class BaseTypesVisitor<
       .export()
       .asKind(type)
       .withName(this.convertName(node))
-      .withComment((node.description as any) as string);
+      .withComment(node.description as any as string);
 
     if (type === 'interface' || type === 'class') {
       if (interfacesNames.length > 0) {
@@ -463,7 +540,7 @@ export class BaseTypesVisitor<
       .export()
       .asKind(this._parsedConfig.declarationKind.interface)
       .withName(this.convertName(node))
-      .withComment((node.description as any) as string);
+      .withComment(node.description as any as string);
 
     return declarationBlock.withBlock(node.fields.join('\n'));
   }
@@ -530,7 +607,7 @@ export class BaseTypesVisitor<
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {
-    const enumName = (node.name as any) as string;
+    const enumName = node.name as any as string;
 
     // In case of mapped external enum string
     if (this.config.enumValues[enumName] && this.config.enumValues[enumName].sourceFile) {
@@ -541,7 +618,7 @@ export class BaseTypesVisitor<
       .export()
       .asKind('enum')
       .withName(this.convertName(node, { useTypesPrefix: this.config.enumPrefix }))
-      .withComment((node.description as any) as string)
+      .withComment(node.description as any as string)
       .withBlock(this.buildEnumValuesBlock(enumName, node.values)).string;
   }
 
@@ -567,7 +644,7 @@ export class BaseTypesVisitor<
         const optionName = this.makeValidEnumIdentifier(
           this.convertName(enumOption, { useTypesPrefix: false, transformUnderscore: true })
         );
-        const comment = transformComment((enumOption.description as any) as string, 1);
+        const comment = transformComment(enumOption.description as any as string, 1);
         const schemaEnumValue =
           schemaEnumType && !this.config.ignoreEnumValuesFromSchema
             ? schemaEnumType.getValue(enumOption.name as any).value
@@ -643,8 +720,27 @@ export class BaseTypesVisitor<
     return `Scalars['${name}']`;
   }
 
+  protected _getDirectiveMapping(name: string): string {
+    return `Directives['${name}']`;
+  }
+
+  protected _getDirectiveOverrideType(directives: ReadonlyArray<DirectiveNode>): string | null {
+    const type = directives
+      .map(directive => {
+        const directiveName = directive.name as any as string;
+        if (this.config.directiveMappers[directiveName]) {
+          return this._getDirectiveMapping(directiveName);
+        }
+        return null;
+      })
+      .reverse()
+      .find(a => !!a);
+
+    return type || null;
+  }
+
   protected _getTypeForNode(node: NamedTypeNode): string {
-    const typeAsString = (node.name as any) as string;
+    const typeAsString = node.name as any as string;
 
     if (this.scalars[typeAsString]) {
       return this._getScalar(typeAsString);
@@ -674,7 +770,7 @@ export class BaseTypesVisitor<
   }
 
   ListType(node: ListTypeNode): string {
-    const asString = (node.type as any) as string;
+    const asString = node.type as any as string;
 
     return this.wrapWithListType(asString);
   }

--- a/packages/plugins/other/visitor-plugin-common/src/declaration-kinds.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/declaration-kinds.ts
@@ -1,6 +1,7 @@
 import { DeclarationKindConfig, DeclarationKind } from './types';
 
 export const DEFAULT_DECLARATION_KINDS: DeclarationKindConfig = {
+  directive: 'type',
   scalar: 'type',
   input: 'type',
   type: 'type',
@@ -13,6 +14,7 @@ export function normalizeDeclarationKind(
 ): DeclarationKindConfig {
   if (typeof declarationKind === 'string') {
     return {
+      directive: declarationKind,
       scalar: declarationKind,
       input: declarationKind,
       type: declarationKind,

--- a/packages/plugins/other/visitor-plugin-common/src/mappers.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/mappers.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-inner-declarations */
 import { RawResolversConfig, ParsedResolversConfig } from './base-resolvers-visitor';
+import { DirectivesMap, ParsedDirectivesMap } from './types';
 
 export type ParsedMapper = InternalParsedMapper | ExternalParsedMapper;
 export interface InternalParsedMapper {
@@ -180,6 +181,21 @@ export function transformMappers(
     const mapperDef = rawMappers[gqlTypeName];
     const parsedMapper = parseMapper(mapperDef, gqlTypeName, mapperTypeSuffix);
     result[gqlTypeName] = parsedMapper;
+  });
+
+  return result;
+}
+
+export function transformDirectiveMappers(
+  rawDirectiveMappers: DirectivesMap,
+  directiveMapperTypeSuffix?: string
+): ParsedDirectivesMap {
+  const result: ParsedDirectivesMap = {};
+
+  Object.keys(rawDirectiveMappers).forEach(directive => {
+    const mapperDef = rawDirectiveMappers[directive];
+    const parsedMapper = parseMapper(mapperDef, directive, directiveMapperTypeSuffix);
+    result[directive] = parsedMapper;
   });
 
   return result;

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -2,6 +2,17 @@ import { ASTNode, FragmentDefinitionNode } from 'graphql';
 import { ParsedMapper } from './mappers';
 
 /**
+ * A map between the GraphQL directive name and the identifier that should be used
+ */
+export type DirectivesMap = { [name: string]: string };
+
+/**
+ * Parsed directives map - a mapping between GraphQL directice name and the parsed mapper object,
+ * including all required information for generting code for that mapping.
+ */
+export type ParsedDirectivesMap = { [name: string]: ParsedMapper };
+
+/**
  * Scalars map or a string, a map between the GraphQL scalar name and the identifier that should be used
  */
 export type ScalarsMap = string | { [name: string]: string };
@@ -71,6 +82,7 @@ export type LoadedFragment<AdditionalFields = {}> = {
 export type DeclarationKind = 'type' | 'interface' | 'class' | 'abstract class';
 
 export interface DeclarationKindConfig {
+  directive?: DeclarationKind;
   scalar?: DeclarationKind;
   input?: DeclarationKind;
   type?: DeclarationKind;

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -16,6 +16,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   /** A feed of repository submissions */
@@ -289,6 +292,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   /** A feed of repository submissions */
@@ -500,6 +506,9 @@ export type Scalars = {
   Int: number;
   Float: number;
 };
+
+/** Type overrides using directives */
+export type Directives = {};
 
 export type Query = {
   __typename?: 'Query';

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -16,6 +16,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   /** A feed of repository submissions */
@@ -301,6 +304,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   /** A feed of repository submissions */
@@ -577,6 +583,9 @@ export type Scalars = {
   Int: number;
   Float: number;
 };
+
+/** Type overrides using directives */
+export type Directives = {};
 
 export type Query = {
   __typename?: 'Query';
@@ -857,6 +866,9 @@ export type Scalars = {
   Int: number;
   Float: number;
 };
+
+/** Type overrides using directives */
+export type Directives = {};
 
 export type Query = {
   __typename?: 'Query';
@@ -1139,6 +1151,9 @@ export type Scalars = {
   Int: number;
   Float: number;
 };
+
+/** Type overrides using directives */
+export type Directives = {};
 
 export type Query = {
   __typename?: 'Query';

--- a/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
+++ b/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
@@ -77,6 +77,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Venue = {
   id: Scalars['String'];
   name: Scalars['String'];
@@ -343,6 +346,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   __typename?: 'Query';
   search?: Maybe<Array<Searchable>>;
@@ -458,6 +464,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Error = {
   message: Scalars['String'];
 };
@@ -549,6 +558,9 @@ export type Scalars = {
   Int: number;
   Float: number;
 };
+
+/** Type overrides using directives */
+export type Directives = {};
 
 
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -3714,6 +3714,9 @@ describe('TypeScript Operations Plugin', () => {
           Float: number;
         };
 
+        /** Type overrides using directives */
+        export type Directives = {};
+
         export type Query = {
           __typename?: 'Query';
           search?: Maybe<Array<Searchable>>;

--- a/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
+++ b/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
@@ -17,6 +17,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>;
@@ -210,6 +213,9 @@ export type Scalars = {
   Int: number;
   Float: number;
 };
+
+/** Type overrides using directives */
+export type Directives = {};
 
 export type GQLQuery = {
   /** A feed of repository submissions */
@@ -405,6 +411,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Query = {
   /** A feed of repository submissions */
   feed?: Maybe<Array<Maybe<Entry>>>;
@@ -598,6 +607,9 @@ export type Scalars = {
   Int: number;
   Float: number;
 };
+
+/** Type overrides using directives */
+export type Directives = {};
 
 export type Query = {
   /** A feed of repository submissions */

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -18,6 +18,9 @@ export type Scalars = {
   MyScalar: any;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 
 export type MyType = {
   __typename?: 'MyType';
@@ -452,6 +455,9 @@ export type Scalars = {
   Float: number;
   MyScalar: any;
 };
+
+/** Type overrides using directives */
+export type Directives = {};
 
 
 export type MyType = {

--- a/packages/plugins/typescript/typescript/src/typescript-variables-to-object.ts
+++ b/packages/plugins/typescript/typescript/src/typescript-variables-to-object.ts
@@ -5,6 +5,7 @@ import {
   ConvertNameFn,
   AvoidOptionalsConfig,
   normalizeAvoidOptionals,
+  ParsedDirectivesMap,
 } from '@graphql-codegen/visitor-plugin-common';
 import { TypeNode, Kind } from 'graphql';
 
@@ -18,9 +19,19 @@ export class TypeScriptOperationVariablesToObject extends OperationVariablesToOb
     _enumNames: string[] = [],
     _enumPrefix = true,
     _enumValues: ParsedEnumValuesMap = {},
-    _applyCoercion: Boolean = false
+    _applyCoercion: Boolean = false,
+    _directiveMappers: ParsedDirectivesMap = {}
   ) {
-    super(_scalars, _convertName, _namespacedImportName, _enumNames, _enumPrefix, _enumValues, _applyCoercion);
+    super(
+      _scalars,
+      _convertName,
+      _namespacedImportName,
+      _enumNames,
+      _enumPrefix,
+      _enumValues,
+      _applyCoercion,
+      _directiveMappers
+    );
   }
 
   private clearOptional(str: string): string {

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -82,7 +82,9 @@ export class TsVisitor<
         null,
         enumNames,
         pluginConfig.enumPrefix,
-        this.config.enumValues
+        this.config.enumValues,
+        false,
+        this.config.directiveMappers
       )
     );
     this.setDeclarationBlockConfig({
@@ -243,13 +245,19 @@ export class TsVisitor<
       (originalFieldNode.type.kind !== Kind.NON_NULL_TYPE ||
         (!this.config.avoidOptionals.defaultValue && node.defaultValue !== undefined));
     const comment = transformComment(node.description as any as string, 1);
-    const { type } = this.config.declarationKind;
+    const declarationKind = this.config.declarationKind.type;
+
+    let type: string = node.type as any as string;
+    if (node.directives && this.config.directiveMappers) {
+      type = this._getDirectiveOverrideType(node.directives) || type;
+    }
+
     return (
       comment +
       indent(
-        `${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${addOptionalSign ? '?' : ''}: ${
-          node.type
-        }${this.getPunctuation(type)}`
+        `${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${
+          addOptionalSign ? '?' : ''
+        }: ${type}${this.getPunctuation(declarationKind)}`
       )
     );
   }

--- a/packages/plugins/typescript/typescript/tests/__snapshots__/typescript.spec.ts.snap
+++ b/packages/plugins/typescript/typescript/tests/__snapshots__/typescript.spec.ts.snap
@@ -10,6 +10,9 @@ export type Scalars = {
   Float: number;
 };
 
+/** Type overrides using directives */
+export type Directives = {};
+
 export type Matrix = {
   __typename?: 'Matrix';
   pills: Array<RedPill | GreenPill>;


### PR DESCRIPTION
## Description

This adds a new configuration parameter to specify directives that can affect the final type.
- This currently only works if we have access to the raw schema since the introspected schema doesn't contain the directives.
- I only implemented it for typescript plugin but I built it so it should be trivial to support it in flow
- I am unsure of the naming of it all, so suggestions are welcome!

Related https://github.com/dotansimha/graphql-code-generator/issues/6393

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Only ran the unit tests, but I will give it a try soon on a real project.
I created a bunch of unit tests for this feature.

**Test Environment**:
- OS: MacOS
- `@graphql-codegen/...`:  Latest
- NodeJS: 14

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
