### PR TITLE
[typescript-operations] fix merging inline fragment and fragment spread

### DIFF
--- a/.changeset/early-starfishes-check.md
+++ b/.changeset/early-starfishes-check.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Do not throw an error when trying to merge inline fragment usages.

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -360,7 +360,7 @@ export function mergeSelectionSets(selectionSet1: SelectionSetNode, selectionSet
   const newSelections = [...selectionSet1.selections];
 
   for (let selection2 of selectionSet2.selections) {
-    if (selection2.kind === 'FragmentSpread') {
+    if (selection2.kind === 'FragmentSpread' || selection2.kind === 'InlineFragment') {
       newSelections.push(selection2);
       continue;
     }


### PR DESCRIPTION
## Description

The follow valid fragment definitions (which merge a fragment spread with an inline fragment) cause an error.
```graphql
fragment Post on Post {
  id
  comments {
    ... on TextComment {
      text
    }
  }
}

fragment PostPlus on Post {
  ...Post
  comments {
    id
  }
}
```

Error is thrown from this line: https://github.com/dotansimha/graphql-code-generator/blob/a910a79892e88222ec8594e59c50e440eb3d800a/packages/plugins/other/visitor-plugin-common/src/utils.ts

Closes #6409
Closes #6410

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added a failing test, added the fix.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
