### PR TITLE
Name example query in React guide

### DIFF
--- a/website/docs/guides/react.mdx
+++ b/website/docs/guides/react.mdx
@@ -347,7 +347,8 @@ For this, create a colocated `.graphql` file for each GraphQL document, as follo
 ```graphql
 # postsQuery.graphql
 
-query {
+# 'Document' will be appended to the name of the query in the generated output
+query postsQuery {
   posts {
     id
     title


### PR DESCRIPTION
## Description

In order to be able to import the following:

```typescript
import { postsQueryDocument } from "./graphql/generated"
```

one needs to name the query in the `.graphql` file accordingly. Following the guide (and therefore not doing so) can lead to confusion as the generated document will just be called `Document` instead of `postsQueryDocument`, leading to various issues and headaches.

Related # none

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This is just one line of documentation, therefore no issue is linked and no tests are provided.
