### PR TITLE
feat(react-query): Adding 'exposeMutationKeys' config option to react…

### DIFF
--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -534,6 +534,7 @@ export const useSubmitRepositoryMutation = <TError = unknown, TContext = unknown
   options?: UseMutationOptions<SubmitRepositoryMutation, TError, SubmitRepositoryMutationVariables, TContext>
 ) =>
   useMutation<SubmitRepositoryMutation, TError, SubmitRepositoryMutationVariables, TContext>(
+    'submitRepository',
     (variables?: SubmitRepositoryMutationVariables) =>
       fetcher<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(
         dataSource.endpoint,
@@ -555,6 +556,7 @@ export const useSubmitCommentMutation = <TError = unknown, TContext = unknown>(
   options?: UseMutationOptions<SubmitCommentMutation, TError, SubmitCommentMutationVariables, TContext>
 ) =>
   useMutation<SubmitCommentMutation, TError, SubmitCommentMutationVariables, TContext>(
+    'submitComment',
     (variables?: SubmitCommentMutationVariables) =>
       fetcher<SubmitCommentMutation, SubmitCommentMutationVariables>(
         dataSource.endpoint,
@@ -580,6 +582,7 @@ export const useVoteMutation = <TError = unknown, TContext = unknown>(
   options?: UseMutationOptions<VoteMutation, TError, VoteMutationVariables, TContext>
 ) =>
   useMutation<VoteMutation, TError, VoteMutationVariables, TContext>(
+    'vote',
     (variables?: VoteMutationVariables) =>
       fetcher<VoteMutation, VoteMutationVariables>(
         dataSource.endpoint,

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -57,18 +57,18 @@ export interface ReactQueryRawPluginConfig
    */
   exposeQueryKeys?: boolean;
 
-   /**
+  /**
    * @default false
-   * @description For each generate mutation hook adds getKey(variables: QueryVariables) function. Useful for call outside of functional component.
+   * @description For each generate mutation hook adds getKey() function. Useful for call outside of functional component.
    * @exampleMarkdown
    * ```ts
    *  const mutation = useUserDetailsMutation(...);
-   *  const key = useUserDetailsMutation.getKey({id: theUsersId});
+   *  const key = useUserDetailsMutation.getKey();
    * ```
    */
-     exposeMutationKeys?: boolean;
+  exposeMutationKeys?: boolean;
 
- /**
+  /**
    * @default false
    * @description For each generate query hook adds `fetcher` field with a corresponding GraphQL query using the fetcher.
    * It is useful for `queryClient.fetchQuery` and `queryClient.prefetchQuery`.

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -57,7 +57,18 @@ export interface ReactQueryRawPluginConfig
    */
   exposeQueryKeys?: boolean;
 
-  /**
+   /**
+   * @default false
+   * @description For each generate mutation hook adds getKey(variables: QueryVariables) function. Useful for call outside of functional component.
+   * @exampleMarkdown
+   * ```ts
+   *  const mutation = useUserDetailsMutation(...);
+   *  const key = useUserDetailsMutation.getKey({id: theUsersId});
+   * ```
+   */
+     exposeMutationKeys?: boolean;
+
+ /**
    * @default false
    * @description For each generate query hook adds `fetcher` field with a corresponding GraphQL query using the fetcher.
    * It is useful for `queryClient.fetchQuery` and `queryClient.prefetchQuery`.

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -3,7 +3,7 @@ import { ReactQueryVisitor } from './visitor';
 import { FetcherRenderer } from './fetcher';
 import { parseMapper, ParsedMapper, buildMapperImport } from '@graphql-codegen/visitor-plugin-common';
 import { CustomFetch } from './config';
-import { generateQueryKey } from './variables-generator';
+import { generateKey } from './variables-generator';
 
 export class CustomMapperFetcher implements FetcherRenderer {
   private _mapper: ParsedMapper;
@@ -62,11 +62,11 @@ export class CustomMapperFetcher implements FetcherRenderer {
       TData = ${operationResultType},
       TError = ${this.visitor.config.errorType}
     >(
-      ${variables}, 
+      ${variables},
       ${options}
-    ) => 
+    ) =>
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateQueryKey(node, hasRequiredVariables)},
+      ${generateKey(node, hasRequiredVariables)},
       ${impl},
       options
     );`;
@@ -77,7 +77,8 @@ export class CustomMapperFetcher implements FetcherRenderer {
     documentVariableName: string,
     operationName: string,
     operationResultType: string,
-    operationVariablesTypes: string
+    operationVariablesTypes: string,
+    hasRequiredVariables: boolean
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
     const hookConfig = this.visitor.queryMethodMap;
@@ -93,8 +94,9 @@ export class CustomMapperFetcher implements FetcherRenderer {
     return `export const use${operationName} = <
       TError = ${this.visitor.config.errorType},
       TContext = unknown
-    >(${options}) => 
+    >(${options}) =>
     ${hookConfig.mutation.hook}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
+      ${generateKey(node, hasRequiredVariables)},
       ${impl},
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -3,7 +3,7 @@ import { ReactQueryVisitor } from './visitor';
 import { FetcherRenderer } from './fetcher';
 import { parseMapper, ParsedMapper, buildMapperImport } from '@graphql-codegen/visitor-plugin-common';
 import { CustomFetch } from './config';
-import { generateKey } from './variables-generator';
+import { generateMutationKey, generateQueryKey } from './variables-generator';
 
 export class CustomMapperFetcher implements FetcherRenderer {
   private _mapper: ParsedMapper;
@@ -66,7 +66,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
       ${options}
     ) =>
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateKey(node, hasRequiredVariables)},
+      ${generateQueryKey(node, hasRequiredVariables)},
       ${impl},
       options
     );`;
@@ -96,7 +96,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
       TContext = unknown
     >(${options}) =>
     ${hookConfig.mutation.hook}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
-      ${generateKey(node, hasRequiredVariables)},
+      ${generateMutationKey(node)},
       ${impl},
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -2,7 +2,7 @@ import { OperationDefinitionNode } from 'graphql';
 import { ReactQueryVisitor } from './visitor';
 import { FetcherRenderer } from './fetcher';
 import { HardcodedFetch } from './config';
-import { generateQueryKey, generateQueryVariablesSignature } from './variables-generator';
+import { generateKey, generateVariablesSignature } from './variables-generator';
 
 export class HardcodedFetchFetcher implements FetcherRenderer {
   constructor(private visitor: ReactQueryVisitor, private config: HardcodedFetch) {}
@@ -57,7 +57,7 @@ ${this.getFetchParams()}
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+    const variables = generateVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
@@ -72,7 +72,7 @@ ${this.getFetchParams()}
       ${options}
     ) =>
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateQueryKey(node, hasRequiredVariables)},
+      ${generateKey(node, hasRequiredVariables)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
       options
     );`;
@@ -83,7 +83,8 @@ ${this.getFetchParams()}
     documentVariableName: string,
     operationName: string,
     operationResultType: string,
-    operationVariablesTypes: string
+    operationVariablesTypes: string,
+    hasRequiredVariables: boolean
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
     const hookConfig = this.visitor.queryMethodMap;
@@ -97,6 +98,7 @@ ${this.getFetchParams()}
       TContext = unknown
     >(${options}) =>
     ${hookConfig.mutation.hook}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
+      ${generateKey(node, hasRequiredVariables)},
       (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables)(),
       options
     );`;
@@ -110,7 +112,7 @@ ${this.getFetchParams()}
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+    const variables = generateVariablesSignature(hasRequiredVariables, operationVariablesTypes);
 
     return `\nuse${operationName}.fetcher = (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables);`;
   }

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -2,7 +2,7 @@ import { OperationDefinitionNode } from 'graphql';
 import { ReactQueryVisitor } from './visitor';
 import { FetcherRenderer } from './fetcher';
 import { HardcodedFetch } from './config';
-import { generateKey, generateVariablesSignature } from './variables-generator';
+import { generateMutationKey, generateQueryKey, generateQueryVariablesSignature } from './variables-generator';
 
 export class HardcodedFetchFetcher implements FetcherRenderer {
   constructor(private visitor: ReactQueryVisitor, private config: HardcodedFetch) {}
@@ -57,7 +57,7 @@ ${this.getFetchParams()}
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = generateVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
@@ -72,7 +72,7 @@ ${this.getFetchParams()}
       ${options}
     ) =>
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateKey(node, hasRequiredVariables)},
+      ${generateQueryKey(node, hasRequiredVariables)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
       options
     );`;
@@ -98,7 +98,7 @@ ${this.getFetchParams()}
       TContext = unknown
     >(${options}) =>
     ${hookConfig.mutation.hook}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
-      ${generateKey(node, hasRequiredVariables)},
+      ${generateMutationKey(node)},
       (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables)(),
       options
     );`;
@@ -112,7 +112,7 @@ ${this.getFetchParams()}
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = generateVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
 
     return `\nuse${operationName}.fetcher = (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables);`;
   }

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -1,7 +1,7 @@
 import { OperationDefinitionNode } from 'graphql';
 import { ReactQueryVisitor } from './visitor';
 import { FetcherRenderer } from './fetcher';
-import { generateKey, generateVariablesSignature } from './variables-generator';
+import { generateQueryKey, generateMutationKey, generateQueryVariablesSignature } from './variables-generator';
 
 export class FetchFetcher implements FetcherRenderer {
   constructor(private visitor: ReactQueryVisitor) {}
@@ -37,7 +37,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = generateVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
@@ -53,7 +53,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
       ${options}
     ) =>
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateKey(node, hasRequiredVariables)},
+      ${generateQueryKey(node, hasRequiredVariables)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables),
       options
     );`;
@@ -82,7 +82,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
       ${options}
     ) =>
     ${hookConfig.mutation.hook}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
-      ${generateKey(node, hasRequiredVariables)},
+      ${generateMutationKey(node)},
       (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables)(),
       options
     );`;
@@ -96,7 +96,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = generateVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
 
     return `\nuse${operationName}.fetcher = (dataSource: { endpoint: string, fetchParams?: RequestInit }, ${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables);`;
   }

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -1,7 +1,7 @@
 import { OperationDefinitionNode } from 'graphql';
 import { ReactQueryVisitor } from './visitor';
 import { FetcherRenderer } from './fetcher';
-import { generateKey, generateVariablesSignature } from './variables-generator';
+import { generateMutationKey, generateQueryKey, generateQueryVariablesSignature } from './variables-generator';
 
 export class GraphQLRequestClientFetcher implements FetcherRenderer {
   constructor(private visitor: ReactQueryVisitor) {}
@@ -21,7 +21,7 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = generateVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
 
     const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
     this.visitor.imports.add(`${typeImport} { GraphQLClient } from 'graphql-request';`);
@@ -43,7 +43,7 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
       headers?: RequestInit['headers']
     ) =>
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateKey(node, hasRequiredVariables)},
+      ${generateQueryKey(node, hasRequiredVariables)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables, headers),
       options
     );`;
@@ -75,7 +75,7 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
       headers?: RequestInit['headers']
     ) =>
     ${hookConfig.mutation.hook}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>(
-      ${generateKey(node, hasRequiredVariables)},
+      ${generateMutationKey(node)},
       (${variables}) => fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables, headers)(),
       options
     );`;
@@ -89,7 +89,7 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = generateVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
 
     return `\nuse${operationName}.fetcher = (client: GraphQLClient, ${variables}, headers?: RequestInit['headers']) => fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables, headers);`;
   }

--- a/packages/plugins/typescript/react-query/src/fetcher.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher.ts
@@ -15,7 +15,8 @@ export interface FetcherRenderer {
     documentVariableName: string,
     operationName: string,
     operationResultType: string,
-    operationVariablesTypes: string
+    operationVariablesTypes: string,
+    hasRequiredVariables: boolean
   ) => string;
   generateFetcherFetch: (
     node: OperationDefinitionNode,

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -1,23 +1,20 @@
 import { OperationDefinitionNode } from 'graphql';
 
-export function generateQueryVariablesSignature(
-  hasRequiredVariables: boolean,
-  operationVariablesTypes: string
-): string {
+export function generateVariablesSignature(hasRequiredVariables: boolean, operationVariablesTypes: string): string {
   return `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
 }
 
-export function generateQueryKey(node: OperationDefinitionNode, hasRequiredVariables: boolean): string {
+export function generateKey(node: OperationDefinitionNode, hasRequiredVariables: boolean): string {
   if (hasRequiredVariables) return `['${node.name.value}', variables]`;
   return `variables === undefined ? ['${node.name.value}'] : ['${node.name.value}', variables]`;
 }
 
-export function generateQueryKeyMaker(
+export function generateKeyMaker(
   node: OperationDefinitionNode,
   operationName: string,
   operationVariablesTypes: string,
   hasRequiredVariables: boolean
 ) {
-  const signature = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
-  return `\nuse${operationName}.getKey = (${signature}) => ${generateQueryKey(node, hasRequiredVariables)};\n`;
+  const signature = generateVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+  return `\nuse${operationName}.getKey = (${signature}) => ${generateKey(node, hasRequiredVariables)};\n`;
 }

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -1,20 +1,31 @@
 import { OperationDefinitionNode } from 'graphql';
 
-export function generateVariablesSignature(hasRequiredVariables: boolean, operationVariablesTypes: string): string {
+export function generateQueryVariablesSignature(
+  hasRequiredVariables: boolean,
+  operationVariablesTypes: string
+): string {
   return `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
 }
 
-export function generateKey(node: OperationDefinitionNode, hasRequiredVariables: boolean): string {
+export function generateQueryKey(node: OperationDefinitionNode, hasRequiredVariables: boolean): string {
   if (hasRequiredVariables) return `['${node.name.value}', variables]`;
   return `variables === undefined ? ['${node.name.value}'] : ['${node.name.value}', variables]`;
 }
 
-export function generateKeyMaker(
+export function generateQueryKeyMaker(
   node: OperationDefinitionNode,
   operationName: string,
   operationVariablesTypes: string,
   hasRequiredVariables: boolean
 ) {
-  const signature = generateVariablesSignature(hasRequiredVariables, operationVariablesTypes);
-  return `\nuse${operationName}.getKey = (${signature}) => ${generateKey(node, hasRequiredVariables)};\n`;
+  const signature = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+  return `\nuse${operationName}.getKey = (${signature}) => ${generateQueryKey(node, hasRequiredVariables)};\n`;
+}
+
+export function generateMutationKey(node: OperationDefinitionNode): string {
+  return `'${node.name.value}'`;
+}
+
+export function generateMutationKeyMaker(node: OperationDefinitionNode, operationName: string) {
+  return `\nuse${operationName}.getKey = () => ${generateMutationKey(node)}};\n`;
 }

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -15,7 +15,7 @@ import { HardcodedFetchFetcher } from './fetcher-fetch-hardcoded';
 import { GraphQLRequestClientFetcher } from './fetcher-graphql-request';
 import { CustomMapperFetcher } from './fetcher-custom-mapper';
 import { pascalCase } from 'change-case-all';
-import { generateKeyMaker } from './variables-generator';
+import { generateQueryKeyMaker, generateMutationKeyMaker } from './variables-generator';
 
 export interface ReactQueryPluginConfig extends ClientSideBasePluginConfig {
   errorType: string;
@@ -152,7 +152,7 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
         query += `\nuse${operationName}.document = ${documentVariableName};\n`;
       }
       if (this.config.exposeQueryKeys) {
-        query += generateKeyMaker(node, operationName, operationVariablesTypes, hasRequiredVariables);
+        query += generateQueryKeyMaker(node, operationName, operationVariablesTypes, hasRequiredVariables);
       }
 
       // The reason we're looking at the private field of the CustomMapperFetcher to see if it's a react hook
@@ -179,7 +179,7 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
         hasRequiredVariables
       );
       if (this.config.exposeMutationKeys) {
-        query += generateKeyMaker(node, operationName, operationVariablesTypes, hasRequiredVariables);
+        query += generateMutationKeyMaker(node, operationName);
       }
       if (this.config.exposeFetcher && !(this.fetcher as any)._isReactHook) {
         query += this.fetcher.generateFetcherFetch(

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -41,7 +41,7 @@ export const useTestMutation = <
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-      variables === undefined ? ['test'] : ['test', variables],
+      'test',
       useCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument),
       options
     );"
@@ -88,7 +88,7 @@ export const useTestMutation = <
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-      variables === undefined ? ['test'] : ['test', variables],
+      'test',
       (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"
@@ -135,7 +135,7 @@ export const useTestMutation = <
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-      variables === undefined ? ['test'] : ['test', variables],
+      'test',
       (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"
@@ -186,7 +186,7 @@ export const useTestMutation = <
       options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
     ) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-      variables === undefined ? ['test'] : ['test', variables],
+      'test',
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
       options
     );"
@@ -239,7 +239,7 @@ export const useTestMutation = <
       headers?: RequestInit['headers']
     ) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-      variables === undefined ? ['test'] : ['test', variables],
+      'test',
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables, headers)(),
       options
     );"
@@ -286,7 +286,7 @@ export const useTestMutation = <
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-      variables === undefined ? ['test'] : ['test', variables],
+      'test',
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"
@@ -333,7 +333,7 @@ export const useTestMutation = <
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-      variables === undefined ? ['test'] : ['test', variables],
+      'test',
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"
@@ -380,7 +380,7 @@ export const useTestMutation = <
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-      variables === undefined ? ['test'] : ['test', variables],
+      'test',
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"
@@ -427,7 +427,7 @@ export const useTestMutation = <
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-      variables === undefined ? ['test'] : ['test', variables],
+      'test',
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -21,9 +21,9 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      variables?: TTestQueryVariables, 
+      variables?: TTestQueryVariables,
       options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) => 
+    ) =>
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
@@ -39,8 +39,9 @@ export const TestDocument = \`
 export const useTestMutation = <
       TError = unknown,
       TContext = unknown
-    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      variables === undefined ? ['test'] : ['test', variables],
       useCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument),
       options
     );"
@@ -67,9 +68,9 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      variables?: TTestQueryVariables, 
+      variables?: TTestQueryVariables,
       options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) => 
+    ) =>
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -85,8 +86,9 @@ export const TestDocument = \`
 export const useTestMutation = <
       TError = unknown,
       TContext = unknown
-    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      variables === undefined ? ['test'] : ['test', variables],
       (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"
@@ -113,9 +115,9 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      variables?: TTestQueryVariables, 
+      variables?: TTestQueryVariables,
       options?: UseQueryOptions<TTestQuery, TError, TData>
-    ) => 
+    ) =>
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
@@ -131,8 +133,9 @@ export const TestDocument = \`
 export const useTestMutation = <
       TError = unknown,
       TContext = unknown
-    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) => 
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      variables === undefined ? ['test'] : ['test', variables],
       (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"
@@ -183,6 +186,7 @@ export const useTestMutation = <
       options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
     ) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      variables === undefined ? ['test'] : ['test', variables],
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
       options
     );"
@@ -209,11 +213,11 @@ export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown
     >(
-      client: GraphQLClient, 
-      variables?: TTestQueryVariables, 
+      client: GraphQLClient,
+      variables?: TTestQueryVariables,
       options?: UseQueryOptions<TTestQuery, TError, TData>,
       headers?: RequestInit['headers']
-    ) => 
+    ) =>
     useQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test'] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables, headers),
@@ -230,11 +234,12 @@ export const useTestMutation = <
       TError = unknown,
       TContext = unknown
     >(
-      client: GraphQLClient, 
+      client: GraphQLClient,
       options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>,
       headers?: RequestInit['headers']
-    ) => 
+    ) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      variables === undefined ? ['test'] : ['test', variables],
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables, headers)(),
       options
     );"
@@ -281,6 +286,7 @@ export const useTestMutation = <
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      variables === undefined ? ['test'] : ['test', variables],
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"
@@ -327,6 +333,7 @@ export const useTestMutation = <
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      variables === undefined ? ['test'] : ['test', variables],
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"
@@ -373,6 +380,7 @@ export const useTestMutation = <
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      variables === undefined ? ['test'] : ['test', variables],
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"
@@ -419,6 +427,7 @@ export const useTestMutation = <
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      variables === undefined ? ['test'] : ['test', variables],
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
       options
     );"

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -159,10 +159,11 @@ describe('React-Query', () => {
           options
         );`);
       expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
-        TError = unknown,
-        TContext = unknown
-      >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+        variables === undefined ? ['test'] : ['test', variables],
         (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
         options
       );`);
@@ -200,6 +201,7 @@ describe('React-Query', () => {
         TContext = unknown
       >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+        variables === undefined ? ['test'] : ['test', variables],
         (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
         options
       );`);
@@ -240,6 +242,7 @@ describe('React-Query', () => {
         TContext = unknown
       >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+        variables === undefined ? ['test'] : ['test', variables],
         useCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument),
         options
       );`);
@@ -273,6 +276,46 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).not.toBeSimilarStringTo(`useTestQuery.fetcher`);
+    });
+
+    it("Should generate mutation fetcher field when exposeFetcher is true and the fetcher isn't a react hook", async () => {
+      const config = {
+        fetcher: {
+          func: './my-file#customFetcher',
+        },
+        exposeFetcher: true,
+      };
+
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toBeSimilarStringTo(
+        `useTestMutation.fetcher = (variables?: TestMutationVariables) => customFetcher<TestMutation, TestMutationVariables>(TestDocument, variables);`
+      );
+    });
+
+    it('Should NOT generate mutation fetcher field when exposeFetcher is true and the fetcher IS a react hook', async () => {
+      const config = {
+        fetcher: {
+          func: './my-file#useCustomFetcher',
+          isReactHook: true,
+        },
+        exposeFetcher: true,
+      };
+
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).not.toBeSimilarStringTo(`useTestMutation.fetcher`);
+    });
+
+    describe('exposeMutationKeys: true', () => {
+      it('Should generate getKey for each mutation', async () => {
+        const config = {
+          fetcher: 'fetch',
+          exposeMutationKeys: true,
+        };
+        const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+        expect(out.content).toBeSimilarStringTo(
+          `useTestMutation.getKey = (variables?: TestMutationVariables) => variables === undefined ? ['test'] : ['test', variables];`
+        );
+      });
     });
 
     it(`tests for dedupeOperationSuffix`, async () => {
@@ -423,6 +466,7 @@ describe('React-Query', () => {
       headers?: RequestInit['headers']
     ) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      variables === undefined ? ['test'] : ['test', variables],
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables, headers)(),
       options
     );`);
@@ -608,6 +652,7 @@ describe('React-Query', () => {
         TContext = unknown
       >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+        variables === undefined ? ['test'] : ['test', variables],
         (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
         options
       );`);
@@ -883,6 +928,7 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
           options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
         ) =>
         useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+          variables === undefined ? ['test'] : ['test', variables],
           (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
           options
         );`);

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -163,7 +163,7 @@ describe('React-Query', () => {
       TContext = unknown
     >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-        variables === undefined ? ['test'] : ['test', variables],
+        'test',
         (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
         options
       );`);
@@ -201,7 +201,7 @@ describe('React-Query', () => {
         TContext = unknown
       >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-        variables === undefined ? ['test'] : ['test', variables],
+        'test',
         (variables?: TTestMutationVariables) => myCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
         options
       );`);
@@ -242,7 +242,7 @@ describe('React-Query', () => {
         TContext = unknown
       >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-        variables === undefined ? ['test'] : ['test', variables],
+        'test',
         useCustomFetcher<TTestMutation, TTestMutationVariables>(TestDocument),
         options
       );`);
@@ -312,9 +312,7 @@ describe('React-Query', () => {
           exposeMutationKeys: true,
         };
         const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
-        expect(out.content).toBeSimilarStringTo(
-          `useTestMutation.getKey = (variables?: TestMutationVariables) => variables === undefined ? ['test'] : ['test', variables];`
-        );
+        expect(out.content).toBeSimilarStringTo(`useTestMutation.getKey = () => 'test'`);
       });
     });
 
@@ -466,7 +464,7 @@ describe('React-Query', () => {
       headers?: RequestInit['headers']
     ) =>
     useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-      variables === undefined ? ['test'] : ['test', variables],
+      'test',
       (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(client, TestDocument, variables, headers)(),
       options
     );`);
@@ -652,7 +650,7 @@ describe('React-Query', () => {
         TContext = unknown
       >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
       useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-        variables === undefined ? ['test'] : ['test', variables],
+        'test',
         (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
         options
       );`);
@@ -928,7 +926,7 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
           options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>
         ) =>
         useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
-          variables === undefined ? ['test'] : ['test', variables],
+          'test',
           (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
           options
         );`);

--- a/website/static/config.schema.json
+++ b/website/static/config.schema.json
@@ -146,6 +146,10 @@
           "description": "For each generate query hook adds getKey(variables: QueryVariables) function. Useful for cache updates.\nDefault value: \"false\"",
           "type": "boolean"
         },
+        "exposeMutationKeys": {
+          "description": "For each generate mutation hook adds getKey() function. Useful for call outside of functional component.\nDefault value: \"false\"",
+          "type": "boolean"
+        },
         "exposeFetcher": {
           "description": "For each generate query hook addds `fetcher` field with a corresponding GraphQL query using the fetcher.\nIt is useful for `queryClient.fetchQuery` and `queryClient.prefetchQuery`.\nDefault value: \"false\"",
           "type": "boolean"


### PR DESCRIPTION
react-query plugin

## Description

We need to use keys and fetcher of generated mutations. Also, right now `useMutation` is generated without key and every call of `useMutation` creates new subscriber. This PR adds key for each mutation that provide their uniqually so we can subscribe to mutation in case of passed variables.

Related #6724 
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

The tests is similar to useQuery `exposeFetcher` and `exposeQueryKeys` configuration

- [x] Should generate mutation fetcher field when exposeFetcher is true and the fetcher isn't a react hook
- [x] Should NOT generate mutation fetcher field when exposeFetcher is true and the fetcher IS a react hook
- [x] Should generate getKey for each mutation if exposeMutationKeys is true

**Test Environment**:
- OS: macOS Big Sur 11.2.3 (20D91)
- NodeJS: v12.22.6

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
