### PR TITLE
Respect `useTypeImports` config in `typescript-urql-graphcache` plugin

### DIFF
--- a/.changeset/six-icons-sneeze.md
+++ b/.changeset/six-icons-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-urql-graphcache': patch
+---
+
+Make typescript-urql-graphcache respect the `useTypeImports` option.

--- a/packages/plugins/typescript/urql-graphcache/src/constants.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/constants.ts
@@ -1,3 +1,0 @@
-export const imports =
-  `import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';\n` +
-  `import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';`;

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -10,7 +10,6 @@ import {
 
 import { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
 import { UrqlGraphCacheConfig } from './config';
-import { imports } from './constants';
 import { convertFactory, ConvertFn } from '@graphql-codegen/visitor-plugin-common';
 
 type GraphQLFlatType = Exclude<TypeNode, GraphQLWrappingType>;
@@ -228,12 +227,24 @@ function getOptimisticUpdatersConfig(
   }
 }
 
+function getImports(config: UrqlGraphCacheConfig): string {
+  return (
+    `${
+      config.useTypeImports ? 'import type' : 'import'
+    } { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';\n` +
+    `${
+      config.useTypeImports ? 'import type' : 'import'
+    } { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';`
+  );
+}
+
 export const plugin: PluginFunction<UrqlGraphCacheConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
   _documents,
   config
 ) => {
   const convertName = convertFactory(config);
+  const imports = getImports(config);
   const keys = getKeysConfig(schema, convertName, config);
   const resolvers = getResolversConfig(schema, convertName, config);
   const { mutationUpdaters, subscriptionUpdaters } = getRootUpdatersConfig(schema, convertName, config);

--- a/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
@@ -1,3 +1,4 @@
+import '@graphql-codegen/testing';
 import { mergeOutputs } from '@graphql-codegen/plugin-helpers';
 import { buildSchema } from 'graphql';
 import { plugin } from '../src/index';
@@ -161,9 +162,10 @@ describe('urql graphcache', () => {
       }
     `);
     const result = mergeOutputs([await plugin(schema, [], { useTypeImports: true })]);
-    const output = `import type { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
-import type { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';`;
 
-    expect(result.startsWith(output));
+    expect(result).toBeSimilarStringTo(
+      `import type { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
+import type { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';`
+    );
   });
 });


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related #6912 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

See #6912 for sandbox example of the issue.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Locally linked the modified `@graphql-codegen/typescript-urql-graphcache` into my [test project](https://github.com/rossng/repro-gql-codegen-urql).
- Added a test to `typescript-urql-graphcache` which tests for the presence of correctly-worded imports when `useTypeImports` is enabled.

**Test Environment**:
- OS: macOS Monterey
- `@graphql-codegen/...`: see https://github.com/rossng/repro-gql-codegen-urql
- NodeJS: 17.0.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas - **N/A**
- [ ] I have made corresponding changes to the documentation - **N/A**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I have considered that there is a theoretically 'breaking' change in the sense that the import statements will now be generated differently for any `typescript-urql-graphcache` users who have `useTypeImports` enabled globally.

However, I find it hard to imagine that anyone using this plugin and enabling `useTypeImports` globally would expect anything other than the post-fix behaviour. Indeed (like me) their builds would probably be broken. So I would frame this as a bug-fix (i.e. patch bump) instead.