### PR TITLE
Preset: near-operation-file. Don't emit imports to same location.

### DIFF
--- a/packages/presets/near-operation-file/src/fragment-resolver.ts
+++ b/packages/presets/near-operation-file/src/fragment-resolver.ts
@@ -152,10 +152,12 @@ export default function buildFragmentResolver<T>(
           (dedupeFragments &&
             ['OperationDefinition', 'FragmentDefinition'].includes(documentFileContent.definitions[0].kind))
         ) {
-          if (fragmentFileImports[fragmentDetails.filePath] === undefined) {
-            fragmentFileImports[fragmentDetails.filePath] = fragmentDetails.imports;
-          } else {
-            fragmentFileImports[fragmentDetails.filePath].push(...fragmentDetails.imports);
+          if (fragmentDetails.filePath !== generatedFilePath) { // don't emit imports to same location
+            if (fragmentFileImports[fragmentDetails.filePath] === undefined) {
+              fragmentFileImports[fragmentDetails.filePath] = fragmentDetails.imports;
+            } else {
+              fragmentFileImports[fragmentDetails.filePath].push(...fragmentDetails.imports);
+            }
           }
         }
 

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -484,6 +484,48 @@ describe('near-operation-file preset', () => {
     });
   });
 
+  it('should not add imports for fragments in the same location', async () => {
+    const location = '/some/deep/path/src/graphql/me-query.graphql';
+    const result = await preset.buildGeneratesSection({
+      baseOutputDir: './src/',
+      config: {
+        dedupeOperationSuffix: true,
+      },
+      presetConfig: {
+        cwd: '/some/deep/path',
+        baseTypesPath: 'types.ts',
+      },
+      schemaAst: schemaNode,
+      schema: schemaDocumentNode,
+      documents: [
+        {
+          location: location,
+          document: parse(/* GraphQL */ `
+            query {
+              user {
+                id
+                ...UserFieldsFragment
+              }
+            }
+          `),
+        },
+        {
+          location: location,
+          document: parse(/* GraphQL */ `
+            fragment UserFieldsFragment on User {
+              id
+              username
+            }
+          `),
+        },
+      ],
+      plugins: [{ 'typescript-react-apollo': {} }],
+      pluginMap: { 'typescript-react-apollo': {} as any },
+    });
+
+    expect(getFragmentImportsFromResult(result)).toEqual("");
+  });
+
   it('Should build the correct operation files paths', async () => {
     const result = await preset.buildGeneratesSection({
       baseOutputDir: './src/',


### PR DESCRIPTION
When using the preset `near-operation-file` types for gql documents in a source file will be combined to `[sourcefile].generated.ts`. Additionally when using `inlineFragmentTypes: combine` fragments will be re-used using imports (instead of redeclared inline). When implementing this, a practical case was missed: fragments that are defined in the same source file don't need to be imported. You would get something like: `import { myFragment } from "[sourcefile].generated.ts";` and then tsc warns about a nameclash because `myFragment` is already defined in this file.

For more details the see related issue.

Related issue: https://github.com/dotansimha/graphql-code-generator/issues/6641

This is a bug fix. The emitted output changes, but not in a breaking way. The previous output was syntactically incorrect and tsc would give an error (TS2440).

I've add a test "should not add imports for fragments in the same location" which tests for this behavior.
Additionally running the codegen with this fix on my codebase gives the output I expect.

There are many ways to implement this behavior. I thought it would make the most sense to add the path checking logic as close to the place where the import is generated. In theory the pruning of 'bad imports' (imports from itself) can be done at any stage.

It might be worthwhile to verify that the logic for other properties (such as `externalFragments`) is also correct. I'm not sure what it's used for so I haven't touched it.