### PR TITLE
feat: set input value deprecation to true

### DIFF
--- a/.changeset/smart-worms-design.md
+++ b/.changeset/smart-worms-design.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/cli": patch
+---
+
+Default inputValueDeprecation to true

--- a/packages/graphql-codegen-cli/src/load.ts
+++ b/packages/graphql-codegen-cli/src/load.ts
@@ -20,6 +20,7 @@ export const defaultSchemaLoadOptions = {
   sort: true,
   convertExtensions: true,
   includeSources: true,
+  inputValueDeprecation: true,
 };
 
 export const defaultDocumentsLoadOptions = {


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Sets `inputValueDeprecation` to true so that the graphql plugin by default returns information on input value deprecations

Related #7768 (issue)

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Set `inputValueDeprecation` in `config` key to `true` in `graphql-codegen.yml`. Run project and see @deprecated annotations.
- Run with default config set and see @deprecated annotations for input.

**Test Environment**:

- OS: MacOSX
- `@graphql-codegen/...`:
- NodeJS: 16

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
