### PR TITLE
fix: proper indentation of DirectiveArgs

### DIFF
--- a/.changeset/tiny-lions-laugh.md
+++ b/.changeset/tiny-lions-laugh.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Apply proper indentation to DirectiveArgs types

--- a/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
+++ b/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
@@ -97,9 +97,11 @@ export type ResolversParentTypes = {
   Boolean: $ElementType<Scalars, 'Boolean'>,
 };
 
-export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
+export type MyDirectiveDirectiveArgs = {
+  arg: $ElementType<Scalars, 'Int'>,
   arg2: $ElementType<Scalars, 'String'>,
-  arg3: $ElementType<Scalars, 'Boolean'>, };
+  arg3: $ElementType<Scalars, 'Boolean'>,
+};
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 

--- a/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
+++ b/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
@@ -105,7 +105,7 @@ export type MyDirectiveDirectiveArgs = {
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
-export type AuthenticatedDirectiveArgs = {  };
+export type AuthenticatedDirectiveArgs = { };
 
 export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 

--- a/packages/plugins/flow/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/mapping.spec.ts
@@ -214,8 +214,11 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { MyCustomOtherType } from './my-file';`);
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
-    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'>, };
+    export type MyDirectiveDirectiveArgs = {
+      arg: $ElementType<Scalars, 'Int'>,
+      arg2: $ElementType<Scalars, 'String'>,
+      arg3: $ElementType<Scalars, 'Boolean'>,
+    };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -293,8 +296,11 @@ describe('ResolversTypes', () => {
 
     expect(result.prepend).toContain(`import { MyCustomOtherType } from './my-file';`);
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
-    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'>, };
+    export type MyDirectiveDirectiveArgs = {
+      arg: $ElementType<Scalars, 'Int'>,
+      arg2: $ElementType<Scalars, 'String'>,
+      arg3: $ElementType<Scalars, 'Boolean'>,
+    };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -371,8 +377,11 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
-    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'>, };
+    export type MyDirectiveDirectiveArgs = {
+      arg: $ElementType<Scalars, 'Int'>,
+      arg2: $ElementType<Scalars, 'String'>,
+      arg3: $ElementType<Scalars, 'Boolean'>,
+    };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -448,8 +457,11 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
-    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'>, };
+    export type MyDirectiveDirectiveArgs = {
+      arg: $ElementType<Scalars, 'Int'>,
+      arg2: $ElementType<Scalars, 'String'>,
+      arg3: $ElementType<Scalars, 'Boolean'>,
+    };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -525,8 +537,11 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { MyBaseType } from './my-file';`);
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: $ElementType<Scalars, 'Int'>,
-    arg2: $ElementType<Scalars, 'String'>, arg3: $ElementType<Scalars, 'Boolean'>, };
+    export type MyDirectiveDirectiveArgs = {
+      arg: $ElementType<Scalars, 'Int'>,
+      arg2: $ElementType<Scalars, 'String'>,
+      arg3: $ElementType<Scalars, 'Boolean'>,
+    };
     `);
 
     expect(result.content).toBeSimilarStringTo(`

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1127,9 +1127,9 @@ export class BaseResolversVisitor<
         .asKind('type')
         .withName(directiveArgsTypeName)
         .withContent(
-          `{ ${
-            hasArguments ? this._variablesTransformer.transform<InputValueDefinitionNode>(sourceNode.arguments) : ''
-          } }`
+          hasArguments
+            ? `{\n${this._variablesTransformer.transform<InputValueDefinitionNode>(sourceNode.arguments)}\n}`
+            : '{ }'
         ).string,
       new DeclarationBlock({
         ...this._declarationBlockConfig,

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -169,13 +169,15 @@ export type ResolversParentTypes = ResolversObject<{
   Boolean: Scalars['Boolean'];
 }>;
 
-export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+export type MyDirectiveDirectiveArgs = {
+  arg: Scalars['Int'];
   arg2: Scalars['String'];
-  arg3: Scalars['Boolean']; };
+  arg3: Scalars['Boolean'];
+};
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
-export type AuthenticatedDirectiveArgs = {  };
+export type AuthenticatedDirectiveArgs = { };
 
 export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
@@ -364,13 +366,15 @@ export type ResolversParentTypes = ResolversObject<{
   Boolean: Types.Scalars['Boolean'];
 }>;
 
-export type MyDirectiveDirectiveArgs = {   arg: Types.Scalars['Int'];
+export type MyDirectiveDirectiveArgs = {
+  arg: Types.Scalars['Int'];
   arg2: Types.Scalars['String'];
-  arg3: Types.Scalars['Boolean']; };
+  arg3: Types.Scalars['Boolean'];
+};
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
-export type AuthenticatedDirectiveArgs = {  };
+export type AuthenticatedDirectiveArgs = { };
 
 export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
@@ -612,13 +616,15 @@ export type ResolversParentTypes = ResolversObject<{
   Boolean: Scalars['Boolean'];
 }>;
 
-export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
+export type MyDirectiveDirectiveArgs = {
+  arg: Scalars['Int'];
   arg2: Scalars['String'];
-  arg3: Scalars['Boolean']; };
+  arg3: Scalars['Boolean'];
+};
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
-export type AuthenticatedDirectiveArgs = {  };
+export type AuthenticatedDirectiveArgs = { };
 
 export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 

--- a/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
@@ -722,8 +722,11 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { MyCustomOtherType } from './my-file';`);
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
-    arg2: Scalars['String']; arg3: Scalars['Boolean']; };
+    export type MyDirectiveDirectiveArgs = {
+      arg: Scalars['Int'];
+      arg2: Scalars['String'];
+      arg3: Scalars['Boolean'];
+    };
     `);
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
@@ -802,8 +805,11 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { MyCustomOtherType } from './my-file';`);
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
-    arg2: Scalars['String']; arg3: Scalars['Boolean']; };
+    export type MyDirectiveDirectiveArgs = {
+      arg: Scalars['Int'];
+      arg2: Scalars['String'];
+      arg3: Scalars['Boolean'];
+    };
     `);
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
@@ -880,8 +886,11 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
-    arg2: Scalars['String']; arg3: Scalars['Boolean']; };
+    export type MyDirectiveDirectiveArgs = {
+      arg: Scalars['Int'];
+      arg2: Scalars['String'];
+      arg3: Scalars['Boolean'];
+    };
     `);
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -619,9 +619,11 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     const result = await plugin(schema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
-    arg2: Scalars['String'];
-    arg3: Scalars['Boolean']; };
+    export type MyDirectiveDirectiveArgs = {
+      arg: Scalars['Int'];
+      arg2: Scalars['String'];
+      arg3: Scalars['Boolean'];
+    };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -693,9 +695,11 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
-    arg2: Scalars['String'];
-    arg3: Scalars['Boolean']; };`);
+    export type MyDirectiveDirectiveArgs = {
+      arg: Scalars['Int'];
+      arg2: Scalars['String'];
+      arg3: Scalars['Boolean'];
+    };`);
 
     expect(result.content).toBeSimilarStringTo(`
     export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`);
@@ -768,9 +772,11 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
-    arg2: Scalars['String'];
-    arg3: Scalars['Boolean']; };
+    export type MyDirectiveDirectiveArgs = {
+      arg: Scalars['Int'];
+      arg2: Scalars['String'];
+      arg3: Scalars['Boolean'];
+    };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -857,9 +863,11 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.prepend).toContain(`import { MyCustomCtx } from './my-file';`);
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
-    arg2: Scalars['String'];
-    arg3: Scalars['Boolean']; };
+    export type MyDirectiveDirectiveArgs = {
+      arg: Scalars['Int'];
+      arg2: Scalars['String'];
+      arg3: Scalars['Boolean'];
+    };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -930,9 +938,11 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.prepend).toContain(`import ContextType from './my-file';`);
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
-    arg2: Scalars['String'];
-    arg3: Scalars['Boolean']; };
+    export type MyDirectiveDirectiveArgs = {
+      arg: Scalars['Int'];
+      arg2: Scalars['String'];
+      arg3: Scalars['Boolean'];
+    };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -1003,9 +1013,11 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.prepend).toContain(`import type { default as ContextType } from './my-file';`);
 
     expect(result.content).toBeSimilarStringTo(`
-    export type MyDirectiveDirectiveArgs = {   arg: Scalars['Int'];
-    arg2: Scalars['String'];
-    arg3: Scalars['Boolean']; };
+    export type MyDirectiveDirectiveArgs = {
+      arg: Scalars['Int'];
+      arg2: Scalars['String'];
+      arg3: Scalars['Boolean'];
+    };
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -2209,7 +2221,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         { outputFile: 'graphql.ts' }
       )) as Types.ComplexPluginOutput;
 
-      expect(output.content).toContain(`export type GqlAuthDirectiveArgs = {   role?: Maybe<UserRole>; };`);
+      expect(output.content).toContain(`export type GqlAuthDirectiveArgs = {\n  role?: Maybe<UserRole>;\n};`);
       expect(output.content).toContain(
         `export type GqlAuthDirectiveResolver<Result, Parent, ContextType = any, Args = GqlAuthDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`
       );


### PR DESCRIPTION
## Description

Fix indentation of DirectiveArgs

Related #6652 
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

I ran the tests and updated the snapshots accordingly.

- [X] Updated existing tests and snapshots

**Test Environment**:
- OS: MacOS
- `@graphql-codegen/...`: `master`
- NodeJS: 14

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
-
