### PR TITLE
enhance(plugins): use getDocumentNodeFromSchema and other utilities from @graphql-tools/utils

### DIFF
--- a/.changeset/lovely-needles-pretend.md
+++ b/.changeset/lovely-needles-pretend.md
@@ -1,0 +1,20 @@
+---
+'@graphql-codegen/cli': minor
+'@graphql-codegen/core': minor
+'@graphql-codegen/c-sharp': minor
+'@graphql-codegen/c-sharp-operations': minor
+'@graphql-codegen/flow': minor
+'@graphql-codegen/flow-resolvers': minor
+'@graphql-codegen/java': minor
+'@graphql-codegen/kotlin': minor
+'@graphql-codegen/java-resolvers': minor
+'@graphql-codegen/jsdoc': minor
+'@graphql-codegen/schema-ast': minor
+'@graphql-codegen/typescript-mongodb': minor
+'@graphql-codegen/typescript-resolvers': minor
+'@graphql-codegen/typescript-type-graphql': minor
+'@graphql-codegen/near-operation-file-preset': minor
+'@graphql-codegen/plugin-helpers': minor
+---
+
+enhance(plugins): use getDocumentNodeFromSchema and other utilities from @graphql-tools/utils

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,24 @@
 {
-    "yaml.schemas": {
-      "./website/static/config.schema.json": "*codegen.*"
-    }
-  }
+  "yaml.schemas": {
+    "./website/static/config.schema.json": "*codegen.*"
+  },
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "editor.rulers": [80],
+  "editor.wordWrapColumn": 110,
+  "prettier.semi": true,
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "prettier.singleQuote": true,
+  "prettier.printWidth": 110,
+  "files.exclude": {
+    "**/.git": true,
+    "**/.DS_Store": true,
+    "node_modules": true,
+    "test-lib": true,
+    "lib": true,
+    "coverage": true,
+    "npm": true
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/examples/programmatic-typescript/package.json
+++ b/examples/programmatic-typescript/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@graphql-codegen/core": "*",
+    "@graphql-codegen/plugin-helpers": "*",
     "@graphql-codegen/typed-document-node": "*",
     "@graphql-codegen/typescript": "*",
     "@graphql-codegen/typescript-operations": "*",

--- a/examples/programmatic-typescript/src/index.ts
+++ b/examples/programmatic-typescript/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import { promises } from 'fs';
-import { parse, printSchema } from 'graphql';
+import { getCachedDocumentNodeFromSchema } from '@graphql-codegen/plugin-helpers';
 import gql from 'graphql-tag';
 import prettier from 'prettier';
 
@@ -43,8 +43,11 @@ const schema = makeExecutableSchema({
     useTypeImports: true,
   };
 
+  const schemaAsDocumentNode = getCachedDocumentNodeFromSchema(schema);
+
   const codegenCode = await codegen({
-    schema: parse(printSchema(schema)),
+    schema: schemaAsDocumentNode,
+    schemaAst: schema,
     config,
     documents: loadedDocuments,
     filename: 'gql.generated.ts',

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -5,15 +5,15 @@ import {
   normalizeOutputParam,
   normalizeInstanceOrArray,
   normalizeConfig,
+  getCachedDocumentNodeFromSchema,
 } from '@graphql-codegen/plugin-helpers';
 import { codegen } from '@graphql-codegen/core';
 
 import { Renderer, ErrorRenderer } from './utils/listr-renderer';
-import { GraphQLError, GraphQLSchema, DocumentNode, parse } from 'graphql';
+import { GraphQLError, GraphQLSchema, DocumentNode } from 'graphql';
 import { getPluginByName } from './plugins';
 import { getPresetByName } from './presets';
 import { debugLog } from './utils/debugging';
-import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import { CodegenContext, ensureContext } from './config';
 import fs from 'fs';
 import path from 'path';
@@ -109,7 +109,7 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
         'Invalid Codegen Configuration!',
         `
         Please make sure that your codegen config file contains the "generates" field, with a specification for the plugins you need.
-        
+
         It should looks like that:
 
         schema:
@@ -131,9 +131,9 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
           'Invalid Codegen Configuration!',
           `
           Please make sure that your codegen config file has defined plugins list for output "${filename}".
-          
+
           It should looks like that:
-  
+
           schema:
             - my-schema.graphql
           generates:
@@ -153,9 +153,9 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
       throw new DetailedError(
         'Invalid Codegen Configuration!',
         `
-        Please make sure that your codegen config file contains either the "schema" field 
+        Please make sure that your codegen config file contains either the "schema" field
         or every generated file has its own "schema" field.
-        
+
         It should looks like that:
         schema:
           - my-schema.graphql
@@ -211,7 +211,7 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
                         }
                       }
                       outputSchemaAst = await context.loadSchema(schemaPointerMap);
-                      outputSchema = parse(printSchemaWithDirectives(outputSchemaAst));
+                      outputSchema = getCachedDocumentNodeFromSchema(outputSchemaAst);
                     }, filename),
                   },
                   {

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -1,12 +1,13 @@
-import { DetailedError, Types, isComplexPluginOutput, federationSpec } from '@graphql-codegen/plugin-helpers';
-import { visit, parse, DefinitionNode, Kind, print, NameNode } from 'graphql';
-import { executePlugin } from './execute-plugin';
 import {
-  checkValidationErrors,
-  validateGraphQlDocuments,
-  printSchemaWithDirectives,
-  Source,
-} from '@graphql-tools/utils';
+  DetailedError,
+  Types,
+  isComplexPluginOutput,
+  federationSpec,
+  getCachedDocumentNodeFromSchema,
+} from '@graphql-codegen/plugin-helpers';
+import { visit, DefinitionNode, Kind, print, NameNode } from 'graphql';
+import { executePlugin } from './execute-plugin';
+import { checkValidationErrors, validateGraphQlDocuments, Source } from '@graphql-tools/utils';
 
 import { mergeSchemas } from '@graphql-tools/schema';
 
@@ -67,7 +68,7 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
   }
 
   if (schemaChanged) {
-    options.schema = parse(printSchemaWithDirectives(schemaAst));
+    options.schema = getCachedDocumentNodeFromSchema(schemaAst);
   }
 
   const skipDocumentValidation =

--- a/packages/plugins/c-sharp/c-sharp-operations/src/index.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/index.ts
@@ -1,5 +1,10 @@
-import { Types, PluginValidateFn, PluginFunction } from '@graphql-codegen/plugin-helpers';
-import { visit, GraphQLSchema, concatAST, Kind, FragmentDefinitionNode, printSchema, parse } from 'graphql';
+import {
+  Types,
+  PluginValidateFn,
+  PluginFunction,
+  getCachedDocumentNodeFromSchema,
+} from '@graphql-codegen/plugin-helpers';
+import { visit, GraphQLSchema, concatAST, Kind, FragmentDefinitionNode } from 'graphql';
 import { LoadedFragment } from '@graphql-codegen/visitor-plugin-common';
 import { CSharpOperationsVisitor } from './visitor';
 import { extname } from 'path';
@@ -11,7 +16,7 @@ export const plugin: PluginFunction<CSharpOperationsRawPluginConfig> = (
   documents: Types.DocumentFile[],
   config
 ) => {
-  const schemaAST = parse(printSchema(schema));
+  const schemaAST = getCachedDocumentNodeFromSchema(schema);
   const allAst = concatAST(documents.map(v => v.document).concat(schemaAST));
   const allFragments: LoadedFragment[] = [
     ...(allAst.definitions.filter(d => d.kind === Kind.FRAGMENT_DEFINITION) as FragmentDefinitionNode[]).map(

--- a/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
@@ -18,8 +18,6 @@ import {
   VariableDefinitionNode,
   isScalarType,
   FieldNode,
-  printSchema,
-  parse,
   DocumentNode,
   isEnumType,
   isInputObjectType,
@@ -30,7 +28,7 @@ import {
   FragmentSpreadNode,
 } from 'graphql';
 import { CSharpOperationsRawPluginConfig } from './config';
-import { Types } from '@graphql-codegen/plugin-helpers';
+import { getCachedDocumentNodeFromSchema, Types } from '@graphql-codegen/plugin-helpers';
 import {
   getListInnerTypeNode,
   C_SHARP_SCALARS,
@@ -97,7 +95,7 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
     this.overruleConfigSettings();
     autoBind(this);
 
-    this._schemaAST = parse(printSchema(schema));
+    this._schemaAST = getCachedDocumentNodeFromSchema(schema);
   }
 
   // Some settings aren't supported with C#, overruled here

--- a/packages/plugins/c-sharp/c-sharp/src/index.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/index.ts
@@ -1,5 +1,5 @@
-import { parse, GraphQLSchema, printSchema, visit } from 'graphql';
-import { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
+import { GraphQLSchema, visit } from 'graphql';
+import { PluginFunction, Types, getCachedDocumentNodeFromSchema } from '@graphql-codegen/plugin-helpers';
 import { CSharpResolversVisitor } from './visitor';
 import { CSharpResolversPluginRawConfig } from './config';
 
@@ -9,8 +9,7 @@ export const plugin: PluginFunction<CSharpResolversPluginRawConfig> = async (
   config: CSharpResolversPluginRawConfig
 ): Promise<string> => {
   const visitor = new CSharpResolversVisitor(config, schema);
-  const printedSchema = printSchema(schema);
-  const astNode = parse(printedSchema);
+  const astNode = getCachedDocumentNodeFromSchema(schema);
   const visitorResult = visit(astNode, { leave: visitor as any });
   const imports = visitor.getImports();
   const blockContent = visitorResult.definitions.filter(d => typeof d === 'string').join('\n');

--- a/packages/plugins/flow/flow/src/index.ts
+++ b/packages/plugins/flow/flow/src/index.ts
@@ -1,5 +1,5 @@
-import { Types, PluginFunction } from '@graphql-codegen/plugin-helpers';
-import { parse, printSchema, visit, GraphQLSchema } from 'graphql';
+import { Types, PluginFunction, getCachedDocumentNodeFromSchema } from '@graphql-codegen/plugin-helpers';
+import { visit, GraphQLSchema } from 'graphql';
 import { FlowVisitor } from './visitor';
 import { FlowPluginConfig } from './config';
 
@@ -12,8 +12,7 @@ export const plugin: PluginFunction<FlowPluginConfig, Types.ComplexPluginOutput>
   config: FlowPluginConfig
 ) => {
   const header = `// @flow\n`;
-  const printedSchema = printSchema(schema);
-  const astNode = parse(printedSchema);
+  const astNode = getCachedDocumentNodeFromSchema(schema);
   const visitor = new FlowVisitor(schema, config);
 
   const visitorResult = visit(astNode, {

--- a/packages/plugins/flow/resolvers/src/index.ts
+++ b/packages/plugins/flow/resolvers/src/index.ts
@@ -1,7 +1,11 @@
-import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import { RawResolversConfig } from '@graphql-codegen/visitor-plugin-common';
-import { Types, PluginFunction, addFederationReferencesToSchema } from '@graphql-codegen/plugin-helpers';
-import { parse, printSchema, visit, GraphQLSchema } from 'graphql';
+import {
+  Types,
+  PluginFunction,
+  addFederationReferencesToSchema,
+  getCachedDocumentNodeFromSchema,
+} from '@graphql-codegen/plugin-helpers';
+import { visit, GraphQLSchema } from 'graphql';
 import { FlowResolversVisitor } from './visitor';
 
 /**
@@ -25,10 +29,7 @@ export const plugin: PluginFunction<RawFlowResolversConfig, Types.ComplexPluginO
 
   const transformedSchema = config.federation ? addFederationReferencesToSchema(schema) : schema;
 
-  const printedSchema = config.federation
-    ? printSchemaWithDirectives(transformedSchema)
-    : printSchema(transformedSchema);
-  const astNode = parse(printedSchema);
+  const astNode = getCachedDocumentNodeFromSchema(transformedSchema);
   const visitor = new FlowResolversVisitor(config, transformedSchema);
   const visitorResult = visit(astNode, { leave: visitor });
 

--- a/packages/plugins/java/java/src/index.ts
+++ b/packages/plugins/java/java/src/index.ts
@@ -1,5 +1,5 @@
-import { parse, GraphQLSchema, printSchema, visit } from 'graphql';
-import { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
+import { GraphQLSchema, visit } from 'graphql';
+import { PluginFunction, Types, getCachedDocumentNodeFromSchema } from '@graphql-codegen/plugin-helpers';
 import { JavaResolversVisitor } from './visitor';
 import { buildPackageNameFromPath } from '@graphql-codegen/java-common';
 import { dirname, normalize } from 'path';
@@ -14,8 +14,7 @@ export const plugin: PluginFunction<JavaResolversPluginRawConfig> = async (
   const relevantPath = dirname(normalize(outputFile));
   const defaultPackageName = buildPackageNameFromPath(relevantPath);
   const visitor = new JavaResolversVisitor(config, schema, defaultPackageName);
-  const printedSchema = printSchema(schema);
-  const astNode = parse(printedSchema);
+  const astNode = getCachedDocumentNodeFromSchema(schema);
   const visitorResult = visit(astNode, { leave: visitor as any });
   const imports = visitor.getImports();
   const packageName = visitor.getPackageName();

--- a/packages/plugins/java/kotlin/src/index.ts
+++ b/packages/plugins/java/kotlin/src/index.ts
@@ -1,5 +1,5 @@
-import { parse, GraphQLSchema, printSchema, visit } from 'graphql';
-import { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
+import { GraphQLSchema, visit } from 'graphql';
+import { PluginFunction, Types, getCachedDocumentNodeFromSchema } from '@graphql-codegen/plugin-helpers';
 import { KotlinResolversVisitor } from './visitor';
 import { buildPackageNameFromPath } from '@graphql-codegen/java-common';
 import { dirname, normalize } from 'path';
@@ -14,8 +14,7 @@ export const plugin: PluginFunction<KotlinResolversPluginRawConfig> = async (
   const relevantPath = dirname(normalize(outputFile));
   const defaultPackageName = buildPackageNameFromPath(relevantPath);
   const visitor = new KotlinResolversVisitor(config, schema, defaultPackageName);
-  const printedSchema = printSchema(schema);
-  const astNode = parse(printedSchema);
+  const astNode = getCachedDocumentNodeFromSchema(schema);
   const visitorResult = visit(astNode, { leave: visitor as any });
   const packageName = visitor.getPackageName();
   const blockContent = visitorResult.definitions.filter(d => typeof d === 'string').join('\n\n');

--- a/packages/plugins/java/resolvers/src/index.ts
+++ b/packages/plugins/java/resolvers/src/index.ts
@@ -1,5 +1,5 @@
-import { parse, GraphQLSchema, printSchema, visit } from 'graphql';
-import { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
+import { GraphQLSchema, visit } from 'graphql';
+import { getCachedDocumentNodeFromSchema, PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
 import { JavaResolversVisitor } from './visitor';
 import { buildPackageNameFromPath } from '@graphql-codegen/java-common';
 import { dirname, normalize } from 'path';
@@ -14,8 +14,7 @@ export const plugin: PluginFunction<JavaResolversPluginRawConfig> = async (
   const relevantPath = dirname(normalize(outputFile));
   const defaultPackageName = buildPackageNameFromPath(relevantPath);
   const visitor = new JavaResolversVisitor(config, schema, defaultPackageName);
-  const printedSchema = printSchema(schema);
-  const astNode = parse(printedSchema);
+  const astNode = getCachedDocumentNodeFromSchema(schema);
   const visitorResult = visit(astNode, { leave: visitor as any });
   const mappersImports = visitor.getImports();
   const packageName = visitor.getPackageName();

--- a/packages/plugins/other/jsdoc/src/index.ts
+++ b/packages/plugins/other/jsdoc/src/index.ts
@@ -51,6 +51,9 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
         return node.definitions;
       },
     },
+    SchemaDefinition: {
+      leave: () => '',
+    },
     ObjectTypeDefinition: {
       leave(node: unknown) {
         const typedNode = node as { name: string; fields: Array<string> };

--- a/packages/plugins/other/jsdoc/src/index.ts
+++ b/packages/plugins/other/jsdoc/src/index.ts
@@ -1,7 +1,5 @@
-import { PluginFunction } from '@graphql-codegen/plugin-helpers';
+import { PluginFunction, getCachedDocumentNodeFromSchema } from '@graphql-codegen/plugin-helpers';
 import {
-  printSchema,
-  parse,
   visit,
   ListTypeNode,
   DocumentNode,
@@ -43,7 +41,7 @@ const createDescriptionBlock = (nodeWithDesc: any | { description?: StringValueN
 };
 
 export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) => {
-  const parsedSchema = parse(printSchema(schema));
+  const parsedSchema = getCachedDocumentNodeFromSchema(schema);
   const mappedDocuments = documents.map(document => document.document).filter(document => document !== undefined);
   const ast = concatAST([parsedSchema, ...(mappedDocuments as Array<DocumentNode>)]);
 

--- a/packages/plugins/other/schema-ast/src/index.ts
+++ b/packages/plugins/other/schema-ast/src/index.ts
@@ -1,12 +1,11 @@
+import { GraphQLSchema, lexicographicSortSchema, printSchema, visit, buildASTSchema } from 'graphql';
 import {
-  GraphQLSchema,
-  lexicographicSortSchema,
-  printSchema,
-  visit,
-  buildASTSchema,
-  parse as parseSchema,
-} from 'graphql';
-import { PluginFunction, PluginValidateFn, Types, removeFederation } from '@graphql-codegen/plugin-helpers';
+  PluginFunction,
+  PluginValidateFn,
+  Types,
+  removeFederation,
+  getCachedDocumentNodeFromSchema,
+} from '@graphql-codegen/plugin-helpers';
 import { extname } from 'path';
 import { printSchemaWithDirectives } from '@graphql-tools/utils';
 
@@ -85,8 +84,7 @@ export const validate: PluginValidateFn<any> = async (
 };
 
 export function transformSchemaAST(schema: GraphQLSchema, config: { [key: string]: any }) {
-  const printedSchema = printSchema(schema);
-  const astNode = parseSchema(printedSchema);
+  const astNode = getCachedDocumentNodeFromSchema(schema);
 
   const transformedAST = config.disableDescriptions
     ? visit(astNode, {

--- a/packages/plugins/typescript/mongodb/src/index.ts
+++ b/packages/plugins/typescript/mongodb/src/index.ts
@@ -1,6 +1,10 @@
-import { Types, PluginFunction, PluginValidateFn } from '@graphql-codegen/plugin-helpers';
-import { parse, visit, GraphQLSchema } from 'graphql';
-import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import {
+  Types,
+  PluginFunction,
+  PluginValidateFn,
+  getCachedDocumentNodeFromSchema,
+} from '@graphql-codegen/plugin-helpers';
+import { visit, GraphQLSchema } from 'graphql';
 import { extname } from 'path';
 import gql from 'graphql-tag';
 import { TsMongoVisitor } from './visitor';
@@ -12,8 +16,7 @@ export const plugin: PluginFunction<TypeScriptMongoPluginConfig> = (
   config: TypeScriptMongoPluginConfig
 ) => {
   const visitor = new TsMongoVisitor(schema, config);
-  const printedSchema = printSchemaWithDirectives(schema);
-  const astNode = parse(printedSchema);
+  const astNode = getCachedDocumentNodeFromSchema(schema);
   const visitorResult = visit(astNode, { leave: visitor as any });
   const header = visitor.objectIdImport;
 

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -1,7 +1,11 @@
-import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import { parseMapper } from '@graphql-codegen/visitor-plugin-common';
-import { Types, PluginFunction, addFederationReferencesToSchema } from '@graphql-codegen/plugin-helpers';
-import { parse, visit, GraphQLSchema, printSchema } from 'graphql';
+import {
+  Types,
+  PluginFunction,
+  addFederationReferencesToSchema,
+  getCachedDocumentNodeFromSchema,
+} from '@graphql-codegen/plugin-helpers';
+import { visit, GraphQLSchema } from 'graphql';
 import { TypeScriptResolversVisitor } from './visitor';
 import { TypeScriptResolversPluginConfig } from './config';
 
@@ -28,10 +32,7 @@ export const plugin: PluginFunction<TypeScriptResolversPluginConfig, Types.Compl
   const visitor = new TypeScriptResolversVisitor(config, transformedSchema);
   const namespacedImportPrefix = visitor.config.namespacedImportName ? `${visitor.config.namespacedImportName}.` : '';
 
-  const printedSchema = config.federation
-    ? printSchemaWithDirectives(transformedSchema)
-    : printSchema(transformedSchema);
-  const astNode = parse(printedSchema);
+  const astNode = getCachedDocumentNodeFromSchema(transformedSchema);
   // runs visitor
   const visitorResult = visit(astNode, { leave: visitor });
 

--- a/packages/plugins/typescript/type-graphql/src/index.ts
+++ b/packages/plugins/typescript/type-graphql/src/index.ts
@@ -1,5 +1,5 @@
-import { Types, PluginFunction } from '@graphql-codegen/plugin-helpers';
-import { parse, printSchema, visit, GraphQLSchema } from 'graphql';
+import { Types, PluginFunction, getCachedDocumentNodeFromSchema } from '@graphql-codegen/plugin-helpers';
+import { visit, GraphQLSchema } from 'graphql';
 import { TypeGraphQLVisitor } from './visitor';
 import { TsIntrospectionVisitor, includeIntrospectionDefinitions } from '@graphql-codegen/typescript';
 import { TypeGraphQLPluginConfig } from './config';
@@ -15,8 +15,7 @@ export const plugin: PluginFunction<TypeGraphQLPluginConfig, Types.ComplexPlugin
   config: TypeGraphQLPluginConfig
 ) => {
   const visitor = new TypeGraphQLVisitor(schema, config);
-  const printedSchema = printSchema(schema);
-  const astNode = parse(printedSchema);
+  const astNode = getCachedDocumentNodeFromSchema(schema);
   const visitorResult = visit(astNode, { leave: visitor });
   const introspectionDefinitions = includeIntrospectionDefinitions(schema, documents, config);
   const scalars = visitor.scalarsDefinition;

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -1,6 +1,6 @@
-import { Types } from '@graphql-codegen/plugin-helpers';
+import { getCachedDocumentNodeFromSchema, Types } from '@graphql-codegen/plugin-helpers';
 import { generateFragmentImportStatement } from '@graphql-codegen/visitor-plugin-common';
-import { buildASTSchema, buildSchema, parse, printSchema } from 'graphql';
+import { buildASTSchema, buildSchema, parse } from 'graphql';
 import { preset } from '../src/index';
 
 describe('near-operation-file preset', () => {
@@ -194,7 +194,7 @@ describe('near-operation-file preset', () => {
             baseTypesPath: 'types.ts',
           },
           schemaAst: testSchema,
-          schema: parse(printSchema(testSchema)),
+          schema: getCachedDocumentNodeFromSchema(testSchema),
           documents: [
             {
               location: '/some/deep/path/src/graphql/queries.graphql',

--- a/packages/utils/plugins-helpers/src/federation.ts
+++ b/packages/utils/plugins-helpers/src/federation.ts
@@ -8,14 +8,14 @@ import {
   GraphQLObjectType,
   isObjectType,
   GraphQLNamedType,
-  printType,
-  Kind,
   visit,
   DefinitionNode,
   OperationDefinitionNode,
 } from 'graphql';
 import merge from 'lodash/merge.js';
 import { getBaseType } from './utils';
+import { MapperKind, mapSchema, astFromObjectType } from '@graphql-tools/utils';
+import { getRootTypeNames } from '@graphql-codegen/visitor-plugin-common';
 
 /**
  * Federation Spec
@@ -34,39 +34,22 @@ export const federationSpec = parse(/* GraphQL */ `
  * @param schema
  */
 export function addFederationReferencesToSchema(schema: GraphQLSchema): GraphQLSchema {
-  const typeMap = schema.getTypeMap();
-  for (const typeName in typeMap) {
-    const type = schema.getType(typeName);
-    if (isObjectType(type) && isFederationObjectType(type)) {
-      const typeConfig = type.toConfig();
-      typeConfig.fields = {
-        [resolveReferenceFieldName]: {
-          type,
-        },
-        ...typeConfig.fields,
-      };
-
-      const newType = new GraphQLObjectType(typeConfig);
-      newType.astNode = newType.astNode || (parse(printType(newType)).definitions[0] as ObjectTypeDefinitionNode);
-      (newType.astNode.fields as FieldDefinitionNode[]).unshift({
-        kind: Kind.FIELD_DEFINITION,
-        name: {
-          kind: Kind.NAME,
-          value: resolveReferenceFieldName,
-        },
-        type: {
-          kind: Kind.NAMED_TYPE,
-          name: {
-            kind: Kind.NAME,
-            value: typeName,
+  return mapSchema(schema, {
+    [MapperKind.OBJECT_TYPE]: type => {
+      if (isFederationObjectType(type, schema)) {
+        const typeConfig = type.toConfig();
+        typeConfig.fields = {
+          [resolveReferenceFieldName]: {
+            type,
           },
-        },
-      });
-      typeMap[typeName] = newType;
-    }
-  }
+          ...typeConfig.fields,
+        };
 
-  return schema;
+        return new GraphQLObjectType(typeConfig);
+      }
+      return type;
+    },
+  });
 }
 
 /**
@@ -75,17 +58,27 @@ export function addFederationReferencesToSchema(schema: GraphQLSchema): GraphQLS
  * @param config
  */
 export function removeFederation(schema: GraphQLSchema): GraphQLSchema {
-  const queryType = schema.getQueryType();
-  const queryTypeFields = queryType.getFields();
-  delete queryTypeFields._entities;
-  delete queryTypeFields._service;
-
-  const typeMap = schema.getTypeMap();
-  delete typeMap._Service;
-  delete typeMap._Entity;
-  delete typeMap._Any;
-
-  return schema;
+  return mapSchema(schema, {
+    [MapperKind.QUERY]: queryType => {
+      const queryTypeConfig = queryType.toConfig();
+      delete queryTypeConfig.fields._entities;
+      delete queryTypeConfig.fields._service;
+      return new GraphQLObjectType(queryTypeConfig);
+    },
+    [MapperKind.UNION_TYPE]: unionType => {
+      const unionTypeName = unionType.name;
+      if (unionTypeName === '_Entity' || unionTypeName === '_Any') {
+        return null;
+      }
+      return unionType;
+    },
+    [MapperKind.OBJECT_TYPE]: objectType => {
+      if (objectType.name === '_Service') {
+        return null;
+      }
+      return objectType;
+    },
+  });
 }
 
 const resolveReferenceFieldName = '__resolveReference';
@@ -138,7 +131,7 @@ export class ApolloFederation {
    * @param data
    */
   skipField({ fieldNode, parentType }: { fieldNode: FieldDefinitionNode; parentType: GraphQLNamedType }): boolean {
-    if (!this.enabled || !isObjectType(parentType) || !isFederationObjectType(parentType)) {
+    if (!this.enabled || !isObjectType(parentType) || !isFederationObjectType(parentType, this.schema)) {
       return false;
     }
 
@@ -166,8 +159,8 @@ export class ApolloFederation {
     if (
       this.enabled &&
       isObjectType(parentType) &&
-      isFederationObjectType(parentType) &&
-      (isTypeExtension(parentType) || fieldNode.name.value === resolveReferenceFieldName)
+      isFederationObjectType(parentType, this.schema) &&
+      (isTypeExtension(parentType, this.schema) || fieldNode.name.value === resolveReferenceFieldName)
     ) {
       const keys = getDirectivesByName('key', parentType);
 
@@ -296,15 +289,14 @@ export class ApolloFederation {
  * Checks if Object Type is involved in Federation. Based on `@key` directive
  * @param node Type
  */
-function isFederationObjectType(node: ObjectTypeDefinitionNode | GraphQLObjectType): boolean {
-  const definition = isObjectType(node)
-    ? node.astNode || (parse(printType(node)).definitions[0] as ObjectTypeDefinitionNode)
-    : node;
+function isFederationObjectType(node: ObjectTypeDefinitionNode | GraphQLObjectType, schema: GraphQLSchema): boolean {
+  const {
+    name: { value: name },
+    directives,
+  } = isObjectType(node) ? astFromObjectType(node, schema) : node;
 
-  const name = definition.name.value;
-  const directives = definition.directives;
-
-  const isNotRoot = !['Query', 'Mutation', 'Subscription'].includes(name);
+  const rootTypeNames = getRootTypeNames(schema);
+  const isNotRoot = !rootTypeNames.includes(name);
   const isNotIntrospection = !name.startsWith('__');
   const hasKeyDirective = directives.some(d => d.name.value === 'key');
 
@@ -328,11 +320,7 @@ function getDirectivesByName(
     astNode = node;
   }
 
-  if (astNode && astNode.directives) {
-    return astNode.directives.filter(d => d.name.value === name);
-  }
-
-  return [];
+  return astNode?.directives?.filter(d => d.name.value === name) || [];
 }
 
 /**
@@ -340,9 +328,7 @@ function getDirectivesByName(
  * Based on if any of its fields contain the `@external` directive
  * @param node Type
  */
-function isTypeExtension(node: ObjectTypeDefinitionNode | GraphQLObjectType): boolean {
-  const definition = isObjectType(node)
-    ? node.astNode || (parse(printType(node)).definitions[0] as ObjectTypeDefinitionNode)
-    : node;
+function isTypeExtension(node: ObjectTypeDefinitionNode | GraphQLObjectType, schema: GraphQLSchema): boolean {
+  const definition = isObjectType(node) ? node.astNode || astFromObjectType(node, schema) : node;
   return definition.fields?.some(field => getDirectivesByName('external', field).length);
 }

--- a/packages/utils/plugins-helpers/src/getCachedDocumentNodeFromSchema.ts
+++ b/packages/utils/plugins-helpers/src/getCachedDocumentNodeFromSchema.ts
@@ -1,0 +1,13 @@
+import { getDocumentNodeFromSchema } from '@graphql-tools/utils';
+import { GraphQLSchema, DocumentNode } from 'graphql';
+
+const schemaDocumentNodeCache = new WeakMap<GraphQLSchema, DocumentNode>();
+
+export function getCachedDocumentNodeFromSchema(schema: GraphQLSchema) {
+  let documentNode = schemaDocumentNodeCache.get(schema);
+  if (!documentNode) {
+    documentNode = getDocumentNodeFromSchema(schema);
+    schemaDocumentNodeCache.set(schema, documentNode);
+  }
+  return documentNode;
+}

--- a/packages/utils/plugins-helpers/src/index.ts
+++ b/packages/utils/plugins-helpers/src/index.ts
@@ -4,3 +4,4 @@ export * from './utils';
 export * from './helpers';
 export * from './federation';
 export * from './errors';
+export * from './getCachedDocumentNodeFromSchema';

--- a/website/docs/custom-codegen/using-visitor.md
+++ b/website/docs/custom-codegen/using-visitor.md
@@ -37,27 +37,24 @@ MyOtherType.myOtherField
 To get started with a basic visitor, start by extracting the `astNode` of your `GraphQLSchema`:
 
 ```javascript
-const { printSchema, parse } = require('graphql');
+const { getCachedDocumentNodeFromSchema } = require('@graphql-codegen/plugin-helpers');
 
 module.exports = {
   plugin: (schema, documents, config) => {
-    const printedSchema = printSchema(schema); // Returns a string representation of the schema
-    const astNode = parse(printedSchema); // Transforms the string into ASTNode
+    const astNode = getCachedDocumentNodeFromSchema(schema); // Transforms the GraphQLSchema into ASTNode
   },
 };
 ```
 
-> Note: if you wish to have GraphQL directives when you print your schema, use `printSchemaWithDirectives` from `graphql-toolkit` package.
-
 Then, create your initial visitor, in our case, we would like to transform a `FieldDefinition` and `ObjectTypeDefinition`, so let's create an object with a stub definitions, an use `visit` to run it:
 
 ```javascript
-const { printSchema, parse, visit } = require('graphql');
+const { getCachedDocumentNodeFromSchema } = require('@graphql-codegen/plugin-helpers');
+const { visit } = require('graphql');
 
 module.exports = {
   plugin: (schema, documents, config) => {
-    const printedSchema = printSchema(schema); // Returns a string representation of the schema
-    const astNode = parse(printedSchema); // Transforms the string into ASTNode
+    const astNode = getCachedDocumentNodeFromSchema(schema); // Transforms the GraphQLSchema into ASTNode
     const visitor = {
       FieldDefinition: node => {
         // This function triggered per each field
@@ -77,12 +74,12 @@ module.exports = {
 Now, let's implement `ObjectTypeDefinition` and `FieldDefinition`:
 
 ```javascript
-const { printSchema, parse, visit } = require('graphql');
+const { getCachedDocumentNodeFromSchema } = require('@graphql-codegen/plugin-helpers');
+const { visit } = require('graphql');
 
 module.exports = {
   plugin: (schema, documents, config) => {
-    const printedSchema = printSchema(schema); // Returns a string representation of the schema
-    const astNode = parse(printedSchema); // Transforms the string into ASTNode
+    const astNode = getCachedDocumentNodeFromSchema(schema); // Transforms the GraphQLSchema into ASTNode
     const visitor = {
       FieldDefinition: node => {
         // Transform the field AST node into a string, containing only the name of the field


### PR DESCRIPTION
Use utility functions such as `getDocumentNodeFromSchema`(in favor of `parse(printSchema(` chain), `mapSchema`, `astFromObjectType`(instead of `parse(printType` chain) and etc. from `@graphql-tools/utils` if possible.
Implement `getCachedDocumentNodeFromSchema` instead of multiple calls of `printSchemaWithDirectives`, `printSchema` and `parse` which probably increases the performance(removes the duplicate workload on large schemas).