### PR TITLE
Fix #7566 external resolver name export for directiveResolverMappings

### DIFF
--- a/.changeset/soft-colts-matter.md
+++ b/.changeset/soft-colts-matter.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-resolvers": patch
+---
+
+Fix #7566 external resolver name export for directiveResolverMappings

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -59,7 +59,7 @@ export type Resolver${capitalizedDirectiveName}WithResolve<TResult, TParent, TCo
             }} from '${parsedMapper.source}';`
           );
         }
-        prepend.push(`export${config.useTypeImports ? ' type' : ''} { ResolverFn };`);
+        prepend.push(`export${config.useTypeImports ? ' type' : ''} { ${resolverFnName} };`);
       } else {
         defsToInclude.push(`export type ${resolverFnName}<TResult, TParent, TContext, TArgs> = ${parsedMapper.type}`);
       }

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -238,6 +238,9 @@ export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParen
     expect(result.prepend).toContain(
       "import { AuthenticatedResolver as ResolverFnAuthenticated } from '../resolver-types.ts';"
     );
+    expect(result.prepend).toContain(
+      "export { ResolverFnAuthenticated };"
+    )
     expect(result.content).toBeSimilarStringTo(`
 export type ResolverAuthenticatedWithResolve<TResult, TParent, TContext, TArgs> = {
   resolve: ResolverFnAuthenticated<TResult, TParent, TContext, TArgs>;


### PR DESCRIPTION
## Description

This fixes #7566 wich creates typescript errors on generated file when using `directiveResolverMappings` with external type (details and example in issue).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I used the example given in the issue and could generate the expected output. Tested in a production project and it works perfectly.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

👆 I might need some help on the tests