### PR TITLE
fix: gql-tag-operations generates invalid types on Windows #7362

### DIFF
--- a/.changeset/orange-keys-guess.md
+++ b/.changeset/orange-keys-guess.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/gql-tag-operations-preset': patch
+---
+
+fix: gql-tag-operations generates invalid types on Windows #7362

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# This fixture must contain CRLF as line breaks. See https://github.com/dotansimha/graphql-code-generator/issues/7362
+packages/presets/gql-tag-operations/tests/fixtures/crlf-operation.ts eol=crlf

--- a/packages/presets/gql-tag-operations/tests/fixtures/crlf-operation.ts
+++ b/packages/presets/gql-tag-operations/tests/fixtures/crlf-operation.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+//@ts-ignore
+import gql from 'gql-tag';
+
+//@ts-ignore
+const A = gql(/* GraphQL */ `
+  query a {
+    a
+  }
+`);
+
+//@ts-ignore
+const B = gql(/* GraphQL */ `
+  query b {
+    b
+  }
+`);
+
+//@ts-ignore
+const C = gql(/* GraphQL */ `
+  fragment C on Query {
+    c
+  }
+`);

--- a/packages/presets/gql-tag-operations/tests/gql-tag-operations.spec.ts
+++ b/packages/presets/gql-tag-operations/tests/gql-tag-operations.spec.ts
@@ -90,6 +90,49 @@ describe('gql-tag-operations-preset', () => {
     `);
   });
 
+  it('generates \\n regardless of whether the source contains LF or CRLF', async () => {
+    const result = await executeCodegen({
+      schema: [
+        /* GraphQL */ `
+          type Query {
+            a: String
+            b: String
+            c: String
+          }
+        `,
+      ],
+      documents: path.join(__dirname, 'fixtures/crlf-operation.ts'),
+      generates: {
+        'out1.ts': {
+          preset,
+          plugins: [],
+        },
+      },
+    });
+    expect(result[0].content).toMatchInlineSnapshot(`
+      "/* eslint-disable */
+      import * as graphql from './graphql';
+      import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+
+      const documents = {
+          \\"\\\\n  query a {\\\\n    a\\\\n  }\\\\n\\": graphql.ADocument,
+          \\"\\\\n  query b {\\\\n    b\\\\n  }\\\\n\\": graphql.BDocument,
+          \\"\\\\n  fragment C on Query {\\\\n    c\\\\n  }\\\\n\\": graphql.CFragmentDoc,
+      };
+
+      export function gql(source: \\"\\\\n  query a {\\\\n    a\\\\n  }\\\\n\\"): (typeof documents)[\\"\\\\n  query a {\\\\n    a\\\\n  }\\\\n\\"];
+      export function gql(source: \\"\\\\n  query b {\\\\n    b\\\\n  }\\\\n\\"): (typeof documents)[\\"\\\\n  query b {\\\\n    b\\\\n  }\\\\n\\"];
+      export function gql(source: \\"\\\\n  fragment C on Query {\\\\n    c\\\\n  }\\\\n\\"): (typeof documents)[\\"\\\\n  fragment C on Query {\\\\n    c\\\\n  }\\\\n\\"];
+
+      export function gql(source: string): unknown;
+      export function gql(source: string) {
+        return (documents as any)[source] ?? {};
+      }
+
+      export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
+    `);
+  });
+
   it("follows 'useTypeImports': true", async () => {
     const result = await executeCodegen({
       schema: [


### PR DESCRIPTION
## Description

Related #7362 

#### Problem summary

`gql-tag-operations` generates invalid types on Windows, causing compile-time error when attempting to launch the application.

#### Root cause

Source file is read by `@graphql/tools` using `fs.promises.readFile`, which means that the linebreaks are read as-is and the result will be different depending on the OS: it will contain LF (`\n`) on Linux/MacOS and CRLF (`\r\n`) on Windows.

In most scenarios that would be OK. However, `gql-tag-operations` is using the resulting string as a TypeScript type. Which means that the string will be compared against a template literal, for example:

```typescript
`
query a {
   a
 }
` === '\n query a {\n    a\n  }\n '
```

According to [clause 12.8.6.2 of ECMAScript Language Specification](https://tc39.es/ecma262/#sec-static-semantics-trv), when comparing strings, JavaScript doesn't care which linebreaks does the source file contain, any linebreak (CR, LF or CRLF) is LF from JavaScript standpoint (otherwise the result of the above comparison would be OS-dependent, which doesn't make sense).

The reason `gql-tag-operations` breaks on Windows is that it generates `\r\n query a {\r\n    a\r\n  }\r\n `, which is NOT equal to

```
`
query a {
   a
 }
`
```

#### Solution

`@graphql/tools` is doing its job correctly. Also it probably doesn't make sense to make changes on `typescript` plugin level, as `gql-tag-operations` is probably the only place where it matters. Therefore the solution is to replace `\r\n` with `\n` during the preset-specific processing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] This PR adds a unit test replicating the issue. In order to reproduce the issue, revert the `fix` commit (leaving only `test` commit) and run the tests.
- [x] In addition I have tested a local build of `gql-tag-operations` within [this application](https://github.com/Amplicode/amplicode-frontend/tree/master/example-app) manually on a Windows machine.

**Test Environment**:
- OS: Windows
- `@graphql-codegen/typescript: ^2.2.2`: 
- NodeJS: 14

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules