### PR TITLE
Bump GraphQL Tools for Schema Sorting and the fix for the schema definition handling

### DIFF
--- a/.changeset/heavy-tables-float.md
+++ b/.changeset/heavy-tables-float.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+fix: handle convertExtensions properly with schema definitions

--- a/.changeset/quick-candles-suffer.md
+++ b/.changeset/quick-candles-suffer.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/cli': minor
+'@graphql-codegen/schema-ast': minor
+---
+
+feat: sort the schema if "sort" option is provided

--- a/examples/programmatic-typescript/package.json
+++ b/examples/programmatic-typescript/package.json
@@ -14,7 +14,7 @@
     "@graphql-codegen/typescript-operations": "*",
     "@graphql-codegen/typescript-resolvers": "*",
     "@graphql-tools/graphql-file-loader": "^7.0.1",
-    "@graphql-tools/load": "^7.1.8",
+    "@graphql-tools/load": "^7.3.0",
     "@graphql-tools/schema": "^8.1.2",
     "graphql": "^15.5.1",
     "graphql-tag": "^2.12.5",

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -48,7 +48,7 @@
     "@graphql-tools/github-loader": "^7.0.5",
     "@graphql-tools/graphql-file-loader": "^7.0.5",
     "@graphql-tools/json-file-loader": "^7.1.2",
-    "@graphql-tools/load": "^7.1.8",
+    "@graphql-tools/load": "^7.3.0",
     "@graphql-tools/prisma-loader": "^7.0.6",
     "@graphql-tools/url-loader": "^7.0.11",
     "@graphql-tools/utils": "^8.1.1",

--- a/packages/graphql-codegen-cli/tests/codegen.spec.ts
+++ b/packages/graphql-codegen-cli/tests/codegen.spec.ts
@@ -1011,4 +1011,54 @@ describe('Codegen Executor', () => {
     expect(output.length).toBe(1);
     expect(output[0].content).toContain('Hello world!');
   });
+
+  it('Should sort the input schema', async () => {
+    const nonSortedSchema = /* GraphQL */ `
+      type Query {
+        d: String
+        z: String
+        a: String
+      }
+
+      type User {
+        aa: String
+        a: String
+      }
+
+      type A {
+        s: String
+        b: String
+      }
+    `;
+    const output = await executeCodegen({
+      schema: [nonSortedSchema],
+      generates: {
+        'out1.graphql': {
+          plugins: ['schema-ast'],
+        },
+      },
+      config: {
+        sort: true,
+      },
+    });
+
+    expect(output.length).toBe(1);
+    expect(output[0].content).toBeSimilarStringTo(/* GraphQL */ `
+      type A {
+        b: String
+        s: String
+      }
+
+      type Query {
+        a: String
+        d: String
+        z: String
+      }
+
+      type User {
+        a: String
+        aa: String
+      }
+    `);
+  });
 });

--- a/packages/plugins/other/schema-ast/src/index.ts
+++ b/packages/plugins/other/schema-ast/src/index.ts
@@ -83,7 +83,9 @@ export const validate: PluginValidateFn<any> = async (
   }
 };
 
-export function transformSchemaAST(schema: GraphQLSchema, config: { [key: string]: any }) {
+export function transformSchemaAST(schemaRaw: GraphQLSchema, config: { [key: string]: any }) {
+  const schema = config.sort ? lexicographicSortSchema(schemaRaw) : schemaRaw;
+
   const astNode = getCachedDocumentNodeFromSchema(schema);
 
   const transformedAST = config.disableDescriptions

--- a/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
+++ b/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
@@ -1,4 +1,4 @@
-import { validate, plugin } from '../src/index';
+import { validate, plugin, transformSchemaAST } from '../src/index';
 import { buildSchema, parse } from 'graphql';
 import '@graphql-codegen/testing';
 import { Types } from '@graphql-codegen/plugin-helpers';
@@ -9,24 +9,25 @@ const SHOULD_THROW_ERROR = 'SHOULD_THROW_ERROR';
 
 describe('Schema AST', () => {
   describe('Issues', () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        d: String
+        z: String
+        a: String
+      }
+
+      type User {
+        aa: String
+        a: String
+      }
+
+      type A {
+        s: String
+        b: String
+      }
+    `);
+
     it('#4919 - should support sorting the schema', async () => {
-      const schema = buildSchema(/* GraphQL */ `
-        type Query {
-          d: String
-          z: String
-          a: String
-        }
-
-        type User {
-          aa: String
-          a: String
-        }
-
-        type A {
-          s: String
-          b: String
-        }
-      `);
       const content = await plugin(schema, [], { sort: true });
       expect(content).toBeSimilarStringTo(`
       type A {
@@ -44,6 +45,15 @@ describe('Schema AST', () => {
         a: String
         aa: String
       }`);
+    });
+
+    it('#6624 - transformSchemaAST should support sorting the schema', () => {
+      expect(JSON.stringify(transformSchemaAST(schema, { sort: true }))).toBeSimilarStringTo(
+        `{"schema":{"extensionASTNodes":[],"_queryType":"Query","_directives":["@deprecated","@include","@skip","@specifiedBy"],"_typeMap":{"A":"A","Boolean":"Boolean","Query":"Query","String":"String","User":"User","__Directive":"__Directive","__DirectiveLocation":"__DirectiveLocation","__EnumValue":"__EnumValue","__Field":"__Field","__InputValue":"__InputValue","__Schema":"__Schema","__Type":"__Type","__TypeKind":"__TypeKind"},"_subTypeMap":{},"_implementationsMap":{}},"ast":{"kind":"Document","definitions":[{"kind":"SchemaDefinition","operationTypes":[{"kind":"OperationTypeDefinition","operation":"query","type":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}}}],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"A"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"b"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"s"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"Query"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"a"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"d"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"z"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"User"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"a"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"aa"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]}]}}`
+      );
+      expect(JSON.stringify(transformSchemaAST(schema, { sort: false }))).toBeSimilarStringTo(
+        `{"schema":{"extensionASTNodes":[],"_queryType":"Query","_directives":["@include","@skip","@deprecated","@specifiedBy"],"_typeMap":{"Query":"Query","String":"String","User":"User","A":"A","Boolean":"Boolean","__Schema":"__Schema","__Type":"__Type","__TypeKind":"__TypeKind","__Field":"__Field","__InputValue":"__InputValue","__EnumValue":"__EnumValue","__Directive":"__Directive","__DirectiveLocation":"__DirectiveLocation"},"_subTypeMap":{},"_implementationsMap":{}},"ast":{"kind":"Document","definitions":[{"kind":"SchemaDefinition","operationTypes":[{"kind":"OperationTypeDefinition","operation":"query","type":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}}}],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"Query"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"d"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"z"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"a"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"User"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"aa"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"a"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"A"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"s"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"b"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]}]}}`
+      );
     });
   });
   describe('Validation', () => {

--- a/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
+++ b/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
@@ -1,4 +1,4 @@
-import { validate, plugin, transformSchemaAST } from '../src/index';
+import { validate, plugin } from '../src/index';
 import { buildSchema, parse } from 'graphql';
 import '@graphql-codegen/testing';
 import { Types } from '@graphql-codegen/plugin-helpers';
@@ -8,54 +8,6 @@ import { codegen } from '@graphql-codegen/core';
 const SHOULD_THROW_ERROR = 'SHOULD_THROW_ERROR';
 
 describe('Schema AST', () => {
-  describe('Issues', () => {
-    const schema = buildSchema(/* GraphQL */ `
-      type Query {
-        d: String
-        z: String
-        a: String
-      }
-
-      type User {
-        aa: String
-        a: String
-      }
-
-      type A {
-        s: String
-        b: String
-      }
-    `);
-
-    it('#4919 - should support sorting the schema', async () => {
-      const content = await plugin(schema, [], { sort: true });
-      expect(content).toBeSimilarStringTo(`
-      type A {
-        b: String
-        s: String
-      }
-      
-      type Query {
-        a: String
-        d: String
-        z: String
-      }
-      
-      type User {
-        a: String
-        aa: String
-      }`);
-    });
-
-    it('#6624 - transformSchemaAST should support sorting the schema', () => {
-      expect(JSON.stringify(transformSchemaAST(schema, { sort: true }))).toBeSimilarStringTo(
-        `{"schema":{"extensionASTNodes":[],"_queryType":"Query","_directives":["@deprecated","@include","@skip","@specifiedBy"],"_typeMap":{"A":"A","Boolean":"Boolean","Query":"Query","String":"String","User":"User","__Directive":"__Directive","__DirectiveLocation":"__DirectiveLocation","__EnumValue":"__EnumValue","__Field":"__Field","__InputValue":"__InputValue","__Schema":"__Schema","__Type":"__Type","__TypeKind":"__TypeKind"},"_subTypeMap":{},"_implementationsMap":{}},"ast":{"kind":"Document","definitions":[{"kind":"SchemaDefinition","operationTypes":[{"kind":"OperationTypeDefinition","operation":"query","type":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}}}],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"A"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"b"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"s"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"Query"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"a"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"d"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"z"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"User"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"a"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"aa"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]}]}}`
-      );
-      expect(JSON.stringify(transformSchemaAST(schema, { sort: false }))).toBeSimilarStringTo(
-        `{"schema":{"extensionASTNodes":[],"_queryType":"Query","_directives":["@include","@skip","@deprecated","@specifiedBy"],"_typeMap":{"Query":"Query","String":"String","User":"User","A":"A","Boolean":"Boolean","__Schema":"__Schema","__Type":"__Type","__TypeKind":"__TypeKind","__Field":"__Field","__InputValue":"__InputValue","__EnumValue":"__EnumValue","__Directive":"__Directive","__DirectiveLocation":"__DirectiveLocation"},"_subTypeMap":{},"_implementationsMap":{}},"ast":{"kind":"Document","definitions":[{"kind":"SchemaDefinition","operationTypes":[{"kind":"OperationTypeDefinition","operation":"query","type":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}}}],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"Query"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"d"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"z"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"a"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"User"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"aa"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"a"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]},{"kind":"ObjectTypeDefinition","name":{"kind":"Name","value":"A"},"fields":[{"kind":"FieldDefinition","name":{"kind":"Name","value":"s"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]},{"kind":"FieldDefinition","name":{"kind":"Name","value":"b"},"arguments":[],"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"directives":[]}],"interfaces":[],"directives":[]}]}}`
-      );
-    });
-  });
   describe('Validation', () => {
     it('Should enforce graphql extension when its the only plugin', async () => {
       const fileName = 'output.ts';
@@ -174,7 +126,7 @@ describe('Schema AST', () => {
       const content = await plugin(schema, [], { includeDirectives: true });
 
       expect(content).toBeSimilarStringTo(`
-        directive @modify(limit: Int) on FIELD_DEFINITION 
+        directive @modify(limit: Int) on FIELD_DEFINITION
       `);
       expect(content).toBeSimilarStringTo(`
         type Query {
@@ -241,14 +193,14 @@ describe('Schema AST', () => {
           id: ID
           side: String
         }
-        
+
         type Droid {
           id: ID
           model: String
         }
-        
+
         union People = Character | Jedi | Droid
-        
+
         type Query {
           allPeople: [People]
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,13 +2093,13 @@
     unixify "1.0.0"
     valid-url "1.0.9"
 
-"@graphql-tools/load@^7.1.0", "@graphql-tools/load@^7.1.8":
-  version "7.1.8"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-7.1.8.tgz#c6f2ce19e7497d2f56d572d4fe2aded01a87edf1"
-  integrity sha512-dVl2jJon9VL0qLTC98hJH4CkQ/oat6j9TouCk69ezzWHFxiPlz6tF78BzLr86Mz+bY6QCGeNIJ75Ovyn7EutCQ==
+"@graphql-tools/load@^7.1.0", "@graphql-tools/load@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-7.3.0.tgz#dc4177bb4b7ae537c833a2fcd97ab07b6c789c65"
+  integrity sha512-ZVipT7yzOpf/DJ2sLI3xGwnULVFp/icu7RFEgDo2ZX0WHiS7EjWZ0cegxEm87+WN4fMwpiysRLzWx67VIHwKGA==
   dependencies:
-    "@graphql-tools/schema" "8.1.2"
-    "@graphql-tools/utils" "^8.1.1"
+    "@graphql-tools/schema" "8.2.0"
+    "@graphql-tools/utils" "^8.2.0"
     p-limit "3.1.0"
     tslib "~2.3.0"
 
@@ -3262,7 +3262,12 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
-"@types/node@*", "@types/node@14.17.14", "@types/node@^14.14.33":
+"@types/node@*", "@types/node@^16.4.10":
+  version "16.4.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.13.tgz#7dfd9c14661edc65cccd43a29eb454174642370d"
+  integrity sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==
+
+"@types/node@14.17.14", "@types/node@^14.14.33":
   version "14.17.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.14.tgz#6fda9785b41570eb628bac27be4b602769a3f938"
   integrity sha512-rsAj2u8Xkqfc332iXV12SqIsjVi07H479bOP4q94NAcjzmAvapumEhuVIt53koEf7JFrpjgNKjBga5Pnn/GL8A==
@@ -3281,11 +3286,6 @@
   version "15.14.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.7.tgz#29fea9a5b14e2b75c19028e1c7a32edd1e89fe92"
   integrity sha512-FA45p37/mLhpebgbPWWCKfOisTjxGK9lwcHlJ6XVLfu3NgfcazOJHdYUZCWPMK8QX4LhNZdmfo6iMz9FqpUbaw==
-
-"@types/node@^16.4.10":
-  version "16.4.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.13.tgz#7dfd9c14661edc65cccd43a29eb454174642370d"
-  integrity sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -13561,12 +13561,12 @@ rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.1, rxjs@^6.6.0, rxjs@^6.6.3, rxjs@^6.6.7:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.1.2, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==


### PR DESCRIPTION
## Description

Use graphql.lexicographicSortSchema in transformSchemaAST depending on the parameter - sort
Bumps GraphQL Tools package that handles schema definitions correctly

Related #6624 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

**Test Environment**:
- OS: macOS Catalina version: 0.15.7
- `@graphql-codegen/typescript`: "2.2.0"
