### PR TITLE
[typescript-urql-graphcache] add support for typesPrefix and typesSuffix options

### DIFF
--- a/.changeset/seven-ladybugs-beg.md
+++ b/.changeset/seven-ladybugs-beg.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-urql-graphcache': patch
+---
+
+Make typescript-urql-graphcache respect the typesPrefix and typesSuffix options

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -54,6 +54,63 @@ export type GraphCacheConfig = {
 };"
 `;
 
+exports[`urql graphcache Should output the cache-generic correctly (with typesPrefix and typesSuffix) 1`] = `
+"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
+import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
+export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
+
+export type GraphCacheKeysConfig = {
+  Author?: (data: WithTypename<PrefixAuthorSuffix>) => null | string,
+  Todo?: (data: WithTypename<PrefixTodoSuffix>) => null | string
+}
+
+export type GraphCacheResolvers = {
+  Query?: {
+    todos?: GraphCacheResolver<WithTypename<PrefixQuerySuffix>, Record<string, never>, Array<WithTypename<PrefixTodoSuffix> | string>>
+  },
+  Author?: {
+    id?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, Record<string, never>, Scalars['ID'] | string>,
+    name?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, Record<string, never>, Scalars['String'] | string>,
+    friends?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, Record<string, never>, Array<WithTypename<PrefixAuthorSuffix> | string>>,
+    friendsPaginated?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, PrefixAuthorFriendsPaginatedArgsSuffix, Array<WithTypename<PrefixAuthorSuffix> | string>>
+  },
+  Todo?: {
+    id?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, Scalars['ID'] | string>,
+    text?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, Scalars['String'] | string>,
+    complete?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, Scalars['Boolean'] | string>,
+    author?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, WithTypename<PrefixAuthorSuffix> | string>
+  }
+};
+
+export type GraphCacheOptimisticUpdaters = {
+  toggleTodo?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodoArgsSuffix, WithTypename<PrefixTodoSuffix>>,
+  toggleTodos?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosArgsSuffix, Array<WithTypename<PrefixTodoSuffix>>>,
+  toggleTodosOptionalArray?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalArrayArgsSuffix, Maybe<Array<WithTypename<PrefixTodoSuffix>>>>,
+  toggleTodosOptionalEntity?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalEntityArgsSuffix, Array<WithTypename<PrefixTodoSuffix>>>,
+  toggleTodosOptional?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalArgsSuffix, Maybe<Array<WithTypename<PrefixTodoSuffix>>>>
+};
+
+export type GraphCacheUpdaters = {
+  Mutation?: {
+    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: WithTypename<PrefixTodoSuffix> }, PrefixMutationToggleTodoArgsSuffix>,
+    toggleTodos?: GraphCacheUpdateResolver<{ toggleTodos: Array<WithTypename<PrefixTodoSuffix>> }, PrefixMutationToggleTodosArgsSuffix>,
+    toggleTodosOptionalArray?: GraphCacheUpdateResolver<{ toggleTodosOptionalArray: Maybe<Array<WithTypename<PrefixTodoSuffix>>> }, PrefixMutationToggleTodosOptionalArrayArgsSuffix>,
+    toggleTodosOptionalEntity?: GraphCacheUpdateResolver<{ toggleTodosOptionalEntity: Array<WithTypename<PrefixTodoSuffix>> }, PrefixMutationToggleTodosOptionalEntityArgsSuffix>,
+    toggleTodosOptional?: GraphCacheUpdateResolver<{ toggleTodosOptional: Maybe<Array<WithTypename<PrefixTodoSuffix>>> }, PrefixMutationToggleTodosOptionalArgsSuffix>
+  },
+  Subscription?: {},
+};
+
+export type GraphCacheConfig = {
+  schema?: IntrospectionData,
+  updates?: GraphCacheUpdaters,
+  keys?: GraphCacheKeysConfig,
+  optimistic?: GraphCacheOptimisticUpdaters,
+  resolvers?: GraphCacheResolvers,
+  storage?: GraphCacheStorageAdapter
+};"
+`;
+
 exports[`urql graphcache Should output the cache-generic correctly (with unions) 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';

--- a/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
@@ -99,4 +99,36 @@ describe('urql graphcache', () => {
     const result = mergeOutputs([await plugin(schema, [], {})]);
     expect(result).toMatchSnapshot();
   });
+
+  it('Should output the cache-generic correctly (with typesPrefix and typesSuffix)', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        todos: [Todo]
+      }
+
+      type Mutation {
+        toggleTodo(id: ID!): Todo!
+        toggleTodos(id: [ID!]!): [Todo!]!
+        toggleTodosOptionalArray(id: [ID!]!): [Todo!]
+        toggleTodosOptionalEntity(id: [ID!]!): [Todo]!
+        toggleTodosOptional(id: [ID!]!): [Todo]
+      }
+
+      type Author {
+        id: ID
+        name: String
+        friends: [Author]
+        friendsPaginated(from: Int!, limit: Int!): [Author]
+      }
+
+      type Todo {
+        id: ID
+        text: String
+        complete: Boolean
+        author: Author
+      }
+    `);
+    const result = mergeOutputs([await plugin(schema, [], { typesPrefix: 'Prefix', typesSuffix: 'Suffix' })]);
+    expect(result).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Description

This PR gets the typescript-urql-graphcache plugin to respect the typesPrefix and typesSuffix options when generating type names.

Related #6544.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

None.

## How Has This Been Tested?

- [x] Added the relevant tests and made sure they pass
- [x] Ran my modified version of the plugin against my in-development app and verified that the type names were correctly

**Test Environment**:
- OS: macOS 11.5.1
- @graphql-codegen/typescript-urql-graphcache: 2.1.1
- NodeJS: v16.6.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

None.