### PR TITLE
docs: add react tag to rtk-query plugin

### DIFF
--- a/website/src/lib/plugins.ts
+++ b/website/src/lib/plugins.ts
@@ -212,7 +212,7 @@ const PACKAGES: Package<Tags>[] = [
     title: 'TypeScript RTK-Query',
     npmPackage: '@graphql-codegen/typescript-rtk-query',
     iconUrl: '/assets/img/icons/typescript.svg',
-    tags: ['plugin', 'typescript'],
+    tags: ['plugin', 'typescript', 'react'],
   },
   {
     identifier: 'typescript-stencil-apollo',


### PR DESCRIPTION
## Description

The RTK-Query plugin was missing the `react` tag, so this adds it. I hope I am not missing another place where I have to add it.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project (but I am still not sure if this needs a changeset or is fine as it is)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
