### PR TITLE
[typescript-react-query] Allow passing `headers` to `graphql-request`

### DIFF
--- a/.changeset/stupid-actors-kneel.md
+++ b/.changeset/stupid-actors-kneel.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': minor
+---
+
+Allow passing `headers` to `graphql-request`.

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -21,9 +21,9 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      variables?: TTestQueryVariables,
+      variables?: TTestQueryVariables, 
       options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) =>
+    ) => 
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
@@ -39,7 +39,7 @@ export const TestDocument = \`
 export const useTestMutation = <
       TError = unknown,
       TContext = unknown
-    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
       useCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument),
       options
@@ -67,9 +67,9 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      variables?: TTestQueryVariables,
+      variables?: TTestQueryVariables, 
       options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) =>
+    ) => 
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -85,7 +85,7 @@ export const TestDocument = \`
 export const useTestMutation = <
       TError = unknown,
       TContext = unknown
-    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
       (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
@@ -113,9 +113,9 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      variables?: TTestQueryVariables,
+      variables?: TTestQueryVariables, 
       options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) =>
+    ) => 
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -131,7 +131,7 @@ export const TestDocument = \`
 export const useTestMutation = <
       TError = unknown,
       TContext = unknown
-    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
       (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
@@ -159,10 +159,10 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      dataSource: { endpoint: string, fetchParams?: RequestInit },
-      variables?: TTestQueryVariables,
+      dataSource: { endpoint: string, fetchParams?: RequestInit }, 
+      variables?: TTestQueryVariables, 
       options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) =>
+    ) => 
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
@@ -179,9 +179,9 @@ export const useTestMutation = <
       TError = unknown,
       TContext = unknown
     >(
-      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      dataSource: { endpoint: string, fetchParams?: RequestInit }, 
       options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
-    ) =>
+    ) => 
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
       options
@@ -209,11 +209,11 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      client: GraphQLClient,
-      variables?: TTestQueryVariables,
+      client: GraphQLClient, 
+      variables?: TTestQueryVariables, 
       options?: UseQueryOptions<TTestQuery, TError, TData>,
       headers?: RequestInit['headers']
-    ) =>
+    ) => 
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables, headers),
@@ -230,10 +230,10 @@ export const useTestMutation = <
       TError = unknown,
       TContext = unknown
     >(
-      client: GraphQLClient,
+      client: GraphQLClient, 
       options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>,
       headers?: RequestInit['headers']
-    ) =>
+    ) => 
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables, headers)(),
       options

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -21,9 +21,9 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      variables?: TTestQueryVariables, 
+      variables?: TTestQueryVariables,
       options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) => 
+    ) =>
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
@@ -39,7 +39,7 @@ export const TestDocument = \`
 export const useTestMutation = <
       TError = unknown,
       TContext = unknown
-    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
       useCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument),
       options
@@ -67,9 +67,9 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      variables?: TTestQueryVariables, 
+      variables?: TTestQueryVariables,
       options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) => 
+    ) =>
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -85,7 +85,7 @@ export const TestDocument = \`
 export const useTestMutation = <
       TError = unknown,
       TContext = unknown
-    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
       (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
@@ -113,9 +113,9 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      variables?: TTestQueryVariables, 
+      variables?: TTestQueryVariables,
       options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) => 
+    ) =>
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -131,7 +131,7 @@ export const TestDocument = \`
 export const useTestMutation = <
       TError = unknown,
       TContext = unknown
-    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
       (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
@@ -159,10 +159,10 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      dataSource: { endpoint: string, fetchParams?: RequestInit }, 
-      variables?: TTestQueryVariables, 
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      variables?: TTestQueryVariables,
       options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) => 
+    ) =>
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
@@ -179,9 +179,9 @@ export const useTestMutation = <
       TError = unknown,
       TContext = unknown
     >(
-      dataSource: { endpoint: string, fetchParams?: RequestInit }, 
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
       options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
-    ) => 
+    ) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
       options
@@ -209,13 +209,14 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      client: GraphQLClient, 
-      variables?: TTestQueryVariables, 
-      options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) => 
+      client: GraphQLClient,
+      variables?: TTestQueryVariables,
+      options?: UseQueryOptions<TTestQuery, TError, TData>,
+      headers?: RequestInit['headers']
+    ) =>
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
-      fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
+      fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables, headers),
       options
     );
 export const TestDocument = \`
@@ -229,11 +230,12 @@ export const useTestMutation = <
       TError = unknown,
       TContext = unknown
     >(
-      client: GraphQLClient, 
-      options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
-    ) => 
+      client: GraphQLClient,
+      options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>,
+      headers?: RequestInit['headers']
+    ) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables)(),
+      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables, headers)(),
       options
     );"
 `;

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -344,34 +344,37 @@ describe('React-Query', () => {
         `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
       );
       expect(out.prepend).toContain(`import { GraphQLClient } from 'graphql-request';`);
-      expect(out.prepend[2])
-        .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variables?: TVariables) {
-          return async (): Promise<TData> => client.request<TData, TVariables>(query, variables);
+      expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom';`);
+      expect(out.prepend[3])
+        .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variables?: TVariables, headers?: RequestInit['headers']) {
+          return async (): Promise<TData> => client.request<TData, TVariables>(query, variables, headers);
         }`);
       expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
-          TData = TTestQuery,
-          TError = unknown
-        >(
-          client: GraphQLClient,
-          variables?: TTestQueryVariables,
-          options?: UseQueryOptions<TTestQuery, TError, TData>
-        ) =>
-        useQuery<TTestQuery, TError, TData>(
-          variables === undefined ? ['test'] : ['test', variables],
-          fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
-          options
-        );`);
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      client: GraphQLClient, 
+      variables?: TTestQueryVariables, 
+      options?: UseQueryOptions<TTestQuery, TError, TData>,
+      headers?: RequestInit['headers']
+    ) => 
+    useQuery<TTestQuery, TError, TData>(
+      variables === undefined ? ['test'] :['test', variables],
+      fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables, headers),
+      options
+    );`);
       expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
-        TError = unknown,
-        TContext = unknown
-      >(
-        client: GraphQLClient,
-        options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
-      ) =>
-      useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-        (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables)(),
-        options
-      );`);
+      TError = unknown,
+      TContext = unknown
+    >(
+      client: GraphQLClient,
+      options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>,
+      headers?: RequestInit['headers']
+    ) =>
+    useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables, headers)(),
+      options
+    );`);
 
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config);
@@ -394,7 +397,7 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toBeSimilarStringTo(
-        `useTestQuery.fetcher = (client: GraphQLClient, variables?: TestQueryVariables) => fetcher<TestQuery, TestQueryVariables>(client, TestDocument, variables);`
+        `useTestQuery.fetcher = (client: GraphQLClient, variables?: TestQueryVariables, headers?: RequestInit['headers']) => fetcher<TestQuery, TestQueryVariables>(client, TestDocument, variables, headers);`
       );
     });
     it(`tests for dedupeOperationSuffix`, async () => {

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -359,7 +359,7 @@ describe('React-Query', () => {
       headers?: RequestInit['headers']
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] :['test', variables],
+      variables === undefined ? ['test'] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables, headers),
       options
     );`);


### PR DESCRIPTION
## Description

With `graphql-request` it's possible to pass in `headers` on a per request basis. With the current implementation, this can not be achieved with `@graphql-codegen/typescript-react-query`. This PR adds an optional parameter `headers` to the hook and fetcher.


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Existing tests have been extended

**Test Environment**:
- OS: macOS
- `@graphql-codegen/...`: 
- NodeJS: 

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules