### PR TITLE
Preset: resolve absolute path

### DIFF
--- a/.changeset/twenty-boats-pull.md
+++ b/.changeset/twenty-boats-pull.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+resolve local presets

--- a/packages/graphql-codegen-cli/src/presets.ts
+++ b/packages/graphql-codegen-cli/src/presets.ts
@@ -1,10 +1,16 @@
 import { DetailedError, Types } from '@graphql-codegen/plugin-helpers';
+import { resolve } from 'path';
 
 export async function getPresetByName(
   name: string,
   loader: Types.PackageLoaderFn<{ preset?: Types.OutputPreset; default?: Types.OutputPreset }>
 ): Promise<Types.OutputPreset> {
-  const possibleNames = [`@graphql-codegen/${name}`, `@graphql-codegen/${name}-preset`, name];
+  const possibleNames = [
+    `@graphql-codegen/${name}`,
+    `@graphql-codegen/${name}-preset`,
+    name,
+    resolve(process.cwd(), name),
+  ];
 
   for (const moduleName of possibleNames) {
     try {


### PR DESCRIPTION
Developing presets locally fails without this change. 

The change is similar to what is already being done in `getPluginByName`

### Without this change
Config:

```yaml
schema: "https://api.spacex.land/graphql"
generates:
  generated/src:
    preset: dist/my-preset.js
```

Error on generate:

```
Unable to find preset matching 'dist/my-preset.js'
    Install one of the following packages:


    - @graphql-codegen/dist/my-preset.js
    - @graphql-codegen/dist/my-preset.js-preset
    - dist/my-preset.js

    Error: Unable to find preset matching dist/my-preset.js
        at getPresetByName (/Users/staffordwilliams/git/graphql-code-generator/packages/graphql-codegen-cli/dist/bin.js:405:11)
        at processTicksAndRejections (internal/process/task_queues.js:93:5)
        at async /Users/staffordwilliams/git/graphql-code-generator/packages/graphql-codegen-cli/dist/bin.js:968:47
        at async Task.task (/Users/staffordwilliams/git/graphql-code-generator/packages/graphql-codegen-cli/dist/bin.js:797:17)
    Error: Unable to find preset matching dist/my-preset.js
        at getPresetByName (/Users/staffordwilliams/git/graphql-code-generator/packages/graphql-codegen-cli/dist/bin.js:405:11)
        at processTicksAndRejections (internal/process/task_queues.js:93:5)
        at async /Users/staffordwilliams/git/graphql-code-generator/packages/graphql-codegen-cli/dist/bin.js:968:47
        at async Task.task (/Users/staffordwilliams/git/graphql-code-generator/packages/graphql-codegen-cli/dist/bin.js:797:17)
```