### PR TITLE
Fix: Flow Plugin not defining some types in generated file

### DIFF
--- a/.changeset/moody-elephants-hope.md
+++ b/.changeset/moody-elephants-hope.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/flow-resolvers": patch
+---
+
+Fix: Flow Plugin not defining some types in generated file

--- a/packages/plugins/flow/resolvers/src/index.ts
+++ b/packages/plugins/flow/resolvers/src/index.ts
@@ -26,8 +26,6 @@ export const plugin: PluginFunction<RawFlowResolversConfig, Types.ComplexPluginO
   const imports = ['type GraphQLResolveInfo'];
   const showUnusedMappers = typeof config.showUnusedMappers === 'boolean' ? config.showUnusedMappers : true;
 
-  const gqlImports = `import { ${imports.join(', ')} } from 'graphql';`;
-
   const transformedSchema = config.federation ? addFederationReferencesToSchema(schema) : schema;
 
   const astNode = getCachedDocumentNodeFromSchema(transformedSchema);
@@ -113,8 +111,10 @@ ${defsToInclude.join('\n')}
   const { getRootResolver, getAllDirectiveResolvers, mappersImports, unusedMappers, hasScalars } = visitor;
 
   if (hasScalars()) {
-    imports.push('type GraphQLScalarTypeConfig');
+    imports.push('type GraphQLScalarType', 'type GraphQLScalarTypeConfig');
   }
+
+  const gqlImports = `import { ${imports.join(', ')} } from 'graphql';`;
 
   if (showUnusedMappers && unusedMappers.length) {
     // eslint-disable-next-line no-console

--- a/packages/plugins/flow/resolvers/src/visitor.ts
+++ b/packages/plugins/flow/resolvers/src/visitor.ts
@@ -118,6 +118,8 @@ export class FlowResolversVisitor extends BaseResolversVisitor<RawResolversConfi
   ScalarTypeDefinition(node: ScalarTypeDefinitionNode): string {
     const nameAsString = node.name as any as string;
     const baseName = this.getTypeToUse(nameAsString);
+
+    this._hasScalars = true;
     this._collectedResolvers[node.name as any] = 'GraphQLScalarType';
 
     return new DeclarationBlock({

--- a/packages/plugins/flow/resolvers/src/visitor.ts
+++ b/packages/plugins/flow/resolvers/src/visitor.ts
@@ -55,9 +55,7 @@ export class FlowResolversVisitor extends BaseResolversVisitor<RawResolversConfi
   }
 
   protected formatRootResolver(schemaTypeName: string, resolverType: string, declarationKind: DeclarationKind): string {
-    return `${schemaTypeName}?: ${resolverType}${resolverType.includes('<') ? '' : '<>'}${this.getPunctuation(
-      declarationKind
-    )}`;
+    return `${schemaTypeName}?: ${resolverType}${this.getPunctuation(declarationKind)}`;
   }
 
   protected transformParentGenericType(parentType: string): string {

--- a/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
+++ b/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
@@ -169,7 +169,7 @@ export type Resolvers<ContextType = any> = {
   Node?: NodeResolvers<ContextType>,
   SomeNode?: SomeNodeResolvers<ContextType>,
   MyUnion?: MyUnionResolvers<ContextType>,
-  MyScalar?: GraphQLScalarType<>,
+  MyScalar?: GraphQLScalarType,
 };
 
 export type DirectiveResolvers<ContextType = any> = {

--- a/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
+++ b/packages/plugins/flow/resolvers/tests/__snapshots__/flow-resolvers.spec.ts.snap
@@ -178,7 +178,7 @@ export type DirectiveResolvers<ContextType = any> = {
 };
 ",
   "prepend": Array [
-    "import { type GraphQLResolveInfo } from 'graphql';",
+    "import { type GraphQLResolveInfo, type GraphQLScalarType, type GraphQLScalarTypeConfig } from 'graphql';",
     "export type $RequireFields<Origin, Keys> = $Diff<Origin, Keys> & $ObjMapi<Keys, <Key>(k: Key) => $NonMaybeType<$ElementType<Origin, Key>>>;",
   ],
 }

--- a/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
@@ -4,6 +4,7 @@ import { plugin } from '../src';
 import { schema } from '../../../typescript/resolvers/tests/common';
 import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 import { ENUM_RESOLVERS_SIGNATURE } from '../src/visitor';
+import { ConstructorDeclarationContext } from 'java-ast';
 
 describe('Flow Resolvers Plugin', () => {
   describe('Enums', () => {
@@ -77,6 +78,7 @@ describe('Flow Resolvers Plugin', () => {
       expect(result.content).toContain(
         `export type MyEnumResolvers = EnumResolverSignature<{| A?: *, B?: *, C?: * |}, $ElementType<ResolversTypes, 'MyEnum'>>;`
       );
+      expect(result.content).toContain(`MyEnum?: MyEnumResolvers,`);
     });
 
     it('Should generate enum internal values resolvers when enum has mappers pointing to external enum', async () => {

--- a/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
@@ -4,7 +4,6 @@ import { plugin } from '../src';
 import { schema } from '../../../typescript/resolvers/tests/common';
 import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers';
 import { ENUM_RESOLVERS_SIGNATURE } from '../src/visitor';
-import { ConstructorDeclarationContext } from 'java-ast';
 
 describe('Flow Resolvers Plugin', () => {
   describe('Enums', () => {

--- a/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
+++ b/packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts
@@ -181,7 +181,9 @@ describe('Flow Resolvers Plugin', () => {
   it('Should generate the correct imports when schema has scalars', () => {
     const result = plugin(buildSchema(`scalar MyScalar`), [], {}, { outputFile: '' }) as Types.ComplexPluginOutput;
 
-    expect(result.prepend).toContain(`import { type GraphQLResolveInfo } from 'graphql';`);
+    expect(result.prepend).toContain(
+      `import { type GraphQLResolveInfo, type GraphQLScalarType, type GraphQLScalarTypeConfig } from 'graphql';`
+    );
   });
 
   it('Should generate the correct imports when schema has no scalars', () => {
@@ -192,9 +194,7 @@ describe('Flow Resolvers Plugin', () => {
       { outputFile: '' }
     ) as Types.ComplexPluginOutput;
 
-    expect(result.prepend).not.toContain(
-      `import { type GraphQLResolveInfo, type GraphQLScalarTypeConfig } from 'graphql';`
-    );
+    expect(result.prepend).toContain(`import { type GraphQLResolveInfo } from 'graphql';`);
   });
 
   it('Should generate valid output with args', async () => {


### PR DESCRIPTION
## Description

This change corrects tests and fixes the issue of the `flow-resolver` plugin not adding the correct imports to the generated file.

Related #5322 
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

For now, just unit tests in `packages/plugins/flow/resolvers/tests/flow-resolvers.spec.ts` - these were incorrect, so have been corrected.

**Test Environment**:
- OS: MacOS 12
- `@graphql-codegen/...`: 
- NodeJS: 14

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
