### PR TITLE
Add new config property that removes ResolverWithResolve from the Resolver union

### DIFF
--- a/.changeset/six-eagles-agree.md
+++ b/.changeset/six-eagles-agree.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-resolvers': minor
+---
+
+Add makeResolverTypeCallable property to config which allows a resolver function to be called

--- a/packages/plugins/typescript/resolvers/src/config.ts
+++ b/packages/plugins/typescript/resolvers/src/config.ts
@@ -136,4 +136,14 @@ export interface TypeScriptResolversPluginConfig extends RawResolversConfig {
    *
    */
   optionalInfoArgument?: boolean;
+  /**
+   * @description Set to `true` in order to allow the Resolver type to be callable
+   *
+   * @exampleMarkdown
+   * ```yml
+   *  config:
+   *    makeResolverTypeCallable: true
+   * ```
+   */
+  makeResolverTypeCallable?: boolean;
 }

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -134,16 +134,17 @@ export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
   }
 
   if (noSchemaStitching) {
-    // Resolver = ResolverFn | ResolverWithResolve (Optional);
     const defs = config.makeResolverTypeCallable
-      ? `${resolverType} ${resolverFnUsage};`
-      : `${resolverType} ${resolverFnUsage} | ${resolverWithResolveUsage};`;
+      ? // Resolver = ResolverFn
+        `${resolverType} ${resolverFnUsage};`
+      : // Resolver = ResolverFn | ResolverWithResolve
+        `${resolverType} ${resolverFnUsage} | ${resolverWithResolveUsage};`;
     defsToInclude.push(defs);
   } else {
     // StitchingResolver
     // Resolver =
     // | ResolverFn
-    // | ResolverWithResolve (Optional)
+    // | ResolverWithResolve
     // | StitchingResolver;
     defsToInclude.push(
       [

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -63,11 +63,11 @@ export type Resolver${capitalizedDirectiveName}WithResolve<TResult, TParent, TCo
         defsToInclude.push(`export type ${resolverFnName}<TResult, TParent, TContext, TArgs> = ${parsedMapper.type}`);
       }
 
-      if (!config.makeResolverTypeCallable) {
+      if (config.makeResolverTypeCallable) {
+        defsToInclude.push(`${resolverType} ${resolverFnUsage};`);
+      } else {
         defsToInclude.push(resolverWithResolve);
         defsToInclude.push(`${resolverType} ${resolverFnUsage} | ${resolverWithResolveUsage};`);
-      } else {
-        defsToInclude.push(`${resolverType} ${resolverFnUsage};`);
       }
 
       directiveResolverMappings[directiveName] = resolverTypeName;

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -191,6 +191,23 @@ export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParen
 };
       `);
     });
+
+    it('makeResolverTypeCallable - should remove ResolverWithResolve type from resolver union', async () => {
+      const result = await plugin(schema, [], { makeResolverTypeCallable: true }, { outputFile: '' });
+
+      expect(result.content).toBeSimilarStringTo(`
+      export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+      ResolverFn<TResult, TParent, TContext, TArgs>;
+    `);
+
+      expect(result.content).not.toBeSimilarStringTo(`
+      export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+      ResolverFn<TResult, TParent, TContext, TArgs>
+      | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+    `);
+
+      await validate(result);
+    });
   });
 
   it('directiveResolverMappings - should generate correct types (import definition)', async () => {

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -208,6 +208,23 @@ export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParen
 
       await validate(result);
     });
+
+    it('makeResolverTypeCallable - adds ResolverWithResolve type to resolver union when set to false', async () => {
+      const result = await plugin(schema, [], { makeResolverTypeCallable: false }, { outputFile: '' });
+
+      expect(result.content).not.toBeSimilarStringTo(`
+      export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+      ResolverFn<TResult, TParent, TContext, TArgs>;
+    `);
+
+      expect(result.content).toBeSimilarStringTo(`
+      export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+      ResolverFn<TResult, TParent, TContext, TArgs>
+      | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+    `);
+
+      await validate(result);
+    });
   });
 
   it('directiveResolverMappings - should generate correct types (import definition)', async () => {

--- a/website/static/config.schema.json
+++ b/website/static/config.schema.json
@@ -1414,6 +1414,10 @@
           "description": "Sets `info` argument of resolver function to be optional field. Useful for testing.",
           "type": "boolean"
         },
+        "makeResolverTypeCallable": {
+          "description": "Set to `true` if want to make resolveFn type callable directly. Useful for testing resolvers",
+          "type": "boolean"
+        },
         "addUnderscoreToArgsType": {
           "description": "Adds `_` to generated `Args` types in order to avoid duplicate identifiers.",
           "type": "boolean"


### PR DESCRIPTION
## Description

Adds a config property called, makeResolverTypeCallable, which removes the resolverWithResolve type from the resolver union when set to true

Related https://github.com/dotansimha/graphql-code-generator/issues/6310

## Type of change

- [x]  New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

None

## How Has This Been Tested?

- [x] Created a test that examines the output string of the plugin and checks that the ResolveFn doesn't contain the ResolverWithResolve type when the configuration property, makeResolverTypeCallable, is set to true.

**Test Environment**:
- OS: MacOS
- `@graphql-codegen/...`: 
- NodeJS: v16

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
