### PR TITLE
[jsdocs] Handle directive & schema definitions

### DIFF
--- a/.changeset/lovely-ways-live.md
+++ b/.changeset/lovely-ways-live.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/jsdoc': patch
+---
+
+JSDoc plugin ignores unused Directive definitions, instead of outputting `[object Object]`

--- a/packages/plugins/other/jsdoc/src/index.ts
+++ b/packages/plugins/other/jsdoc/src/index.ts
@@ -130,6 +130,12 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
         return ` - DEPRECATED: ${reason.value.value}`;
       },
     },
+    DirectiveDefinition: {
+      enter() {
+          /** This plugin currently does not support unused Directives. */
+          return null;
+      }
+    },
     FieldDefinition: {
       enter(node) {
         if (node.type.kind === 'NonNullType') {
@@ -180,6 +186,12 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
       leave(node) {
         return createDocBlock([createDescriptionBlock(node), `@typedef {*} ${node.name}`]);
       },
+    },
+    SchemaDefinition: {
+      enter() {
+          /** This plugin currently does not support Schema. */
+          return null;
+      }
     },
     EnumTypeDefinition: {
       leave(node) {

--- a/packages/plugins/other/jsdoc/src/index.ts
+++ b/packages/plugins/other/jsdoc/src/index.ts
@@ -52,7 +52,7 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
       },
     },
     SchemaDefinition: {
-      leave: () => '',
+      leave: () => null,
     },
     ObjectTypeDefinition: {
       leave(node: unknown) {
@@ -132,9 +132,9 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
     },
     DirectiveDefinition: {
       enter() {
-          /** This plugin currently does not support unused Directives. */
-          return null;
-      }
+        /** This plugin currently does not support unused Directives. */
+        return null;
+      },
     },
     FieldDefinition: {
       enter(node) {
@@ -186,12 +186,6 @@ export const plugin: PluginFunction<RawDocumentsConfig> = (schema, documents) =>
       leave(node) {
         return createDocBlock([createDescriptionBlock(node), `@typedef {*} ${node.name}`]);
       },
-    },
-    SchemaDefinition: {
-      enter() {
-          /** This plugin currently does not support Schema. */
-          return null;
-      }
     },
     EnumTypeDefinition: {
       leave(node) {

--- a/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
+++ b/packages/plugins/other/jsdoc/tests/jsdoc-schema-types.spec.ts
@@ -212,5 +212,46 @@ describe('JSDoc Plugin', () => {
 
       expect(result).toEqual(expect.stringContaining(`* @property {string} foo - DEPRECATED: ${warning}`));
     });
+
+    it('should not generate [object Object] for directives', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        directive @client(always: Boolean) on FIELD | FRAGMENT_DEFINITION | INLINE_FRAGMENT
+      `);
+
+      const config = {};
+      const result = await plugin(schema, [], config, { outputFile: '' });
+
+      expect(result).not.toEqual(expect.stringContaining('[object Object]'));
+    });
+
+    it('should not generate [object Object] or extra lines for Schema', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        schema {
+          query: RootQueryType
+          mutation: RootMutationType
+        }
+
+        type RootMutationType {
+          addItem(name: String!): String
+        }
+
+        type RootQueryType {
+          items: [String!]!
+        }
+      `);
+      const config = {};
+      const result = await plugin(schema, [], config, { outputFile: '' });
+
+      expect(result).not.toEqual(expect.stringContaining('[object Object]'));
+      expect(result).toEqual(`/**
+ * @typedef {Object} RootMutationType
+ * @property {string} [addItem]
+ */
+
+/**
+ * @typedef {Object} RootQueryType
+ * @property {Array<string>} items
+ */`);
+    });
   });
 });


### PR DESCRIPTION
## Description

See my existing issue for what's up. In short: schema and directives cause the JSDocs plugin to output `[object Object]`, which is kind of annoying. Adding a `DirectiveDefinition` and `SchemaDefinition` which returns `null` solves this problem since the expected behaviour is to not write anything out.

This _does not_ affect directives that are used. If a field is marked `@deprecated(reason: ...)` then that reason will be output as per normal. It just avoids trying to write the definition of the directive to the file.

Related #6505 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Code sandbox is available here: https://codesandbox.io/s/nifty-euclid-o963o?file=/schema.graphql

## How Has This Been Tested?

1. Include an unused directive in the schema. Nothing extra is printed out, the file looks like it should.
2. Include a deprecated field, marked with the directive. The field is marked as deprecated in the JSDocs as expected.

**Test Environment**:
- OS: macOS
- `@graphql-codegen/jsdoc`: 2.0.0
- NodeJS: v16.1.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments


