### PR TITLE
[React-Query]: Add `options` to exposed fetcher

### DIFF
--- a/.changeset/early-carrots-exist.md
+++ b/.changeset/early-carrots-exist.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/typescript-react-query': minor
+---
+
+Add options to exposed custom fetcher.
+eg. This enables passing headers to fetcher for prefetchQuery & get more query possibilities (user authentication)

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -48,6 +48,10 @@ export class CustomMapperFetcher implements FetcherRenderer {
     hasRequiredVariables: boolean
   ): string {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
+
+    const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
+    this.visitor.imports.add(`${typeImport} { RequestInit } from 'graphql-request/dist/types.dom';`);
+
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.options);
@@ -84,6 +88,10 @@ export class CustomMapperFetcher implements FetcherRenderer {
     hasRequiredVariables: boolean
   ): string {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
+
+    const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
+    this.visitor.imports.add(`${typeImport} { RequestInit } from 'graphql-request/dist/types.dom';`);
+
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -154,8 +154,8 @@ export class CustomMapperFetcher implements FetcherRenderer {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
 
     const typedFetcher = this.getFetcherFnName(operationResultType, operationVariablesTypes);
-    const impl = `${typedFetcher}(${documentVariableName}, variables)`;
+    const impl = `${typedFetcher}(${documentVariableName}, variables, options)`;
 
-    return `\nuse${operationName}.fetcher = (${variables}) => ${impl};`;
+    return `\nuse${operationName}.fetcher = (${variables}, options?: HeadersInit) => ${impl};`;
   }
 }

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -156,6 +156,6 @@ export class CustomMapperFetcher implements FetcherRenderer {
     const typedFetcher = this.getFetcherFnName(operationResultType, operationVariablesTypes);
     const impl = `${typedFetcher}(${documentVariableName}, variables, options)`;
 
-    return `\nuse${operationName}.fetcher = (${variables}, options?: HeadersInit) => ${impl};`;
+    return `\nuse${operationName}.fetcher = (${variables}, options?: RequestInit['headers']) => ${impl};`;
   }
 }

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -291,7 +291,7 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toBeSimilarStringTo(
-        `useTestQuery.fetcher = (variables?: TestQueryVariables, options?: HeadersInit) => customFetcher<TestQuery, TestQueryVariables>(TestDocument, variables, options);`
+        `useTestQuery.fetcher = (variables?: TestQueryVariables, options?: RequestInit['headers']) => customFetcher<TestQuery, TestQueryVariables>(TestDocument, variables, options);`
       );
     });
 
@@ -318,7 +318,7 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toBeSimilarStringTo(
-        `useTestMutation.fetcher = (variables?: TestMutationVariables, options?: HeadersInit) => customFetcher<TestMutation, TestMutationVariables>(TestDocument, variables, options);`
+        `useTestMutation.fetcher = (variables?: TestMutationVariables, options?: RequestInit['headers']) => customFetcher<TestMutation, TestMutationVariables>(TestDocument, variables, options);`
       );
     });
 

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -291,7 +291,7 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toBeSimilarStringTo(
-        `useTestQuery.fetcher = (variables?: TestQueryVariables) => customFetcher<TestQuery, TestQueryVariables>(TestDocument, variables);`
+        `useTestQuery.fetcher = (variables?: TestQueryVariables, options?: HeadersInit) => customFetcher<TestQuery, TestQueryVariables>(TestDocument, variables, options);`
       );
     });
 
@@ -318,7 +318,7 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toBeSimilarStringTo(
-        `useTestMutation.fetcher = (variables?: TestMutationVariables) => customFetcher<TestMutation, TestMutationVariables>(TestDocument, variables);`
+        `useTestMutation.fetcher = (variables?: TestMutationVariables, options?: HeadersInit) => customFetcher<TestMutation, TestMutationVariables>(TestDocument, variables, options);`
       );
     });
 

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -147,6 +147,8 @@ describe('React-Query', () => {
       expect(out.prepend).toContain(
         `import { useQuery, UseQueryOptions, useInfiniteQuery, UseInfiniteQueryOptions, useMutation, UseMutationOptions, QueryFunctionContext } from 'react-query';`
       );
+      expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom';`);
+
       expect(out.prepend).toContain(`import { myCustomFetcher } from './my-file';`);
       expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
           TData = TTestQuery,
@@ -279,6 +281,19 @@ describe('React-Query', () => {
 
       expect(out.content).toMatchSnapshot();
       await validateTypeScript(mergeOutputs(out), schema, docs, config);
+    });
+
+    it('Should support useTypeImports', async () => {
+      const config = {
+        fetcher: {
+          func: './my-file#customFetcher',
+        },
+        useTypeImports: true,
+      };
+
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+
+      expect(out.prepend).toContain(`import type { RequestInit } from 'graphql-request/dist/types.dom';`);
     });
 
     it("Should generate fetcher field when exposeFetcher is true and the fetcher isn't a react hook", async () => {

--- a/website/docs-templates/typescript-react-query.md
+++ b/website/docs-templates/typescript-react-query.md
@@ -180,22 +180,27 @@ Depending on the `isReactHook` property, your `myFetcher` should be in the follo
 
 - `isReactHook: false`
   ```ts
-  type MyFetcher<TData, TVariables> = (operation: string, variables?: TVariables): (() => Promise<TData>)
+  type MyFetcher<TData, TVariables> = (operation: string, variables?: TVariables, options?: RequestInit['headers']): (() => Promise<TData>)
   ```
 - `isReactHook: true`
   ```ts
-  type MyFetcher<TData, TVariables> = (operation: string): ((variables?: TVariables) => Promise<TData>)
+  type MyFetcher<TData, TVariables> = (operation: string, options?: RequestInit['headers']): ((variables?: TVariables) => Promise<TData>)
   ```
 
 #### Usage example (`isReactHook: false`)
 
 ```tsx
-export const fetchData = <TData, TVariables>(query: string, variables?: TVariables): (() => Promise<TData>) => {
+export const fetchData = <TData, TVariables>(
+  query: string,
+  variables?: TVariables,
+  options?: RequestInit['headers']
+): (() => Promise<TData>) => {
   return async () => {
     const res = await fetch('https://api.url', {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...(options ?? {})
       },
       body: JSON.stringify({
         query,
@@ -218,15 +223,20 @@ export const fetchData = <TData, TVariables>(query: string, variables?: TVariabl
 #### Usage example (`isReactHook: true`)
 
 ```tsx
-export const useFetchData = <TData, TVariables>(query: string): ((variables?: TVariables) => Promise<TData>) => {
+export const useFetchData = <TData, TVariables>(
+  query: string,
+  options?: RequestInit['headers']
+): ((variables?: TVariables) => Promise<TData>) => {
   // it is safe to call React Hooks here.
   const { url, headers } = React.useContext(FetchParamsContext)
+
   return async (variables?: TVariables) => {
     const res = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        ...headers
+        ...headers,
+        ...(options ?? {})
       },
       body: JSON.stringify({
         query,


### PR DESCRIPTION
Add a new `options?: HeadersInit` property on the `useQuery.fetcher` function.

## Description

Most of the time, fetchers can have more information than the `query` & the `variables`.
For example, the GraphQL Request fetcher can receive [`requestHeaders`](https://github.com/prisma-labs/graphql-request/blob/12c2e8d387bf2b4f467335babd2989f0a1d33f53/src/types.ts#L75).
Adding this PR would allow the `prefetchQuery` to be used like this : 

```typescript
queryClient.prefetchQuery(
   useCoursesByUserQuery.getKey(variables),
   useCoursesByUserQuery.fetcher(variables, options), // `Ex: { Authorization: "Bearer xxx" }`
  );
```

Related # (issue)
https://github.com/dotansimha/graphql-code-generator/issues/7370

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Using the same sets of current tests.
I just updated `/packages/plugins/typescript/react-query/tests/react-query.spec.ts` file by adding the change.

**Test Environment**:
- OS: MacOs Big Sur 11.4
- NodeJS: v14.18.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
