### PR TITLE
React-query: `getKey` on infinite queries

### DIFF
--- a/.changeset/yellow-walls-refuse.md
+++ b/.changeset/yellow-walls-refuse.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+Generate `getKey` function on generated infinite queries when both `exposeQueryKeys` and `addInfiniteQuery` settings are `true`.

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -49,7 +49,7 @@ export interface ReactQueryRawPluginConfig
 
   /**
    * @default false
-   * @description For each generate query hook adds getKey(variables: QueryVariables) function. Useful for cache updates.
+   * @description For each generate query hook adds getKey(variables: QueryVariables) function. Useful for cache updates. If addInfiniteQuery is true, it will also add a getKey function to each infinite query.
    * @exampleMarkdown
    * ```ts
    * const query = useUserDetailsQuery(...)

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -11,6 +11,19 @@ export function generateInfiniteQueryKey(node: OperationDefinitionNode, hasRequi
   return `variables === undefined ? ['${node.name.value}.infinite'] : ['${node.name.value}.infinite', variables]`;
 }
 
+export function generateInfiniteQueryKeyMaker(
+  node: OperationDefinitionNode,
+  operationName: string,
+  operationVariablesTypes: string,
+  hasRequiredVariables: boolean
+) {
+  const signature = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
+  return `\nuseInfinite${operationName}.getKey = (${signature}) => ${generateInfiniteQueryKey(
+    node,
+    hasRequiredVariables
+  )};\n`;
+}
+
 export function generateQueryKey(node: OperationDefinitionNode, hasRequiredVariables: boolean): string {
   if (hasRequiredVariables) return `['${node.name.value}', variables]`;
   return `variables === undefined ? ['${node.name.value}'] : ['${node.name.value}', variables]`;

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -6,7 +6,7 @@ import {
   getConfigValue,
 } from '@graphql-codegen/visitor-plugin-common';
 import { GraphQLSchema, OperationDefinitionNode } from 'graphql';
-import { generateMutationKeyMaker, generateQueryKeyMaker } from './variables-generator';
+import { generateMutationKeyMaker, generateQueryKeyMaker, generateInfiniteQueryKeyMaker } from './variables-generator';
 
 import { CustomMapperFetcher } from './fetcher-custom-mapper';
 import { FetchFetcher } from './fetcher-fetch';
@@ -178,6 +178,14 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
           operationVariablesTypes,
           hasRequiredVariables
         )}\n`;
+        if (this.config.exposeQueryKeys) {
+          query += `\n${generateInfiniteQueryKeyMaker(
+            node,
+            operationName,
+            operationVariablesTypes,
+            hasRequiredVariables
+          )};\n`;
+        }
       }
 
       // The reason we're looking at the private field of the CustomMapperFetcher to see if it's a react hook

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -1148,6 +1148,23 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
     });
   });
 
+  describe.only('exposeQueryKeys: true, addInfiniteQuery: true', () => {
+    it('Should generate getKey for each query - also infinite queries', async () => {
+      const config = {
+        fetcher: 'fetch',
+        exposeQueryKeys: true,
+        addInfiniteQuery: true,
+      };
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toBeSimilarStringTo(
+        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];`
+      );
+      expect(out.content).toBeSimilarStringTo(
+        `useInfiniteTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test.infinite'] : ['test.infinite', variables];`
+      );
+    });
+  });
+
   it('Should not generate fetcher if there are no operations', async () => {
     const out = (await plugin(schema, notOperationDocs, {})) as Types.ComplexPluginOutput;
     expect(out.prepend).not.toBeSimilarStringTo(`function fetcher<TData, TVariables>(`);

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -1148,7 +1148,7 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
     });
   });
 
-  describe.only('exposeQueryKeys: true, addInfiniteQuery: true', () => {
+  describe('exposeQueryKeys: true, addInfiniteQuery: true', () => {
     it('Should generate getKey for each query - also infinite queries', async () => {
       const config = {
         fetcher: 'fetch',


### PR DESCRIPTION
## Description

This adds support for a `getKey` function on generated infinite queries when using the `react-query` plugin. Currently, the `getKey` function is only available on regular queries. By adding a `getKey` function to infinite queries as well, it will allow safer and more useful invalidations for people who rely on the generated infinite queries.

Related #7365

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

An additional test was added that verifies the `getKey` function is added to infinite queries as well as to regular queries. See the test `exposeQueryKeys: true, addInfiniteQuery: true`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules