### PR TITLE
Change ObjectID import to ObjectId

### DIFF
--- a/.changeset/real-pugs-leave.md
+++ b/.changeset/real-pugs-leave.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-mongodb': minor
+---
+
+Change ObjectID import to ObjectId since mongodb has deprecated ObjectID

--- a/packages/plugins/typescript/mongodb/src/visitor.ts
+++ b/packages/plugins/typescript/mongodb/src/visitor.ts
@@ -38,7 +38,7 @@ type Directivable = { directives?: ReadonlyArray<DirectiveNode> };
 
 function resolveObjectId(pointer: string | null | undefined): { identifier: string; module: string } {
   if (!pointer) {
-    return { identifier: 'ObjectID', module: 'mongodb' };
+    return { identifier: 'ObjectId', module: 'mongodb' };
   }
 
   if (pointer.includes('#')) {

--- a/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
+++ b/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
@@ -125,10 +125,10 @@ describe('TypeScript Mongo', () => {
     });
 
     it('Should allow to customize objectIdType import with custom import', async () => {
-      const result = await plugin(schema, [], { objectIdType: 'ObjectId#bson' }, { outputFile: '' });
-      expect(result).toContain(`_id: ObjectId`);
-      expect(result).not.toContain(`ObjectID`);
-      expect(result).toContain(`import { ObjectId } from 'bson';`);
+      const result = await plugin(schema, [], { objectIdType: 'ObjectID#bson' }, { outputFile: '' });
+      expect(result).toContain(`_id: ObjectID`);
+      expect(result).not.toContain(`ObjectId`);
+      expect(result).toContain(`import { ObjectID } from 'bson';`);
       await validate(result, schema, {});
     });
 

--- a/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
+++ b/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
@@ -127,7 +127,7 @@ describe('TypeScript Mongo', () => {
     it('Should allow to customize objectIdType import with custom import', async () => {
       const result = await plugin(schema, [], { objectIdType: 'ObjectId#bson' }, { outputFile: '' });
       expect(result).toContain(`_id: ObjectId`);
-      expect(result).not.toContain(`ObjectId`);
+      expect(result).not.toContain(`ObjectID`);
       expect(result).toContain(`import { ObjectId } from 'bson';`);
       await validate(result, schema, {});
     });

--- a/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
+++ b/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
@@ -120,21 +120,21 @@ describe('TypeScript Mongo', () => {
     it('Should allow to customize objectIdType import with basic type', async () => {
       const result = await plugin(schema, [], { objectIdType: 'string' }, { outputFile: '' });
       expect(result).toContain(`_id: string`);
-      expect(result).not.toContain(`ObjectID`);
+      expect(result).not.toContain(`ObjectId`);
       await validate(result, schema, {});
     });
 
     it('Should allow to customize objectIdType import with custom import', async () => {
       const result = await plugin(schema, [], { objectIdType: 'ObjectId#bson' }, { outputFile: '' });
       expect(result).toContain(`_id: ObjectId`);
-      expect(result).not.toContain(`ObjectID`);
+      expect(result).not.toContain(`ObjectId`);
       expect(result).toContain(`import { ObjectId } from 'bson';`);
       await validate(result, schema, {});
     });
 
     it('Should allow to customize idFieldName', async () => {
       const result = await plugin(schema, [], { idFieldName: 'id' }, { outputFile: '' });
-      expect(result).toContain(`id: ObjectID`);
+      expect(result).toContain(`id: ObjectId`);
       expect(result).not.toContain(`_id`);
       await validate(result, schema, {});
     });
@@ -195,7 +195,7 @@ describe('TypeScript Mongo', () => {
 
     it('Should output the correct values for @id directive', async () => {
       const result = await plugin(schema, [], {}, { outputFile: '' });
-      expect(result).toContain('_id?: Maybe<ObjectID>'); // optional id
+      expect(result).toContain('_id?: Maybe<ObjectId>'); // optional id
       await validate(result, schema, {});
     });
 
@@ -226,7 +226,7 @@ describe('TypeScript Mongo', () => {
 
       expect(result).toBeSimilarStringTo(`
       export type TestDbObject = {
-        _id: ObjectID,
+        _id: ObjectId,
         foo: string,
       };
 

--- a/website/docs-templates/typescript-mongodb.md
+++ b/website/docs-templates/typescript-mongodb.md
@@ -19,10 +19,10 @@ type User @entity {
 We can have the following TypeScript output:
 
 ```ts
-import { ObjectID } from 'mongodb'
+import { ObjectId } from 'mongodb'
 
 export interface UserDbObject {
-  _id: ObjectID
+  _id: ObjectId
   username: string
   email?: string | null
 }
@@ -102,7 +102,7 @@ Use this directive on the filed that should be mapped to a MongoDB `_id`. By def
 
 #### `@link` (on `FIELD_DEFINITION`)
 
-Use this directive to declare that a specific field is a link to another type in another table. This will use the `ObjectID` type in the generated result.
+Use this directive to declare that a specific field is a link to another type in another table. This will use the `ObjectId` type in the generated result.
 
 #### `@embedded` (on `FIELD_DEFINITION`)
 
@@ -157,7 +157,7 @@ This way, you will get:
 ```typescript
 export interface BaseNotificationDbInterface {
   notificationType: string
-  _id: ObjectID
+  _id: ObjectId
   createdAt: Date
 }
 
@@ -222,14 +222,14 @@ type Profile @entity(embedded: true) {
 The generated MongoDB models should look like so:
 
 ```ts
-import { ObjectID } from 'mongodb'
+import { ObjectId } from 'mongodb'
 
 export interface UserDbObject {
-  _id: ObjectID
+  _id: ObjectId
   username: string
   email: string
   profile: ProfileDbObject
-  friends: ObjectID[]
+  friends: ObjectId[]
 }
 
 export interface ProfileDbObject {


### PR DESCRIPTION
* Change ObjectID import to ObjectId, due to ObjectID is deprecated
  in mongodb v4.1

## Description
Changes ObjectID import from mongodb to ObjectId instead.

Related #6830

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] `npm run test`
- [ ] run `graphql-codegen` in project with mongodb and @graphql-codegen/typescript-mongodb for e.g. mongodb 3.6 there are no lint warnings but for 4.1.3 lint complains about ObjectID being deprecated

**Test Environment**:
- OS: linux
- `@graphql-codegen/typescript-mongodb`: 2.1.4
- NodeJS: 14.17.4
- mongodb: 4.1.3