### PR TITLE
Fix typo in extend schema documentation

### DIFF
--- a/website/docs/custom-codegen/extend-schema.md
+++ b/website/docs/custom-codegen/extend-schema.md
@@ -20,7 +20,7 @@ module.exports = {
 };
 ```
 
-It's useful when you wish to add things like declerative `@directive` to your `GraphQLSchema`, that effects only the output of the codegen.
+It's useful when you wish to add things like declarative `@directive` to your `GraphQLSchema`, that effects only the output of the codegen.
 
 For example, let's add a custom `@directive` that tells the codegen to ignore a specific `type`:
 


### PR DESCRIPTION
## Description

There is a typo on the website https://www.graphql-code-generator.com/docs/custom-codegen/extend-schema

## Type of change

- n/a Bug fix (non-breaking change which fixes an issue)
- n/a New feature (non-breaking change which adds functionality)
- n/a Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

![Screenshot 2021-09-27 at 15 43 24](https://user-images.githubusercontent.com/2437969/134920551-9d385c7e-23ff-45e4-8d1e-329d6db641d3.jpeg)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- n/a I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- n/a My changes generate no new warnings
- n/a I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- n/a Any dependent changes have been merged and published in downstream modules

