### PR TITLE
Fix addExplicitOverride for custom namedClient

### DIFF
--- a/.changeset/brave-apricots-yawn.md
+++ b/.changeset/brave-apricots-yawn.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-apollo-angular": patch
+---
+
+Fix addExplicitOverride for custom namedClient

--- a/packages/plugins/typescript/apollo-angular/src/visitor.ts
+++ b/packages/plugins/typescript/apollo-angular/src/visitor.ts
@@ -292,6 +292,7 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
       operationVariablesTypes,
       serviceName,
     });
+    const namedClient = this._namedClient(node);
 
     operationResultType = this._externalImportPrefix + operationResultType;
     operationVariablesTypes = this._externalImportPrefix + operationVariablesTypes;
@@ -305,7 +306,7 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
       node,
       documentVariableName
     )};
-    ${this._namedClient(node)}
+    ${namedClient !== '' ? (this.config.addExplicitOverride ? 'override ' : '') + namedClient : ''}
     constructor(${this.dependencyInjections}) {
       super(${this.dependencyInjectionArgs});
     }

--- a/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
+++ b/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
@@ -129,6 +129,25 @@ describe('Apollo Angular', () => {
       // await validateTypeScript(content, schema, docs, {});
     });
 
+    it(`should add explicit override to document and namedClient property`, async () => {
+      const docs = [{ location: '', document: basicDoc }];
+      const content = (await plugin(
+        schema,
+        docs,
+        {
+          addExplicitOverride: true,
+          namedClient: 'custom',
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`override document = TestDocument;`);
+      expect(content.content).toBeSimilarStringTo(`override client = 'custom';`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it(`should add the correct angular imports with override`, async () => {
       const docs = [{ location: '', document: basicDoc }];
       const content = (await plugin(
@@ -518,7 +537,7 @@ describe('Apollo Angular', () => {
         constructor(
           private myFeedGql: MyFeedGQL
         ) {}
-        
+
         myFeed(variables?: MyFeedQueryVariables, options?: QueryOptionsAlone<MyFeedQueryVariables>) {
           return this.myFeedGql.fetch(variables, options)
         }
@@ -562,7 +581,7 @@ describe('Apollo Angular', () => {
         constructor(
           private myFeedGql: MyFeedGQL
         ) {}
-        
+
         myFeed(variables?: MyFeedQueryVariables, options?: QueryOptionsAlone<MyFeedQueryVariables>) {
           return this.myFeedGql.fetch(variables, options)
         }


### PR DESCRIPTION
## Description
PR #7322 adds the option `addExplicitOverride` with the `override` modifier to the `document` property.
When making use of the config option `namedClient` like so:
```yaml
config:
  namedClient: 'customName'
```
This ends up in a `client` property that doesn't have the required `override` modifier. 

Related #7548

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I added a jest test for `addExplicitOverride` since it was missing and I added the `customName` check in there as well.

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
None.