### PR TITLE
Fix validation of enum list args for Java

### DIFF
--- a/.changeset/pink-mugs-cover.md
+++ b/.changeset/pink-mugs-cover.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/java': patch
+---
+
+Fix use of enum list args when the list contains Strings

--- a/packages/plugins/java/java/src/visitor.ts
+++ b/packages/plugins/java/java/src/visitor.ts
@@ -201,6 +201,15 @@ export class JavaResolversVisitor extends BaseVisitor<JavaResolversPluginRawConf
 
         if (typeToUse.isArray && !typeToUse.isScalar) {
           this._addListImport = true;
+          if (typeToUse.isEnum) {
+            return indentMultiline(
+              `this.${this.config.classMembersPrefix}${arg.name.value} = ((List<Object>) args.get("${arg.name.value}")).stream()
+		.map(item -> item instanceof ${typeToUse.baseType} ? item : ${typeToUse.baseType}.valueOf((String) item))
+		.map(${typeToUse.baseType}.class::cast)
+		.collect(Collectors.toList());`,
+              3
+            );
+          }
           return indentMultiline(
             `if (args.get("${arg.name.value}") != null) {
 		this.${arg.name.value} = (${this.config.listType}<${typeToUse.baseType}>) args.get("${arg.name.value}");

--- a/packages/plugins/java/java/src/visitor.ts
+++ b/packages/plugins/java/java/src/visitor.ts
@@ -203,10 +203,12 @@ export class JavaResolversVisitor extends BaseVisitor<JavaResolversPluginRawConf
           this._addListImport = true;
           if (typeToUse.isEnum) {
             return indentMultiline(
-              `this.${this.config.classMembersPrefix}${arg.name.value} = ((List<Object>) args.get("${arg.name.value}")).stream()
-		.map(item -> item instanceof ${typeToUse.baseType} ? item : ${typeToUse.baseType}.valueOf((String) item))
-		.map(${typeToUse.baseType}.class::cast)
-		.collect(Collectors.toList());`,
+              `if (args.get("${arg.name.value}") != null) {
+		this.${this.config.classMembersPrefix}${arg.name.value} = ((List<Object>) args.get("${arg.name.value}")).stream()
+				.map(item -> item instanceof ${typeToUse.baseType} ? item : ${typeToUse.baseType}.valueOf((String) item))
+				.map(${typeToUse.baseType}.class::cast)
+				.collect(Collectors.toList());
+}`,
               3
             );
           }

--- a/packages/plugins/java/java/tests/java.spec.ts
+++ b/packages/plugins/java/java/tests/java.spec.ts
@@ -244,7 +244,7 @@ describe('Java', () => {
     it('Should generate check type for enum when arg with enum list', async () => {
       const result = await plugin(schema, [], {}, { outputFile: OUTPUT_FILE });
       expect(result).toBeSimilarStringTo(`this.roles = ((List<Object>) args.get("roles")).stream()
-		.map(item -> item instanceof UserRole ? item : UserRole.valueOf((String) item))
+        .map(item -> item instanceof UserRole ? item : UserRole.valueOf((String) item))
         .map(UserRole.class::cast)
         .collect(Collectors.toList());`);
     });

--- a/packages/plugins/java/java/tests/java.spec.ts
+++ b/packages/plugins/java/java/tests/java.spec.ts
@@ -241,6 +241,14 @@ describe('Java', () => {
       }`);
     });
 
+    it('Should generate check type for enum when arg with enum list', async () => {
+      const result = await plugin(schema, [], {}, { outputFile: OUTPUT_FILE });
+      expect(result).toBeSimilarStringTo(`this.roles = ((List<Object>) args.get("roles")).stream()
+		.map(item -> item instanceof UserRole ? item : UserRole.valueOf((String) item))
+        .map(UserRole.class::cast)
+        .collect(Collectors.toList());`);
+    });
+
     it('Should generate input class per each input, also with nested input types', async () => {
       const result = await plugin(schema, [], {}, { outputFile: OUTPUT_FILE });
 

--- a/packages/plugins/java/java/tests/java.spec.ts
+++ b/packages/plugins/java/java/tests/java.spec.ts
@@ -15,6 +15,7 @@ describe('Java', () => {
       user(id: ID!): User!
       searchUser(searchFields: SearchUser!): [User!]!
       updateUser(input: UpdateUserMetadataInput!): [User!]!
+      authorize(roles: [UserRole]): Boolean
     }
 
     input InputWithArray {

--- a/packages/plugins/java/java/tests/java.spec.ts
+++ b/packages/plugins/java/java/tests/java.spec.ts
@@ -244,10 +244,12 @@ describe('Java', () => {
 
     it('Should generate check type for enum when arg with enum list', async () => {
       const result = await plugin(schema, [], {}, { outputFile: OUTPUT_FILE });
-      expect(result).toBeSimilarStringTo(`this.roles = ((List<Object>) args.get("roles")).stream()
-        .map(item -> item instanceof UserRole ? item : UserRole.valueOf((String) item))
-        .map(UserRole.class::cast)
-        .collect(Collectors.toList());`);
+      expect(result).toBeSimilarStringTo(`if (args.get("roles") != null) {
+        this.roles = ((List<Object>) args.get("roles")).stream()
+                .map(item -> item instanceof UserRole ? item : UserRole.valueOf((String) item))
+                .map(UserRole.class::cast)
+                .collect(Collectors.toList());
+       }`);
     });
 
     it('Should generate input class per each input, also with nested input types', async () => {


### PR DESCRIPTION
## Description

* Adds a failing test for generated Java enum list args
* Fixes the issue by returning the enums if args contain an Iterable<String> instead of Iterable<Enum>

Related #7002

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Can be found in the linked issue.

## How Has This Been Tested?

Tested through the added unit test and in a project that has query arguments which contain a list of enum options.

**Test Environment**:
- OS: Debian 10
- `@graphql-codegen/java`: 
- NodeJS: 12.22.7

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
