### PR TITLE
[ReactQuery]Add infinite query options

### DIFF
--- a/.changeset/neat-cougars-confess.md
+++ b/.changeset/neat-cougars-confess.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': minor
+---
+
+Added extra options for infinite queries generation

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -2,6 +2,7 @@ import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-c
 
 export type HardcodedFetch = { endpoint: string; fetchParams?: string | Record<string, any> };
 export type CustomFetch = { func: string; isReactHook?: boolean } | string;
+export type InfiniteQueryOptions = { exposeQueryKeys?: boolean; markAsInfinite?: boolean };
 
 /**
  * @description This plugin generates `React-Query` Hooks with TypeScript typings.
@@ -91,5 +92,5 @@ export interface ReactQueryRawPluginConfig
    * @default false
    * @description Adds an Infinite Query along side the standard one
    */
-  addInfiniteQuery?: boolean;
+  addInfiniteQuery?: boolean | InfiniteQueryOptions;
 }

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -1,5 +1,10 @@
 import { ParsedMapper, buildMapperImport, parseMapper } from '@graphql-codegen/visitor-plugin-common';
-import { generateInfiniteQueryKey, generateMutationKey, generateQueryKey } from './variables-generator';
+import {
+  generateInfiniteQueryKey,
+  generateMutationKey,
+  generateQueryKey,
+  generateQueryVariablesSignature,
+} from './variables-generator';
 
 import { CustomFetch } from './config';
 import { FetcherRenderer } from './fetcher';
@@ -47,7 +52,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.options);
@@ -83,7 +88,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
+    const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -39,19 +39,6 @@ export function generateQueryKeyMaker(
   return `\nuse${operationName}.getKey = (${signature}) => ${generateQueryKey(node, hasRequiredVariables)};\n`;
 }
 
-export function generateInfiniteQueryKeyMaker(
-  node: OperationDefinitionNode,
-  operationName: string,
-  operationVariablesTypes: string,
-  hasRequiredVariables: boolean
-) {
-  const signature = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
-  return `\nuseInfinite${operationName}.getKey = (${signature}) => ${generateInfiniteQueryKey(
-    node,
-    hasRequiredVariables
-  )};\n`;
-}
-
 export function generateMutationKey(node: OperationDefinitionNode): string {
   return `'${node.name.value}'`;
 }

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -39,6 +39,19 @@ export function generateQueryKeyMaker(
   return `\nuse${operationName}.getKey = (${signature}) => ${generateQueryKey(node, hasRequiredVariables)};\n`;
 }
 
+export function generateInfiniteQueryKeyMaker(
+  node: OperationDefinitionNode,
+  operationName: string,
+  operationVariablesTypes: string,
+  hasRequiredVariables: boolean
+) {
+  const signature = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+  return `\nuseInfinite${operationName}.getKey = (${signature}) => ${generateInfiniteQueryKey(
+    node,
+    hasRequiredVariables
+  )};\n`;
+}
+
 export function generateMutationKey(node: OperationDefinitionNode): string {
   return `'${node.name.value}'`;
 }

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -175,7 +175,7 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
         query += `\nuse${operationName}.document = ${documentVariableName};\n`;
       }
       if (this.config.exposeQueryKeys) {
-        query += `\n${generateQueryKeyMaker(node, operationName, operationVariablesTypes, hasRequiredVariables)};\n`;
+        query += generateQueryKeyMaker(node, operationName, operationVariablesTypes, hasRequiredVariables);
       }
       if (this.config.addInfiniteQuery) {
         query += `\n${this.fetcher.generateInfiniteQueryHook(
@@ -188,12 +188,7 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
         )}\n`;
 
         if (this.config.addInfiniteQuery.exposeQueryKeys ?? this.config.exposeQueryKeys) {
-          query += `\n${generateInfiniteQueryKeyMaker(
-            node,
-            operationName,
-            operationVariablesTypes,
-            hasRequiredVariables
-          )};\n`;
+          query += generateInfiniteQueryKeyMaker(node, operationName, operationVariablesTypes, hasRequiredVariables);
         }
 
         if (this.config.addInfiniteQuery.markAsInfinite) {

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -1165,6 +1165,42 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
     });
   });
 
+  describe('advanced infinite query options', () => {
+    it('Should generate getKey for each query', async () => {
+      const configs = [
+        {
+          fetcher: 'fetch',
+          addInfiniteQuery: {
+            exposeQueryKeys: true,
+          },
+        },
+        {
+          fetcher: 'fetch',
+          exposeQueryKeys: true,
+          addInfiniteQuery: true,
+        },
+      ];
+
+      for (const config of configs) {
+        const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+        expect(out.content).toBeSimilarStringTo(
+          `useInfiniteTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test.infinite'] : ['test.infinite', variables];`
+        );
+      }
+    });
+
+    it('Should generate isInfinite property', async () => {
+      const config = {
+        fetcher: 'fetch',
+        addInfiniteQuery: {
+          markAsInfinite: true,
+        },
+      };
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toBeSimilarStringTo('useInfiniteTestQuery.isInfinite = true as const;');
+    });
+  });
+
   it('Should not generate fetcher if there are no operations', async () => {
     const out = (await plugin(schema, notOperationDocs, {})) as Types.ComplexPluginOutput;
     expect(out.prepend).not.toBeSimilarStringTo(`function fetcher<TData, TVariables>(`);


### PR DESCRIPTION
## Description
- Allow `addInfiniteQuery` to be a configuration object (which will imply the queries are generated)
- Add `exposeQueryKey` for infinite queries as well. If omitted defaults to the outer `exposeQueryKey`
- Add `markAsInfinite` which will generate a `useInfiniteQueryName.isInfinite = true` for the infinite queries

## Usage:
- I am using both properties (`getKey` and `isInfinite`) to update the query cache.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- Added unit tests

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

