### PR TITLE
fix(typescript-urql): respect dedupeOperationSuffix in hooks

### DIFF
--- a/.changeset/breezy-llamas-chew.md
+++ b/.changeset/breezy-llamas-chew.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-urql': patch
+---
+
+Respect dedupeOperationSuffix in hooks

--- a/packages/plugins/typescript/urql/package.json
+++ b/packages/plugins/typescript/urql/package.json
@@ -17,7 +17,6 @@
     "@graphql-codegen/plugin-helpers": "^2.3.2",
     "@graphql-codegen/visitor-plugin-common": "2.5.2",
     "auto-bind": "~4.0.0",
-    "change-case-all": "1.0.14",
     "tslib": "~2.3.0"
   },
   "peerDependencies": {

--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -9,7 +9,6 @@ import {
 import { UrqlRawPluginConfig } from './config';
 import autoBind from 'auto-bind';
 import { OperationDefinitionNode, Kind, GraphQLSchema } from 'graphql';
-import { pascalCase } from 'change-case-all';
 
 export interface UrqlPluginConfig extends ClientSideBasePluginConfig {
   withComponent: boolean;
@@ -106,7 +105,7 @@ export const ${componentName} = (props: Omit<Urql.${operationType}Props<${generi
     operationVariablesTypes: string
   ): string {
     const operationName: string = this.convertName(node.name?.value ?? '', {
-      suffix: this.config.omitOperationSuffix ? '' : pascalCase(operationType),
+      suffix: this.getOperationSuffix(node, operationType),
       useTypesPrefix: false,
     });
 

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -637,6 +637,31 @@ export function useSubmitRepositoryMutation() {
       expect(content.content).toContain(`export function useTest(`);
     });
 
+    it('should respect dedupeOperationSuffix for hooks', async () => {
+      const docs = [
+        {
+          location: '',
+          document: parse(/* GraphQL */ `
+            query testQuery {
+              feed {
+                id
+              }
+            }
+          `),
+        },
+      ];
+      const content = (await plugin(
+        schema,
+        docs,
+        { withHooks: true, dedupeOperationSuffix: true },
+        {
+          outputFile: 'graphql.tsx',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toContain(`export function useTestQuery(`);
+    });
+
     it('should output warning if documentMode = external and importDocumentNodeExternallyFrom is not set', async () => {
       jest.spyOn(console, 'warn');
       const docs = [{ location: '', document: basicDoc }];


### PR DESCRIPTION
## Description

This PR fixes the `dedupeOperationSuffix` option for hooks generated by `typescript-urql`.

Related #7384
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Reproduction sandbox: https://codesandbox.io/s/loving-lalande-hs196

## How Has This Been Tested?

Unit test added to verify deduping of operation suffix.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
 
