### PR TITLE
Issue #7615: allow fields to reference interfaces in typescript-mongodb plugin

### DIFF
--- a/packages/plugins/typescript/mongodb/src/config.ts
+++ b/packages/plugins/typescript/mongodb/src/config.ts
@@ -24,6 +24,17 @@ export interface TypeScriptMongoPluginConfig extends RawConfig {
    */
   dbInterfaceSuffix?: string;
   /**
+   * @default DbObject
+   * @description: Sets the default suffix for the generated GraphQL when a `@link` directive is used with an `overrideType` value that does not reference a type, interface, or union explicitly defined in the schema.
+   *
+   * @exampleMarkdown
+   * ```yml
+   * config:
+   *   defaultLinkOverrideTypeSuffix: MySuffix
+   * ```
+   */
+  defaultLinkOverrideTypeSuffix?: string;
+  /**
    * @default mongodb#ObjectId
    * @description Customize the type of `_id` fields. You can either specify a type name, or specify `module#type`.
    *

--- a/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
+++ b/packages/plugins/typescript/mongodb/tests/typescript-mongo.spec.ts
@@ -46,6 +46,16 @@ describe('TypeScript Mongo', () => {
       nullableLinkMap: LinkType @link @map(path: "nullableLinkId")
       nullableColumnMapPath: String @column @map(path: "nullableColumnMap.level")
       nonNullableColumnMapPath: String! @column @map(path: "nonNullableColumnMap.level")
+      nullableInterfaceLink: FeedItem @link
+      nonNullableInterfaceLink: FeedItem! @link
+      nullableInterfaceLinkWithOverride: String @link(overrideType: "FeedItem")
+      nonNullableInterfaceLinkWithOverride: String! @link(overrideType: "FeedItem")
+      nullableInterfaceWithoutDirective: FeedItem
+      nonNullableInterfaceWithoutDirective: FeedItem!
+      nullableMultipleInterfaceLinks: [FeedItem] @link
+      nonNullableMultipleInterfaceLinks: [FeedItem!]! @link
+      nullabeInterfaceLinkMap: FeedItem @link @map(path: "nullableInterfaceLinkId")
+      nonNullableInterfaceLinkMap: FeedItem! @link @map(path: "nonNullableInterfaceLinkId")
     }
 
     type EmbeddedType @entity {
@@ -287,6 +297,24 @@ describe('TypeScript Mongo', () => {
       const result = await plugin(schema, [], {}, { outputFile: '' });
       expect(result).toContain(`nonSchemaOptionalField?: string`); // non schema optional additional field
       await validate(result, schema, {});
+    });
+
+    it('Interfaces should be valid field types, not just objects - issue #7615', async () => {
+      const result = await plugin(schema, [], {}, { outputFile: '' });
+
+      const interfaceRef = `FeedItemDbInterface['_id']`;
+      expect(result).toContain(`nullableInterfaceLink?: Maybe<${interfaceRef}>`);
+      expect(result).toContain(`nonNullableInterfaceLink: ${interfaceRef}`);
+      expect(result).toContain(`nullableInterfaceLinkWithOverride?: Maybe<${interfaceRef}>`);
+      expect(result).toContain(`nonNullableInterfaceLinkWithOverride: ${interfaceRef}`);
+      expect(result).not.toContain('nullableInterfaceWithoutDirective');
+      expect(result).not.toContain(`nonNullableInterfaceWithoutDirective`);
+      expect(result).toContain(`nullableMultipleInterfaceLinks?: Maybe<Array<Maybe<${interfaceRef}>>>`);
+      expect(result).toContain(`nonNullableMultipleInterfaceLinks: Array<${interfaceRef}>`);
+      expect(result).toContain(`nullableInterfaceLinkId?: Maybe<${interfaceRef}>`);
+      expect(result).not.toContain(`nullableInterfaceLinkMap`);
+      expect(result).toContain(`nonNullableInterfaceLinkId: ${interfaceRef}`);
+      expect(result).not.toContain(`nonNullableInterfaceLinkMap`);
     });
   });
 });


### PR DESCRIPTION
## Description

This change allows users to reference interfaces in the type fields of their GraphQL schema and generate correct MongoDB output. Previously, using the `@link` directive would cause the `typescript-mongodb` plugin to always assume the `@link` referenced an object, when the GraphQL spec explicitly allows users to reference interfaces. This would cause the generated TypeScript to break immediately as it would try to reference a `DbObject` that was never generated, because it should have instead tried to reference a `DbInterface`. 

Related #7615 
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

I don't believe this is relevant, but let me know if you'd prefer something.

## How Has This Been Tested?

A new test was added to the bottom of `typescript-mongo.spec.ts` that checks that referecing an interface in a type's field does not try to access output that was never generated.

- [X] `Interfaces should be valid field types, not just objects - issue #7615`

**Test Environment**:
- OS: macOS Monterey v12.2.1
- `@graphql-codegen/typescript-mongodb`: 4.4.1
- NodeJS: 17.2.0

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

This change works by checking whether the type referenced in a field with the `@link` directive is an object, union, or interface in the user's GraphQL schema. If it's an object or union we can use the config's `dbTypeSuffix` and if it's an interface we can use the config's `dbInterfaceSuffix` to generate the correct output. However, despite the fact that this feature was never documented, the `@link` directive can take an `overrideType` argument. While this isn't an issue if the user references an `overrideType` that is explicitly defined in the schema, it _is_ an issue if it's not defined. In fact, `typescript-mongo.spec.ts` even references an instance when it's not (look for `@link(overrideType: "MachineDocument"`, `MachineDocument` is never defined in the schema). One way to account for this was to just check whether the type is an interface, and if so use the `dbInterfaceSuffix` and in all other instances use the `dbTypeSuffix`. This would not break backwards-compatibility as previously `dbTypeSuffix` was (incorrectly) always used. However, this felt like a duct-tapey hacky fix, and it made much more sense to me to add a new value to the config of `typescript-mongodb` which I called `defaultLinkOverrideTypeSuffix`, which has a default value of `DbObject`. Then, the code can explicitly check if a specified type is an object, interface, or union in the schema, and in all other instances default to the new config value. By default, it is of value `DbObject`, which maintains backwards-compatibility and passes all current checks.
