### PR TITLE
Fix typo in docs

### DIFF
--- a/website/docs/getting-started/installation.mdx
+++ b/website/docs/getting-started/installation.mdx
@@ -38,7 +38,7 @@ Otherwise, you can start exploring the [plugins](/plugins) and [setting up them 
 
 Once installed, GraphQL Code Generator CLI can help you configure your project based on some popular flows:
 
-<PackageRun scripts={['graphql-codegen init', 'install # install the choose plugins']} />
+<PackageRun scripts={['graphql-codegen init', 'install # install the chosen plugins']} />
 
 Question by question, it will guide you through the whole process of setting up a schema, selecting and installing plugins, picking a destination to where your files are generated, and a lot more.
 


### PR DESCRIPTION
I also wanted to fix this, which errors (there is no `graphql-codegen` script—you have to do `npx graphql-codegen init`), but I don't see where `<PackageRun>` is defined?

<img width="854" alt="image" src="https://user-images.githubusercontent.com/251288/169708577-3010e93a-9f43-4941-8819-b09fa9b212bb.png">
