### PR TITLE
Add override modifier in apollo-angular to abide by noImplicitOverride compiler options

### DIFF
--- a/.changeset/yellow-sloths-check.md
+++ b/.changeset/yellow-sloths-check.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-apollo-angular': minor
+---
+
+Add `override` modifier to make the generated code compatible with the `noImplicitOverride` compilation option of Typescript v4.3+

--- a/packages/plugins/typescript/apollo-angular/src/config.ts
+++ b/packages/plugins/typescript/apollo-angular/src/config.ts
@@ -127,4 +127,15 @@ export interface ApolloAngularRawPluginConfig extends RawClientSideBasePluginCon
    * ```
    */
   additionalDI?: string[];
+  /**
+   * @description Add `override` modifier to make the generated code compatible with the `noImplicitOverride` option of Typescript v4.3+.
+   * @default false
+   *
+   * @exampleMarkdown
+   * ```yml
+   * config:
+   *   addExplicitOverride: true
+   * ```
+   */
+  addExplicitOverride?: boolean;
 }

--- a/packages/plugins/typescript/apollo-angular/src/visitor.ts
+++ b/packages/plugins/typescript/apollo-angular/src/visitor.ts
@@ -32,6 +32,7 @@ export interface ApolloAngularPluginConfig extends ClientSideBasePluginConfig {
   subscriptionSuffix?: string;
   apolloAngularPackage: string;
   additionalDI?: string[];
+  addExplicitOverride: boolean;
 }
 
 export class ApolloAngularVisitor extends ClientSideBaseVisitor<
@@ -78,6 +79,7 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
           rawConfig.gqlImport,
           !rawConfig.apolloAngularVersion || rawConfig.apolloAngularVersion === 2 ? `apollo-angular#gql` : null
         ),
+        addExplicitOverride: getConfigValue(rawConfig.addExplicitOverride, false),
       },
       documents
     );
@@ -299,7 +301,10 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
     providedIn: ${this._providedIn(node)}
   })
   export class ${serviceName} extends Apollo.${operationType}<${operationResultType}, ${operationVariablesTypes}> {
-    override document = ${this._getDocumentNodeVariable(node, documentVariableName)};
+    ${this.config.addExplicitOverride ? 'override ' : ''}document = ${this._getDocumentNodeVariable(
+      node,
+      documentVariableName
+    )};
     ${this._namedClient(node)}
     constructor(${this.dependencyInjections}) {
       super(${this.dependencyInjectionArgs});
@@ -377,13 +382,13 @@ ${camelCase(o.node.name.value)}Watch(variables${
 
   interface WatchQueryOptionsAlone<V>
     extends Omit<ApolloCore.WatchQueryOptions<V>, 'query' | 'variables'> {}
-    
+
   interface QueryOptionsAlone<V>
     extends Omit<ApolloCore.QueryOptions<V>, 'query' | 'variables'> {}
-    
+
   interface MutationOptionsAlone<T, V>
     extends Omit<ApolloCore.MutationOptions<T, V>, 'mutation' | 'variables'> {}
-    
+
   interface SubscriptionOptionsAlone<V>
     extends Omit<ApolloCore.SubscriptionOptions<V>, 'query' | 'variables'> {}
 

--- a/packages/plugins/typescript/apollo-angular/src/visitor.ts
+++ b/packages/plugins/typescript/apollo-angular/src/visitor.ts
@@ -299,7 +299,7 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
     providedIn: ${this._providedIn(node)}
   })
   export class ${serviceName} extends Apollo.${operationType}<${operationResultType}, ${operationVariablesTypes}> {
-    document = ${this._getDocumentNodeVariable(node, documentVariableName)};
+    override document = ${this._getDocumentNodeVariable(node, documentVariableName)};
     ${this._namedClient(node)}
     constructor(${this.dependencyInjections}) {
       super(${this.dependencyInjectionArgs});


### PR DESCRIPTION
## Description

TypeScript 4.3 added a new feature to explicitly mark class override. It can be enabled with the `noImplicitOverride` compiler option.

This PR adds the `override` modifier so that generated angular classes don't fail the compilation when this flag is on.


Related #7038 
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added the modifier by hand, and obviously sound.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Can't go much lighter than this PR :)
