### PR TITLE
feat(typescript-urql): generate wrappers for urql/core methods

### DIFF
--- a/packages/plugins/typescript/urql/src/config.ts
+++ b/packages/plugins/typescript/urql/src/config.ts
@@ -16,6 +16,12 @@ export interface UrqlRawPluginConfig extends RawClientSideBasePluginConfig {
    */
   withHooks?: boolean;
   /**
+   * @description You can specify that the output should include typed wrappers around
+   * urql/core for imperative querying or usage in Node.js
+   * @default false
+   */
+  withCore?: boolean;
+  /**
    * @description You can specify module that exports components `Query`, `Mutation`, `Subscription` and HOCs
    * This is useful for further abstraction of some common tasks (eg. error handling).
    * Filepath relative to generated file can be also specified.


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

This PR adds a config flag to the `typescript-urql` plugin and an extra method on the visitor class for the plugin which together allow using the plugin to generate a typesafe wrapper around the core query methods on instances of the urql client. 

This is useful because if one wishes to use urql in a node/backend context or on the client side without React or Vue, it probably makes sense to use urql/core. This PR allows doing so with some type safety.

Related Issue #6769  
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I've updated the unit tests and have also tried using the `dev-test` tooling in the repo; the resulting generated code is usable as expected and is typesafe.


## Further comments

Apologies if I should not be opening this PR until there is discussion on the issue-- I'd finished the change in a fork before reading the PR template and seeing the issue template, and I'm excited to potentially be able to use this in a project. Happy to address any and all feedback!