### PR TITLE
fix(rtk query): bad api export in fragment generated files [issue #7278]

### DIFF
--- a/.changeset/light-rockets-design.md
+++ b/.changeset/light-rockets-design.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-rtk-query': patch
+---
+
+bugfix: remove attempt to export injected api for fragment files

--- a/packages/plugins/typescript/rtk-query/src/visitor.ts
+++ b/packages/plugins/typescript/rtk-query/src/visitor.ts
@@ -53,6 +53,10 @@ export class RTKQueryVisitor extends ClientSideBaseVisitor<RTKQueryRawPluginConf
   }
 
   public getInjectCall() {
+    if (!this.hasOperations) {
+      return '';
+    }
+
     return (
       `
 const injectedRtkApi = api.injectEndpoints({

--- a/packages/plugins/typescript/rtk-query/tests/__snapshots__/rtk-query.spec.ts.snap
+++ b/packages/plugins/typescript/rtk-query/tests/__snapshots__/rtk-query.spec.ts.snap
@@ -1,71 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RTK Query Without hooks 1`] = `
-"
-export const CommentDocument = \`
-    query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
-  currentUser {
-    login
-    html_url
-  }
-  entry(repoFullName: $repoFullName) {
-    id
-    postedBy {
-      login
-      html_url
-    }
-    createdAt
-    comments(limit: $limit, offset: $offset) {
-      ...CommentsPageComment
-    }
-    commentCount
-    repository {
-      full_name
-      html_url
-      ... on Repository {
-        description
-        open_issues_count
-        stargazers_count
-      }
-    }
-  }
-}
-    \${CommentsPageCommentFragmentDoc}\`;
-export const FeedDocument = \`
-    query Feed($type: FeedType!, $offset: Int, $limit: Int) {
-  currentUser {
-    login
-  }
-  feed(type: $type, offset: $offset, limit: $limit) {
-    ...FeedEntry
-  }
-}
-    \${FeedEntryFragmentDoc}\`;
-export const SubmitRepositoryDocument = \`
-    mutation submitRepository($repoFullName: String!) {
-  submitRepository(repoFullName: $repoFullName) {
-    createdAt
+exports[`RTK Query For fragment 1`] = `
+"export const VoteButtonsFragmentDoc = \`
+    fragment VoteButtons on Entry {
+  score
+  vote {
+    vote_value
   }
 }
     \`;
-
-const injectedRtkApi = api.injectEndpoints({
-  endpoints: (build) => ({
-    Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument, variables })
-    }),
-    Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument, variables })
-    }),
-    submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument, variables })
-    }),
-  }),
-});
-
-export { injectedRtkApi as api };
-
-
 "
 `;
 
@@ -189,6 +132,75 @@ export const SubmitRepositoryDocument = \`
 
 const injectedRtkApi = api.injectEndpoints({
   overrideExisting: module.hot?.status() === \\"apply\\",
+  endpoints: (build) => ({
+    Comment: build.query<CommentQuery, CommentQueryVariables>({
+      query: (variables) => ({ document: CommentDocument, variables })
+    }),
+    Feed: build.query<FeedQuery, FeedQueryVariables>({
+      query: (variables) => ({ document: FeedDocument, variables })
+    }),
+    submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
+      query: (variables) => ({ document: SubmitRepositoryDocument, variables })
+    }),
+  }),
+});
+
+export { injectedRtkApi as api };
+
+
+"
+`;
+
+exports[`RTK Query Without hooks 1`] = `
+"
+export const CommentDocument = \`
+    query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
+  currentUser {
+    login
+    html_url
+  }
+  entry(repoFullName: $repoFullName) {
+    id
+    postedBy {
+      login
+      html_url
+    }
+    createdAt
+    comments(limit: $limit, offset: $offset) {
+      ...CommentsPageComment
+    }
+    commentCount
+    repository {
+      full_name
+      html_url
+      ... on Repository {
+        description
+        open_issues_count
+        stargazers_count
+      }
+    }
+  }
+}
+    \${CommentsPageCommentFragmentDoc}\`;
+export const FeedDocument = \`
+    query Feed($type: FeedType!, $offset: Int, $limit: Int) {
+  currentUser {
+    login
+  }
+  feed(type: $type, offset: $offset, limit: $limit) {
+    ...FeedEntry
+  }
+}
+    \${FeedEntryFragmentDoc}\`;
+export const SubmitRepositoryDocument = \`
+    mutation submitRepository($repoFullName: String!) {
+  submitRepository(repoFullName: $repoFullName) {
+    createdAt
+  }
+}
+    \`;
+
+const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
       query: (variables) => ({ document: CommentDocument, variables })

--- a/packages/plugins/typescript/rtk-query/tests/rtk-query.spec.ts
+++ b/packages/plugins/typescript/rtk-query/tests/rtk-query.spec.ts
@@ -21,6 +21,7 @@ describe('RTK Query', () => {
   const gql = {
     commentQuery: readFileSync(join(githunt, 'comment.query.graphql'), { encoding: 'utf-8' }),
     feedQuery: readFileSync(join(githunt, 'feed.query.graphql'), { encoding: 'utf-8' }),
+    voteButtonsFragment: readFileSync(join(githunt, 'vote-buttons.fragment.graphql'), { encoding: 'utf-8' }),
     newEntryMutation: readFileSync(join(githunt, 'new-entry.mutation.graphql'), { encoding: 'utf-8' }),
   };
 
@@ -83,6 +84,27 @@ describe('RTK Query', () => {
 
     expect(content.prepend).toContain("import { api } from './baseApi';");
     expect(content.content).toContain('overrideExisting: module.hot?.status() === "apply",');
+
+    expect(content.content).toMatchSnapshot();
+  });
+  test('For fragment', async () => {
+    const documents = parse(gql.voteButtonsFragment);
+    const docs = [{ location: '', document: documents }];
+
+    const content = (await plugin(
+      schema,
+      docs,
+      {
+        importBaseApiFrom: './baseApi',
+        exportHooks: true,
+      },
+      {
+        outputFile: 'graphql.ts',
+      }
+    )) as Types.ComplexPluginOutput;
+
+    expect(content.prepend).not.toContain("import { api } from './baseApi';");
+    expect(content.content).not.toContain('api.injectEndpoints');
 
     expect(content.content).toMatchSnapshot();
   });


### PR DESCRIPTION

## Description

does not export an attempt to inject the rtk query api for graphql fragment files

Related # (issue)
https://github.com/dotansimha/graphql-code-generator/issues/7278

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):
repro of issue: https://github.com/hkasemir/gql-codegen-issue

## How Has This Been Tested?

- [x] added a test for generating files for fragments in the rtk-query plugin test suite

**Test Environment**:
- OS: Mac OS Big Sur (11.2.3)
- `@graphql-codegen/typescript-rtk-query`: 2.2.1
- NodeJS: 17.2.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

