### PR TITLE
[typescript-react-query] Remove undefined variables from query key

### DIFF
--- a/.changeset/ninety-insects-kick.md
+++ b/.changeset/ninety-insects-kick.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': major
+---
+
+Queries without variables will no longer have an undefined entry in their query key

--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -408,7 +408,7 @@ export const useCurrentUserForProfileQuery = <TData = CurrentUserForProfileQuery
   options?: UseQueryOptions<CurrentUserForProfileQuery, TError, TData>
 ) =>
   useQuery<CurrentUserForProfileQuery, TError, TData>(
-    ['CurrentUserForProfile', variables],
+    variables === undefined ? ['CurrentUserForProfile'] : ['CurrentUserForProfile', variables],
     fetcher<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>(
       dataSource.endpoint,
       dataSource.fetchParams || {},

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -3,6 +3,7 @@ import { ReactQueryVisitor } from './visitor';
 import { FetcherRenderer } from './fetcher';
 import { parseMapper, ParsedMapper, buildMapperImport } from '@graphql-codegen/visitor-plugin-common';
 import { CustomFetch } from './config';
+import { generateQueryKey } from './variables-generator';
 
 export class CustomMapperFetcher implements FetcherRenderer {
   private _mapper: ParsedMapper;
@@ -65,7 +66,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
       ${options}
     ) => 
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ['${node.name.value}', variables],
+      ${generateQueryKey(node, hasRequiredVariables)},
       ${impl},
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -76,7 +76,7 @@ ${this.getFetchParams()}
       ${options}
     ) => 
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateQueryKey(node)},
+      ${generateQueryKey(node, hasRequiredVariables)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -53,7 +53,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
       ${options}
     ) => 
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateQueryKey(node)},
+      ${generateQueryKey(node, hasRequiredVariables)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -41,7 +41,7 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
       ${options}
     ) => 
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateQueryKey(node)},
+      ${generateQueryKey(node, hasRequiredVariables)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -9,7 +9,7 @@ export function generateQueryVariablesSignature(
 
 export function generateQueryKey(node: OperationDefinitionNode, hasRequiredVariables: boolean): string {
   if (hasRequiredVariables) return `['${node.name.value}', variables]`;
-  return `variables === undefined ? ['${node.name.value}', variables] : ['${node.name.value}']`;
+  return `variables === undefined ? ['${node.name.value}'] : ['${node.name.value}', variables]`;
 }
 
 export function generateQueryKeyMaker(

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -7,8 +7,9 @@ export function generateQueryVariablesSignature(
   return `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
 }
 
-export function generateQueryKey(node: OperationDefinitionNode): string {
-  return `['${node.name.value}', variables]`;
+export function generateQueryKey(node: OperationDefinitionNode, hasRequiredVariables: boolean): string {
+  if (hasRequiredVariables) return `['${node.name.value}', variables]`;
+  return `variables === undefined ? ['${node.name.value}', variables] : ['${node.name.value}']`;
 }
 
 export function generateQueryKeyMaker(
@@ -18,5 +19,5 @@ export function generateQueryKeyMaker(
   hasRequiredVariables: boolean
 ) {
   const signature = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
-  return `\nuse${operationName}.getKey = (${signature}) => ${generateQueryKey(node)};\n`;
+  return `\nuse${operationName}.getKey = (${signature}) => ${generateQueryKey(node, hasRequiredVariables)};\n`;
 }

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -25,7 +25,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      ['test', variables],
+      variables === undefined ? ['test', variables] : ['test'],
       useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
       options
     );
@@ -71,7 +71,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      ['test', variables],
+      variables === undefined ? ['test', variables] : ['test'],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -117,7 +117,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      ['test', variables],
+      variables === undefined ? ['test', variables] : ['test'],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -164,7 +164,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      ['test', variables],
+      variables === undefined ? ['test', variables] : ['test'],
       fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     );
@@ -214,7 +214,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      ['test', variables],
+      variables === undefined ? ['test', variables] : ['test'],
       fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
       options
     );
@@ -263,7 +263,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      ['test', variables],
+      variables === undefined ? ['test', variables] : ['test'],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -309,7 +309,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      ['test', variables],
+      variables === undefined ? ['test', variables] : ['test'],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -355,7 +355,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      ['test', variables],
+      variables === undefined ? ['test', variables] : ['test'],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -401,7 +401,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      ['test', variables],
+      variables === undefined ? ['test', variables] : ['test'],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -25,7 +25,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test', variables] : ['test'],
+      variables === undefined ? ['test'] : ['test', variables],
       useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
       options
     );
@@ -71,7 +71,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test', variables] : ['test'],
+      variables === undefined ? ['test'] : ['test', variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -117,7 +117,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test', variables] : ['test'],
+      variables === undefined ? ['test'] : ['test', variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -164,7 +164,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test', variables] : ['test'],
+      variables === undefined ? ['test'] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     );
@@ -214,7 +214,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test', variables] : ['test'],
+      variables === undefined ? ['test'] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
       options
     );
@@ -263,7 +263,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test', variables] : ['test'],
+      variables === undefined ? ['test'] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -309,7 +309,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test', variables] : ['test'],
+      variables === undefined ? ['test'] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -355,7 +355,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test', variables] : ['test'],
+      variables === undefined ? ['test'] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -401,7 +401,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) => 
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test', variables] : ['test'],
+      variables === undefined ? ['test'] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -104,7 +104,7 @@ describe('React-Query', () => {
           options?: UseQueryOptions<TTestQuery, TError, TData>
         ) => 
         useQuery<TTestQuery, TError, TData>(
-          ['test', variables],
+          variables === undefined ? ['test', variables] : ['test'],
           myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
           options
         );`);
@@ -140,7 +140,7 @@ describe('React-Query', () => {
         options?: UseQueryOptions<TTestQuery, TError, TData>
       ) => 
       useQuery<TTestQuery, TError, TData>(
-        ['test', variables],
+        variables === undefined ? ['test', variables] : ['test'],
         myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
         options
       );`);
@@ -181,7 +181,7 @@ describe('React-Query', () => {
           options?: UseQueryOptions<TTestQuery, TError, TData>
         ) => 
         useQuery<TTestQuery, TError, TData>(
-          ['test', variables],
+          variables === undefined ? ['test', variables] : ['test'],
           useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
           options
         );`);
@@ -225,7 +225,7 @@ describe('React-Query', () => {
           options?: UseQueryOptions<TTestQuery, TError, TData>
         ) => 
         useQuery<TTestQuery, TError, TData>(
-          ['test', variables],
+          variables === undefined ? ['test', variables] : ['test'],
           fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
           options
         );`);
@@ -297,7 +297,7 @@ describe('React-Query', () => {
         options?: UseQueryOptions<TTestQuery, TError, TData>
       ) => 
       useQuery<TTestQuery, TError, TData>(
-        ['test', variables],
+        variables === undefined ? ['test', variables] : ['test'],
         fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
         options
       );`);
@@ -446,7 +446,7 @@ describe('React-Query', () => {
         options?: UseQueryOptions<TTestQuery, TError, TData>
       ) => 
       useQuery<TTestQuery, TError, TData>(
-        ['test', variables],
+        variables === undefined ? ['test', variables] : ['test'],
         fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
         options
       );`);
@@ -476,7 +476,7 @@ describe('React-Query', () => {
       };
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toBeSimilarStringTo(
-        `useTestQuery.getKey = (variables?: TestQueryVariables) => ['test', variables];`
+        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test', variables] : ['test'];`
       );
     });
   });

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -104,7 +104,7 @@ describe('React-Query', () => {
           options?: UseQueryOptions<TTestQuery, TError, TData>
         ) => 
         useQuery<TTestQuery, TError, TData>(
-          variables === undefined ? ['test', variables] : ['test'],
+          variables === undefined ? ['test'] : ['test', variables],
           myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
           options
         );`);
@@ -140,7 +140,7 @@ describe('React-Query', () => {
         options?: UseQueryOptions<TTestQuery, TError, TData>
       ) => 
       useQuery<TTestQuery, TError, TData>(
-        variables === undefined ? ['test', variables] : ['test'],
+        variables === undefined ? ['test'] : ['test', variables],
         myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
         options
       );`);
@@ -181,7 +181,7 @@ describe('React-Query', () => {
           options?: UseQueryOptions<TTestQuery, TError, TData>
         ) => 
         useQuery<TTestQuery, TError, TData>(
-          variables === undefined ? ['test', variables] : ['test'],
+          variables === undefined ? ['test'] : ['test', variables],
           useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
           options
         );`);
@@ -225,7 +225,7 @@ describe('React-Query', () => {
           options?: UseQueryOptions<TTestQuery, TError, TData>
         ) => 
         useQuery<TTestQuery, TError, TData>(
-          variables === undefined ? ['test', variables] : ['test'],
+          variables === undefined ? ['test'] : ['test', variables],
           fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables),
           options
         );`);
@@ -297,7 +297,7 @@ describe('React-Query', () => {
         options?: UseQueryOptions<TTestQuery, TError, TData>
       ) => 
       useQuery<TTestQuery, TError, TData>(
-        variables === undefined ? ['test', variables] : ['test'],
+        variables === undefined ? ['test'] : ['test', variables],
         fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
         options
       );`);
@@ -446,7 +446,7 @@ describe('React-Query', () => {
         options?: UseQueryOptions<TTestQuery, TError, TData>
       ) => 
       useQuery<TTestQuery, TError, TData>(
-        variables === undefined ? ['test', variables] : ['test'],
+        variables === undefined ? ['test'] : ['test', variables],
         fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
         options
       );`);
@@ -476,7 +476,7 @@ describe('React-Query', () => {
       };
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toBeSimilarStringTo(
-        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test', variables] : ['test'];`
+        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];`
       );
     });
   });


### PR DESCRIPTION
## Description

Related #6496 by modifying `generateQueryKey` to not include `undefined` variables.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This can be a breaking change if you rely on the undefined entry in the query key. I would consider the previous behavior a bug though.

## How Has This Been Tested?

I have tested it in a private project, where I applied the listed changes via patch-package.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules