### PR TITLE
Fix Urql imports being prefixed with operation import name

### DIFF
--- a/.changeset/mighty-tools-repair.md
+++ b/.changeset/mighty-tools-repair.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-urql': minor
+---
+
+Fix Urql import operations being prefixed into the Urql type import

--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -138,7 +138,6 @@ export function use${operationName}(options: Omit<Urql.Use${operationType}Args<$
     operationVariablesTypes: string
   ): string {
     const documentVariablePrefixed = this._externalImportPrefix + documentVariableName;
-    const operationTypePrefixed = this._externalImportPrefix + operationType;
     const operationResultTypePrefixed = this._externalImportPrefix + operationResultType;
     const operationVariablesTypesPrefixed = this._externalImportPrefix + operationVariablesTypes;
 
@@ -146,7 +145,7 @@ export function use${operationName}(options: Omit<Urql.Use${operationType}Args<$
       ? this._buildComponent(
           node,
           documentVariablePrefixed,
-          operationTypePrefixed,
+          operationType,
           operationResultTypePrefixed,
           operationVariablesTypesPrefixed
         )
@@ -154,7 +153,7 @@ export function use${operationName}(options: Omit<Urql.Use${operationType}Args<$
     const hooks = this.config.withHooks
       ? this._buildHooks(
           node,
-          operationTypePrefixed,
+          operationType,
           documentVariablePrefixed,
           operationResultTypePrefixed,
           operationVariablesTypesPrefixed

--- a/packages/plugins/typescript/urql/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql/tests/__snapshots__/urql.spec.ts.snap
@@ -17,3 +17,14 @@ export function useListenToCommentsSubscription<TData = ListenToCommentsSubscrip
   return Urql.useSubscription<ListenToCommentsSubscription, TData, ListenToCommentsSubscriptionVariables>({ query: ListenToCommentsDocument, ...options }, handler);
 };"
 `;
+
+exports[`urql Hooks should allow importing operations and documents from another file 1`] = `
+"import * as Operations from '@myproject/generated';
+import * as Urql from 'urql';
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+
+export function useTestQuery(options: Omit<Urql.UseQueryArgs<Operations.TestQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<Operations.TestQuery>({ query: Operations.TestDocument, ...options });
+};"
+`;

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -740,7 +740,13 @@ export function useSubmitRepositoryMutation() {
       expect(content.content).toContain('Operations.TestQuery');
       expect(content.content).toContain('Operations.TestQueryVariables');
 
+      expect(content.content).not.toContain('Urql.UseOperations');
+      expect(content.content).toContain('Urql.UseQueryArgs');
+      expect(content.content).toContain('Urql.useQuery');
+
       await validateTypeScript(content, schema, docs, {});
+
+      expect(mergeOutputs([content])).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
## Description

Pull request #6651 had an issue where the import operation name "Operations." would be also prefixed to the Urql type import.

Expected
```js
export function useTestQuery(options: Omit<Urql.UseQueryArgs<Operations.TestQueryVariables>, 'query'> = {}) {
  return Urql.useQuery<Operations.TestQuery>({ query: Operations.TestDocument, ...options });
};
```

Issue:
```js
export function useTestQuery(options: Omit<Urql.UseOperations.QueryArgs<Operations.TestQueryVariables>, 'query'> = {}) {
  return Urql.useOperations.Query<Operations.TestQuery>({ query: Operations.TestDocument, ...options });
};
```


Related # (issue)
#6651 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I've updated the tests to check explicitly for this case, and I've also added a snapshot test which will help prevent this in the future

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

