### PR TITLE
Apply missing namingConvention when numericEnums is used

### DIFF
--- a/.changeset/tame-items-film.md
+++ b/.changeset/tame-items-film.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript': patch
+---
+
+Apply missing namingConvention when numericEnums is used

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -332,8 +332,10 @@ export class TsVisitor<
               const valueFromConfig = getValueFromConfig(enumOption.name as unknown as string);
               const enumValue: string | number = valueFromConfig ?? i;
               const comment = transformComment(enumOption.description as any as string, 1);
-
-              return comment + indent(enumOption.name as unknown as string) + ` = ${enumValue}`;
+              const optionName = this.makeValidEnumIdentifier(
+                this.convertName(enumOption, { useTypesPrefix: false, transformUnderscore: true })
+              );
+              return comment + indent(optionName) + ` = ${enumValue}`;
             })
             .concat(...withFutureAddedValue)
             .join(',\n')

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -604,6 +604,37 @@ describe('TypeScript', () => {
       expect(output).toContain(`SomethingElse = '99'`);
     });
 
+    it('#6532 - numeric enum values with namingConvention', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        type Query {
+          test: Test!
+        }
+
+        enum Test {
+          Boop
+          BIP
+          BaP
+          TEST_VALUE
+        }
+      `);
+
+      const result = (await plugin(
+        testSchema,
+        [],
+        {
+          numericEnums: true,
+        },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      const output = mergeOutputs([result]);
+      expect(output).toBeSimilarStringTo(`export enum Test {
+        Boop = 0,
+        Bip = 1,
+        BaP = 2,
+        TestValue = 3
+      }`);
+    });
+
     it('#3137 - numeric enum value', async () => {
       const testSchema = buildSchema(/* GraphQL */ `
         type Query {
@@ -1111,7 +1142,7 @@ describe('TypeScript', () => {
         A
         B
       }
-      
+
       type MyType {
         required: MyEnum!
         optional: MyEnum
@@ -1146,7 +1177,7 @@ describe('TypeScript', () => {
           A
           B
         }
-        
+
         type MyType {
           required: MyEnum!
           optional: MyEnum
@@ -1182,7 +1213,7 @@ describe('TypeScript', () => {
           A
           B
         }
-        
+
         type MyType {
           required: MyEnum!
           optional: MyEnum


### PR DESCRIPTION
Related: https://github.com/dotansimha/graphql-code-generator/issues/6532 