### PR TITLE
feat(cli): export loadCodegenConfig to load codegen configuration files

### DIFF
--- a/.changeset/calm-cherries-visit.md
+++ b/.changeset/calm-cherries-visit.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': minor
+---
+
+feat(cli): export loadCodegenConfig to load codegen configuration files

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,6 @@
 module.exports = {
-  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
+  presets: [
+    ['@babel/preset-env', { targets: { node: process.versions.node.split('.')[0] } }],
+    '@babel/preset-typescript',
+  ],
 };

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -93,14 +93,17 @@ export interface LoadCodegenConfigResult {
 }
 
 export async function loadCodegenConfig({
-  configFilePath = process.cwd(),
-  moduleName = 'codegen',
-  searchPlaces: additionalSearchPlaces = [],
-  packageProp = moduleName,
-  loaders: customLoaders = {},
+  configFilePath,
+  moduleName,
+  searchPlaces: additionalSearchPlaces,
+  packageProp,
+  loaders: customLoaders,
 }: LoadCodegenConfigOptions): Promise<LoadCodegenConfigResult> {
+  configFilePath = configFilePath || process.cwd();
+  moduleName = moduleName || 'codegen';
+  packageProp = packageProp || moduleName;
   const cosmi = cosmiconfig(moduleName, {
-    searchPlaces: generateSearchPlaces(moduleName).concat(additionalSearchPlaces),
+    searchPlaces: generateSearchPlaces(moduleName).concat(additionalSearchPlaces || []),
     packageProp,
     loaders: {
       '.json': customLoader('json'),
@@ -112,7 +115,7 @@ export async function loadCodegenConfig({
     },
   });
   const pathStats = await lstat(configFilePath);
-  return pathStats.isDirectory ? cosmi.search(configFilePath) : cosmi.load(configFilePath);
+  return pathStats.isDirectory() ? cosmi.search(configFilePath) : cosmi.load(configFilePath);
 }
 
 export async function loadContext(configFilePath?: string): Promise<CodegenContext> | never {


### PR DESCRIPTION
Tests might be added later but I don't think it is necessary now because it is internal already.