### PR TITLE
React-query: useTypeImports

### DIFF
--- a/.changeset/rotten-coins-flow.md
+++ b/.changeset/rotten-coins-flow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+enable useTypeImports

--- a/.changeset/wet-tomatoes-suffer.md
+++ b/.changeset/wet-tomatoes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+respect useTypeImports in react-query

--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -1,4 +1,5 @@
-import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';
+import { useQuery, useMutation } from 'react-query';
+import { UseQueryOptions, UseMutationOptions } from 'react-query';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -1,5 +1,4 @@
-import { useQuery, useMutation } from 'react-query';
-import { UseQueryOptions, UseMutationOptions } from 'react-query';
+import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -50,8 +50,8 @@ export class CustomMapperFetcher implements FetcherRenderer {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
 
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.infiniteQuery.options);
 
     const options = `options?: ${hookConfig.infiniteQuery.options}<${operationResultType}, TError, TData>`;
 
@@ -87,8 +87,8 @@ export class CustomMapperFetcher implements FetcherRenderer {
     const variables = `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
 
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.query.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.query.options);
 
     const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
 
@@ -121,8 +121,8 @@ export class CustomMapperFetcher implements FetcherRenderer {
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.mutation.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.mutation.options);
 
     const options = `options?: ${hookConfig.mutation.options}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>`;
     const typedFetcher = this.getFetcherFnName(operationResultType, operationVariablesTypes);

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -68,8 +68,8 @@ ${this.getFetchParams()}
   ): string {
     const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.infiniteQuery.options);
 
     const options = `options?: ${hookConfig.infiniteQuery.options}<${operationResultType}, TError, TData>`;
 
@@ -98,8 +98,8 @@ ${this.getFetchParams()}
   ): string {
     const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.query.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.query.options);
 
     const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
 
@@ -127,8 +127,8 @@ ${this.getFetchParams()}
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.mutation.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.mutation.options);
 
     const options = `options?: ${hookConfig.mutation.options}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>`;
 

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -45,8 +45,8 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
   ): string {
     const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.infiniteQuery.options);
 
     const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
 
@@ -76,8 +76,8 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
   ): string {
     const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.query.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.query.options);
 
     const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
 
@@ -106,8 +106,8 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
   ): string {
     const variables = `variables?: ${operationVariablesTypes}`;
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.mutation.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.mutation.options);
 
     const options = `options?: ${hookConfig.mutation.options}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>`;
 

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -33,8 +33,8 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     this.visitor.imports.add(`${typeImport} { GraphQLClient } from 'graphql-request';`);
 
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.infiniteQuery.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.infiniteQuery.options);
 
     const options = `options?: ${hookConfig.infiniteQuery.options}<${operationResultType}, TError, TData>`;
 
@@ -70,8 +70,8 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     this.visitor.imports.add(`${typeImport} { RequestInit } from 'graphql-request/dist/types.dom';`);
 
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.query.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.query.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.query.options);
 
     const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
 
@@ -99,13 +99,13 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = `variables?: ${operationVariablesTypes}`;    
+    const variables = `variables?: ${operationVariablesTypes}`;
     const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
     this.visitor.imports.add(`${typeImport} { GraphQLClient } from 'graphql-request';`);
 
     const hookConfig = this.visitor.queryMethodMap;
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);
-    this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.options);
+    this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.mutation.hook);
+    this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.mutation.options);
 
     const options = `options?: ${hookConfig.mutation.options}<${operationResultType}, TError, ${operationVariablesTypes}, TContext>`;
 

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -99,8 +99,9 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     operationVariablesTypes: string,
     hasRequiredVariables: boolean
   ): string {
-    const variables = `variables?: ${operationVariablesTypes}`;
-    this.visitor.imports.add(`import { GraphQLClient } from 'graphql-request';`);
+    const variables = `variables?: ${operationVariablesTypes}`;    
+    const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
+    this.visitor.imports.add(`${typeImport} { GraphQLClient } from 'graphql-request';`);
 
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryIdentifiersInUse.add(hookConfig.mutation.hook);

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -116,13 +116,14 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
       this.reactQueryOptionsIdentifiersInUse.add('QueryFunctionContext');
     }
 
-    const typeImport = this.config.useTypeImports ? 'import type' : 'import';
-
-    return [
-      ...baseImports,
-      `import { ${Array.from(this.reactQueryHookIdentifiersInUse).join(', ')} } from 'react-query';`,
-      `${typeImport} { ${Array.from(this.reactQueryOptionsIdentifiersInUse).join(', ')} } from 'react-query';`,
+    const hookAndTypeImports = [
+      ...Array.from(this.reactQueryHookIdentifiersInUse),
+      ...Array.from(this.reactQueryOptionsIdentifiersInUse).map(
+        identifier => `${this.config.useTypeImports ? 'type ' : ''}${identifier}`
+      ),
     ];
+
+    return [...baseImports, `import { ${hookAndTypeImports.join(', ')} } from 'react-query';`];
   }
 
   public getFetcherImplementation(): string {

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -45,7 +45,8 @@ export interface ReactQueryMethodMap {
 export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPluginConfig, ReactQueryPluginConfig> {
   private _externalImportPrefix: string;
   public fetcher: FetcherRenderer;
-  public reactQueryIdentifiersInUse = new Set<string>();
+  public reactQueryHookIdentifiersInUse = new Set<string>();
+  public reactQueryOptionsIdentifiersInUse = new Set<string>();
 
   public queryMethodMap: ReactQueryMethodMap = {
     infiniteQuery: {
@@ -112,10 +113,16 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
     }
 
     if (this.config.addInfiniteQuery) {
-      this.reactQueryIdentifiersInUse.add('QueryFunctionContext');
+      this.reactQueryOptionsIdentifiersInUse.add('QueryFunctionContext');
     }
 
-    return [...baseImports, `import { ${Array.from(this.reactQueryIdentifiersInUse).join(', ')} } from 'react-query';`];
+    const typeImport = this.config.useTypeImports ? 'import type' : 'import';
+
+    return [
+      ...baseImports,
+      `import { ${Array.from(this.reactQueryHookIdentifiersInUse).join(', ')} } from 'react-query';`,
+      `${typeImport} { ${Array.from(this.reactQueryOptionsIdentifiersInUse).join(', ')} } from 'react-query';`,
+    ];
   }
 
   public getFetcherImplementation(): string {

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -481,7 +481,7 @@ describe('React-Query', () => {
       expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
       expect(out.prepend).toContain(`import { GraphQLClient } from 'graphql-request';`);
       expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom';`);
-      expect(out.prepend[3])
+      expect(out.prepend[4])
         .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variables?: TVariables, headers?: RequestInit['headers']) {
           return async (): Promise<TData> => client.request<TData, TVariables>(query, variables, headers);
         }`);
@@ -657,7 +657,7 @@ describe('React-Query', () => {
 
       expect(out.prepend).toContain(`import { useQuery, useMutation } from 'react-query';`);
       expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
-      expect(out.prepend[1])
+      expect(out.prepend[2])
         .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
         return async (): Promise<TData> => {
           const res = await fetch("http://localhost:3000/graphql", {
@@ -718,7 +718,7 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend[1]).toMatchInlineSnapshot(`
+      expect(out.prepend[2]).toMatchInlineSnapshot(`
 "
 function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
   return async (): Promise<TData> => {
@@ -760,7 +760,7 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend[1]).toMatchInlineSnapshot(`
+      expect(out.prepend[2]).toMatchInlineSnapshot(`
 "
 function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
   return async (): Promise<TData> => {
@@ -797,7 +797,7 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend[1])
+      expect(out.prepend[2])
         .toBeSimilarStringTo(`function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
         return async (): Promise<TData> => {
           const res = await fetch(process.env.ENDPOINT_URL as string, {
@@ -831,7 +831,7 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend[1])
+      expect(out.prepend[2])
         .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
         return async (): Promise<TData> => {
           const res = await fetch(myEndpoint as string, {

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -144,8 +144,9 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
+      expect(out.prepend).toContain(`import { useQuery, useInfiniteQuery, useMutation } from 'react-query';`);
       expect(out.prepend).toContain(
-        `import { useQuery, UseQueryOptions, useInfiniteQuery, UseInfiniteQueryOptions, useMutation, UseMutationOptions, QueryFunctionContext } from 'react-query';`
+        `import { UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions, QueryFunctionContext } from 'react-query';`
       );
 
       expect(out.prepend).toContain(`import { myCustomFetcher } from './my-file';`);
@@ -196,9 +197,8 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend).toContain(
-        `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
-      );
+      expect(out.prepend).toContain(`import { useQuery, useMutation } from 'react-query';`);
+      expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
       expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
         TData = TTestQuery,
         TError = unknown
@@ -238,8 +238,9 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
+      expect(out.prepend).toContain(`import { useQuery, useInfiniteQuery, useMutation } from 'react-query';`);
       expect(out.prepend).toContain(
-        `import { useQuery, UseQueryOptions, useInfiniteQuery, UseInfiniteQueryOptions, useMutation, UseMutationOptions, QueryFunctionContext } from 'react-query';`
+        `import { UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions, QueryFunctionContext } from 'react-query';`
       );
       expect(out.prepend).toContain(`import { useCustomFetcher } from './my-file';`);
       expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
@@ -476,9 +477,8 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend).toContain(
-        `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
-      );
+      expect(out.prepend).toContain(`import { useQuery, useMutation } from 'react-query';`);
+      expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
       expect(out.prepend).toContain(`import { GraphQLClient } from 'graphql-request';`);
       expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom';`);
       expect(out.prepend[3])
@@ -525,6 +525,7 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
       expect(out.prepend).toContain(`import type { GraphQLClient } from 'graphql-request';`);
+      expect(out.prepend).toContain(`import type { UseQueryOptions, UseMutationOptions } from 'react-query';`);
     });
     it('Should generate fetcher field when exposeFetcher is true', async () => {
       const config = {
@@ -654,9 +655,8 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend).toContain(
-        `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
-      );
+      expect(out.prepend).toContain(`import { useQuery, useMutation } from 'react-query';`);
+      expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
       expect(out.prepend[1])
         .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
         return async (): Promise<TData> => {
@@ -986,9 +986,8 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend).toContain(
-        `import { useQuery, UseQueryOptions, useMutation, UseMutationOptions } from 'react-query';`
-      );
+      expect(out.prepend).toContain(`import { useQuery, useMutation } from 'react-query';`);
+      expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
 
       expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
         TData = TTestQuery,

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -481,7 +481,7 @@ describe('React-Query', () => {
       expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
       expect(out.prepend).toContain(`import { GraphQLClient } from 'graphql-request';`);
       expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom';`);
-      expect(out.prepend[4])
+      expect(out.prepend[3])
         .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variables?: TVariables, headers?: RequestInit['headers']) {
           return async (): Promise<TData> => client.request<TData, TVariables>(query, variables, headers);
         }`);
@@ -657,7 +657,7 @@ describe('React-Query', () => {
 
       expect(out.prepend).toContain(`import { useQuery, useMutation } from 'react-query';`);
       expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
-      expect(out.prepend[2])
+      expect(out.prepend[1])
         .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
         return async (): Promise<TData> => {
           const res = await fetch("http://localhost:3000/graphql", {
@@ -718,7 +718,7 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend[2]).toMatchInlineSnapshot(`
+      expect(out.prepend[1]).toMatchInlineSnapshot(`
 "
 function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
   return async (): Promise<TData> => {
@@ -760,7 +760,7 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend[2]).toMatchInlineSnapshot(`
+      expect(out.prepend[1]).toMatchInlineSnapshot(`
 "
 function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
   return async (): Promise<TData> => {
@@ -797,7 +797,7 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend[2])
+      expect(out.prepend[1])
         .toBeSimilarStringTo(`function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
         return async (): Promise<TData> => {
           const res = await fetch(process.env.ENDPOINT_URL as string, {
@@ -831,7 +831,7 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend[2])
+      expect(out.prepend[1])
         .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
         return async (): Promise<TData> => {
           const res = await fetch(myEndpoint as string, {

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -144,9 +144,8 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend).toContain(`import { useQuery, useInfiniteQuery, useMutation } from 'react-query';`);
       expect(out.prepend).toContain(
-        `import { UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions, QueryFunctionContext } from 'react-query';`
+        `import { useQuery, useInfiniteQuery, useMutation, UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions, QueryFunctionContext } from 'react-query';`
       );
 
       expect(out.prepend).toContain(`import { myCustomFetcher } from './my-file';`);
@@ -197,8 +196,9 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend).toContain(`import { useQuery, useMutation } from 'react-query';`);
-      expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
+      expect(out.prepend).toContain(
+        `import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';`
+      );
       expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
         TData = TTestQuery,
         TError = unknown
@@ -238,9 +238,8 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend).toContain(`import { useQuery, useInfiniteQuery, useMutation } from 'react-query';`);
       expect(out.prepend).toContain(
-        `import { UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions, QueryFunctionContext } from 'react-query';`
+        `import { useQuery, useInfiniteQuery, useMutation, UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions, QueryFunctionContext } from 'react-query';`
       );
       expect(out.prepend).toContain(`import { useCustomFetcher } from './my-file';`);
       expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
@@ -477,8 +476,9 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend).toContain(`import { useQuery, useMutation } from 'react-query';`);
-      expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
+      expect(out.prepend).toContain(
+        `import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';`
+      );
       expect(out.prepend).toContain(`import { GraphQLClient } from 'graphql-request';`);
       expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom';`);
       expect(out.prepend[3])
@@ -525,7 +525,9 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
       expect(out.prepend).toContain(`import type { GraphQLClient } from 'graphql-request';`);
-      expect(out.prepend).toContain(`import type { UseQueryOptions, UseMutationOptions } from 'react-query';`);
+      expect(out.prepend).toContain(
+        `import { useQuery, useMutation, type UseQueryOptions, type UseMutationOptions } from 'react-query';`
+      );
     });
     it('Should generate fetcher field when exposeFetcher is true', async () => {
       const config = {
@@ -655,8 +657,9 @@ describe('React-Query', () => {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend).toContain(`import { useQuery, useMutation } from 'react-query';`);
-      expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
+      expect(out.prepend).toContain(
+        `import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';`
+      );
       expect(out.prepend[1])
         .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
         return async (): Promise<TData> => {
@@ -986,8 +989,9 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
 
-      expect(out.prepend).toContain(`import { useQuery, useMutation } from 'react-query';`);
-      expect(out.prepend).toContain(`import { UseQueryOptions, UseMutationOptions } from 'react-query';`);
+      expect(out.prepend).toContain(
+        `import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';`
+      );
 
       expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
         TData = TTestQuery,


### PR DESCRIPTION
## Description

corrects behavior so that `typescript-react-query` respects `useTypeImports` flag

Related # (issue)
fixes #7666 main issue
fixes #7661 the graphql-request fetcher portion

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

tests all pass.  added test to [prove functionality](https://github.com/dotansimha/graphql-code-generator/blob/6cdb68b9123dccc80009b2af9ac66bb7de961cd9/packages/plugins/typescript/react-query/tests/react-query.spec.ts#L528).

**Test Environment**:
n/a

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
