### PR TITLE
fix(typescript-resolvers): Fix optional resolver types

### DIFF
--- a/.changeset/fluffy-pumpkins-build.md
+++ b/.changeset/fluffy-pumpkins-build.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-resolvers": patch
+"@graphql-codegen/visitor-plugin-common": patch
+---
+
+fix(typescript-resolvers): Fix optional field types

--- a/packages/plugins/other/visitor-plugin-common/src/avoid-optionals.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/avoid-optionals.ts
@@ -5,6 +5,7 @@ export const DEFAULT_AVOID_OPTIONALS: AvoidOptionalsConfig = {
   inputValue: false,
   field: false,
   defaultValue: false,
+  resolvers: false,
 };
 
 export function normalizeAvoidOptionals(avoidOptionals?: boolean | AvoidOptionalsConfig): AvoidOptionalsConfig {
@@ -14,6 +15,7 @@ export function normalizeAvoidOptionals(avoidOptionals?: boolean | AvoidOptional
       inputValue: avoidOptionals,
       field: avoidOptionals,
       defaultValue: avoidOptionals,
+      resolvers: avoidOptionals,
     };
   }
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -987,7 +987,7 @@ export class BaseResolversVisitor<
 
       const resolverType = isSubscriptionType ? 'SubscriptionResolver' : directiveMappings[0] ?? 'Resolver';
 
-      const avoidOptionals = this.config.avoidOptionals?.object ?? this.config.avoidOptionals === true;
+      const avoidOptionals = this.config.avoidOptionals?.resolvers ?? this.config.avoidOptionals === true;
       const signature: {
         name: string;
         modifier: string;

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -987,6 +987,7 @@ export class BaseResolversVisitor<
 
       const resolverType = isSubscriptionType ? 'SubscriptionResolver' : directiveMappings[0] ?? 'Resolver';
 
+      const avoidOptionals = this.config.avoidOptionals?.object ?? this.config.avoidOptionals === true;
       const signature: {
         name: string;
         modifier: string;
@@ -994,7 +995,7 @@ export class BaseResolversVisitor<
         genericTypes: string[];
       } = {
         name: node.name as any,
-        modifier: this.config.avoidOptionals ? '' : '?',
+        modifier: avoidOptionals ? '' : '?',
         type: resolverType,
         genericTypes: [
           mappedTypeKey,

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -95,6 +95,7 @@ export interface AvoidOptionalsConfig {
   object?: boolean;
   inputValue?: boolean;
   defaultValue?: boolean;
+  resolvers?: boolean;
 }
 
 export interface ParsedImport {

--- a/packages/plugins/typescript/resolvers/src/visitor.ts
+++ b/packages/plugins/typescript/resolvers/src/visitor.ts
@@ -74,7 +74,7 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<
   }
 
   protected formatRootResolver(schemaTypeName: string, resolverType: string, declarationKind: DeclarationKind): string {
-    const avoidOptionals = this.config.avoidOptionals?.object ?? this.config.avoidOptionals === true;
+    const avoidOptionals = this.config.avoidOptionals?.resolvers ?? this.config.avoidOptionals === true;
     return `${schemaTypeName}${avoidOptionals ? '' : '?'}: ${resolverType}${this.getPunctuation(declarationKind)}`;
   }
 

--- a/packages/plugins/typescript/resolvers/src/visitor.ts
+++ b/packages/plugins/typescript/resolvers/src/visitor.ts
@@ -74,9 +74,8 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<
   }
 
   protected formatRootResolver(schemaTypeName: string, resolverType: string, declarationKind: DeclarationKind): string {
-    return `${schemaTypeName}${this.config.avoidOptionals ? '' : '?'}: ${resolverType}${this.getPunctuation(
-      declarationKind
-    )}`;
+    const avoidOptionals = this.config.avoidOptionals?.object ?? this.config.avoidOptionals === true;
+    return `${schemaTypeName}${avoidOptionals ? '' : '?'}: ${resolverType}${this.getPunctuation(declarationKind)}`;
   }
 
   private clearOptional(str: string): string {

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -2291,7 +2291,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     await validate(result);
   });
 
-  it('#7005 - avoidOptionals should preserve optional object', async () => {
+  it('#7005 - avoidOptionals should preserve optional resolvers', async () => {
     const testSchema = buildSchema(/* GraphQL */ `
       type Query {
         users(filter: UserFilterInput = {}): [User!]!
@@ -2313,9 +2313,10 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
       {
         avoidOptionals: {
           defaultValue: true,
-          field: false,
+          field: true,
           inputValue: true,
-          object: false,
+          object: true,
+          resolvers: false,
         },
       } as any,
       { outputFile: 'graphql.ts' }

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2998,31 +2998,6 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
-    it('Should generate optional object fields with required default values - broken in #5112', async () => {
-      const schema = buildSchema(`
-        type Query { foo(input: String = "testing"): String! }
-      `);
-      const result = await plugin(
-        schema,
-        [],
-        { avoidOptionals: { object: false, defaultValue: true } },
-        { outputFile: '' }
-      );
-
-      expect(result.content).toBeSimilarStringTo(`
-        export type Query = {
-          __typename?: 'Query';
-          foo?: Scalars['String'];
-        };
-
-        export type QueryFooArgs = {
-          input: Maybe<Scalars['String']>;
-        }
-      `);
-
-      validateTs(result);
-    });
-
     it('Should generate correctly types for field arguments with default value and avoidOptionals.defaultValue option set to true - #5112', async () => {
       const schema = buildSchema(
         `type MyType { foo(a: String = "default", b: String! = "default", c: String, d: String!): String }`
@@ -3042,6 +3017,31 @@ describe('TypeScript', () => {
           d: Scalars['String'];
         };
     `);
+
+      validateTs(result);
+    });
+
+    it('Should generate optional object fields with required default values - broken in #5112', async () => {
+      const schema = buildSchema(`
+        type Query { foo(input: String = "testing"): String! }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        { avoidOptionals: { object: false, field: false, inputValue: true, defaultValue: true } },
+        { outputFile: '' }
+      );
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type Query = {
+          __typename?: 'Query';
+          foo?: Scalars['String'];
+        };
+
+        export type QueryFooArgs = {
+          input: Maybe<Scalars['String']>;
+        }
+      `);
 
       validateTs(result);
     });

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -3011,9 +3011,9 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
-          a?: Maybe<Scalars['String']>;
+          a?: InputMaybe<Scalars['String']>;
           b: Scalars['String'];
-          c?: Maybe<Scalars['String']>;
+          c?: InputMaybe<Scalars['String']>;
           d: Scalars['String'];
         };
     `);

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -3020,31 +3020,6 @@ describe('TypeScript', () => {
 
       validateTs(result);
     });
-
-    it('Should generate optional object fields with required default values - broken in #5112', async () => {
-      const schema = buildSchema(`
-        type Query { foo(input: String = "testing"): String! }
-      `);
-      const result = await plugin(
-        schema,
-        [],
-        { avoidOptionals: { object: false, field: false, inputValue: true, defaultValue: true } },
-        { outputFile: '' }
-      );
-
-      expect(result.content).toBeSimilarStringTo(`
-        export type Query = {
-          __typename?: 'Query';
-          foo?: Scalars['String'];
-        };
-
-        export type QueryFooArgs = {
-          input: Maybe<Scalars['String']>;
-        }
-      `);
-
-      validateTs(result);
-    });
   });
 
   describe('Enum', () => {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2998,31 +2998,6 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
-    it('Should generate optional object fields with required default values - broken in #5112', async () => {
-      const schema = buildSchema(`
-        type Query { foo(input: String = "testing"): String! }
-      `);
-      const result = await plugin(
-        schema,
-        [],
-        { avoidOptionals: { object: false, defaultValue: true } },
-        { outputFile: '' }
-      );
-
-      expect(result.content).toBeSimilarStringTo(`
-        export type Query = {
-          __typename?: 'Query';
-          foo?: Scalars['String'];
-        };
-
-        export type QueryFooArgs = {
-          input: Maybe<Scalars['String']>;
-        }
-      `);
-
-      validateTs(result);
-    });
-
     it('Should generate correctly types for field arguments with default value and avoidOptionals.defaultValue option set to true - #5112', async () => {
       const schema = buildSchema(
         `type MyType { foo(a: String = "default", b: String! = "default", c: String, d: String!): String }`
@@ -3036,12 +3011,37 @@ describe('TypeScript', () => {
 
       expect(result.content).toBeSimilarStringTo(`
         export type MyTypeFooArgs = {
-          a?: InputMaybe<Scalars['String']>;
+          a?: Maybe<Scalars['String']>;
           b: Scalars['String'];
-          c?: InputMaybe<Scalars['String']>;
+          c?: Maybe<Scalars['String']>;
           d: Scalars['String'];
         };
     `);
+
+      validateTs(result);
+    });
+
+    it('Should generate optional object fields with required default values - broken in #5112', async () => {
+      const schema = buildSchema(`
+        type Query { foo(input: String = "testing"): String! }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        { avoidOptionals: { object: false, field: false, inputValue: true, defaultValue: true } },
+        { outputFile: '' }
+      );
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type Query = {
+          __typename?: 'Query';
+          foo?: Scalars['String'];
+        };
+
+        export type QueryFooArgs = {
+          input: Maybe<Scalars['String']>;
+        }
+      `);
 
       validateTs(result);
     });

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2998,6 +2998,31 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
+    it('Should generate optional object fields with required default values - broken in #5112', async () => {
+      const schema = buildSchema(`
+        type Query { foo(input: String = "testing"): String! }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        { avoidOptionals: { object: false, defaultValue: true } },
+        { outputFile: '' }
+      );
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type Query = {
+          __typename?: 'Query';
+          foo?: Scalars['String'];
+        };
+
+        export type QueryFooArgs = {
+          input: Maybe<Scalars['String']>;
+        }
+      `);
+
+      validateTs(result);
+    });
+
     it('Should generate correctly types for field arguments with default value and avoidOptionals.defaultValue option set to true - #5112', async () => {
       const schema = buildSchema(
         `type MyType { foo(a: String = "default", b: String! = "default", c: String, d: String!): String }`


### PR DESCRIPTION
## Description

Fix https://github.com/dotansimha/graphql-code-generator/issues/7005.

Possibly broken in #5112.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Failing test diff:

```diff
-   users?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUsersArgs, 'filter'>>;
-   ping?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+   users: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUsersArgs, 'filter'>>;
+   ping: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+ };
```

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts`

**Test Environment**:
- OS: 
- `@graphql-codegen/...`: 
- NodeJS: 

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
