### PR TITLE
Add config option to omit export of empty fragment subtypes

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
@@ -36,6 +36,7 @@ export interface ParsedDocumentsConfig extends ParsedTypesConfig {
   omitOperationSuffix: boolean;
   namespacedImportName: string | null;
   exportFragmentSpreadSubTypes: boolean;
+  omitEmptyFragments: boolean;
   skipTypeNameForRoot: boolean;
   experimentalFragmentVariables: boolean;
   mergeFragmentTypes: boolean;
@@ -101,6 +102,11 @@ export interface RawDocumentsConfig extends RawTypesConfig {
   exportFragmentSpreadSubTypes?: boolean;
   /**
    * @default false
+   * @description If set to true, it will not export empty fragment spread sub-types
+   */
+  omitEmptyFragments?: boolean;
+  /**
+   * @default false
    * @description If set to true, it will enable support for parsing variables on fragments.
    */
   experimentalFragmentVariables?: boolean;
@@ -134,6 +140,7 @@ export class BaseDocumentsVisitor<
   ) {
     super(rawConfig, {
       exportFragmentSpreadSubTypes: getConfigValue(rawConfig.exportFragmentSpreadSubTypes, false),
+      omitEmptyFragments: !!rawConfig.omitEmptyFragments,
       enumPrefix: getConfigValue(rawConfig.enumPrefix, true),
       preResolveTypes: getConfigValue(rawConfig.preResolveTypes, true),
       dedupeOperationSuffix: getConfigValue(rawConfig.dedupeOperationSuffix, false),

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -27,6 +27,7 @@ export interface ParsedConfig {
   typesPrefix: string;
   typesSuffix: string;
   addTypename: boolean;
+  omitEmptyFragments: boolean;
   nonOptionalTypename: boolean;
   externalFragments: LoadedFragment[];
   fragmentImports: ImportDeclaration<FragmentImport>[];
@@ -186,6 +187,10 @@ export interface RawConfig {
   /**
    * @ignore
    */
+  omitEmptyFragments?: boolean;
+  /**
+   * @ignore
+   */
   fragmentImports?: ImportDeclaration<FragmentImport>[];
   /**
    * @ignore
@@ -224,6 +229,7 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
       convert: convertFactory(rawConfig),
       typesPrefix: rawConfig.typesPrefix || '',
       typesSuffix: rawConfig.typesSuffix || '',
+      omitEmptyFragments: !!rawConfig.omitEmptyFragments,
       externalFragments: rawConfig.externalFragments || [],
       fragmentImports: rawConfig.fragmentImports || [],
       addTypename: !rawConfig.skipTypename,

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -297,7 +297,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
    */
   protected _buildGroupedSelections(): { grouped: Record<string, string[]>; mustAddEmptyObject: boolean } {
     if (!this._selectionSet || !this._selectionSet.selections || this._selectionSet.selections.length === 0) {
-      return { grouped: {}, mustAddEmptyObject: true };
+      return { grouped: {}, mustAddEmptyObject: !this._config.omitEmptyFragments };
     }
 
     const selectionNodesByTypeName = this.flattenSelectionSet(this._selectionSet.selections);
@@ -328,7 +328,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
         if (transformedSet) {
           prev[typeName].push(transformedSet);
         } else {
-          mustAddEmptyObject = true;
+          mustAddEmptyObject = !this._config.omitEmptyFragments;
         }
 
         return prev;
@@ -670,7 +670,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
         const declarationName = this.buildFragmentTypeName(fragmentName, fragmentSuffix, typeName);
 
         if (possibleFields.length === 0) {
-          if (!this._config.addTypename) {
+          if (!this._config.addTypename && !this._config.omitEmptyFragments) {
             return { name: declarationName, content: this.getEmptyObjectType() };
           }
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -131,6 +131,44 @@ describe('TypeScript Operations Plugin', () => {
       await validate(content, config);
     });
 
+    it('Should not generate empty fragments when omitEmptyFragments is set to true', async () => {
+      const ast = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            ... on TextNotification {
+              id
+            }
+          }
+        }
+      `);
+      const config = { skipTypename: true, omitEmptyFragments: true };
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+
+      expect(content).not.toContain('{}');
+      await validate(content, config);
+    });
+
+    it('Should generate empty fragments when omitEmptyFragments is set to false', async () => {
+      const ast = parse(/* GraphQL */ `
+        query notifications {
+          notifications {
+            ... on TextNotification {
+              id
+            }
+          }
+        }
+      `);
+      const config = { skipTypename: true, omitEmptyFragments: false };
+      const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
+        outputFile: '',
+      });
+
+      expect(content).toContain('{}');
+      await validate(content, config);
+    });
+
     it('Should handle "namespacedImportName" and add it when specified', async () => {
       const ast = parse(/* GraphQL */ `
         query notifications {

--- a/website/public/config.schema.json
+++ b/website/public/config.schema.json
@@ -592,6 +592,10 @@
           "description": "If set to true, it will export the sub-types created in order to make it easier to access fields declared under fragment spread.\nDefault value: \"false\"",
           "type": "boolean"
         },
+        "omitEmptyFragments": {
+          "description": "If set to true, it will not export empty fragment spread sub-types",
+          "type": "boolean"
+        },
         "experimentalFragmentVariables": {
           "description": "If set to true, it will enable support for parsing variables on fragments.\nDefault value: \"false\"",
           "type": "boolean"
@@ -2997,6 +3001,10 @@
         },
         "exportFragmentSpreadSubTypes": {
           "description": "If set to true, it will export the sub-types created in order to make it easier to access fields declared under fragment spread.\nDefault value: \"false\"",
+          "type": "boolean"
+        },
+        "omitEmptyFragments": {
+          "description": "If set to true, it will not export empty fragment spread sub-types",
           "type": "boolean"
         },
         "experimentalFragmentVariables": {


### PR DESCRIPTION
## Description

Adds an extra config field for omitting empty objects when using inline fragment spreads in combination with `skipTypename`.
This makes an upgrade from `@graphql-codegen/typescript-operations` version 1.18.0 to version 2 possible for people who run into problems with this. This also allows the upgrade from graphql 15 to 16, since `typescript-operations` 1.18 is incompatible with version 16.

Related # [(issue)](https://github.com/dotansimha/graphql-code-generator/issues/6873)

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

## How Has This Been Tested?

Added unit tests:

- [x] Config Should not generate empty fragments when omitEmptyFragments is set to true
- [x] Config Should generate empty fragments when omitEmptyFragments is set to false

**Test Environment**:

- OS: Ubuntu
- `@graphql-codegen/...`: typescript-operations
- NodeJS: v17.8.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
n/a