### PR TITLE
fix(react-query): exposeMutationKey adds unnecessary bracket

### DIFF
--- a/.changeset/four-humans-rescue.md
+++ b/.changeset/four-humans-rescue.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+exposeMutationKey adds unnecessary bracket

--- a/.changeset/four-humans-rescue.md
+++ b/.changeset/four-humans-rescue.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/typescript-react-query': patch
 ---
 
-exposeMutationKey adds unnecessary bracket
+fix invalid generated TypeScript code due to the `exposeMutationKey` option adding an unnecessary bracket

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -31,5 +31,5 @@ export function generateMutationKey(node: OperationDefinitionNode): string {
 }
 
 export function generateMutationKeyMaker(node: OperationDefinitionNode, operationName: string) {
-  return `\nuse${operationName}.getKey = () => ${generateMutationKey(node)}};\n`;
+  return `\nuse${operationName}.getKey = () => ${generateMutationKey(node)};\n`;
 }

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -341,7 +341,7 @@ describe('React-Query', () => {
           exposeMutationKeys: true,
         };
         const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
-        expect(out.content).toBeSimilarStringTo(`useTestMutation.getKey = () => 'test'`);
+        expect(out.content).toBeSimilarStringTo(`useTestMutation.getKey = () => 'test'\n`);
       });
     });
 


### PR DESCRIPTION
react-query plugin

## Description

Found a little bug after testing new `exposeMutationKeys` option: it adds unnecessary bracket. This PR provides fix and test case for it.

Related PR https://github.com/dotansimha/graphql-code-generator/pull/6863
Related issue #6724 
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Add `\n` to `exposeMutationKeys: true` test case

**Test Environment**:
- OS: macOS Big Sur 11.2.3 (20D91)
- NodeJS: v12.22.6

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
