### PR TITLE
fix(typescript-operations): Import type definitions of dependent fragments when `inlineFragmentType` is `mask`

### DIFF
--- a/.changeset/fifty-students-fail.md
+++ b/.changeset/fifty-students-fail.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-operations': patch
+---
+
+Import type definitions of dependent fragments when `inlineFragmentType` is `mask`

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -118,7 +118,8 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
   }
 
   public getImports(): Array<string> {
-    return !this.config.globalNamespace && this.config.inlineFragmentTypes === 'combine'
+    return !this.config.globalNamespace &&
+      (this.config.inlineFragmentTypes === 'combine' || this.config.inlineFragmentTypes === 'mask')
       ? this.config.fragmentImports.map(fragmentImport => generateFragmentImportStatement(fragmentImport, 'type'))
       : [];
   }

--- a/packages/presets/near-operation-file/tests/fixtures/issue-7798-child.ts
+++ b/packages/presets/near-operation-file/tests/fixtures/issue-7798-child.ts
@@ -1,0 +1,5 @@
+export const UserNameFragment = /* GraphQL */ `
+  fragment UserName on User {
+    name
+  }
+`;

--- a/packages/presets/near-operation-file/tests/fixtures/issue-7798-parent.ts
+++ b/packages/presets/near-operation-file/tests/fixtures/issue-7798-parent.ts
@@ -1,0 +1,8 @@
+import { UserNameFragment } from './issue-7798-child';
+
+export const UserFragment = /* GraphQL */ `
+  fragment User on User {
+    ...UserName
+  }
+  ${UserNameFragment}
+`;

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -544,6 +544,41 @@ describe('near-operation-file preset', () => {
         );
       }
     });
+
+    it('#7798 - importing type definitions of dependent fragments when `inlineFragmentType` is `mask`', async () => {
+      const result = await executeCodegen({
+        schema: [
+          /* GraphQL */ `
+            type User {
+              id: ID!
+              name: String!
+            }
+
+            type Query {
+              user(id: ID!): User!
+            }
+          `,
+        ],
+        documents: [
+          path.join(__dirname, 'fixtures/issue-7798-parent.ts'),
+          path.join(__dirname, 'fixtures/issue-7798-child.ts'),
+        ],
+        generates: {
+          'out1.ts': {
+            preset,
+            presetConfig: {
+              baseTypesPath: 'types.ts',
+            },
+            plugins: ['typescript-operations'],
+            config: { inlineFragmentTypes: 'mask' },
+          },
+        },
+      });
+
+      const parentContent = result.find(generatedDoc => generatedDoc.filename.match(/issue-7798-parent/)).content;
+      const imports = parentContent.match(/import.*UserNameFragment/g);
+      expect(imports).toHaveLength(1);
+    });
   });
 
   it('Should build the correct operation files paths', async () => {


### PR DESCRIPTION
## Description

Fix bug of #7798 

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- ~~[ ] Any dependent changes have been merged and published in downstream modules~~

