### PR TITLE
chore(react-query): use `@exampleMarkdown` for config examples

### DIFF
--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -34,20 +34,26 @@ export interface ReactQueryRawPluginConfig
   /**
    * @default false
    * @description For each generate query hook adds `document` field with a
-   * corresponding GraphQL query. Useful for `queryClient.fetchQuery`. Example:
-   * queryClient.fetchQuery(
-   *   useUserDetailsQuery.getKey(variables),
-   *   () => gqlRequest(useUserDetailsQuery.document, variables),
-   * )
+   * corresponding GraphQL query. Useful for `queryClient.fetchQuery`.
+   * @exampleMarkdown
+   * ```ts
+   *  queryClient.fetchQuery(
+   *    useUserDetailsQuery.getKey(variables),
+   *    () => gqlRequest(useUserDetailsQuery.document, variables),
+   *  )
+   * ```
    */
   exposeDocument?: boolean;
 
   /**
    * @default false
-   * @description For each generate query hook adds getKey(variables: QueryVariables) function. Useful for cache updates. Example:
-   * const query = useUserDetailsQuery(...);
-   * const key = useUserDetailsQuery.getKey({id: theUsersId});
-   * // use key in a cache update after a mutation
+   * @description For each generate query hook adds getKey(variables: QueryVariables) function. Useful for cache updates.
+   * @exampleMarkdown
+   * ```ts
+   *  const query = useUserDetailsQuery(...);
+   *  const key = useUserDetailsQuery.getKey({id: theUsersId});
+   *  // use key in a cache update after a mutation
+   * ```
    */
   exposeQueryKeys?: boolean;
 


### PR DESCRIPTION
## Description

React Query's config options `exposeDocument` and `exposeQueryStrings` documentation examples aren't rendering as code blocks.
The `exposeFetcher` documentation example uses `@exampleMarkdown` to render as a code block.

Related #6475

## Type of change

- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Existing `exposeDocument` and `exposeQueryStrings` examples vs `exposeFetcher` which uses `@exampleMarkdown`.

![Screenshot 2021-08-13 at 10 24 44](https://user-images.githubusercontent.com/3301714/129336029-579c6e06-35ed-4bc0-abde-8f5e6420ce4d.png)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules