### PR TITLE
Require non-null variables in react-apollo refetchFn

### DIFF
--- a/.changeset/tame-cups-fetch.md
+++ b/.changeset/tame-cups-fetch.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-apollo': patch
+---
+
+require non-null non-default variables in react-apollo refetchFn

--- a/dev-test/star-wars/types.refetchFn.tsx
+++ b/dev-test/star-wars/types.refetchFn.tsx
@@ -591,7 +591,7 @@ export type HeroNameConditionalInclusionQueryResult = Apollo.QueryResult<
   HeroNameConditionalInclusionQuery,
   HeroNameConditionalInclusionQueryVariables
 >;
-export function refetchHeroNameConditionalInclusionQuery(variables?: HeroNameConditionalInclusionQueryVariables) {
+export function refetchHeroNameConditionalInclusionQuery(variables: HeroNameConditionalInclusionQueryVariables) {
   return { query: HeroNameConditionalInclusionDocument, variables: variables };
 }
 export const HeroNameConditionalExclusionDocument = gql`
@@ -648,7 +648,7 @@ export type HeroNameConditionalExclusionQueryResult = Apollo.QueryResult<
   HeroNameConditionalExclusionQuery,
   HeroNameConditionalExclusionQueryVariables
 >;
-export function refetchHeroNameConditionalExclusionQuery(variables?: HeroNameConditionalExclusionQueryVariables) {
+export function refetchHeroNameConditionalExclusionQuery(variables: HeroNameConditionalExclusionQueryVariables) {
   return { query: HeroNameConditionalExclusionDocument, variables: variables };
 }
 export const HeroParentTypeDependentFieldDocument = gql`


### PR DESCRIPTION
## Description

This eliminates a potential source of bugs: the current definition
always generates variables as optional, whereas they should be
required if the variables contain non-null arguments.

Follow up to https://github.com/dotansimha/graphql-code-generator/issues/3478 and https://github.com/dotansimha/graphql-code-generator/pull/3479

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I added an automated test to ensure the proper code is generated.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~ No need for any config changes, this will simply uncover some bugs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- ~[ ] Any dependent changes have been merged and published in downstream modules~ no dependencies
