### PR TITLE
modify urql visitor to allow external operation definitions

### DIFF
--- a/.changeset/small-knives-yawn.md
+++ b/.changeset/small-knives-yawn.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-urql': minor
+---
+
+Modify urql visitor to allow external operation definitions


### PR DESCRIPTION
## Description

This fixes the  typescript-urql plugin ignores documentMode importDocumentNodeExternallyFrom and importOperationTypesFrom settings

I've used the code from https://github.com/dotansimha/graphql-code-generator/pull/4765 as a basis to add this


Related #6650

## Type of change
Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):
the issue is shown in the following sandbox also linked in issue #6650
https://codesandbox.io/s/confident-dream-l0sd5?file=/urql.ts 

## How Has This Been Tested?
Ran unit tests

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

