### PR TITLE
[c-sharp-operations] Use ampersand prefix for C# keyword name collisions

### DIFF
--- a/.changeset/quick-shoes-visit.md
+++ b/.changeset/quick-shoes-visit.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/c-sharp-operations': patch
+---
+
+Use ampersand prefix for C# keyword name collisions

--- a/.changeset/quick-shoes-visit.md
+++ b/.changeset/quick-shoes-visit.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/c-sharp-operations': patch
 ---
 
-Use ampersand prefix for C# keyword name collisions
+Use at-sign (`@`) prefix for C# keyword name collisions

--- a/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
@@ -184,7 +184,9 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
   }
 
   public getCSharpImports(): string {
-    return ['Newtonsoft.Json', 'GraphQL', 'GraphQL.Client.Abstractions'].map(i => `using ${i};`).join('\n') + '\n';
+    return (
+      ['System', 'Newtonsoft.Json', 'GraphQL', 'GraphQL.Client.Abstractions'].map(i => `using ${i};`).join('\n') + '\n'
+    );
   }
 
   private _operationSuffix(operationType: string): string {

--- a/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
@@ -35,6 +35,7 @@ import {
   getListTypeField,
   getListTypeDepth,
   CSharpFieldType,
+  convertSafeName,
   isValueType,
   wrapFieldType,
   CSharpDeclarationBlock,
@@ -303,7 +304,7 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
           return indentMultiline(
             [
               `[JsonProperty("${node.name.value}")]`,
-              `public ${responseTypeName} ${node.name.value} { get; set; }`,
+              `public ${responseTypeName} ${convertSafeName(node.name.value)} { get; set; }`,
             ].join('\n') + '\n'
           );
         } else {
@@ -323,7 +324,7 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
           const innerClassDefinition = new CSharpDeclarationBlock()
             .access('public')
             .asKind('class')
-            .withName(selectionBaseTypeName)
+            .withName(convertSafeName(selectionBaseTypeName))
             .withBlock(
               '\n' +
                 node.selectionSet.selections
@@ -339,7 +340,7 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
             [
               innerClassDefinition,
               `[JsonProperty("${node.name.value}")]`,
-              `public ${selectionTypeName} ${node.name.value} { get; set; }`,
+              `public ${selectionTypeName} ${convertSafeName(node.name.value)} { get; set; }`,
             ].join('\n') + '\n'
           );
         }
@@ -385,7 +386,7 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
               return indentMultiline(
                 [
                   `[JsonProperty("${v.variable.name.value}")]`,
-                  `public ${inputTypeName} ${v.variable.name.value} { get; set; }`,
+                  `public ${inputTypeName} ${convertSafeName(v.variable.name.value)} { get; set; }`,
                 ].join('\n') + '\n'
               );
             })
@@ -453,9 +454,9 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
     let documentString = '';
     if (this.config.documentMode !== DocumentMode.external) {
       const gqlBlock = indentMultiline(this._gql(node), 4);
-      documentString = `${
-        this.config.noExport ? '' : 'public'
-      } static string ${documentVariableName} = @"\n${gqlBlock}";`;
+      documentString = `${this.config.noExport ? '' : 'public'} static string ${convertSafeName(
+        documentVariableName
+      )} = @"\n${gqlBlock}";`;
     }
 
     const operationType: string = node.operation;
@@ -546,7 +547,7 @@ ${this._getOperationMethod(node)}
     const inputClass = new CSharpDeclarationBlock()
       .access('public')
       .asKind('class')
-      .withName(this.convertName(node))
+      .withName(convertSafeName(this.convertName(node)))
       .withBlock(
         '\n' +
           node.fields
@@ -557,9 +558,10 @@ ${this._getOperationMethod(node)}
               const inputType = this.resolveFieldType(f.type);
               const inputTypeName = wrapFieldType(inputType, inputType.listType, 'System.Collections.Generic.List');
               return indentMultiline(
-                [`[JsonProperty("${f.name.value}")]`, `public ${inputTypeName} ${f.name.value} { get; set; }`].join(
-                  '\n'
-                ) + '\n'
+                [
+                  `[JsonProperty("${f.name.value}")]`,
+                  `public ${inputTypeName} ${convertSafeName(f.name.value)} { get; set; }`,
+                ].join('\n') + '\n'
               );
             })
             .filter(f => !!f)
@@ -577,7 +579,7 @@ ${this._getOperationMethod(node)}
     const enumDefinition = new CSharpDeclarationBlock()
       .access('public')
       .asKind('enum')
-      .withName(this.convertName(node.name))
+      .withName(convertSafeName(this.convertName(node.name)))
       .withBlock(indentMultiline(node.values?.map(v => v.name.value).join(',\n'))).string;
 
     return indentMultiline(enumDefinition, 2);

--- a/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
@@ -330,6 +330,43 @@ describe('C# Operations', () => {
         }
       `);
     });
+    it('Should prefix with @ when name is a reserved keyword', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          case(record: ID!): CourtCase!
+        }
+        type CourtCase {
+          operator: String!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query findOperator($record: ID!) {
+          case(record: $record) {
+            operator
+          }
+        }
+      `);
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        { typesafeOperation: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public class Variables {
+          [JsonProperty("record")]
+          public string @record { get; set; }
+        }
+        public class Response {
+          public class CourtCaseSelection {
+            [JsonProperty("operator")]
+            public string @operator { get; set; }
+          }
+          [JsonProperty("case")]
+          public CourtCaseSelection @case { get; set; }
+        }
+      `);
+    });
   });
 
   describe('Mutation', () => {
@@ -593,6 +630,43 @@ describe('C# Operations', () => {
       expect(result.content).toBeSimilarStringTo(`
         public static System.Threading.Tasks.Task<GraphQLResponse<Response>> SendMutationAsync(IGraphQLClient client, Variables variables, System.Threading.CancellationToken cancellationToken = default) {
           return client.SendMutationAsync<Response>(Request(variables), cancellationToken);
+        }
+      `);
+    });
+    it('Should prefix with @ when name is a reserved keyword', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Mutation {
+          case(record: ID!): CourtCase!
+        }
+        type CourtCase {
+          operator: String!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        mutation updateCase($record: ID!) {
+          case(record: $record) {
+            operator
+          }
+        }
+      `);
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        { typesafeOperation: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public class Variables {
+          [JsonProperty("record")]
+          public string @record { get; set; }
+        }
+        public class Response {
+          public class CourtCaseSelection {
+            [JsonProperty("operator")]
+            public string @operator { get; set; }
+          }
+          [JsonProperty("case")]
+          public CourtCaseSelection @case { get; set; }
         }
       `);
     });
@@ -868,6 +942,43 @@ describe('C# Operations', () => {
         }
       `);
     });
+    it('Should prefix with @ when name is a reserved keyword', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Subscription {
+          case(record: ID!): CourtCase!
+        }
+        type CourtCase {
+          operator: String!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        subscription onUpdate($record: ID!) {
+          case(record: $record) {
+            operator
+          }
+        }
+      `);
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        { typesafeOperation: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public class Variables {
+          [JsonProperty("record")]
+          public string @record { get; set; }
+        }
+        public class Response {
+          public class CourtCaseSelection {
+            [JsonProperty("operator")]
+            public string @operator { get; set; }
+          }
+          [JsonProperty("case")]
+          public CourtCaseSelection @case { get; set; }
+        }
+      `);
+    });
   });
 
   describe('Fragments', () => {
@@ -983,6 +1094,58 @@ describe('C# Operations', () => {
 
           [JsonProperty("me")]
           public PersonSelection me { get; set; }
+        }
+      `);
+    });
+
+    it('Should prefix with @ when name is a reserved keyword', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          case(record: ID!): CourtCase!
+        }
+        type CourtCase {
+          operator: String!
+          public: String!
+          private: String!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query findCase($record: ID!) {
+          case(record: $record) {
+            private
+            ...Fragment1
+            ...Fragment2
+          }
+        }
+        fragment Fragment1 on CourtCase {
+          public
+        }
+        fragment Fragment2 on CourtCase {
+          operator
+        }
+      `);
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        { typesafeOperation: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public class Variables {
+          [JsonProperty("record")]
+          public string @record { get; set; }
+        }
+        public class Response {
+          public class CourtCaseSelection {
+            [JsonProperty("private")]
+            public string @private { get; set; }
+            [JsonProperty("public")]
+            public string @public { get; set; }
+            [JsonProperty("operator")]
+            public string @operator { get; set; }
+          }
+          [JsonProperty("case")]
+          public CourtCaseSelection @case { get; set; }
         }
       `);
     });

--- a/packages/plugins/c-sharp/common/keywords.ts
+++ b/packages/plugins/c-sharp/common/keywords.ts
@@ -1,8 +1,10 @@
+import { NameNode } from 'graphql';
+
 /**
  * C# keywords
  * https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/
  */
-export const csharpKeywords = [
+const csharpKeywords = new Set([
   'abstract',
   'as',
   'base',
@@ -81,4 +83,19 @@ export const csharpKeywords = [
   'void',
   'volatile',
   'while',
-];
+]);
+
+/**
+ * Checks name against list of keywords. If it is, will prefix value with @
+ *
+ * Note:
+ * This class should first invoke the convertName from base-visitor to convert the string or node
+ * value according the naming configuration, eg upper or lower case. Then resulting string checked
+ * against the list or keywords.
+ * However the generated C# code is not yet able to handle fields that are in a different case so
+ * the invocation of convertName is omitted purposely.
+ */
+export function convertSafeName(node: NameNode | string): string {
+  const name = typeof node === 'string' ? node : node.value;
+  return csharpKeywords.has(name) ? `@${name}` : name;
+}


### PR DESCRIPTION
## Description

This adds logic to the `c-sharp-operations` plugin to add a `@` prefix to properties whose names collide with reserved C# keywords.  This logic already existed in the `c-sharp` plugin, and it was simply missing from the `c-sharp-operations` plugin.

For example:
```cs
public string @operator { get; set; }
```

Related #5556

This also adds `System` as an import because `DateTime` is a very common type that would need to be used in the resulting C# code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I created GraphQL schemas that contain properties whose names collide with reserved keywords in C#, such as `private`. Added relevant automated tests.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I moved `convertSafeName()` to the common `packages/plugins/c-sharp/common/keywords.ts` file, since it's shared functionality between the two C# plugins.