### PR TITLE
docs(codegen-config): remove extra backtick

### DIFF
--- a/website/docs/getting-started/codegen-config.md
+++ b/website/docs/getting-started/codegen-config.md
@@ -135,4 +135,4 @@ That means, you can use `codegen.yml`, but also `codegen.json` or `codegen.js` w
 
 For more information, [please refer to `cosmiconfig` documentation](https://github.com/davidtheclark/cosmiconfig#cosmiconfig).
 
-GraphQL-Codgen is also integratable with [`GraphQL-Config](https://graphql-config.com/), so you can specify `.graphqlrc` as your configuration file.
+GraphQL-Codgen is also integratable with [GraphQL-Config](https://graphql-config.com/), so you can specify `.graphqlrc` as your configuration file.


### PR DESCRIPTION
This is a small PR removing an extra backtick character from the [codegen.yml](https://www.graphql-code-generator.com/docs/getting-started/codegen-config) documentation page.