### PR TITLE
fix: module-duplicate-type

### DIFF
--- a/.changeset/flat-spoons-fail.md
+++ b/.changeset/flat-spoons-fail.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/graphql-modules-preset": patch
+---
+
+Duplication of TS interfaces when GraphQL type definition and type extension are in the same module

--- a/packages/presets/graphql-modules/src/utils.ts
+++ b/packages/presets/graphql-modules/src/utils.ts
@@ -198,7 +198,8 @@ export function pushUnique<T extends any>(list: T[], item: T): void {
 }
 
 export function concatByKey<T extends Record<string, any[]>, K extends keyof T>(left: T, right: T, key: K) {
-  return left[key].concat(right[key]);
+  // Remove duplicate, if an element is in right & left, it will be only once in the returned array.
+  return [...new Set([...left[key], ...right[key]])];
 }
 
 export function uniqueByKey<T extends Record<string, any[]>, K extends keyof T>(left: T, right: T, key: K) {

--- a/packages/presets/graphql-modules/tests/integration.spec.ts
+++ b/packages/presets/graphql-modules/tests/integration.spec.ts
@@ -47,7 +47,22 @@ describe('Integration', () => {
     }
   });
 
-  test.only('should allow to override importBaseTypesFrom correctly', async () => {
+  test('should not duplicate type even if type and extend type are in the same module', async () => {
+    try {
+      const output = await executeCodegen(options);
+
+      const userResolversStr = `export type UserResolvers = Pick<Types.UserResolvers, DefinedFields['User'] | '__isTypeOf'>;`;
+      const nbOfTimeUserResolverFound = output[4].content.split(userResolversStr).length - 1;
+
+      expect(nbOfTimeUserResolverFound).toBe(1);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      throw e;
+    }
+  });
+
+  test('should allow to override importBaseTypesFrom correctly', async () => {
     const output = await executeCodegen({
       generates: {
         './tests/test-files/modules': {

--- a/packages/presets/graphql-modules/tests/test-files/modules/users/types/ext_user.graphql
+++ b/packages/presets/graphql-modules/tests/test-files/modules/users/types/ext_user.graphql
@@ -1,0 +1,3 @@
+extend type User {
+  age: Int
+}


### PR DESCRIPTION
For now, I just added the test failing... Now I need to code the fix.


## Description

In one module if you declare a type and extend the type (in another file of the same module), codegen will generate 2 times the same type and will generate an invalid file.

Related https://github.com/dotansimha/graphql-code-generator/issues/6534

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- With a Unit test

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules