### PR TITLE
fix: apollo-angular peer dependencies

### DIFF
--- a/packages/plugins/typescript/apollo-angular/package.json
+++ b/packages/plugins/typescript/apollo-angular/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-    "graphql-tag": "^2.0.0"
+    "apollo-angular": "^2.0.0"
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^2.4.0",


### PR DESCRIPTION

## Description

`apollo-angular` as of version 2 now bundles `gql` instead of requiring `graphql-tag` peer. Apollo angular version 2 came out two years ago so it seems safe to make that the new peer-dependency.

Related  #7495 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
