### PR TITLE
Allow ResolverTypeWrapper to return null or Promise<null>

### DIFF
--- a/dev-test/modules/types.ts
+++ b/dev-test/modules/types.ts
@@ -93,7 +93,7 @@ export type User = {
   paymentOptions?: Maybe<Array<PaymentOption>>;
 };
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T | null;
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;

--- a/dev-test/test-schema/flow-types.flow.js
+++ b/dev-test/test-schema/flow-types.flow.js
@@ -90,7 +90,7 @@ export type DirectiveResolverFn<Result = {}, Parent = {}, Args = {}, Context = {
   info: GraphQLResolveInfo
 ) => Result | Promise<Result>;
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T | null;
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {

--- a/dev-test/test-schema/resolvers-federation.ts
+++ b/dev-test/test-schema/resolvers-federation.ts
@@ -44,7 +44,7 @@ export type User = {
   name: Scalars['String'];
 };
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T | null;
 
 export type ReferenceResolver<TResult, TReference, TContext> = (
   reference: TReference,

--- a/dev-test/test-schema/resolvers-root.ts
+++ b/dev-test/test-schema/resolvers-root.ts
@@ -43,7 +43,7 @@ export type User = {
   name: Scalars['String'];
 };
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T | null;
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;

--- a/dev-test/test-schema/resolvers-types.ts
+++ b/dev-test/test-schema/resolvers-types.ts
@@ -40,7 +40,7 @@ export type User = {
   name: Scalars['String'];
 };
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T | null;
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;

--- a/dev-test/test-schema/typings.ts
+++ b/dev-test/test-schema/typings.ts
@@ -32,7 +32,7 @@ export type User = {
   name: Scalars['String'];
 };
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T | null;
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;

--- a/examples/programmatic-typescript/src/gql.generated.ts
+++ b/examples/programmatic-typescript/src/gql.generated.ts
@@ -18,7 +18,7 @@ export type Query = {
   hello: Scalars['String'];
 };
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T | null;
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;

--- a/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
+++ b/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
@@ -59,7 +59,7 @@ export type DirectiveResolverFn<Result = {}, Parent = {}, Args = {}, Context = {
   info: GraphQLResolveInfo
 ) => Result | Promise<Result>;
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T | null;
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {

--- a/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
@@ -262,7 +262,7 @@ describe('Flow Resolvers Plugin', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(content.content).toBeSimilarStringTo(`
-      export type ResolverTypeWrapper<T> = Promise<T> | T;
+      export type ResolverTypeWrapper<T> = Promise<T> | T | null;
     `);
   });
 });

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -270,7 +270,7 @@ export interface RawResolversConfig extends RawConfig {
    */
   enumValues?: EnumValuesMap;
   /**
-   * @default Promise<T> | T
+   * @default Promise<T> | T | null
    * @description Allow you to override `resolverTypeWrapper` definition.
    */
   resolverTypeWrapperSignature?: string;
@@ -373,7 +373,7 @@ export class BaseResolversVisitor<
       optionalResolveType: getConfigValue(rawConfig.optionalResolveType, false),
       enumPrefix: getConfigValue(rawConfig.enumPrefix, true),
       federation: getConfigValue(rawConfig.federation, false),
-      resolverTypeWrapperSignature: getConfigValue(rawConfig.resolverTypeWrapperSignature, 'Promise<T> | T'),
+      resolverTypeWrapperSignature: getConfigValue(rawConfig.resolverTypeWrapperSignature, 'Promise<T> | T | null | null'),
       enumValues: parseEnumValues({
         schema: _schema,
         mapOrStr: rawConfig.enumValues,

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -68,7 +68,7 @@ export type MyUnion = MyType | MyOtherType;
 export type WithIndex<TObject> = TObject & Record<string, any>;
 export type ResolversObject<TObject> = WithIndex<TObject>;
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T | null;
 
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
@@ -265,7 +265,7 @@ export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?:
 export type WithIndex<TObject> = TObject & Record<string, any>;
 export type ResolversObject<TObject> = WithIndex<TObject>;
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T | null;
 
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
@@ -515,7 +515,7 @@ export type MyUnion = MyType | MyOtherType;
 export type WithIndex<TObject> = TObject & Record<string, any>;
 export type ResolversObject<TObject> = WithIndex<TObject>;
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T | null;
 
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -514,7 +514,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       { outputFile: '' }
     )) as Types.ComplexPluginOutput;
 
-    expect(result.content).toContain(`export type ResolverTypeWrapper<T> = Promise<T> | T;`);
+    expect(result.content).toContain(`export type ResolverTypeWrapper<T> = Promise<T> | T | null;`);
   });
 
   it('Should not warn when noSchemaStitching is not defined', async () => {
@@ -1801,7 +1801,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     )) as Types.ComplexPluginOutput;
 
     expect(content.content).toBeSimilarStringTo(`
-      export type ResolverTypeWrapper<T> = Promise<T> | T;
+      export type ResolverTypeWrapper<T> = Promise<T> | T | null;
     `);
   });
 

--- a/website/static/config.schema.json
+++ b/website/static/config.schema.json
@@ -1497,7 +1497,7 @@
           "description": "Overrides the default value of enum values declared in your GraphQL schema, supported\nin this plugin because of the need for integration with `typescript` package.\nSee documentation under `typescript` plugin for more information and examples."
         },
         "resolverTypeWrapperSignature": {
-          "description": "Allow you to override `resolverTypeWrapper` definition.\nDefault value: \"Promise<T> | T\"",
+          "description": "Allow you to override `resolverTypeWrapper` definition.\nDefault value: \"Promise<T> | T | null\"",
           "type": "string"
         },
         "federation": {
@@ -3106,7 +3106,7 @@
           "description": "Overrides the default value of enum values declared in your GraphQL schema, supported\nin this plugin because of the need for integration with `typescript` package.\nSee documentation under `typescript` plugin for more information and examples."
         },
         "resolverTypeWrapperSignature": {
-          "description": "Allow you to override `resolverTypeWrapper` definition.\nDefault value: \"Promise<T> | T\"",
+          "description": "Allow you to override `resolverTypeWrapper` definition.\nDefault value: \"Promise<T> | T | null\"",
           "type": "string"
         },
         "federation": {


### PR DESCRIPTION
In the linked blog post for the typescript-resolvers plugin
there is a TS error (TS2322) because the users query could
find no matching user and therefore return undefined:

```
src/resolvers.ts:16:5 - error TS2322: Type '(parent: {}, args: RequireFields<QueryUserArgs, "id">) => { id: string; email: string; profile: { age: number; name: string; }; } | undefined' is not assignable to type 'Resolver<ResolverTypeWrapper<User>, {}, any, RequireFields<QueryUserArgs, "id">> | undefined'.
  Type '(parent: {}, args: RequireFields<QueryUserArgs, "id">) => { id: string; email: string; profile: { age: number; name: string; }; } | undefined' is not assignable to type 'ResolverFn<ResolverTypeWrapper<User>, {}, any, RequireFields<QueryUserArgs, "id">>'.
    Type '{ id: string; email: string; profile: { age: number; name: string; }; } | undefined' is not assignable to type 'ResolverTypeWrapper<User> | Promise<ResolverTypeWrapper<User>>'.
      Type 'undefined' is not assignable to type 'ResolverTypeWrapper<User> | Promise<ResolverTypeWrapper<User>>'.

16     user: (parent, args) => {
       ~~~~

Found 1 error.
```

I think there is a legitimate case where this would fail
and we'd want to return null or potentially Promise<null>
with `Promise<T | null> | T | null`.

Blog post is here: https://the-guild.dev/blog/better-type-safety-for-resolvers-with-graphql-codegen