### PR TITLE
chore(renovate): use a shared preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,3 @@
 {
-  "extends": ["config:base"],
-  "postUpdateOptions": ["yarnDedupeFewer"],
-  "automerge": true,
-  "major": {
-    "automerge": false
-  },
-  "labels": ["dependencies"]
+  "extends": ["github>the-guild-org/shared-config:renovate"]
 }


### PR DESCRIPTION
Uses the newly created shared renovate config: https://github.com/the-guild-org/shared-config/blob/main/renovate.json

This The Guild preset configures:
- extend `config:base`
- automerges unless major
- add `dependencies` label to PR
- group all non-major updates into a single PR
- Higher priority to `@the-guild/*` and `@guild-docs/*` package (website related)


Any other suggestion?