### PR TITLE
feat: add support for deprecated input fields

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -788,7 +788,7 @@ export class BaseTypesVisitor<
     return null;
   }
 
-  getNodeComment(node: FieldDefinitionNode | EnumValueDefinitionNode): string {
+  getNodeComment(node: FieldDefinitionNode | EnumValueDefinitionNode | InputValueDefinitionNode): string {
     let commentText: string = node.description as any;
     const deprecationDirective = node.directives.find((v: any) => v.name === 'deprecated');
     if (deprecationDirective) {

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -277,7 +277,7 @@ export class TsVisitor<
       !this.config.avoidOptionals.inputValue &&
       (originalFieldNode.type.kind !== Kind.NON_NULL_TYPE ||
         (!this.config.avoidOptionals.defaultValue && node.defaultValue !== undefined));
-    const comment = transformComment(node.description as any as string, 1);
+    const comment = this.getNodeComment(node);
     const declarationKind = this.config.declarationKind.type;
 
     let type: string = node.type as any as string;

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -954,6 +954,23 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
+    it('input value @deprecated directive support', async () => {
+      const schema = buildSchema(`
+      input MyInput {
+        A: Int
+        B: Int @deprecated(reason: "input value \`B\` has been deprecated.")
+      }`);
+
+      const result = await plugin(schema, [], {}, { outputFile: '' });
+      expect(result.content).toBeSimilarStringTo(`
+      export type MyInput = {
+        A?: InputMaybe<Scalars['Int']>;
+        /** @deprecated input value \`B\` has been deprecated. */
+        B?: InputMaybe<Scalars['Int']>;
+      };`);
+      validateTs(result);
+    });
+
     it('#1462 - Union of scalars and argument of directive', async () => {
       const schema = buildSchema(`
       union Any = String | Int | Float | ID


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

- Adds support for @deprecated directives for inputs.

Related #7766 (issue)

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Schema:
<img width="420" alt="image" src="https://user-images.githubusercontent.com/18017094/163200954-e8df3e34-505e-4b68-a556-d600c4ad3362.png">

Codegen:
<img width="353" alt="image" src="https://user-images.githubusercontent.com/18017094/163200912-b9531f09-6f1a-45ab-83f9-6afdce420271.png">

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Unit Tests
- Run against a local project against built version of plugin. (See screenshots

**Test Environment**:

- OS: MacOS
- `@graphql-codegen/...`:
- NodeJS: 16

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
