### PR TITLE
Dynamically Name Optimistic Mutation

### DIFF
--- a/.changeset/warm-buttons-vanish.md
+++ b/.changeset/warm-buttons-vanish.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/typescript-urql-graphcache': patch
 ---
 
-Fixes a bug where the mutationType name is hardcoded creating incorrectly named types. Added dynamic naming of this value.
+Fixes a bug where the mutation root type name was hardcoded as `Mutation` creating incorrectly named types. Now, the correct mutation type as defined in the schema is used.

--- a/.changeset/warm-buttons-vanish.md
+++ b/.changeset/warm-buttons-vanish.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-urql-graphcache': patch
+---
+
+Fixes a bug where the mutationType name is hardcoded creating incorrectly named types. Added dynamic naming of this value.

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -209,7 +209,7 @@ function getOptimisticUpdatersConfig(
 
     fields.forEach(fieldNode => {
       const argsName = fieldNode.arguments?.length
-        ? convertName(`Mutation${capitalize(fieldNode.name.value)}Args`, {
+        ? convertName(`${capitalize(mutationType.name)}${capitalize(fieldNode.name.value)}Args`, {
             prefix: config.typesPrefix,
             suffix: config.typesSuffix,
           })

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -1,5 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`urql graphcache Should correctly name GraphCacheResolvers & GraphCacheOptimisticUpdaters with nonstandard mutationType names 1`] = `
+"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
+import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
+export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
+
+export type GraphCacheKeysConfig = {
+  Author?: (data: WithTypename<Author>) => null | string,
+  Todo?: (data: WithTypename<Todo>) => null | string
+}
+
+export type GraphCacheResolvers = {
+  Query_Root?: {
+    todos?: GraphCacheResolver<WithTypename<Query_Root>, Record<string, never>, Array<WithTypename<Todo> | string>>
+  },
+  Author?: {
+    id?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['ID'] | string>,
+    name?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['String'] | string>,
+    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<WithTypename<Author> | string>>,
+    friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<WithTypename<Author> | string>>
+  },
+  Todo?: {
+    id?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['ID'] | string>,
+    text?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['String'] | string>,
+    complete?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['Boolean'] | string>,
+    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, WithTypename<Author> | string>
+  }
+};
+
+export type GraphCacheOptimisticUpdaters = {
+  toggleTodo?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodoArgs, WithTypename<Todo>>,
+  toggleTodos?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodosArgs, Array<WithTypename<Todo>>>,
+  toggleTodosOptionalArray?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodosOptionalArrayArgs, Maybe<Array<WithTypename<Todo>>>>,
+  toggleTodosOptionalEntity?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodosOptionalEntityArgs, Array<WithTypename<Todo>>>,
+  toggleTodosOptional?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodosOptionalArgs, Maybe<Array<WithTypename<Todo>>>>
+};
+
+export type GraphCacheUpdaters = {
+  Mutation?: {
+    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: WithTypename<Todo> }, Mutation_RootToggleTodoArgs>,
+    toggleTodos?: GraphCacheUpdateResolver<{ toggleTodos: Array<WithTypename<Todo>> }, Mutation_RootToggleTodosArgs>,
+    toggleTodosOptionalArray?: GraphCacheUpdateResolver<{ toggleTodosOptionalArray: Maybe<Array<WithTypename<Todo>>> }, Mutation_RootToggleTodosOptionalArrayArgs>,
+    toggleTodosOptionalEntity?: GraphCacheUpdateResolver<{ toggleTodosOptionalEntity: Array<WithTypename<Todo>> }, Mutation_RootToggleTodosOptionalEntityArgs>,
+    toggleTodosOptional?: GraphCacheUpdateResolver<{ toggleTodosOptional: Maybe<Array<WithTypename<Todo>>> }, Mutation_RootToggleTodosOptionalArgs>
+  },
+  Subscription?: {},
+};
+
+export type GraphCacheConfig = {
+  schema?: IntrospectionData,
+  updates?: GraphCacheUpdaters,
+  keys?: GraphCacheKeysConfig,
+  optimistic?: GraphCacheOptimisticUpdaters,
+  resolvers?: GraphCacheResolvers,
+  storage?: GraphCacheStorageAdapter
+};"
+`;
+
 exports[`urql graphcache Should output the cache-generic correctly (with interfaces) 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -6,7 +6,6 @@ import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
 export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
-  Author?: (data: WithTypename<Author>) => null | string,
   Todo?: (data: WithTypename<Todo>) => null | string
 }
 
@@ -14,35 +13,20 @@ export type GraphCacheResolvers = {
   Query_Root?: {
     todos?: GraphCacheResolver<WithTypename<Query_Root>, Record<string, never>, Array<WithTypename<Todo> | string>>
   },
-  Author?: {
-    id?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['ID'] | string>,
-    name?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['String'] | string>,
-    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<WithTypename<Author> | string>>,
-    friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<WithTypename<Author> | string>>
-  },
   Todo?: {
     id?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['ID'] | string>,
     text?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['String'] | string>,
-    complete?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['Boolean'] | string>,
-    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, WithTypename<Author> | string>
+    complete?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['Boolean'] | string>
   }
 };
 
 export type GraphCacheOptimisticUpdaters = {
-  toggleTodo?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodoArgs, WithTypename<Todo>>,
-  toggleTodos?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodosArgs, Array<WithTypename<Todo>>>,
-  toggleTodosOptionalArray?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodosOptionalArrayArgs, Maybe<Array<WithTypename<Todo>>>>,
-  toggleTodosOptionalEntity?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodosOptionalEntityArgs, Array<WithTypename<Todo>>>,
-  toggleTodosOptional?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodosOptionalArgs, Maybe<Array<WithTypename<Todo>>>>
+  toggleTodo?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodoArgs, WithTypename<Todo>>
 };
 
 export type GraphCacheUpdaters = {
   Mutation?: {
-    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: WithTypename<Todo> }, Mutation_RootToggleTodoArgs>,
-    toggleTodos?: GraphCacheUpdateResolver<{ toggleTodos: Array<WithTypename<Todo>> }, Mutation_RootToggleTodosArgs>,
-    toggleTodosOptionalArray?: GraphCacheUpdateResolver<{ toggleTodosOptionalArray: Maybe<Array<WithTypename<Todo>>> }, Mutation_RootToggleTodosOptionalArrayArgs>,
-    toggleTodosOptionalEntity?: GraphCacheUpdateResolver<{ toggleTodosOptionalEntity: Array<WithTypename<Todo>> }, Mutation_RootToggleTodosOptionalEntityArgs>,
-    toggleTodosOptional?: GraphCacheUpdateResolver<{ toggleTodosOptional: Maybe<Array<WithTypename<Todo>>> }, Mutation_RootToggleTodosOptionalArgs>
+    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: WithTypename<Todo> }, Mutation_RootToggleTodoArgs>
   },
   Subscription?: {},
 };

--- a/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
@@ -168,4 +168,41 @@ describe('urql graphcache', () => {
 import type { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';`
     );
   });
+
+  it('Should correctly name GraphCacheResolvers & GraphCacheOptimisticUpdaters with nonstandard mutationType names', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      schema {
+        query: Query_Root
+        mutation: Mutation_Root
+      }
+
+      type Query_Root {
+        todos: [Todo]
+      }
+
+      type Mutation_Root {
+        toggleTodo(id: ID!): Todo!
+        toggleTodos(id: [ID!]!): [Todo!]!
+        toggleTodosOptionalArray(id: [ID!]!): [Todo!]
+        toggleTodosOptionalEntity(id: [ID!]!): [Todo]!
+        toggleTodosOptional(id: [ID!]!): [Todo]
+      }
+
+      type Author {
+        id: ID
+        name: String
+        friends: [Author]
+        friendsPaginated(from: Int!, limit: Int!): [Author]
+      }
+
+      type Todo {
+        id: ID
+        text: String
+        complete: Boolean
+        author: Author
+      }
+    `);
+    const result = mergeOutputs([await plugin(schema, [], {})]);
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
@@ -182,24 +182,12 @@ import type { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast
 
       type Mutation_Root {
         toggleTodo(id: ID!): Todo!
-        toggleTodos(id: [ID!]!): [Todo!]!
-        toggleTodosOptionalArray(id: [ID!]!): [Todo!]
-        toggleTodosOptionalEntity(id: [ID!]!): [Todo]!
-        toggleTodosOptional(id: [ID!]!): [Todo]
-      }
-
-      type Author {
-        id: ID
-        name: String
-        friends: [Author]
-        friendsPaginated(from: Int!, limit: Int!): [Author]
       }
 
       type Todo {
         id: ID
         text: String
         complete: Boolean
-        author: Author
       }
     `);
     const result = mergeOutputs([await plugin(schema, [], {})]);


### PR DESCRIPTION
## Description

This PR fixes a bug in the urql-graphcache plugin where if the mutationType name in the schema was anything other than `mutation` the generated `GraphCacheOptimisticUpdaters` would have incorrect types.

Related https://github.com/dotansimha/graphql-code-generator/issues/6560

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

![Screenshot from 2021-09-06 17-05-09](https://user-images.githubusercontent.com/8920897/132260478-5907b7c8-82ea-43e0-b7ec-a78705cbb482.png)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I updated the line swapping out `Mutation` for `${capitalize(mutationType.name)`.  This created the correct names inside the `GraphCacheOptimisticUpdaters` type in my generated file.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
