### PR TITLE
issue 6794: add stage 2 failing test case

### DIFF
--- a/.changeset/pretty-frogs-leave.md
+++ b/.changeset/pretty-frogs-leave.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+stringify fetchParams if an object was provided via YAML config

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -1,6 +1,6 @@
 import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-common';
 
-export type HardcodedFetch = { endpoint: string; fetchParams?: string };
+export type HardcodedFetch = { endpoint: string; fetchParams?: string | Record<string, any> };
 export type CustomFetch = { func: string; isReactHook?: boolean } | string;
 
 /**

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -27,7 +27,10 @@ export class HardcodedFetchFetcher implements FetcherRenderer {
     let fetchParamsPartial = '';
 
     if (this.config.fetchParams) {
-      fetchParamsPartial = `\n    ...(${this.config.fetchParams}),`;
+      const fetchParamsString =
+        typeof this.config.fetchParams === 'string' ? this.config.fetchParams : JSON.stringify(this.config.fetchParams);
+
+      fetchParamsPartial = `\n    ...(${fetchParamsString}),`;
     }
 
     return `    method: "POST",${fetchParamsPartial}`;

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -318,6 +318,53 @@ export const useTestMutation = <
     );"
 `;
 
+exports[`React-Query fetcher: hardcoded-fetch Should generate query correctly with fetch config and fetchParams object 2`] = `
+"
+export const TestDocument = \`
+    query test {
+  feed {
+    id
+    commentCount
+    repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+export const useTestQuery = <
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      variables?: TTestQueryVariables,
+      options?: UseQueryOptions<TTestQuery, TError, TData>
+    ) =>
+    useQuery<TTestQuery, TError, TData>(
+      variables === undefined ? ['test'] : ['test', variables],
+      fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
+      options
+    );
+export const TestDocument = \`
+    mutation test($name: String) {
+  submitRepository(repoFullName: $name) {
+    id
+  }
+}
+    \`;
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<TTestMutation, TError, TTestMutationVariables, TContext>) =>
+    useMutation<TTestMutation, TError, TTestMutationVariables, TContext>(
+      'test',
+      (variables?: TTestMutationVariables) => fetcher<TTestMutation, TTestMutationVariables>(TestDocument, variables)(),
+      options
+    );"
+`;
+
 exports[`React-Query fetcher: hardcoded-fetch Should generate query correctly with hardcoded endpoint 1`] = `
 "
 export const TestDocument = \`


### PR DESCRIPTION
## Description

This PR adds a test case `React-Query › fetcher: hardcoded-fetch › Should generate query correctly with fetch config and fetchParams object` into spec `packages/plugins/typescript/react-query/tests/react-query.spec.ts` for the config parameter `fetchParams` as requested in issue https://github.com/dotansimha/graphql-code-generator/issues/6794#issuecomment-968057226. 

In case the `fetchParams` parameter was set via a YAML config, it does contain an Object instead of a String. However, the Typescript type definition in [config.ts](https://github.com/dotansimha/graphql-code-generator/blob/master/packages/plugins/typescript/react-query/src/config.ts#L3) expects a String and doesn't handle the case if an Object was passed via YAML. It is valid to define the parameters as Object according to the documentation: https://www.graphql-code-generator.com/docs/plugins/typescript-react-query#using-fetch-with-codegen-configuration

The newly added test case does currently fail with the following output:

![image](https://user-images.githubusercontent.com/950244/141754000-bcf824bb-54d6-4448-96ba-d58c7c48065e.png)

Related # (issue)
https://github.com/dotansimha/graphql-code-generator/issues/6794#issuecomment-968057226

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
