### PR TITLE
feat: add includeIntrospection option to schema-ast

### DIFF
--- a/.changeset/khaki-masks-whisper.md
+++ b/.changeset/khaki-masks-whisper.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/schema-ast': minor
+---
+
+added includeIntrospectionTypes option

--- a/packages/plugins/other/schema-ast/src/index.ts
+++ b/packages/plugins/other/schema-ast/src/index.ts
@@ -51,10 +51,10 @@ export interface SchemaASTConfig {
    *     plugins:
    *       - schema-ast
    *     config:
-   *       includeIntrospection: true
+   *       includeIntrospectionTypes: true
    * ```
    */
-  includeIntrospection?: boolean;
+  includeIntrospectionTypes?: boolean;
   /**
    * @description Set to true in order to print description as comments (using # instead of """)
    * @default false
@@ -82,12 +82,12 @@ export interface SchemaASTConfig {
 export const plugin: PluginFunction<SchemaASTConfig> = async (
   schema: GraphQLSchema,
   _documents,
-  { commentDescriptions = false, includeDirectives = false, includeIntrospection = false, sort = false, federation }
+  { commentDescriptions = false, includeDirectives = false, includeIntrospectionTypes = false, sort = false, federation }
 ): Promise<string> => {
-  const transformedSchemaAndAst = transformSchemaAST(schema, { sort, federation, includeIntrospection });
+  const transformedSchemaAndAst = transformSchemaAST(schema, { sort, federation, includeIntrospectionTypes });
 
   return [
-    includeIntrospection ? printIntrospectionSchema(transformedSchemaAndAst.schema) : null,
+    includeIntrospectionTypes ? printIntrospectionSchema(transformedSchemaAndAst.schema) : null,
     includeDirectives
       ? print(transformedSchemaAndAst.ast)
       : (printSchema as any)(transformedSchemaAndAst.schema, { commentDescriptions }),
@@ -113,7 +113,7 @@ export const validate: PluginValidateFn<any> = async (
 export function transformSchemaAST(schema: GraphQLSchema, config: { [key: string]: any }) {
   schema = config.federation ? removeFederation(schema) : schema;
 
-  if (config.includeIntrospection) {
+  if (config.includeIntrospectionTypes) {
     // See: https://spec.graphql.org/June2018/#sec-Schema-Introspection
     const introspectionAST = parse(`
       extend type Query {

--- a/packages/plugins/other/schema-ast/src/index.ts
+++ b/packages/plugins/other/schema-ast/src/index.ts
@@ -87,7 +87,7 @@ export const plugin: PluginFunction<SchemaASTConfig> = async (
   const transformedSchemaAndAst = transformSchemaAST(schema, { sort, federation, includeIntrospection });
 
   return [
-    includeIntrospection ? printIntrospectionSchema(transformedSchemaAndAst.schema, { commentDescriptions }) : null,
+    includeIntrospection ? printIntrospectionSchema(transformedSchemaAndAst.schema) : null,
     includeDirectives
       ? print(transformedSchemaAndAst.ast)
       : (printSchema as any)(transformedSchemaAndAst.schema, { commentDescriptions }),

--- a/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
+++ b/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
@@ -137,6 +137,22 @@ describe('Schema AST', () => {
       `);
     });
 
+    it('Should print schema with introspection when "includeIntrospection" is set', async () => {
+      const content = await plugin(schema, [], { includeIntrospection: true });
+
+      expect(content).toBeSimilarStringTo(`
+        type __Schema
+      `);
+
+      expect(content).toBeSimilarStringTo(`
+        type Query {
+          fieldTest: String
+          __schema: __Schema!
+          __type(name: String!): __Type
+        }
+      `);
+    });
+
     it('should support Apollo Federation', async () => {
       const federatedSchema = parse(/* GraphQL */ `
         type Character @key(fields: "id") {

--- a/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
+++ b/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
@@ -153,6 +153,20 @@ describe('Schema AST', () => {
       `);
     });
 
+    it('Should print schema without introspection when "includeIntrospection" is unset', async () => {
+      const content = await plugin(schema, [], { includeIntrospection: false });
+
+      expect(content).not.toBeSimilarStringTo(`
+        type __Schema
+      `);
+
+      expect(content).toBeSimilarStringTo(`
+        type Query {
+          fieldTest: String
+        }
+      `);
+    });
+
     it('should support Apollo Federation', async () => {
       const federatedSchema = parse(/* GraphQL */ `
         type Character @key(fields: "id") {

--- a/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
+++ b/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
@@ -137,8 +137,8 @@ describe('Schema AST', () => {
       `);
     });
 
-    it('Should print schema with introspection when "includeIntrospection" is set', async () => {
-      const content = await plugin(schema, [], { includeIntrospection: true });
+    it('Should print schema with introspection when "includeIntrospectionTypes" is set', async () => {
+      const content = await plugin(schema, [], { includeIntrospectionTypes: true });
 
       expect(content).toBeSimilarStringTo(`
         type __Schema
@@ -153,8 +153,8 @@ describe('Schema AST', () => {
       `);
     });
 
-    it('Should print schema without introspection when "includeIntrospection" is unset', async () => {
-      const content = await plugin(schema, [], { includeIntrospection: false });
+    it('Should print schema without introspection when "includeIntrospectionTypes" is unset', async () => {
+      const content = await plugin(schema, [], { includeIntrospectionTypes: false });
 
       expect(content).not.toBeSimilarStringTo(`
         type __Schema

--- a/packages/plugins/typescript/type-graphql/src/index.ts
+++ b/packages/plugins/typescript/type-graphql/src/index.ts
@@ -1,7 +1,7 @@
 import { Types, PluginFunction, getCachedDocumentNodeFromSchema, oldVisit } from '@graphql-codegen/plugin-helpers';
 import { GraphQLSchema } from 'graphql';
 import { TypeGraphQLVisitor } from './visitor';
-import { TsIntrospectionVisitor, includeIntrospectionDefinitions } from '@graphql-codegen/typescript';
+import { TsIntrospectionVisitor, includeIntrospectionTypesDefinitions } from '@graphql-codegen/typescript';
 import { TypeGraphQLPluginConfig } from './config';
 
 export * from './visitor';
@@ -17,7 +17,7 @@ export const plugin: PluginFunction<TypeGraphQLPluginConfig, Types.ComplexPlugin
   const visitor = new TypeGraphQLVisitor(schema, config);
   const astNode = getCachedDocumentNodeFromSchema(schema);
   const visitorResult = oldVisit(astNode, { leave: visitor });
-  const introspectionDefinitions = includeIntrospectionDefinitions(schema, documents, config);
+  const introspectionDefinitions = includeIntrospectionTypesDefinitions(schema, documents, config);
   const scalars = visitor.scalarsDefinition;
 
   const definitions = visitorResult.definitions;

--- a/packages/plugins/typescript/typescript/src/index.ts
+++ b/packages/plugins/typescript/typescript/src/index.ts
@@ -32,7 +32,7 @@ export const plugin: PluginFunction<TypeScriptPluginConfig, Types.ComplexPluginO
   const visitor = new TsVisitor(_schema, config);
 
   const visitorResult = oldVisit(ast, { leave: visitor });
-  const introspectionDefinitions = includeIntrospectionDefinitions(_schema, documents, config);
+  const introspectionDefinitions = includeIntrospectionTypesDefinitions(_schema, documents, config);
   const scalars = visitor.scalarsDefinition;
   const directiveArgumentAndInputFieldMappings = visitor.directiveArgumentAndInputFieldMappingsDefinition;
 
@@ -54,7 +54,7 @@ export const plugin: PluginFunction<TypeScriptPluginConfig, Types.ComplexPluginO
   };
 };
 
-export function includeIntrospectionDefinitions(
+export function includeIntrospectionTypesDefinitions(
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],
   config: TypeScriptPluginConfig

--- a/website/static/config.schema.json
+++ b/website/static/config.schema.json
@@ -990,7 +990,7 @@
           "description": "Include directives to Schema output.\nDefault value: \"false\"",
           "type": "boolean"
         },
-        "includeIntrospection": {
+        "includeIntrospectionTypes": {
           "description": "Include introspection types to Schema output.\nDefault value: \"false\"",
           "type": "boolean"
         },

--- a/website/static/config.schema.json
+++ b/website/static/config.schema.json
@@ -990,6 +990,10 @@
           "description": "Include directives to Schema output.\nDefault value: \"false\"",
           "type": "boolean"
         },
+        "includeIntrospection": {
+          "description": "Include introspection types to Schema output.\nDefault value: \"false\"",
+          "type": "boolean"
+        },
         "commentDescriptions": {
           "description": "Set to true in order to print description as comments (using # instead of \"\"\")\nDefault value: \"false\"",
           "type": "boolean"


### PR DESCRIPTION
## Description

Related #6900

Adds `includeIntrospection` option to schema-ast plugin.

This is useful when Relay code needs to reference an enum type, e.g.

```js
import { graphql, useLazyLoadQuery } from 'react-relay';
import type { UserFeaturesDebugQuery } from '@/__generated__/UserFeaturesDebugQuery.graphql';
import type { UserFeature } from '@/types/api';

type UserFeaturesDebugProps = {
  currentFeatures: readonly UserFeature[];
};

export const UserFeaturesDebug = ({
  currentFeatures,
}: UserFeaturesDebugProps) => {
  const introspection = useLazyLoadQuery<UserFeaturesDebugQuery>(
    graphql`
      query UserFeaturesDebugQuery {
        __type(name: "UserFeature") {
          name
          enumValues(includeDeprecated: true) {
            name
            deprecationReason
            description
          }
        }
      }
    `,
    {}
  );

  const flags = [...(introspection.__type?.enumValues ?? [])].sort((a, b) =>
    a.name.localeCompare(b.name)
  );
  
  // [..]
``` 

Based on previous work by @erictaylor in https://github.com/erictaylor/graphql-codegen-schema-ast.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test cases

**Test Environment**:
- OS: macOS
- `@graphql-codegen/...`: latest
- NodeJS: 16

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
