### PR TITLE
Adding 'rawRequest' config option to typescript-generic-sdk

### DIFF
--- a/.changeset/wicked-bees-rest.md
+++ b/.changeset/wicked-bees-rest.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-generic-sdk': major
+---
+
+Added config option `rawRequest` to typescript-generic-sdk which allows return to include both `data` and `errors` on the top level

--- a/packages/plugins/typescript/generic-sdk/src/config.ts
+++ b/packages/plugins/typescript/generic-sdk/src/config.ts
@@ -10,4 +10,22 @@ export interface RawGenericSdkPluginConfig extends RawClientSideBasePluginConfig
    * usingObservableFrom: "import { Observable } from 'rxjs';"
    */
   usingObservableFrom?: string;
+
+  /**
+   * @description By default the `request` method return the `data` or `errors` key from the response. If you need to access the `extensions` key you can use the `rawRequest` method.
+   * @default false
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *    - typescript-generic-sdk
+   *  config:
+   *    rawRequest: true
+   * ```
+   */
+  rawRequest?: boolean;
 }

--- a/packages/plugins/typescript/generic-sdk/src/visitor.ts
+++ b/packages/plugins/typescript/generic-sdk/src/visitor.ts
@@ -73,7 +73,7 @@ export class GenericSdkVisitor extends ClientSideBaseVisitor<RawGenericSdkPlugin
           o.node.variableDefinitions.every(v => v.type.kind !== Kind.NON_NULL_TYPE || v.defaultValue);
         const returnType = usingObservable && o.operationType === 'Subscription' ? 'Observable' : 'Promise';
         const resultData = this.config.rawRequest
-          ? `{ data: ${o.operationResultType}, errors: any }`
+          ? `{ data?: ${o.operationResultType}, errors?: Array<{ message: string; extensions?: unknown }>, extensions?: unknown }`
           : o.operationResultType;
         return `${o.node.name.value}(variables${optionalVariables ? '?' : ''}: ${
           o.operationVariablesTypes

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -756,3 +756,276 @@ async function test() {
   }
 }"
 `;
+
+exports[`generic-sdk sdk Should support rawRequest 1`] = `
+"export type Maybe<T> = T | null;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  /** A feed of repository submissions */
+  feed?: Maybe<Array<Maybe<Entry>>>;
+  /** A single entry */
+  entry?: Maybe<Entry>;
+  /** Return the currently logged in user, or null if nobody is logged in */
+  currentUser?: Maybe<User>;
+};
+
+
+export type QueryFeedArgs = {
+  type: FeedType;
+  offset?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryEntryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  /** Sort by a combination of freshness and score, using Reddit's algorithm */
+  Hot = 'HOT',
+  /** Newest entries first */
+  New = 'NEW',
+  /** Highest score entries first */
+  Top = 'TOP'
+}
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type Entry = {
+  __typename?: 'Entry';
+  /** Information about the repository from GitHub */
+  repository: Repository;
+  /** The GitHub user who submitted this entry */
+  postedBy: User;
+  /** A timestamp of when the entry was submitted */
+  createdAt: Scalars['Float'];
+  /** The score of this repository, upvotes - downvotes */
+  score: Scalars['Int'];
+  /** The hot score of this repository */
+  hotScore: Scalars['Float'];
+  /** Comments posted about this repository */
+  comments: Array<Maybe<Comment>>;
+  /** The number of comments posted about this repository */
+  commentCount: Scalars['Int'];
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** XXX to be changed */
+  vote: Vote;
+};
+
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type EntryCommentsArgs = {
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+/**
+ * A repository object from the GitHub API. This uses the exact field names returned by the
+ * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
+ */
+export type Repository = {
+  __typename?: 'Repository';
+  /** Just the name of the repository, e.g. GitHunt-API */
+  name: Scalars['String'];
+  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
+  full_name: Scalars['String'];
+  /** The description of the repository */
+  description?: Maybe<Scalars['String']>;
+  /** The link to the repository on GitHub */
+  html_url: Scalars['String'];
+  /** The number of people who have starred this repository on GitHub */
+  stargazers_count: Scalars['Int'];
+  /** The number of open issues on this repository on GitHub */
+  open_issues_count?: Maybe<Scalars['Int']>;
+  /** The owner of this repository on GitHub, e.g. apollostack */
+  owner?: Maybe<User>;
+};
+
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export type User = {
+  __typename?: 'User';
+  /** The name of the user, e.g. apollostack */
+  login: Scalars['String'];
+  /** The URL to a directly embeddable image for this user's avatar */
+  avatar_url: Scalars['String'];
+  /** The URL of this user's GitHub page */
+  html_url: Scalars['String'];
+};
+
+/** A comment about an entry, submitted by a user */
+export type Comment = {
+  __typename?: 'Comment';
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** The GitHub user who posted the comment */
+  postedBy: User;
+  /** A timestamp of when the comment was posted */
+  createdAt: Scalars['Float'];
+  /** The text of the comment */
+  content: Scalars['String'];
+  /** The repository which this comment is about */
+  repoName: Scalars['String'];
+};
+
+/** XXX to be removed */
+export type Vote = {
+  __typename?: 'Vote';
+  vote_value: Scalars['Int'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** Submit a new repository, returns the new submission */
+  submitRepository?: Maybe<Entry>;
+  /** Vote on a repository submission, returns the submission that was voted on */
+  vote?: Maybe<Entry>;
+  /** Comment on a repository, returns the new comment */
+  submitComment?: Maybe<Comment>;
+};
+
+
+export type MutationSubmitRepositoryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+
+export type MutationVoteArgs = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+
+export type MutationSubmitCommentArgs = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  Up = 'UP',
+  Down = 'DOWN',
+  Cancel = 'CANCEL'
+}
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** Subscription fires on every comment added */
+  commentAdded?: Maybe<Comment>;
+};
+
+
+export type SubscriptionCommentAddedArgs = {
+  repoFullName: Scalars['String'];
+};
+export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null | undefined } } | null | undefined> | null | undefined };
+
+export type Feed2QueryVariables = Exact<{
+  v: Scalars['String'];
+}>;
+
+
+export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null | undefined> | null | undefined };
+
+export type Feed3QueryVariables = Exact<{
+  v?: Maybe<Scalars['String']>;
+}>;
+
+
+export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null | undefined> | null | undefined };
+
+export type Feed4QueryVariables = Exact<{
+  v?: Scalars['String'];
+}>;
+
+
+export type Feed4Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null | undefined> | null | undefined };
+
+export const FeedDocument = gql\`
+    query feed {
+  feed {
+    id
+    commentCount
+    repository {
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+export const Feed2Document = gql\`
+    query feed2($v: String!) {
+  feed {
+    id
+  }
+}
+    \`;
+export const Feed3Document = gql\`
+    query feed3($v: String) {
+  feed {
+    id
+  }
+}
+    \`;
+export const Feed4Document = gql\`
+    query feed4($v: String! = \\"TEST\\") {
+  feed {
+    id
+  }
+}
+    \`;
+export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
+export function getSdk<C>(requester: Requester<C>) {
+  return {
+    feed(variables?: FeedQueryVariables, options?: C): Promise<{ data?: FeedQuery, errors?: Array<{ message: string; extensions?: unknown }>, extensions?: unknown }> {
+      return requester<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options);
+    },
+    feed2(variables: Feed2QueryVariables, options?: C): Promise<{ data?: Feed2Query, errors?: Array<{ message: string; extensions?: unknown }>, extensions?: unknown }> {
+      return requester<Feed2Query, Feed2QueryVariables>(Feed2Document, variables, options);
+    },
+    feed3(variables?: Feed3QueryVariables, options?: C): Promise<{ data?: Feed3Query, errors?: Array<{ message: string; extensions?: unknown }>, extensions?: unknown }> {
+      return requester<Feed3Query, Feed3QueryVariables>(Feed3Document, variables, options);
+    },
+    feed4(variables?: Feed4QueryVariables, options?: C): Promise<{ data?: Feed4Query, errors?: Array<{ message: string; extensions?: unknown }>, extensions?: unknown }> {
+      return requester<Feed4Query, Feed4QueryVariables>(Feed4Document, variables, options);
+    }
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;
+        async function rawRequestTest() {
+          const requester = <R, V> (doc: string, vars: V): Promise<R> => Promise.resolve({} as unknown as R);
+          const sdk = getSdk(requester);
+
+          await sdk.feed();
+          await sdk.feed3();
+          await sdk.feed4();
+
+          const result = await sdk.feed2({ v: \\"1\\" });
+
+          if (result.data.feed) {
+            if (result.data.feed[0]) {
+              const id = result.data.feed[0].id
+            }
+          }
+        }
+      "
+`;

--- a/packages/plugins/typescript/generic-sdk/tests/generic-sdk.spec.ts
+++ b/packages/plugins/typescript/generic-sdk/tests/generic-sdk.spec.ts
@@ -143,6 +143,36 @@ async function test() {
       expect(output).toMatchSnapshot();
     });
 
+    it('Should support rawRequest', async () => {
+      const config = { rawRequest: true };
+      const docs = [{ filePath: '', document: basicDoc }];
+      const result = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      const usage = `
+        async function rawRequestTest() {
+          const requester = <R, V> (doc: string, vars: V): Promise<R> => Promise.resolve({} as unknown as R);
+          const sdk = getSdk(requester);
+
+          await sdk.feed();
+          await sdk.feed3();
+          await sdk.feed4();
+
+          const result = await sdk.feed2({ v: "1" });
+
+          if (result.data.feed) {
+            if (result.data.feed[0]) {
+              const id = result.data.feed[0].id
+            }
+          }
+        }
+      `;
+      const output = await validate(result, config, docs, schema, usage);
+
+      expect(output).toMatchSnapshot();
+    });
+
     it('Should generate a correct wrap method when usingObservableFrom is set', async () => {
       const config = { usingObservableFrom: "import Observable from 'zen-observable';" };
       const docs = [{ filePath: '', document: docWithSubscription }];


### PR DESCRIPTION
## Description

Adding a `rawRequest: boolean` config option to the typescript-generic-sdk. This allows the requestor to return `data` and `errors` on the top level.

Related # (issue)
https://github.com/dotansimha/graphql-code-generator/issues/6854

## Type of change

- [ x ] New feature (non-breaking change which adds functionality)

## Checklist:

- [ x ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] Any dependent changes have been merged and published in downstream modules

