### PR TITLE
update WithTypename to preserve original graphql type

### DIFF
--- a/.changeset/loud-grapes-reflect.md
+++ b/.changeset/loud-grapes-reflect.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-urql-graphcache": patch
+"@graphql-codegen/typescript-urql": patch
+---
+
+removed WithTypename to preserve original graphql type

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -1047,9 +1047,7 @@ export default {
     directives: [],
   },
 } as unknown as IntrospectionQuery;
-export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & {
-  __typename: NonNullable<T['__typename']>;
-};
+export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Comment?: (data: WithTypename<Comment>) => null | string;

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -79,7 +79,7 @@ function constructType(
         case Kind.UNION_TYPE_DEFINITION:
         case Kind.INPUT_OBJECT_TYPE_DEFINITION:
         case Kind.OBJECT_TYPE_DEFINITION: {
-          const finalType = `${tsTypeName}${allowString ? ' | string' : ''}`;
+          const finalType = `WithTypename<${tsTypeName}>${allowString ? ' | string' : ''}`;
           return nullable ? `Maybe<${finalType}>` : finalType;
         }
 
@@ -253,7 +253,7 @@ export const plugin: PluginFunction<UrqlGraphCacheConfig, Types.ComplexPluginOut
   return {
     prepend: [imports],
     content: [
-      `export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };`,
+      `export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };`,
 
       keys,
 

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -79,7 +79,7 @@ function constructType(
         case Kind.UNION_TYPE_DEFINITION:
         case Kind.INPUT_OBJECT_TYPE_DEFINITION:
         case Kind.OBJECT_TYPE_DEFINITION: {
-          const finalType = `WithTypename<${tsTypeName}>${allowString ? ' | string' : ''}`;
+          const finalType = `${tsTypeName}${allowString ? ' | string' : ''}`;
           return nullable ? `Maybe<${finalType}>` : finalType;
         }
 

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -11,7 +11,7 @@ export type GraphCacheKeysConfig = {
 
 export type GraphCacheResolvers = {
   Query_Root?: {
-    todos?: GraphCacheResolver<WithTypename<Query_Root>, Record<string, never>, Array<WithTypename<Todo> | string>>
+    todos?: GraphCacheResolver<WithTypename<Query_Root>, Record<string, never>, Array<Todo | string>>
   },
   Todo?: {
     id?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['ID'] | string>,
@@ -21,12 +21,12 @@ export type GraphCacheResolvers = {
 };
 
 export type GraphCacheOptimisticUpdaters = {
-  toggleTodo?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodoArgs, WithTypename<Todo>>
+  toggleTodo?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodoArgs, Todo>
 };
 
 export type GraphCacheUpdaters = {
   Mutation?: {
-    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: WithTypename<Todo> }, Mutation_RootToggleTodoArgs>
+    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: Todo }, Mutation_RootToggleTodoArgs>
   },
   Subscription?: {},
 };
@@ -59,20 +59,20 @@ export type GraphCacheResolvers = {
   Author?: {
     id?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['ID'] | string>,
     name?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['String'] | string>,
-    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<WithTypename<Author> | string>>,
-    friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<WithTypename<Author> | string>>
+    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<Author | string>>,
+    friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<Author | string>>
   },
   Todo?: {
     id?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['ID'] | string>,
     text?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['String'] | string>,
     complete?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['Boolean'] | string>,
-    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, WithTypename<Author> | string>
+    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Author | string>
   },
   Textbook?: {
     id?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, Scalars['ID'] | string>,
     title?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, Scalars['String'] | string>,
-    author?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, WithTypename<Author> | string>,
-    todo?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, WithTypename<Todo> | string>
+    author?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, Author | string>,
+    todo?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, Todo | string>
   }
 };
 
@@ -107,37 +107,37 @@ export type GraphCacheKeysConfig = {
 
 export type GraphCacheResolvers = {
   Query?: {
-    todos?: GraphCacheResolver<WithTypename<PrefixQuerySuffix>, Record<string, never>, Array<WithTypename<PrefixTodoSuffix> | string>>
+    todos?: GraphCacheResolver<WithTypename<PrefixQuerySuffix>, Record<string, never>, Array<PrefixTodoSuffix | string>>
   },
   Author?: {
     id?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, Record<string, never>, Scalars['ID'] | string>,
     name?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, Record<string, never>, Scalars['String'] | string>,
-    friends?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, Record<string, never>, Array<WithTypename<PrefixAuthorSuffix> | string>>,
-    friendsPaginated?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, PrefixAuthorFriendsPaginatedArgsSuffix, Array<WithTypename<PrefixAuthorSuffix> | string>>
+    friends?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, Record<string, never>, Array<PrefixAuthorSuffix | string>>,
+    friendsPaginated?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, PrefixAuthorFriendsPaginatedArgsSuffix, Array<PrefixAuthorSuffix | string>>
   },
   Todo?: {
     id?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, Scalars['ID'] | string>,
     text?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, Scalars['String'] | string>,
     complete?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, Scalars['Boolean'] | string>,
-    author?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, WithTypename<PrefixAuthorSuffix> | string>
+    author?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, PrefixAuthorSuffix | string>
   }
 };
 
 export type GraphCacheOptimisticUpdaters = {
-  toggleTodo?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodoArgsSuffix, WithTypename<PrefixTodoSuffix>>,
-  toggleTodos?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosArgsSuffix, Array<WithTypename<PrefixTodoSuffix>>>,
-  toggleTodosOptionalArray?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalArrayArgsSuffix, Maybe<Array<WithTypename<PrefixTodoSuffix>>>>,
-  toggleTodosOptionalEntity?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalEntityArgsSuffix, Array<WithTypename<PrefixTodoSuffix>>>,
-  toggleTodosOptional?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalArgsSuffix, Maybe<Array<WithTypename<PrefixTodoSuffix>>>>
+  toggleTodo?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodoArgsSuffix, PrefixTodoSuffix>,
+  toggleTodos?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosArgsSuffix, Array<PrefixTodoSuffix>>,
+  toggleTodosOptionalArray?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalArrayArgsSuffix, Maybe<Array<PrefixTodoSuffix>>>,
+  toggleTodosOptionalEntity?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalEntityArgsSuffix, Array<PrefixTodoSuffix>>,
+  toggleTodosOptional?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalArgsSuffix, Maybe<Array<PrefixTodoSuffix>>>
 };
 
 export type GraphCacheUpdaters = {
   Mutation?: {
-    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: WithTypename<PrefixTodoSuffix> }, PrefixMutationToggleTodoArgsSuffix>,
-    toggleTodos?: GraphCacheUpdateResolver<{ toggleTodos: Array<WithTypename<PrefixTodoSuffix>> }, PrefixMutationToggleTodosArgsSuffix>,
-    toggleTodosOptionalArray?: GraphCacheUpdateResolver<{ toggleTodosOptionalArray: Maybe<Array<WithTypename<PrefixTodoSuffix>>> }, PrefixMutationToggleTodosOptionalArrayArgsSuffix>,
-    toggleTodosOptionalEntity?: GraphCacheUpdateResolver<{ toggleTodosOptionalEntity: Array<WithTypename<PrefixTodoSuffix>> }, PrefixMutationToggleTodosOptionalEntityArgsSuffix>,
-    toggleTodosOptional?: GraphCacheUpdateResolver<{ toggleTodosOptional: Maybe<Array<WithTypename<PrefixTodoSuffix>>> }, PrefixMutationToggleTodosOptionalArgsSuffix>
+    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: PrefixTodoSuffix }, PrefixMutationToggleTodoArgsSuffix>,
+    toggleTodos?: GraphCacheUpdateResolver<{ toggleTodos: Array<PrefixTodoSuffix> }, PrefixMutationToggleTodosArgsSuffix>,
+    toggleTodosOptionalArray?: GraphCacheUpdateResolver<{ toggleTodosOptionalArray: Maybe<Array<PrefixTodoSuffix>> }, PrefixMutationToggleTodosOptionalArrayArgsSuffix>,
+    toggleTodosOptionalEntity?: GraphCacheUpdateResolver<{ toggleTodosOptionalEntity: Array<PrefixTodoSuffix> }, PrefixMutationToggleTodosOptionalEntityArgsSuffix>,
+    toggleTodosOptional?: GraphCacheUpdateResolver<{ toggleTodosOptional: Maybe<Array<PrefixTodoSuffix>> }, PrefixMutationToggleTodosOptionalArgsSuffix>
   },
   Subscription?: {},
 };
@@ -164,7 +164,7 @@ export type GraphCacheKeysConfig = {
 
 export type GraphCacheResolvers = {
   Query?: {
-    media?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, Array<WithTypename<Media> | string>>
+    media?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, Array<Media | string>>
   },
   Book?: {
     id?: GraphCacheResolver<WithTypename<Book>, Record<string, never>, Scalars['ID'] | string>,
@@ -179,12 +179,12 @@ export type GraphCacheResolvers = {
 };
 
 export type GraphCacheOptimisticUpdaters = {
-  updateMedia?: GraphCacheOptimisticMutationResolver<MutationUpdateMediaArgs, Maybe<WithTypename<Media>>>
+  updateMedia?: GraphCacheOptimisticMutationResolver<MutationUpdateMediaArgs, Maybe<Media>>
 };
 
 export type GraphCacheUpdaters = {
   Mutation?: {
-    updateMedia?: GraphCacheUpdateResolver<{ updateMedia: Maybe<WithTypename<Media>> }, MutationUpdateMediaArgs>
+    updateMedia?: GraphCacheUpdateResolver<{ updateMedia: Maybe<Media> }, MutationUpdateMediaArgs>
   },
   Subscription?: {},
 };
@@ -211,37 +211,37 @@ export type GraphCacheKeysConfig = {
 
 export type GraphCacheResolvers = {
   Query?: {
-    todos?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, Array<WithTypename<Todo> | string>>
+    todos?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, Array<Todo | string>>
   },
   Author?: {
     id?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['ID'] | string>,
     name?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['String'] | string>,
-    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<WithTypename<Author> | string>>,
-    friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<WithTypename<Author> | string>>
+    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<Author | string>>,
+    friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<Author | string>>
   },
   Todo?: {
     id?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['ID'] | string>,
     text?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['String'] | string>,
     complete?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['Boolean'] | string>,
-    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, WithTypename<Author> | string>
+    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Author | string>
   }
 };
 
 export type GraphCacheOptimisticUpdaters = {
-  toggleTodo?: GraphCacheOptimisticMutationResolver<MutationToggleTodoArgs, WithTypename<Todo>>,
-  toggleTodos?: GraphCacheOptimisticMutationResolver<MutationToggleTodosArgs, Array<WithTypename<Todo>>>,
-  toggleTodosOptionalArray?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalArrayArgs, Maybe<Array<WithTypename<Todo>>>>,
-  toggleTodosOptionalEntity?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalEntityArgs, Array<WithTypename<Todo>>>,
-  toggleTodosOptional?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalArgs, Maybe<Array<WithTypename<Todo>>>>
+  toggleTodo?: GraphCacheOptimisticMutationResolver<MutationToggleTodoArgs, Todo>,
+  toggleTodos?: GraphCacheOptimisticMutationResolver<MutationToggleTodosArgs, Array<Todo>>,
+  toggleTodosOptionalArray?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalArrayArgs, Maybe<Array<Todo>>>,
+  toggleTodosOptionalEntity?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalEntityArgs, Array<Todo>>,
+  toggleTodosOptional?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalArgs, Maybe<Array<Todo>>>
 };
 
 export type GraphCacheUpdaters = {
   Mutation?: {
-    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: WithTypename<Todo> }, MutationToggleTodoArgs>,
-    toggleTodos?: GraphCacheUpdateResolver<{ toggleTodos: Array<WithTypename<Todo>> }, MutationToggleTodosArgs>,
-    toggleTodosOptionalArray?: GraphCacheUpdateResolver<{ toggleTodosOptionalArray: Maybe<Array<WithTypename<Todo>>> }, MutationToggleTodosOptionalArrayArgs>,
-    toggleTodosOptionalEntity?: GraphCacheUpdateResolver<{ toggleTodosOptionalEntity: Array<WithTypename<Todo>> }, MutationToggleTodosOptionalEntityArgs>,
-    toggleTodosOptional?: GraphCacheUpdateResolver<{ toggleTodosOptional: Maybe<Array<WithTypename<Todo>>> }, MutationToggleTodosOptionalArgs>
+    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: Todo }, MutationToggleTodoArgs>,
+    toggleTodos?: GraphCacheUpdateResolver<{ toggleTodos: Array<Todo> }, MutationToggleTodosArgs>,
+    toggleTodosOptionalArray?: GraphCacheUpdateResolver<{ toggleTodosOptionalArray: Maybe<Array<Todo>> }, MutationToggleTodosOptionalArrayArgs>,
+    toggleTodosOptionalEntity?: GraphCacheUpdateResolver<{ toggleTodosOptionalEntity: Array<Todo> }, MutationToggleTodosOptionalEntityArgs>,
+    toggleTodosOptional?: GraphCacheUpdateResolver<{ toggleTodosOptional: Maybe<Array<Todo>> }, MutationToggleTodosOptionalArgs>
   },
   Subscription?: {},
 };

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`urql graphcache Should correctly name GraphCacheResolvers & GraphCacheOptimisticUpdaters with nonstandard mutationType names 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
-export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Todo?: (data: WithTypename<Todo>) => null | string
@@ -11,7 +11,7 @@ export type GraphCacheKeysConfig = {
 
 export type GraphCacheResolvers = {
   Query_Root?: {
-    todos?: GraphCacheResolver<WithTypename<Query_Root>, Record<string, never>, Array<Todo | string>>
+    todos?: GraphCacheResolver<WithTypename<Query_Root>, Record<string, never>, Array<WithTypename<Todo> | string>>
   },
   Todo?: {
     id?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['ID'] | string>,
@@ -21,12 +21,12 @@ export type GraphCacheResolvers = {
 };
 
 export type GraphCacheOptimisticUpdaters = {
-  toggleTodo?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodoArgs, Todo>
+  toggleTodo?: GraphCacheOptimisticMutationResolver<Mutation_RootToggleTodoArgs, WithTypename<Todo>>
 };
 
 export type GraphCacheUpdaters = {
   Mutation?: {
-    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: Todo }, Mutation_RootToggleTodoArgs>
+    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: WithTypename<Todo> }, Mutation_RootToggleTodoArgs>
   },
   Subscription?: {},
 };
@@ -44,7 +44,7 @@ export type GraphCacheConfig = {
 exports[`urql graphcache Should output the cache-generic correctly (with interfaces) 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
-export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Author?: (data: WithTypename<Author>) => null | string,
@@ -59,20 +59,20 @@ export type GraphCacheResolvers = {
   Author?: {
     id?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['ID'] | string>,
     name?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['String'] | string>,
-    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<Author | string>>,
-    friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<Author | string>>
+    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<WithTypename<Author> | string>>,
+    friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<WithTypename<Author> | string>>
   },
   Todo?: {
     id?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['ID'] | string>,
     text?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['String'] | string>,
     complete?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['Boolean'] | string>,
-    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Author | string>
+    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, WithTypename<Author> | string>
   },
   Textbook?: {
     id?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, Scalars['ID'] | string>,
     title?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, Scalars['String'] | string>,
-    author?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, Author | string>,
-    todo?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, Todo | string>
+    author?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, WithTypename<Author> | string>,
+    todo?: GraphCacheResolver<WithTypename<Textbook>, Record<string, never>, WithTypename<Todo> | string>
   }
 };
 
@@ -98,7 +98,7 @@ export type GraphCacheConfig = {
 exports[`urql graphcache Should output the cache-generic correctly (with typesPrefix and typesSuffix) 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
-export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Author?: (data: WithTypename<PrefixAuthorSuffix>) => null | string,
@@ -107,37 +107,37 @@ export type GraphCacheKeysConfig = {
 
 export type GraphCacheResolvers = {
   Query?: {
-    todos?: GraphCacheResolver<WithTypename<PrefixQuerySuffix>, Record<string, never>, Array<PrefixTodoSuffix | string>>
+    todos?: GraphCacheResolver<WithTypename<PrefixQuerySuffix>, Record<string, never>, Array<WithTypename<PrefixTodoSuffix> | string>>
   },
   Author?: {
     id?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, Record<string, never>, Scalars['ID'] | string>,
     name?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, Record<string, never>, Scalars['String'] | string>,
-    friends?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, Record<string, never>, Array<PrefixAuthorSuffix | string>>,
-    friendsPaginated?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, PrefixAuthorFriendsPaginatedArgsSuffix, Array<PrefixAuthorSuffix | string>>
+    friends?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, Record<string, never>, Array<WithTypename<PrefixAuthorSuffix> | string>>,
+    friendsPaginated?: GraphCacheResolver<WithTypename<PrefixAuthorSuffix>, PrefixAuthorFriendsPaginatedArgsSuffix, Array<WithTypename<PrefixAuthorSuffix> | string>>
   },
   Todo?: {
     id?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, Scalars['ID'] | string>,
     text?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, Scalars['String'] | string>,
     complete?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, Scalars['Boolean'] | string>,
-    author?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, PrefixAuthorSuffix | string>
+    author?: GraphCacheResolver<WithTypename<PrefixTodoSuffix>, Record<string, never>, WithTypename<PrefixAuthorSuffix> | string>
   }
 };
 
 export type GraphCacheOptimisticUpdaters = {
-  toggleTodo?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodoArgsSuffix, PrefixTodoSuffix>,
-  toggleTodos?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosArgsSuffix, Array<PrefixTodoSuffix>>,
-  toggleTodosOptionalArray?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalArrayArgsSuffix, Maybe<Array<PrefixTodoSuffix>>>,
-  toggleTodosOptionalEntity?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalEntityArgsSuffix, Array<PrefixTodoSuffix>>,
-  toggleTodosOptional?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalArgsSuffix, Maybe<Array<PrefixTodoSuffix>>>
+  toggleTodo?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodoArgsSuffix, WithTypename<PrefixTodoSuffix>>,
+  toggleTodos?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosArgsSuffix, Array<WithTypename<PrefixTodoSuffix>>>,
+  toggleTodosOptionalArray?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalArrayArgsSuffix, Maybe<Array<WithTypename<PrefixTodoSuffix>>>>,
+  toggleTodosOptionalEntity?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalEntityArgsSuffix, Array<WithTypename<PrefixTodoSuffix>>>,
+  toggleTodosOptional?: GraphCacheOptimisticMutationResolver<PrefixMutationToggleTodosOptionalArgsSuffix, Maybe<Array<WithTypename<PrefixTodoSuffix>>>>
 };
 
 export type GraphCacheUpdaters = {
   Mutation?: {
-    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: PrefixTodoSuffix }, PrefixMutationToggleTodoArgsSuffix>,
-    toggleTodos?: GraphCacheUpdateResolver<{ toggleTodos: Array<PrefixTodoSuffix> }, PrefixMutationToggleTodosArgsSuffix>,
-    toggleTodosOptionalArray?: GraphCacheUpdateResolver<{ toggleTodosOptionalArray: Maybe<Array<PrefixTodoSuffix>> }, PrefixMutationToggleTodosOptionalArrayArgsSuffix>,
-    toggleTodosOptionalEntity?: GraphCacheUpdateResolver<{ toggleTodosOptionalEntity: Array<PrefixTodoSuffix> }, PrefixMutationToggleTodosOptionalEntityArgsSuffix>,
-    toggleTodosOptional?: GraphCacheUpdateResolver<{ toggleTodosOptional: Maybe<Array<PrefixTodoSuffix>> }, PrefixMutationToggleTodosOptionalArgsSuffix>
+    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: WithTypename<PrefixTodoSuffix> }, PrefixMutationToggleTodoArgsSuffix>,
+    toggleTodos?: GraphCacheUpdateResolver<{ toggleTodos: Array<WithTypename<PrefixTodoSuffix>> }, PrefixMutationToggleTodosArgsSuffix>,
+    toggleTodosOptionalArray?: GraphCacheUpdateResolver<{ toggleTodosOptionalArray: Maybe<Array<WithTypename<PrefixTodoSuffix>>> }, PrefixMutationToggleTodosOptionalArrayArgsSuffix>,
+    toggleTodosOptionalEntity?: GraphCacheUpdateResolver<{ toggleTodosOptionalEntity: Array<WithTypename<PrefixTodoSuffix>> }, PrefixMutationToggleTodosOptionalEntityArgsSuffix>,
+    toggleTodosOptional?: GraphCacheUpdateResolver<{ toggleTodosOptional: Maybe<Array<WithTypename<PrefixTodoSuffix>>> }, PrefixMutationToggleTodosOptionalArgsSuffix>
   },
   Subscription?: {},
 };
@@ -155,7 +155,7 @@ export type GraphCacheConfig = {
 exports[`urql graphcache Should output the cache-generic correctly (with unions) 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
-export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Book?: (data: WithTypename<Book>) => null | string,
@@ -164,7 +164,7 @@ export type GraphCacheKeysConfig = {
 
 export type GraphCacheResolvers = {
   Query?: {
-    media?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, Array<Media | string>>
+    media?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, Array<WithTypename<Media> | string>>
   },
   Book?: {
     id?: GraphCacheResolver<WithTypename<Book>, Record<string, never>, Scalars['ID'] | string>,
@@ -179,12 +179,12 @@ export type GraphCacheResolvers = {
 };
 
 export type GraphCacheOptimisticUpdaters = {
-  updateMedia?: GraphCacheOptimisticMutationResolver<MutationUpdateMediaArgs, Maybe<Media>>
+  updateMedia?: GraphCacheOptimisticMutationResolver<MutationUpdateMediaArgs, Maybe<WithTypename<Media>>>
 };
 
 export type GraphCacheUpdaters = {
   Mutation?: {
-    updateMedia?: GraphCacheUpdateResolver<{ updateMedia: Maybe<Media> }, MutationUpdateMediaArgs>
+    updateMedia?: GraphCacheUpdateResolver<{ updateMedia: Maybe<WithTypename<Media>> }, MutationUpdateMediaArgs>
   },
   Subscription?: {},
 };
@@ -202,7 +202,7 @@ export type GraphCacheConfig = {
 exports[`urql graphcache Should output the cache-generic correctly 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
-export type WithTypename<T extends { __typename?: any }> = { [K in Exclude<keyof T, '__typename'>]?: T[K] } & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Author?: (data: WithTypename<Author>) => null | string,
@@ -211,37 +211,37 @@ export type GraphCacheKeysConfig = {
 
 export type GraphCacheResolvers = {
   Query?: {
-    todos?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, Array<Todo | string>>
+    todos?: GraphCacheResolver<WithTypename<Query>, Record<string, never>, Array<WithTypename<Todo> | string>>
   },
   Author?: {
     id?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['ID'] | string>,
     name?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Scalars['String'] | string>,
-    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<Author | string>>,
-    friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<Author | string>>
+    friends?: GraphCacheResolver<WithTypename<Author>, Record<string, never>, Array<WithTypename<Author> | string>>,
+    friendsPaginated?: GraphCacheResolver<WithTypename<Author>, AuthorFriendsPaginatedArgs, Array<WithTypename<Author> | string>>
   },
   Todo?: {
     id?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['ID'] | string>,
     text?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['String'] | string>,
     complete?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['Boolean'] | string>,
-    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Author | string>
+    author?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, WithTypename<Author> | string>
   }
 };
 
 export type GraphCacheOptimisticUpdaters = {
-  toggleTodo?: GraphCacheOptimisticMutationResolver<MutationToggleTodoArgs, Todo>,
-  toggleTodos?: GraphCacheOptimisticMutationResolver<MutationToggleTodosArgs, Array<Todo>>,
-  toggleTodosOptionalArray?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalArrayArgs, Maybe<Array<Todo>>>,
-  toggleTodosOptionalEntity?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalEntityArgs, Array<Todo>>,
-  toggleTodosOptional?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalArgs, Maybe<Array<Todo>>>
+  toggleTodo?: GraphCacheOptimisticMutationResolver<MutationToggleTodoArgs, WithTypename<Todo>>,
+  toggleTodos?: GraphCacheOptimisticMutationResolver<MutationToggleTodosArgs, Array<WithTypename<Todo>>>,
+  toggleTodosOptionalArray?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalArrayArgs, Maybe<Array<WithTypename<Todo>>>>,
+  toggleTodosOptionalEntity?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalEntityArgs, Array<WithTypename<Todo>>>,
+  toggleTodosOptional?: GraphCacheOptimisticMutationResolver<MutationToggleTodosOptionalArgs, Maybe<Array<WithTypename<Todo>>>>
 };
 
 export type GraphCacheUpdaters = {
   Mutation?: {
-    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: Todo }, MutationToggleTodoArgs>,
-    toggleTodos?: GraphCacheUpdateResolver<{ toggleTodos: Array<Todo> }, MutationToggleTodosArgs>,
-    toggleTodosOptionalArray?: GraphCacheUpdateResolver<{ toggleTodosOptionalArray: Maybe<Array<Todo>> }, MutationToggleTodosOptionalArrayArgs>,
-    toggleTodosOptionalEntity?: GraphCacheUpdateResolver<{ toggleTodosOptionalEntity: Array<Todo> }, MutationToggleTodosOptionalEntityArgs>,
-    toggleTodosOptional?: GraphCacheUpdateResolver<{ toggleTodosOptional: Maybe<Array<Todo>> }, MutationToggleTodosOptionalArgs>
+    toggleTodo?: GraphCacheUpdateResolver<{ toggleTodo: WithTypename<Todo> }, MutationToggleTodoArgs>,
+    toggleTodos?: GraphCacheUpdateResolver<{ toggleTodos: Array<WithTypename<Todo>> }, MutationToggleTodosArgs>,
+    toggleTodosOptionalArray?: GraphCacheUpdateResolver<{ toggleTodosOptionalArray: Maybe<Array<WithTypename<Todo>>> }, MutationToggleTodosOptionalArrayArgs>,
+    toggleTodosOptionalEntity?: GraphCacheUpdateResolver<{ toggleTodosOptionalEntity: Array<WithTypename<Todo>> }, MutationToggleTodosOptionalEntityArgs>,
+    toggleTodosOptional?: GraphCacheUpdateResolver<{ toggleTodosOptional: Maybe<Array<WithTypename<Todo>>> }, MutationToggleTodosOptionalArgs>
   },
   Subscription?: {},
 };


### PR DESCRIPTION
## Description
This preserves the following graphql types:
* `UNION_TYPE_DEFINITION`
* `INPUT_OBJECT_TYPE_DEFINITION`
* `OBJECT_TYPE_DEFINITION`

when generating graphql typescript types using `typescript-urql-graphcache`

Related https://github.com/dotansimha/graphql-code-generator/issues/7447
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been tested in my own [repo](https://github.com/AndysonDK/syncbase)
