### PR TITLE
Fix namespace of JsonPropertyName

### DIFF
--- a/packages/plugins/c-sharp/c-sharp/src/json-attributes.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/json-attributes.ts
@@ -23,7 +23,7 @@ const newtonsoftConfiguration = new JsonAttributesSourceConfiguration(
 );
 
 // System.Text.Json does not have support of `JsonRequired` alternative (as for .NET 5)
-const systemTextJsonConfiguration = new JsonAttributesSourceConfiguration('System.Text.Json', 'JsonPropertyName', null);
+const systemTextJsonConfiguration = new JsonAttributesSourceConfiguration('System.Text.Json.Serialization', 'JsonPropertyName', null);
 
 export function getJsonAttributeSourceConfiguration(attributesSource: JsonAttributesSource) {
   switch (attributesSource) {


### PR DESCRIPTION
The attribute is in `System.Text.Json.Serialization` not `System.Text.Json`.

Fixes #7721 