### PR TITLE
add omitJvmStatic to Kotlin plugin

### DIFF
--- a/.changeset/fresh-islands-own.md
+++ b/.changeset/fresh-islands-own.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/kotlin": patch
+---
+
+add omitJvmStatic to Kotlin plugin

--- a/packages/plugins/java/kotlin/src/config.ts
+++ b/packages/plugins/java/kotlin/src/config.ts
@@ -56,4 +56,19 @@ export interface KotlinResolversPluginRawConfig extends RawConfig {
    * ```
    */
   withTypes?: boolean;
+  /**
+   * @default false
+   * @description Allow you to omit JvmStatic annotation
+   *
+   * @exampleMarkdoWn
+   * ```yml
+   * generates:
+   *   src/main/kotlin/my-org/my-app/Types.kt:
+   *     plugins:
+   *       - kotlin
+   *     config:
+   *       omitJvmStatic: true
+   * ```
+   */
+  omitJvmStatic?: boolean;
 }

--- a/packages/plugins/java/kotlin/src/visitor.ts
+++ b/packages/plugins/java/kotlin/src/visitor.ts
@@ -40,6 +40,7 @@ export interface KotlinResolverParsedConfig extends ParsedConfig {
   listType: string;
   enumValues: EnumValuesMap;
   withTypes: boolean;
+  omitJvmStatic: boolean;
 }
 
 export interface FieldDefinitionReturnType {
@@ -55,6 +56,7 @@ export class KotlinResolversVisitor extends BaseVisitor<KotlinResolversPluginRaw
       withTypes: rawConfig.withTypes || false,
       package: rawConfig.package || defaultPackageName,
       scalars: buildScalarsFromConfig(_schema, rawConfig, KOTLIN_SCALARS),
+      omitJvmStatic: rawConfig.omitJvmStatic || false,
     });
   }
 
@@ -97,7 +99,7 @@ export class KotlinResolversVisitor extends BaseVisitor<KotlinResolversPluginRaw
 ${enumValues}
         
   companion object {
-    @JvmStatic
+    ${this.config.omitJvmStatic ? '' : '@JvmStatic'}
     fun valueOfLabel(label: String): ${enumName}? {
       return values().find { it.label == label }
     }

--- a/packages/plugins/java/kotlin/tests/kotlin.spec.ts
+++ b/packages/plugins/java/kotlin/tests/kotlin.spec.ts
@@ -131,6 +131,24 @@ describe('Kotlin', () => {
       expect(result).toContain(`Admin("AdminRoleValue"),`);
       expect(result).toContain(`User("USER"),`);
     });
+
+    it('Should omit JvmStatic annotation if the option is set', async () => {
+      const result = await plugin(schema, [], { omitJvmStatic: true }, { outputFile: OUTPUT_FILE });
+
+      // language=kotlin
+      expect(result).toBeSimilarStringTo(`    enum class UserRole(val label: String) {
+        Admin("ADMIN"),
+        User("USER"),
+        Editor("EDITOR");
+        
+        companion object {
+          
+          fun valueOfLabel(label: String): UserRole? {
+            return values().find { it.label == label }
+          }
+        }
+      }`);
+    });
   });
 
   describe('Input Types / Arguments', () => {


### PR DESCRIPTION
## Description

Related #7631
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

Added an `omitJvmStatic` option to Kotlin plugin, so that its output can be used in Kotlin Multiplatform Project.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Included a unit test with the PR.


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
