### PR TITLE
Performance work: resolvers plugins, documents loading

### DIFF
--- a/.changeset/witty-carrots-clap.md
+++ b/.changeset/witty-carrots-clap.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/cli": patch
+"@graphql-codegen/visitor-plugin-common": minor
+---
+
+Performance work: resolvers plugins, documents loading

--- a/.changeset/witty-carrots-clap.md
+++ b/.changeset/witty-carrots-clap.md
@@ -1,6 +1,6 @@
 ---
 "@graphql-codegen/cli": patch
-"@graphql-codegen/visitor-plugin-common": minor
+"@graphql-codegen/visitor-plugin-common": patch
 ---
 
 Performance work: resolvers plugins, documents loading

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -510,10 +510,13 @@ export class BaseResolversVisitor<
     const nestedMapping: { [typeName: string]: boolean } = {};
     const typeNames = this._federation.filterTypeNames(Object.keys(allSchemaTypes));
 
-    typeNames.forEach(typeName => {
-      const schemaType = allSchemaTypes[typeName];
-      nestedMapping[typeName] = this.shouldMapType(schemaType, nestedMapping);
-    });
+    // avoid checking all types recursively if we have no `mappers` defined
+    if (Object.keys(this.config.mappers).length > 0) {
+      typeNames.forEach(typeName => {
+        const schemaType = allSchemaTypes[typeName];
+        nestedMapping[typeName] = this.shouldMapType(schemaType, nestedMapping);
+      });
+    }
 
     return typeNames.reduce((prev: ResolverTypes, typeName: string) => {
       const schemaType = allSchemaTypes[typeName];


### PR DESCRIPTION
- [x] skip the type mapping (`shouldMapType()` calls in `createResolversFields()`) if not `mappers` config is provided
- [x] improve documents loading cache

------

On a 4sec total build project:

**Before**
![image](https://user-images.githubusercontent.com/1252066/151982369-23f70529-dec5-4262-bcad-83c762a6d81b.png)

**After**
![image](https://user-images.githubusercontent.com/1252066/151982493-c6e6435e-8d6d-420b-82cd-84e363541094.png)
