### PR TITLE
fix(graphql-request): allow v4 as peer dependency

### DIFF
--- a/.changeset/empty-phones-laugh.md
+++ b/.changeset/empty-phones-laugh.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-graphql-request': patch
+---
+
+Allow `graphql-request@4` in `peerDependencies` range

--- a/packages/plugins/typescript/graphql-request/package.json
+++ b/packages/plugins/typescript/graphql-request/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-    "graphql-request": "^3.4.0",
+    "graphql-request": "^3.4.0 || ^4.0.0",
     "graphql-tag": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

v4 of `graphql-request` has `graphql@16` in their peer range.

Related # (issue)

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

N/A

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A