### PR TITLE
fix: Remove explicit return types from sdk methods

### DIFF
--- a/.changeset/shiny-dogs-press.md
+++ b/.changeset/shiny-dogs-press.md
@@ -1,0 +1,16 @@
+---
+'@graphql-codegen/typescript-graphql-request': major
+'@graphql-codegen/website': patch
+---
+
+Do not specify return types of sdk methods explicitly.
+
+Previously, the return type of all SDK methods was declared manually. This can
+cause the return type to become outdated when graphql-request gets updated.
+This already happened, as graphql-request removed the errors attribute from the
+return type (see https://github.com/prisma-labs/graphql-request/issues/174).
+Also, data was marked as possibly undefined which is wrong. data always exists
+on a successful response (failed requests throw a ClientError).
+
+A sideeffect of this change is that the extensionsType config became obsolete
+and has been removed.

--- a/packages/plugins/typescript/graphql-request/src/config.ts
+++ b/packages/plugins/typescript/graphql-request/src/config.ts
@@ -22,17 +22,4 @@ export interface RawGraphQLRequestPluginConfig extends RawClientSideBasePluginCo
    * ```
    */
   rawRequest?: boolean;
-
-  /**
-   * @description Allows you to override the type for extensions when `rawRequest` is enabled.
-   * @default any
-   *
-   * @exampleMarkdown
-   * ```yml
-   * config:
-   *   rawRequest: true
-   *   extensionsType: unknown
-   * ```
-   */
-  extensionsType?: string;
 }

--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -12,7 +12,6 @@ import { RawGraphQLRequestPluginConfig } from './config';
 
 export interface GraphQLRequestPluginConfig extends ClientSideBasePluginConfig {
   rawRequest: boolean;
-  extensionsType: string;
 }
 
 const additionalExportedTypes = `
@@ -34,7 +33,6 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
   constructor(schema: GraphQLSchema, fragments: LoadedFragment[], rawConfig: RawGraphQLRequestPluginConfig) {
     super(schema, fragments, rawConfig, {
       rawRequest: getConfigValue(rawConfig.rawRequest, false),
-      extensionsType: getConfigValue(rawConfig.extensionsType, 'any'),
     });
 
     autoBind(this);
@@ -111,11 +109,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
           }
           return `${operationName}(variables${optionalVariables ? '?' : ''}: ${
             o.operationVariablesTypes
-          }, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data?: ${
-            o.operationResultType
-          } | undefined; extensions?: ${
-            this.config.extensionsType
-          }; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
+          }, requestHeaders?: Dom.RequestInit["headers"]) {
     return withWrapper((wrappedRequestHeaders) => client.rawRequest<${
       o.operationResultType
     }>(${docArg}, variables, {...requestHeaders, ...wrappedRequestHeaders}), '${operationName}');
@@ -123,7 +117,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
         } else {
           return `${operationName}(variables${optionalVariables ? '?' : ''}: ${
             o.operationVariablesTypes
-          }, requestHeaders?: Dom.RequestInit["headers"]): Promise<${o.operationResultType}> {
+          }, requestHeaders?: Dom.RequestInit["headers"]) {
   return withWrapper((wrappedRequestHeaders) => client.request<${
     o.operationResultType
   }>(${docVarName}, variables, {...requestHeaders, ...wrappedRequestHeaders}), '${operationName}');

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -245,16 +245,16 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
     }
   };
@@ -531,16 +531,16 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
     }
   };
@@ -809,16 +809,16 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
     }
   };
@@ -1093,301 +1093,16 @@ const Feed3DocumentString = print(Feed3Document);
 const Feed4DocumentString = print(Feed4Document);
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: FeedQuery | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<FeedQuery>(FeedDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed2Query | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed2Query>(Feed2DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed3Query | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed3Query>(Feed3DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed4Query | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed4Query>(Feed4DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
-    }
-  };
-}
-export type Sdk = ReturnType<typeof getSdk>;
-async function test() {
-  const Client = require('graphql-request').GraphQLClient;
-  const client = new Client('');
-  const sdk = getSdk(client);
-
-  await sdk.feed();
-  await sdk.feed3();
-  await sdk.feed4();
-
-  const result = await sdk.feed2({ v: \\"1\\" });
-
-  if (result.feed) {
-    if (result.feed[0]) {
-      const id = result.feed[0].id
-    }
-  }
-}"
-`;
-
-exports[`graphql-request sdk Should support extensionType when rawRequest is true and documentMode = "DocumentNode" 1`] = `
-"export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
-import { GraphQLError } from 'graphql-request/dist/types';
-import { print } from 'graphql'
-import gql from 'graphql-tag';
-/** All built-in and custom scalars, mapped to their actual values */
-export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-};
-
-export type Query = {
-  __typename?: 'Query';
-  /** A feed of repository submissions */
-  feed?: Maybe<Array<Maybe<Entry>>>;
-  /** A single entry */
-  entry?: Maybe<Entry>;
-  /** Return the currently logged in user, or null if nobody is logged in */
-  currentUser?: Maybe<User>;
-};
-
-
-export type QueryFeedArgs = {
-  type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
-};
-
-
-export type QueryEntryArgs = {
-  repoFullName: Scalars['String'];
-};
-
-/** A list of options for the sort order of the feed */
-export enum FeedType {
-  /** Sort by a combination of freshness and score, using Reddit's algorithm */
-  Hot = 'HOT',
-  /** Newest entries first */
-  New = 'NEW',
-  /** Highest score entries first */
-  Top = 'TOP'
-}
-
-/** Information about a GitHub repository submitted to GitHunt */
-export type Entry = {
-  __typename?: 'Entry';
-  /** Information about the repository from GitHub */
-  repository: Repository;
-  /** The GitHub user who submitted this entry */
-  postedBy: User;
-  /** A timestamp of when the entry was submitted */
-  createdAt: Scalars['Float'];
-  /** The score of this repository, upvotes - downvotes */
-  score: Scalars['Int'];
-  /** The hot score of this repository */
-  hotScore: Scalars['Float'];
-  /** Comments posted about this repository */
-  comments: Array<Maybe<Comment>>;
-  /** The number of comments posted about this repository */
-  commentCount: Scalars['Int'];
-  /** The SQL ID of this entry */
-  id: Scalars['Int'];
-  /** XXX to be changed */
-  vote: Vote;
-};
-
-
-/** Information about a GitHub repository submitted to GitHunt */
-export type EntryCommentsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-};
-
-/**
- * A repository object from the GitHub API. This uses the exact field names returned by the
- * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
- */
-export type Repository = {
-  __typename?: 'Repository';
-  /** Just the name of the repository, e.g. GitHunt-API */
-  name: Scalars['String'];
-  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
-  full_name: Scalars['String'];
-  /** The description of the repository */
-  description?: Maybe<Scalars['String']>;
-  /** The link to the repository on GitHub */
-  html_url: Scalars['String'];
-  /** The number of people who have starred this repository on GitHub */
-  stargazers_count: Scalars['Int'];
-  /** The number of open issues on this repository on GitHub */
-  open_issues_count?: Maybe<Scalars['Int']>;
-  /** The owner of this repository on GitHub, e.g. apollostack */
-  owner?: Maybe<User>;
-};
-
-/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
-export type User = {
-  __typename?: 'User';
-  /** The name of the user, e.g. apollostack */
-  login: Scalars['String'];
-  /** The URL to a directly embeddable image for this user's avatar */
-  avatar_url: Scalars['String'];
-  /** The URL of this user's GitHub page */
-  html_url: Scalars['String'];
-};
-
-/** A comment about an entry, submitted by a user */
-export type Comment = {
-  __typename?: 'Comment';
-  /** The SQL ID of this entry */
-  id: Scalars['Int'];
-  /** The GitHub user who posted the comment */
-  postedBy: User;
-  /** A timestamp of when the comment was posted */
-  createdAt: Scalars['Float'];
-  /** The text of the comment */
-  content: Scalars['String'];
-  /** The repository which this comment is about */
-  repoName: Scalars['String'];
-};
-
-/** XXX to be removed */
-export type Vote = {
-  __typename?: 'Vote';
-  vote_value: Scalars['Int'];
-};
-
-export type Mutation = {
-  __typename?: 'Mutation';
-  /** Submit a new repository, returns the new submission */
-  submitRepository?: Maybe<Entry>;
-  /** Vote on a repository submission, returns the submission that was voted on */
-  vote?: Maybe<Entry>;
-  /** Comment on a repository, returns the new comment */
-  submitComment?: Maybe<Comment>;
-};
-
-
-export type MutationSubmitRepositoryArgs = {
-  repoFullName: Scalars['String'];
-};
-
-
-export type MutationVoteArgs = {
-  repoFullName: Scalars['String'];
-  type: VoteType;
-};
-
-
-export type MutationSubmitCommentArgs = {
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
-};
-
-/** The type of vote to record, when submitting a vote */
-export enum VoteType {
-  Up = 'UP',
-  Down = 'DOWN',
-  Cancel = 'CANCEL'
-}
-
-export type Subscription = {
-  __typename?: 'Subscription';
-  /** Subscription fires on every comment added */
-  commentAdded?: Maybe<Comment>;
-};
-
-
-export type SubscriptionCommentAddedArgs = {
-  repoFullName: Scalars['String'];
-};
-export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
-
-export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
-}>;
-
-
-export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
-
-export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
-}>;
-
-
-export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
-
-export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
-}>;
-
-
-export type Feed4Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
-
-export const FeedDocument = gql\`
-    query feed {
-  feed {
-    id
-    commentCount
-    repository {
-      owner {
-        avatar_url
-      }
-    }
-  }
-}
-    \`;
-export const Feed2Document = gql\`
-    query feed2($v: String!) {
-  feed {
-    id
-  }
-}
-    \`;
-export const Feed3Document = gql\`
-    query feed3($v: String) {
-  feed {
-    id
-  }
-}
-    \`;
-export const Feed4Document = gql\`
-    query feed4($v: String! = \\"TEST\\") {
-  feed {
-    id
-  }
-}
-    \`;
-
-export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
-
-
-const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
-const FeedDocumentString = print(FeedDocument);
-const Feed2DocumentString = print(Feed2Document);
-const Feed3DocumentString = print(Feed3Document);
-const Feed4DocumentString = print(Feed4Document);
-export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
-  return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: FeedQuery | undefined; extensions?: unknown; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<FeedQuery>(FeedDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
-    },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed2Query | undefined; extensions?: unknown; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed2Query>(Feed2DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
-    },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed3Query | undefined; extensions?: unknown; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed3Query>(Feed3DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
-    },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed4Query | undefined; extensions?: unknown; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed4Query>(Feed4DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
     }
   };
@@ -1663,16 +1378,16 @@ const Feed3DocumentString = print(Feed3Document);
 const Feed4DocumentString = print(Feed4Document);
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: FeedQuery | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<FeedQuery>(FeedDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed2Query | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed2Query>(Feed2DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed3Query | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed3Query>(Feed3DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<{ data?: Feed4Query | undefined; extensions?: any; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed4Query>(Feed4DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
     }
   };
@@ -1943,296 +1658,16 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed4Query> {
-      return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
-    }
-  };
-}
-export type Sdk = ReturnType<typeof getSdk>;
-async function test() {
-  const Client = require('graphql-request').GraphQLClient;
-  const client = new Client('');
-  const sdk = getSdk(client);
-
-  await sdk.feed();
-  await sdk.feed3();
-  await sdk.feed4();
-
-  const result = await sdk.feed2({ v: \\"1\\" });
-
-  if (result.feed) {
-    if (result.feed[0]) {
-      const id = result.feed[0].id
-    }
-  }
-}"
-`;
-
-exports[`graphql-request sdk extensionType should be irrelevant when rawRequest is false 1`] = `
-"export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
-import gql from 'graphql-tag';
-/** All built-in and custom scalars, mapped to their actual values */
-export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-};
-
-export type Query = {
-  __typename?: 'Query';
-  /** A feed of repository submissions */
-  feed?: Maybe<Array<Maybe<Entry>>>;
-  /** A single entry */
-  entry?: Maybe<Entry>;
-  /** Return the currently logged in user, or null if nobody is logged in */
-  currentUser?: Maybe<User>;
-};
-
-
-export type QueryFeedArgs = {
-  type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
-};
-
-
-export type QueryEntryArgs = {
-  repoFullName: Scalars['String'];
-};
-
-/** A list of options for the sort order of the feed */
-export enum FeedType {
-  /** Sort by a combination of freshness and score, using Reddit's algorithm */
-  Hot = 'HOT',
-  /** Newest entries first */
-  New = 'NEW',
-  /** Highest score entries first */
-  Top = 'TOP'
-}
-
-/** Information about a GitHub repository submitted to GitHunt */
-export type Entry = {
-  __typename?: 'Entry';
-  /** Information about the repository from GitHub */
-  repository: Repository;
-  /** The GitHub user who submitted this entry */
-  postedBy: User;
-  /** A timestamp of when the entry was submitted */
-  createdAt: Scalars['Float'];
-  /** The score of this repository, upvotes - downvotes */
-  score: Scalars['Int'];
-  /** The hot score of this repository */
-  hotScore: Scalars['Float'];
-  /** Comments posted about this repository */
-  comments: Array<Maybe<Comment>>;
-  /** The number of comments posted about this repository */
-  commentCount: Scalars['Int'];
-  /** The SQL ID of this entry */
-  id: Scalars['Int'];
-  /** XXX to be changed */
-  vote: Vote;
-};
-
-
-/** Information about a GitHub repository submitted to GitHunt */
-export type EntryCommentsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-};
-
-/**
- * A repository object from the GitHub API. This uses the exact field names returned by the
- * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
- */
-export type Repository = {
-  __typename?: 'Repository';
-  /** Just the name of the repository, e.g. GitHunt-API */
-  name: Scalars['String'];
-  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
-  full_name: Scalars['String'];
-  /** The description of the repository */
-  description?: Maybe<Scalars['String']>;
-  /** The link to the repository on GitHub */
-  html_url: Scalars['String'];
-  /** The number of people who have starred this repository on GitHub */
-  stargazers_count: Scalars['Int'];
-  /** The number of open issues on this repository on GitHub */
-  open_issues_count?: Maybe<Scalars['Int']>;
-  /** The owner of this repository on GitHub, e.g. apollostack */
-  owner?: Maybe<User>;
-};
-
-/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
-export type User = {
-  __typename?: 'User';
-  /** The name of the user, e.g. apollostack */
-  login: Scalars['String'];
-  /** The URL to a directly embeddable image for this user's avatar */
-  avatar_url: Scalars['String'];
-  /** The URL of this user's GitHub page */
-  html_url: Scalars['String'];
-};
-
-/** A comment about an entry, submitted by a user */
-export type Comment = {
-  __typename?: 'Comment';
-  /** The SQL ID of this entry */
-  id: Scalars['Int'];
-  /** The GitHub user who posted the comment */
-  postedBy: User;
-  /** A timestamp of when the comment was posted */
-  createdAt: Scalars['Float'];
-  /** The text of the comment */
-  content: Scalars['String'];
-  /** The repository which this comment is about */
-  repoName: Scalars['String'];
-};
-
-/** XXX to be removed */
-export type Vote = {
-  __typename?: 'Vote';
-  vote_value: Scalars['Int'];
-};
-
-export type Mutation = {
-  __typename?: 'Mutation';
-  /** Submit a new repository, returns the new submission */
-  submitRepository?: Maybe<Entry>;
-  /** Vote on a repository submission, returns the submission that was voted on */
-  vote?: Maybe<Entry>;
-  /** Comment on a repository, returns the new comment */
-  submitComment?: Maybe<Comment>;
-};
-
-
-export type MutationSubmitRepositoryArgs = {
-  repoFullName: Scalars['String'];
-};
-
-
-export type MutationVoteArgs = {
-  repoFullName: Scalars['String'];
-  type: VoteType;
-};
-
-
-export type MutationSubmitCommentArgs = {
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
-};
-
-/** The type of vote to record, when submitting a vote */
-export enum VoteType {
-  Up = 'UP',
-  Down = 'DOWN',
-  Cancel = 'CANCEL'
-}
-
-export type Subscription = {
-  __typename?: 'Subscription';
-  /** Subscription fires on every comment added */
-  commentAdded?: Maybe<Comment>;
-};
-
-
-export type SubscriptionCommentAddedArgs = {
-  repoFullName: Scalars['String'];
-};
-export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
-
-export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
-}>;
-
-
-export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
-
-export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
-}>;
-
-
-export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
-
-export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
-}>;
-
-
-export type Feed4Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
-
-export const FeedDocument = gql\`
-    query feed {
-  feed {
-    id
-    commentCount
-    repository {
-      owner {
-        avatar_url
-      }
-    }
-  }
-}
-    \`;
-export const Feed2Document = gql\`
-    query feed2($v: String!) {
-  feed {
-    id
-  }
-}
-    \`;
-export const Feed3Document = gql\`
-    query feed3($v: String) {
-  feed {
-    id
-  }
-}
-    \`;
-export const Feed4Document = gql\`
-    query feed4($v: String! = \\"TEST\\") {
-  feed {
-    id
-  }
-}
-    \`;
-
-export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
-
-
-const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
-
-export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
-  return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<FeedQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed');
-    },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed2Query> {
-      return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2');
-    },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed3Query> {
-      return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3');
-    },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit[\\"headers\\"]) {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4');
     }
   };

--- a/packages/plugins/typescript/graphql-request/tests/graphql-request.spec.ts
+++ b/packages/plugins/typescript/graphql-request/tests/graphql-request.spec.ts
@@ -247,66 +247,6 @@ async function test() {
 
       expect(output).toMatchSnapshot();
     });
-
-    it('Should support extensionType when rawRequest is true and documentMode = "DocumentNode"', async () => {
-      const config = { rawRequest: true, extensionsType: 'unknown' };
-      const docs = [{ location: '', document: basicDoc }];
-      const result = (await plugin(schema, docs, config, {
-        outputFile: 'graphql.ts',
-      })) as Types.ComplexPluginOutput;
-
-      const usage = `
-async function test() {
-  const Client = require('graphql-request').GraphQLClient;
-  const client = new Client('');
-  const sdk = getSdk(client);
-
-  await sdk.feed();
-  await sdk.feed3();
-  await sdk.feed4();
-
-  const result = await sdk.feed2({ v: "1" });
-
-  if (result.feed) {
-    if (result.feed[0]) {
-      const id = result.feed[0].id
-    }
-  }
-}`;
-      const output = await validate(result, config, docs, schema, usage);
-
-      expect(output).toMatchSnapshot();
-    });
-
-    it('extensionType should be irrelevant when rawRequest is false', async () => {
-      const config = { rawRequest: false, extensionsType: 'unknown' };
-      const docs = [{ location: '', document: basicDoc }];
-      const result = (await plugin(schema, docs, config, {
-        outputFile: 'graphql.ts',
-      })) as Types.ComplexPluginOutput;
-
-      const usage = `
-async function test() {
-  const Client = require('graphql-request').GraphQLClient;
-  const client = new Client('');
-  const sdk = getSdk(client);
-
-  await sdk.feed();
-  await sdk.feed3();
-  await sdk.feed4();
-
-  const result = await sdk.feed2({ v: "1" });
-
-  if (result.feed) {
-    if (result.feed[0]) {
-      const id = result.feed[0].id
-    }
-  }
-}`;
-      const output = await validate(result, config, docs, schema, usage);
-
-      expect(output).toMatchSnapshot();
-    });
   });
 
   describe('issues', () => {

--- a/website/public/config.schema.json
+++ b/website/public/config.schema.json
@@ -1190,10 +1190,6 @@
           "description": "By default, the `request` method return the `data` or `errors` key from the response. If you need to access the `extensions` key you can use the `rawRequest` method.\nDefault value: \"false\"",
           "type": "boolean"
         },
-        "extensionsType": {
-          "description": "Allows you to override the type for extensions when `rawRequest` is enabled.\nDefault value: \"any\"",
-          "type": "string"
-        },
         "noGraphQLTag": {
           "description": "Deprecated. Changes the documentMode to `documentNode`.\nDefault value: \"false\"",
           "type": "boolean"


### PR DESCRIPTION
## Description

Previously, the return type of all SDK methods was declared manually. This can
cause the return type to become outdated when graphql-request gets updated.
This already happened, as graphql-request removed the errors attribute from the
return type (see https://github.com/prisma-labs/graphql-request/issues/174).
Also, `data` was marked as possibly undefined which is wrong. `data` always exists
on a successful response (failed requests throw a `ClientError`).

A sideeffect of this change is that the `extensionsType` config became obsolete
and has been removed. Because of this, I marked this change as a breaking change.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

I removed tests for the now removed `extensionsType` config and ran `yarn test -u`.  All tests are still passing. I also tested the change in a private project and did not experience any issues with the change. 