### PR TITLE
[graphql-request] expose `operationType` to `SdkFunctionWrapper`

### DIFF
--- a/.changeset/warm-seahorses-drop.md
+++ b/.changeset/warm-seahorses-drop.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-graphql-request': minor
+---
+
+Exposes `operationType` to graphql-request sdk middlewares.

--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -16,7 +16,7 @@ export interface GraphQLRequestPluginConfig extends ClientSideBasePluginConfig {
 }
 
 const additionalExportedTypes = `
-export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 `;
 
 export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
@@ -96,6 +96,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
     const extraVariables: string[] = [];
     const allPossibleActions = this._operationsToInclude
       .map(o => {
+        const operationType = o.node.operation;
         const operationName = o.node.name.value;
         const optionalVariables =
           !o.node.variableDefinitions ||
@@ -118,7 +119,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
           }; headers: Dom.Headers; status: number; errors?: GraphQLError[] | undefined; }> {
     return withWrapper((wrappedRequestHeaders) => client.rawRequest<${
       o.operationResultType
-    }>(${docArg}, variables, {...requestHeaders, ...wrappedRequestHeaders}), '${operationName}');
+    }>(${docArg}, variables, {...requestHeaders, ...wrappedRequestHeaders}), '${operationName}', '${operationType}');
 }`;
         } else {
           return `${operationName}(variables${optionalVariables ? '?' : ''}: ${
@@ -126,7 +127,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
           }, requestHeaders?: Dom.RequestInit["headers"]): Promise<${o.operationResultType}> {
   return withWrapper((wrappedRequestHeaders) => client.request<${
     o.operationResultType
-  }>(${docVarName}, variables, {...requestHeaders, ...wrappedRequestHeaders}), '${operationName}');
+  }>(${docVarName}, variables, {...requestHeaders, ...wrappedRequestHeaders}), '${operationName}', '${operationType}');
 }`;
         }
       })
@@ -135,7 +136,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
 
     return `${additionalExportedTypes}
 
-const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType) => action();
 ${extraVariables.join('\n')}
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {


### PR DESCRIPTION
## Description

@charlypoly This PR simply exposes the `operationType` to `graphql-request` middlewares.

Related #7608
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change
- [x] Minor improvement (non-breaking change which adds functionality)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
