### PR TITLE
fix(plugins/react-query): remove useless `RequestInit` import for custom fetcher

### DIFF
--- a/.changeset/sweet-poets-begin.md
+++ b/.changeset/sweet-poets-begin.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-react-query": patch
+---
+
+fix(plugins/react-query): remove useless `RequestInit` import for custom fetcher

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -49,9 +49,6 @@ export class CustomMapperFetcher implements FetcherRenderer {
   ): string {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
 
-    const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
-    this.visitor.imports.add(`${typeImport} { RequestInit } from 'graphql-request/dist/types.dom';`);
-
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.options);
@@ -155,9 +152,6 @@ export class CustomMapperFetcher implements FetcherRenderer {
     // We can't generate a fetcher field since we can't call react hooks outside of a React Fucntion Component
     // Related: https://reactjs.org/docs/hooks-rules.html
     if (this._isReactHook) return '';
-
-    const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
-    this.visitor.imports.add(`${typeImport} { RequestInit } from 'graphql-request/dist/types.dom';`);
 
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
 

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -147,7 +147,6 @@ describe('React-Query', () => {
       expect(out.prepend).toContain(
         `import { useQuery, UseQueryOptions, useInfiniteQuery, UseInfiniteQueryOptions, useMutation, UseMutationOptions, QueryFunctionContext } from 'react-query';`
       );
-      expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom';`);
 
       expect(out.prepend).toContain(`import { myCustomFetcher } from './my-file';`);
       expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
@@ -305,7 +304,6 @@ describe('React-Query', () => {
       };
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
-      expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom';`);
       expect(out.content).toBeSimilarStringTo(
         `useTestQuery.fetcher = (variables?: TestQueryVariables, options?: RequestInit['headers']) => customFetcher<TestQuery, TestQueryVariables>(TestDocument, variables, options);`
       );


### PR DESCRIPTION
Fixes https://github.com/dotansimha/graphql-code-generator/issues/7444#issuecomment-1034370768