### PR TITLE
docs: Swapping rootValueType with directiveContextTypes for correctness

### DIFF
--- a/.changeset/pink-tips-grin.md
+++ b/.changeset/pink-tips-grin.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/visitor-plugin-common": patch
+---
+
+docs: Swapping rootValueType with directiveContextTypes for correctness

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -153,7 +153,7 @@ export interface RawResolversConfig extends RawConfig {
    *     rootValueType: ./my-types#MyRootValue
    * ```
    */
-  directiveContextTypes?: Array<string>;
+  rootValueType?: string;
   /**
    * @description Use this to set a custom type for a specific field `context` decorated by a directive.
    * It will only affect the targeted resolvers.
@@ -172,7 +172,7 @@ export interface RawResolversConfig extends RawConfig {
    * ```
    *
    */
-  rootValueType?: string;
+  directiveContextTypes?: Array<string>;
   /**
    * @description Adds a suffix to the imported names to prevent name clashes.
    *


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

On the [plugin documentation page](https://www.graphql-code-generator.com/plugins/typescript-resolvers) I noticed that `rootValueType` and `directiveContextTypes` were swapped around.

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
