### PR TITLE
Hook options variables should be required if the query variables are required

### DIFF
--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -4,6 +4,7 @@ import {
   LoadedFragment,
   getConfigValue,
   OMIT_TYPE,
+  REQUIRE_FIELDS_TYPE,
   DocumentMode,
 } from '@graphql-codegen/visitor-plugin-common';
 import { UrqlRawPluginConfig } from './config';
@@ -63,6 +64,7 @@ export class UrqlVisitor extends ClientSideBaseVisitor<UrqlRawPluginConfig, Urql
     }
 
     imports.push(OMIT_TYPE);
+    imports.push(REQUIRE_FIELDS_TYPE);
 
     return [...baseImports, ...imports];
   }
@@ -127,10 +129,15 @@ export function use${operationName}<TData = ${operationResultType}>(options: Omi
       variableDef => variableDef.type.kind === Kind.NON_NULL_TYPE && variableDef.defaultValue == null
     );
 
+    const optionsTypeOptionalVariables = `Omit<Urql.Use${operationType}Args<${operationVariablesTypes}>, 'query'>`;
+    const optionsTypeRequiredVariables = `RequireFields<${optionsTypeOptionalVariables}, 'variables'>`;
+
+    const optionsParameter = isVariablesRequired
+      ? `options: ${optionsTypeRequiredVariables}`
+      : `options?: ${optionsTypeOptionalVariables}`;
+
     return `
-export function use${operationName}(options${
-      isVariablesRequired ? '' : '?'
-    }: Omit<Urql.Use${operationType}Args<${operationVariablesTypes}>, 'query'>) {
+export function use${operationName}(${optionsParameter}) {
   return Urql.use${operationType}<${operationResultType}>({ query: ${documentVariableName}, ...options });
 };`;
   }

--- a/packages/plugins/typescript/urql/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql/tests/__snapshots__/urql.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`urql Hooks Should generate subscription hooks 1`] = `
 "import gql from 'graphql-tag';
 import * as Urql from 'urql';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 
 export const ListenToCommentsDocument = gql\`
     subscription ListenToComments($name: String) {
@@ -22,6 +23,7 @@ exports[`urql Hooks should allow importing operations and documents from another
 "import * as Operations from '@myproject/generated';
 import * as Urql from 'urql';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 
 
 export function useTestQuery(options?: Omit<Urql.UseQueryArgs<Operations.TestQueryVariables>, 'query'>) {

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -581,7 +581,7 @@ export function useSubmitRepositoryMutation() {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-export function useRequiredArgQuery(options: Omit<Urql.UseQueryArgs<RequiredArgQueryVariables>, 'query'>) {
+export function useRequiredArgQuery(options: RequireFields<Omit<Urql.UseQueryArgs<RequiredArgQueryVariables>, 'query'>, 'variables'>) {
   return Urql.useQuery<RequiredArgQuery>({ query: RequiredArgDocument, ...options });
 };`);
       await validateTypeScript(content, schema, docs, {});


### PR DESCRIPTION
## Description

When a query has required variables, I would expect the hooks to use them to also require a variables object.  As of right now, the variables field is always optional and can be omitted.

Related #7772
https://github.com/dotansimha/graphql-code-generator/issues/7772

## Type of change

I believe this is a breaking API change as incorrect calls to existing hooks will now begin to fail to compile.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Updated the tests in the repository to ensure RequireFields is used when variables are required.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
