### PR TITLE
[near-operation-file-preset] Importing root types when a fragment spread a fragment without any field

### DIFF
--- a/.changeset/brave-lies-yell.md
+++ b/.changeset/brave-lies-yell.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/near-operation-file-preset": patch
+---
+
+[near-operation-file-preset] Importing root types when a fragment spread a fragment without any field

--- a/packages/presets/near-operation-file/src/resolve-document-imports.ts
+++ b/packages/presets/near-operation-file/src/resolve-document-imports.ts
@@ -63,13 +63,12 @@ export function resolveDocumentImports<T>(
       const importStatements: string[] = [];
       const { externalFragments, fragmentImports } = resolveFragments(generatedFilePath, documentFile.document);
 
-      if (
-        isUsingTypes(
-          documentFile.document,
-          externalFragments.map(m => m.name),
-          schemaObject
-        )
-      ) {
+      const externalFragmentsInjectedDocument = {
+        ...documentFile.document,
+        definitions: [...documentFile.document.definitions, ...externalFragments.map(fragment => fragment.node)],
+      };
+
+      if (isUsingTypes(externalFragmentsInjectedDocument, [], schemaObject)) {
         const schemaTypesImportStatement = generateImportStatement({
           baseDir,
           importSource: resolveImportSource(schemaTypesSource),


### PR DESCRIPTION
## Description

This fixes the issue near-operation-file-preset does not import root type when a fragment spread a fragment without any fields.

Related #7547 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox

| after | before |
|--|--|
| ![image](https://user-images.githubusercontent.com/1481277/156628846-115b98a6-94e0-43e0-aaef-d735a19423f7.png) | ![image](https://user-images.githubusercontent.com/1481277/156628889-fe23db7b-feaf-4a0c-8b60-3c89a5c1e90d.png) |

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
