### PR TITLE
Honor importOperationTypesFrom in graphql-request generator

### DIFF
--- a/.changeset/fuzzy-bears-speak.md
+++ b/.changeset/fuzzy-bears-speak.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-graphql-request': patch
+---
+
+Honor importOperationTypesFrom config option

--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -23,6 +23,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
   RawGraphQLRequestPluginConfig,
   GraphQLRequestPluginConfig
 > {
+  private _externalImportPrefix: string;
   private _operationsToInclude: {
     node: OperationDefinitionNode;
     documentVariableName: string;
@@ -50,6 +51,8 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
         this._additionalImports.push(`import { print } from 'graphql'`);
       }
     }
+
+    this._externalImportPrefix = this.config.importOperationTypesFrom ? `${this.config.importOperationTypesFrom}.` : '';
   }
 
   public OperationDefinition(node: OperationDefinitionNode) {
@@ -75,6 +78,9 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
     operationResultType: string,
     operationVariablesTypes: string
   ): string {
+    operationResultType = this._externalImportPrefix + operationResultType;
+    operationVariablesTypes = this._externalImportPrefix + operationVariablesTypes;
+
     this._operationsToInclude.push({
       node,
       documentVariableName,

--- a/packages/plugins/typescript/graphql-request/tests/graphql-request.spec.ts
+++ b/packages/plugins/typescript/graphql-request/tests/graphql-request.spec.ts
@@ -348,5 +348,19 @@ async function test() {
         `(Operations.Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');`
       );
     });
+
+    it('#7114 - honor importOperationTypesFrom', async () => {
+      const config = { importOperationTypesFrom: 'Types' };
+      const docs = [{ location: '', document: basicDoc }];
+      const result = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+      const output = await validate(result, config, docs, schema, '');
+
+      expect(output).toContain(`Types.FeedQuery`);
+      expect(output).toContain(`Types.Feed2Query`);
+      expect(output).toContain(`Types.Feed3Query`);
+      expect(output).toContain(`Types.Feed4Query`);
+    });
   });
 });


### PR DESCRIPTION
## Description

This adds support for `importOperationTypesFrom` config option for the `typescript-graphql-request` plugin.

Related #7114.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

The documentation already mentions this config option for the plugin but the plugin ignores it.

## How Has This Been Tested?

I reran the codegen configuration in #7114 and verified that it correctly adds the type prefix.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- ~I have commented my code, particularly in hard-to-understand areas~
- ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
-  ~Any dependent changes have been merged and published in downstream modules~