### PR TITLE
#5064 Display detailed errors from CLI

### DIFF
--- a/.changeset/famous-bikes-punch.md
+++ b/.changeset/famous-bikes-punch.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/cli": patch
+---
+
+#5064 Display detailed errors from CLI

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -10,6 +10,8 @@ import {
 } from '@graphql-codegen/plugin-helpers';
 import { codegen } from '@graphql-codegen/core';
 
+import { AggregateError } from '@graphql-tools/utils';
+
 import { Renderer, ErrorRenderer } from './utils/listr-renderer';
 import { GraphQLError, GraphQLSchema, DocumentNode } from 'graphql';
 import { getPluginByName } from './plugins';
@@ -395,7 +397,7 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
           ? `${subErr.message} for "${subErr.source}"${subErr.details}`
           : subErr.message || subErr.toString()
       );
-      const newErr = new DetailedError(`${err.message} ${allErrs.join('\n\n')}`, '');
+      const newErr = new AggregateError(err.errors, `${err.message} ${allErrs.join('\n\n')}`);
       // Best-effort to all stack traces for debugging
       newErr.stack = `${newErr.stack}\n\n${err.errors.map(subErr => subErr.stack).join('\n\n')}`;
       throw newErr;

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -403,7 +403,5 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
     throw err;
   }
 
-  // await listr.run();
-
   return result;
 }

--- a/packages/graphql-codegen-cli/src/utils/cli-error.ts
+++ b/packages/graphql-codegen-cli/src/utils/cli-error.ts
@@ -1,29 +1,17 @@
-import { DetailedError, isDetailedError } from '@graphql-codegen/plugin-helpers';
-
+import { DetailedError } from '@graphql-codegen/plugin-helpers';
 import { isBrowser, isNode } from './is-browser';
 
 type CompositeError = Error | DetailedError;
-type MultipleError = Error & { errors?: CompositeError[] };
-
-function isError(err: any): err is MultipleError {
-  return err instanceof Error;
+type ListrError = Error & { errors: CompositeError[] };
+export function isListrError(err: Error & { name?: unknown; errors?: unknown }): err is ListrError {
+  return err.name === 'ListrError' && Array.isArray(err.errors) && err.errors.length > 0;
 }
 
 export function cliError(err: any, exitOnError = true) {
   let msg: string;
 
-  if (isError(err)) {
+  if (err instanceof Error) {
     msg = err.message || err.toString();
-    if (Array.isArray(err.errors) && err.errors.length) {
-      const allErrs = err.errors.map(errItem => {
-        let subMsg = errItem.message || errItem.toString();
-        if (isDetailedError(errItem)) {
-          subMsg = `${subMsg} for "${errItem.source}"${errItem.details}`;
-        }
-        return subMsg;
-      });
-      msg = `${msg}\n${allErrs.join("\n")}`;
-    }
   } else if (typeof err === 'string') {
     msg = err;
   } else {

--- a/packages/graphql-codegen-cli/src/utils/cli-error.ts
+++ b/packages/graphql-codegen-cli/src/utils/cli-error.ts
@@ -1,10 +1,29 @@
+import { DetailedError, isDetailedError } from '@graphql-codegen/plugin-helpers';
+
 import { isBrowser, isNode } from './is-browser';
+
+type CompositeError = Error | DetailedError;
+type MultipleError = Error & { errors?: CompositeError[] };
+
+function isError(err: any): err is MultipleError {
+  return err instanceof Error;
+}
 
 export function cliError(err: any, exitOnError = true) {
   let msg: string;
 
-  if (err instanceof Error) {
+  if (isError(err)) {
     msg = err.message || err.toString();
+    if (Array.isArray(err.errors) && err.errors.length) {
+      const allErrs = err.errors.map(errItem => {
+        let subMsg = errItem.message || errItem.toString();
+        if (isDetailedError(errItem)) {
+          subMsg = `${subMsg} for "${errItem.source}"${errItem.details}`;
+        }
+        return subMsg;
+      });
+      msg = `${msg}\n${allErrs.join("\n")}`;
+    }
   } else if (typeof err === 'string') {
     msg = err;
   } else {

--- a/packages/graphql-codegen-cli/tests/codegen.spec.ts
+++ b/packages/graphql-codegen-cli/tests/codegen.spec.ts
@@ -261,7 +261,7 @@ describe('Codegen Executor', () => {
         throw SHOULD_NOT_THROW_STRING;
       } catch (e) {
         expect(e).not.toEqual(SHOULD_NOT_THROW_STRING);
-        expect(e.errors[0].message).toContain('Not all operations have an unique name: q');
+        expect(e.message).toContain('Not all operations have an unique name: q');
       }
     });
 
@@ -547,8 +547,7 @@ describe('Codegen Executor', () => {
         throw new Error(SHOULD_NOT_THROW_STRING);
       } catch (e) {
         expect(e.message).not.toBe(SHOULD_NOT_THROW_STRING);
-        expect(e.errors[0].message).toContain('Invalid Custom Plugin');
-        expect(e.errors[0].details).toContain('does not export a valid JS object with');
+        expect(e.message).toContain('Invalid Custom Plugin');
       }
     });
 
@@ -565,8 +564,7 @@ describe('Codegen Executor', () => {
         throw new Error(SHOULD_NOT_THROW_STRING);
       } catch (e) {
         expect(e.message).not.toBe(SHOULD_NOT_THROW_STRING);
-        expect(e.errors[0].message).toContain('validation failed');
-        expect(e.errors[0].details).toContain('Invalid!');
+        expect(e.message).toContain('validation failed');
       }
     });
 
@@ -757,9 +755,8 @@ describe('Codegen Executor', () => {
         });
 
         throw new Error(SHOULD_NOT_THROW_STRING);
-      } catch (listrError) {
-        const e = listrError.errors[0];
-        expect(e.message).toContain('Failed to load schema');
+      } catch (error) {
+        expect(error.message).toContain('Failed to load schema');
       }
     });
 
@@ -781,9 +778,8 @@ describe('Codegen Executor', () => {
         });
 
         throw new Error(SHOULD_NOT_THROW_STRING);
-      } catch (listrError) {
-        const e = listrError.errors[0];
-        expect(e.details).toContain('Failed to load custom loader');
+      } catch (error) {
+        expect(error.message).toContain('Failed to load custom loader');
       }
     });
 
@@ -805,10 +801,9 @@ describe('Codegen Executor', () => {
         });
 
         throw new Error(SHOULD_NOT_THROW_STRING);
-      } catch (listrError) {
-        const e = listrError.errors[0];
-        expect(e.message).toContain('Failed to load schema');
-        expect(e.details).toContain('Failed to load custom loader');
+      } catch (error) {
+        expect(error.message).toContain('Failed to load schema');
+        expect(error.message).toContain('Failed to load custom loader');
       }
     });
   });
@@ -873,9 +868,8 @@ describe('Codegen Executor', () => {
         });
 
         throw new Error(SHOULD_NOT_THROW_STRING);
-      } catch (listrError) {
-        const e = listrError.errors[0];
-        expect(e.message).toContain('Unable to find any GraphQL type definitions for the following pointers');
+      } catch (error) {
+        expect(error.message).toContain('Unable to find any GraphQL type definitions for the following pointers');
       }
     });
 
@@ -898,9 +892,8 @@ describe('Codegen Executor', () => {
         });
 
         throw new Error(SHOULD_NOT_THROW_STRING);
-      } catch (listrError) {
-        const e = listrError.errors[0];
-        expect(e.message).toContain('Failed to load custom loader');
+      } catch (error) {
+        expect(error.message).toContain('Failed to load custom loader');
       }
     });
 
@@ -923,9 +916,8 @@ describe('Codegen Executor', () => {
         });
 
         throw new Error(SHOULD_NOT_THROW_STRING);
-      } catch (listrError) {
-        const e = listrError.errors[0];
-        expect(e.message).toContain('Failed to load custom loader');
+      } catch (error) {
+        expect(error.message).toContain('Failed to load custom loader');
       }
     });
   });
@@ -943,13 +935,7 @@ describe('Codegen Executor', () => {
         },
       });
     } catch (error) {
-      const isExpectedError = error.errors && error.errors.some(e => e.message.includes('Failed to load schema'));
-
-      if (!isExpectedError) {
-        // eslint-disable-next-line no-console
-        console.error(error);
-        throw error;
-      }
+      expect(error.message).toContain('Failed to load schema from http://www.dummyschema.com/graphql');
     }
     expect((global as any).CUSTOM_FETCH_FN_CALLED).toBeTruthy();
   });
@@ -988,7 +974,7 @@ describe('Codegen Executor', () => {
       });
       expect(output.length).toBe(1);
     } catch (e) {
-      expect(e.errors[0].message).not.toBe('Query root type must be provided.');
+      expect(e.message).not.toBe('Query root type must be provided.');
     }
   });
 
@@ -1060,5 +1046,25 @@ describe('Codegen Executor', () => {
         aa: String
       }
     `);
+  });
+
+  it('Handles weird errors due to invalid schema', async () => {
+    const schema = /* GraphQL */ `
+      type Query {
+        brrrt:1
+      }
+    `;
+    try {
+      await executeCodegen({
+        schema: [schema],
+        generates: {
+          'out1.graphql': {
+            plugins: ['schema-ast'],
+          },
+        },
+      });
+    } catch (error) {
+      expect(error.message).toContain('Failed to load schema for "out1.graphql"');
+    }
   });
 });


### PR DESCRIPTION
## Description

All syntax errors in referenced `*.graphql` files resulted in the CLI displaying the generic error message:
> Something went wrong

Investigation found that that the error details were captured by `listr` but were not printed to the CLI. This change checks for aggregate errors, and include them in the CLI error output.

Related #5064

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Tested by running against valid and invalid .graphql files, to ensure the error details were printed out as follows:
```
Something went wrong
Failed to load schema for "path/to/output-types.ts"
        Failed to load schema from path/a.graphql,path/b.graphql:

        Syntax Error: Expected ":", found Name "credentialSetup".
        GraphQLError: Syntax Error: Expected ":", found Name "credentialSetup".
    at syntaxError (/workspace/node_modules/graphql/error/syntaxError.js:15:10)
    at Parser.expectToken (/workspace/node_modules/graphql/language/parser.js:1413:40)
    at Parser.parseFieldDefinition (/workspace/node_modules/graphql/language/parser.js:881:10)
    at Parser.optionalMany (/workspace/node_modules/graphql/language/parser.js:1503:28)
    at Parser.parseFieldsDefinition (/workspace/node_modules/graphql/language/parser.js:868:17)
    at Parser.parseObjectTypeExtension (/workspace/node_modules/graphql/language/parser.js:1176:23)
    at Parser.parseTypeSystemExtension (/workspace/node_modules/graphql/language/parser.js:1094:23)
    at Parser.parseDefinition (/workspace/node_modules/graphql/language/parser.js:153:23)
    at Parser.many (/workspace/node_modules/graphql/language/parser.js:1523:26)
    at Parser.parseDocument (/workspace/node_modules/graphql/language/parser.js:115:25)
    
        GraphQL Code Generator supports:
          - ES Modules and CommonJS exports (export as default or named export "schema")
          - Introspection JSON File
          - URL of GraphQL endpoint
          - Multiple files with type definitions (glob expression)
          - String in config file
    
        Try to use one of above options and run codegen again.
```

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
