### PR TITLE
Don't generate import statements for fragments declared in the same file

### DIFF
--- a/.changeset/nine-kiwis-remain.md
+++ b/.changeset/nine-kiwis-remain.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Don't generate import statements for fragments declared in the file we're outputting to

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -503,7 +503,9 @@ export class ClientSideBaseVisitor<
         documentMode === DocumentMode.documentNodeImportFragments
       ) {
         fragmentImports.forEach(fragmentImport => {
-          this._imports.add(generateFragmentImportStatement(fragmentImport, 'document'));
+          if (fragmentImport.outputPath !== fragmentImport.importSource.path) {
+            this._imports.add(generateFragmentImportStatement(fragmentImport, 'document'));
+          }
         });
       }
     }

--- a/packages/presets/near-operation-file/tests/fixtures/issue-6520.ts
+++ b/packages/presets/near-operation-file/tests/fixtures/issue-6520.ts
@@ -1,0 +1,17 @@
+import gql from 'graphql-tag';
+
+export const userFields = gql`
+  fragment userFields on User {
+    email
+    username
+  }
+`;
+
+export const userQuery = gql`
+  query UserQuery {
+    user(id: "123") {
+      id
+      ...userFields
+    }
+  }
+`;

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -417,6 +417,36 @@ export type CQuery = { __typename?: 'Query', a?: Types.Maybe<string> };
 "
 `);
     });
+
+    it('#6520 - self-importing fragment', async () => {
+      const result = await executeCodegen({
+        schema: [
+          /* GraphQL */ `
+            type Query {
+              user(id: String!): User!
+            }
+
+            type User {
+              id: String!
+              email: String
+              username: String
+            }
+          `,
+        ],
+        documents: [path.join(__dirname, 'fixtures/issue-6520.ts')],
+        generates: {
+          'out1.ts': {
+            preset: preset,
+            presetConfig: {
+              baseTypesPath: 'types.ts',
+            },
+            plugins: ['typescript-operations', 'typescript-react-apollo'],
+          },
+        },
+      });
+
+      expect(result[0].content).not.toMatch(`import { UserFieldsFragmentDoc }`);
+    });
   });
 
   it('Should build the correct operation files paths', async () => {


### PR DESCRIPTION
## Description

This prevents ClientSideBaseVisitor.getImports from generating an import for a fragment declared in the same file it's outputting to.  This type of import is a TypeScript compilation error (and is also not necessary, since the const is declared later on in the file).

Related #6520 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

https://codesandbox.io/s/stoic-minsky-0l3bg

## How Has This Been Tested?

I added a test case in the near-operation-files-preset suite labeled with issue number #6520.  It initially failed (reproducing this behavior) and now passes with my fix.

**Test Environment**:
- OS: macOS 11.5.1
- `@graphql-codegen/cli`: 2.1.1
- `@graphql-codegen/near-operation-file-preset`: 2.1.0
- `@graphql-codegen/typescript`: 2.1.0
- `@graphql-codegen/typescript-graphql-request`: 4.1.0
- `@graphql-codegen/typescript-operations`: 2.1.0
- NodeJS: 14.16.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (n/a)
- [ ] I have made corresponding changes to the documentation (n/a)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (n/a)

## Further comments

n/a
