### PR TITLE
Fix double imports

### DIFF
--- a/.changeset/shiny-eels-smell.md
+++ b/.changeset/shiny-eels-smell.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Don't generate duplicate imports for the same identifier

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -16,7 +16,7 @@ import { getConfigValue, buildScalarsFromConfig } from './utils';
 import { LoadedFragment, ParsedImport } from './types';
 import { basename, extname } from 'path';
 import { pascalCase } from 'change-case-all';
-import { FragmentImport, generateFragmentImportStatement, ImportDeclaration } from './imports';
+import { generateFragmentImportStatement } from './imports';
 import { optimizeDocumentNode } from '@graphql-tools/optimize';
 
 gqlTag.enableExperimentalFragmentVariables();
@@ -502,16 +502,23 @@ export class ClientSideBaseVisitor<
         documentMode === DocumentMode.string ||
         documentMode === DocumentMode.documentNodeImportFragments
       ) {
+        // keep track of what imports we've already generated so we don't try
+        // to import the same identifier twice
         const alreadyImported = new Map<string, Set<string>>();
+
         const deduplicatedImports = fragmentImports
           .map(fragmentImport => {
             const { path, identifiers } = fragmentImport.importSource;
             if (!alreadyImported.has(path)) {
               alreadyImported.set(path, new Set<string>());
             }
+
             const alreadyImportedForPath = alreadyImported.get(path);
             const newIdentifiers = identifiers.filter(identifier => !alreadyImportedForPath.has(identifier.name));
             newIdentifiers.forEach(newIdentifier => alreadyImportedForPath.add(newIdentifier.name));
+
+            // filter the set of identifiers in this fragment import to only
+            // the ones we haven't already imported from this path
             return {
               ...fragmentImport,
               importSource: {
@@ -520,7 +527,9 @@ export class ClientSideBaseVisitor<
               },
             };
           })
+          // remove any imports that now have no identifiers in them
           .filter(fragmentImport => fragmentImport.importSource.identifiers.length > 0);
+
         deduplicatedImports.forEach(fragmentImport => {
           if (fragmentImport.outputPath !== fragmentImport.importSource.path) {
             this._imports.add(generateFragmentImportStatement(fragmentImport, 'document'));

--- a/packages/presets/near-operation-file/tests/fixtures/issue-6546-fragments.ts
+++ b/packages/presets/near-operation-file/tests/fixtures/issue-6546-fragments.ts
@@ -1,0 +1,16 @@
+import gql from 'graphql-tag';
+
+export const usernameFragment = gql`
+  fragment usernameFragment on User {
+    username
+  }
+`;
+
+export const userFields = gql`
+  fragment userFields on User {
+    ...usernameFragment
+    email
+  }
+
+  ${usernameFragment}
+`;

--- a/packages/presets/near-operation-file/tests/fixtures/issue-6546-queries.ts
+++ b/packages/presets/near-operation-file/tests/fixtures/issue-6546-queries.ts
@@ -1,0 +1,27 @@
+import gql from 'graphql-tag';
+import { userFields, usernameFragment } from './issue-6546-fragments';
+
+export const limitedUserFieldsQuery = gql`
+  query user {
+    user(id: "1") {
+      ...usernameFragment
+    }
+  }
+
+  ${usernameFragment}
+`;
+
+export const userAndFriendQuery = gql`
+  query allUserFields {
+    user(id: "1") {
+      ...userFields
+    }
+
+    friend: user(id: "2") {
+      ...usernameFragment
+    }
+  }
+
+  ${userFields}
+  ${usernameFragment}
+`;


### PR DESCRIPTION
## Description

This fixes the duplicate imports for the same identifier bug outlined in #6546.  To do so, it extends `getImports` to track what identifiers it has already imported and not import the same one twice.  It also eliminates empty import statements that might result from this deduplication.

Related #6546 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

https://codesandbox.io/s/proud-bird-jx23b

## How Has This Been Tested?

I added a test case in the near-operation-files-preset suite labeled with issue number #6546.  It initially failed (reproducing this behavior) and now passes with my fix.

**Test Environment**:
- OS: macOS 11.5.1
- `@graphql-codegen/cli`: 2.1.1
- `@graphql-codegen/near-operation-file-preset`: 2.1.1
- `@graphql-codegen/typescript`: 2.1.1
- `@graphql-codegen/typescript-graphql-request`: 4.1.1
- `@graphql-codegen/typescript-operations`: 2.1.1
- NodeJS: 14.16.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (n/a)

## Further comments

n/a