### PR TITLE
feat: support generating correct types for `@oneOf` input types

### DIFF
--- a/.changeset/wicked-geckos-do.md
+++ b/.changeset/wicked-geckos-do.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript': minor
+---
+
+support the `@oneOf` directive on input types.

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -40,6 +40,7 @@ import {
   wrapWithSingleQuotes,
   getConfigValue,
   buildScalarsFromConfig,
+  isOneOfInputObjectType,
 } from './utils';
 import { OperationVariablesToObject } from './variables-to-object';
 import { parseEnumValues } from './enum-values';
@@ -466,7 +467,7 @@ export class BaseTypesVisitor<
     if (this.config.onlyEnums) return '';
 
     // Why the heck is directive.name a string and not { value: string } at runtime ?!
-    if (node.directives?.some(directive => (directive.name as any) === 'oneOf')) {
+    if (isOneOfInputObjectType(this._schema.getType(node.name as unknown as string))) {
       return this.getInputObjectOneOfDeclarationBlock(node).string;
     }
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -466,7 +466,7 @@ export class BaseTypesVisitor<
   InputObjectTypeDefinition(node: InputObjectTypeDefinitionNode): string {
     if (this.config.onlyEnums) return '';
 
-    // Why the heck is directive.name a string and not { value: string } at runtime ?!
+    // Why the heck is node.name a string and not { value: string } at runtime ?!
     if (isOneOfInputObjectType(this._schema.getType(node.name as unknown as string))) {
       return this.getInputObjectOneOfDeclarationBlock(node).string;
     }

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -453,8 +453,22 @@ export class BaseTypesVisitor<
       .withBlock(node.fields.join('\n'));
   }
 
+  getInputObjectOneOfDeclarationBlock(node: InputObjectTypeDefinitionNode): DeclarationBlock {
+    return new DeclarationBlock(this._declarationBlockConfig)
+      .export()
+      .asKind(this._parsedConfig.declarationKind.input)
+      .withName(this.convertName(node))
+      .withComment(node.description as any as string)
+      .withContent(`\n` + node.fields.join('\n  |'));
+  }
+
   InputObjectTypeDefinition(node: InputObjectTypeDefinitionNode): string {
     if (this.config.onlyEnums) return '';
+
+    // Why the heck is directive.name a string and not { value: string } at runtime ?!
+    if (node.directives?.some(directive => (directive.name as any) === 'oneOf')) {
+      return this.getInputObjectOneOfDeclarationBlock(node).string;
+    }
 
     return this.getInputObjectDeclarationBlock(node).string;
   }

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -516,5 +516,7 @@ export function isOneOfInputObjectType(
     ((namedType as unknown as Record<'isOneOf', boolean | undefined>).isOneOf ||
       namedType.astNode?.directives?.some(d => d.name.value === 'oneOf'));
 
+  isOneOfTypeCache.set(namedType, isOneOfType);
+
   return isOneOfType;
 }

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -19,6 +19,8 @@ import {
   isListType,
   isAbstractType,
   GraphQLOutputType,
+  isInputObjectType,
+  GraphQLInputObjectType,
 } from 'graphql';
 import { ScalarsMap, NormalizedScalarsMap, ParsedScalarsMap } from './types';
 import { DEFAULT_SCALARS } from './scalars';
@@ -494,4 +496,25 @@ function clearOptional(str: string): string {
 
 function stripTrailingSpaces(str: string): string {
   return str.replace(/ +\n/g, '\n');
+}
+
+const isOneOfTypeCache = new WeakMap<GraphQLNamedType, boolean>();
+export function isOneOfInputObjectType(
+  namedType: GraphQLNamedType | null | undefined
+): namedType is GraphQLInputObjectType {
+  if (!namedType) {
+    return false;
+  }
+  let isOneOfType = isOneOfTypeCache.get(namedType);
+
+  if (isOneOfType !== undefined) {
+    return isOneOfType;
+  }
+
+  isOneOfType =
+    isInputObjectType(namedType) &&
+    ((namedType as unknown as Record<'isOneOf', boolean | undefined>).isOneOf ||
+      namedType.astNode?.directives?.some(d => d.name.value === 'oneOf'));
+
+  return isOneOfType;
 }

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -415,12 +415,12 @@ export class TypeGraphQLVisitor<
     node: InputValueDefinitionNode,
     key?: number | string,
     parent?: any,
-    path?: any,
-    ancestors?: TypeDefinitionNode[]
+    path?: Array<string | number>,
+    ancestors?: Array<TypeDefinitionNode>
   ): string {
     const parentName = ancestors?.[ancestors.length - 1].name.value;
     if (parent && !this.hasTypeDecorators(parentName)) {
-      return this.typescriptVisitor.InputValueDefinition(node, key, parent);
+      return this.typescriptVisitor.InputValueDefinition(node, key, parent, path, ancestors);
     }
 
     const fieldDecorator = this.config.decoratorName.field;

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -302,9 +302,11 @@ export class TsVisitor<
       type = this._getDirectiveOverrideType(node.directives) || type;
     }
 
-    const inner = `${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${
-      addOptionalSign ? '?' : ''
-    }: ${type}${this.getPunctuation(declarationKind)}`;
+    const buildFieldDefinition = (isOneOf = false) => {
+      return `${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${
+        addOptionalSign && !isOneOf ? '?' : ''
+      }: ${type}${this.getPunctuation(declarationKind)}`;
+    };
 
     const realParent = ancestors?.[ancestors.length - 1];
     if (
@@ -315,7 +317,7 @@ export class TsVisitor<
       for (const field of realParent.fields ?? []) {
         // Why the heck is node.name a string and not { value: string } at runtime ?!
         if (field.name.value === (node.name as any as string)) {
-          fieldParts.push(inner);
+          fieldParts.push(buildFieldDefinition(true));
           continue;
         }
         fieldParts.push(`${field.name.value}?: never;`);
@@ -323,7 +325,7 @@ export class TsVisitor<
       return comment + indent(`{ ${fieldParts.join(' ')} }`);
     }
 
-    return comment + indent(inner);
+    return comment + indent(buildFieldDefinition());
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -26,7 +26,6 @@ import {
   UnionTypeDefinitionNode,
   GraphQLObjectType,
   TypeDefinitionNode,
-  isInputObjectType,
 } from 'graphql';
 import { TypeScriptOperationVariablesToObject } from './typescript-variables-to-object';
 

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -304,10 +304,12 @@ export class TsVisitor<
       type = this._getDirectiveOverrideType(node.directives) || type;
     }
 
+    const readonlyPrefix = this.config.immutableTypes ? 'readonly ' : '';
+
     const buildFieldDefinition = (isOneOf = false) => {
-      return `${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${
-        addOptionalSign && !isOneOf ? '?' : ''
-      }: ${type}${this.getPunctuation(declarationKind)}`;
+      return `${readonlyPrefix}${node.name}${addOptionalSign && !isOneOf ? '?' : ''}: ${
+        isOneOf ? this.clearOptional(type) : type
+      }${this.getPunctuation(declarationKind)}`;
     };
 
     const realParentDef = ancestors?.[ancestors.length - 1];
@@ -327,7 +329,7 @@ export class TsVisitor<
             fieldParts.push(buildFieldDefinition(true));
             continue;
           }
-          fieldParts.push(`${fieldName}?: never;`);
+          fieldParts.push(`${readonlyPrefix}${fieldName}?: never;`);
         }
         return comment + indent(`{ ${fieldParts.join(' ')} }`);
       }

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -311,7 +311,16 @@ export class TsVisitor<
       realParent?.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION &&
       realParent.directives?.some(directive => directive.name.value === 'oneOf')
     ) {
-      return comment + indent(`{ ${inner} }`);
+      const fieldParts: Array<string> = [];
+      for (const field of realParent.fields ?? []) {
+        // Why the heck is node.name a string and not { value: string } at runtime ?!
+        if (field.name.value === (node.name as any as string)) {
+          fieldParts.push(inner);
+          continue;
+        }
+        fieldParts.push(`${field.name.value}?: never;`);
+      }
+      return comment + indent(`{ ${fieldParts.join(' ')} }`);
     }
 
     return comment + indent(inner);

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -24,6 +24,7 @@ import {
   isEnumType,
   UnionTypeDefinitionNode,
   GraphQLObjectType,
+  TypeDefinitionNode,
 } from 'graphql';
 import { TypeScriptOperationVariablesToObject } from './typescript-variables-to-object';
 
@@ -284,8 +285,8 @@ export class TsVisitor<
     node: InputValueDefinitionNode,
     key?: number | string,
     parent?: any,
-    _path?: any,
-    ancestors?: any
+    _path?: Array<string | number>,
+    ancestors?: Array<TypeDefinitionNode>
   ): string {
     const originalFieldNode = parent[key] as FieldDefinitionNode;
 
@@ -301,11 +302,11 @@ export class TsVisitor<
       type = this._getDirectiveOverrideType(node.directives) || type;
     }
 
-    const realParent = ancestors[ancestors.length - 1];
     const inner = `${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${
       addOptionalSign ? '?' : ''
     }: ${type}${this.getPunctuation(declarationKind)}`;
 
+    const realParent = ancestors?.[ancestors.length - 1];
     if (
       realParent?.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION &&
       realParent.directives?.some(directive => directive.name.value === 'oneOf')

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2586,7 +2586,7 @@ describe('TypeScript', () => {
         `);
       });
 
-      it('correct output for type with non-optional fields', async () => {
+      it('raises exception for type with non-optional fields', async () => {
         const schema = buildSchema(
           /* GraphQL */ `
           input Input @oneOf {
@@ -2600,12 +2600,63 @@ describe('TypeScript', () => {
         `.concat(oneOfDirectiveDefinition)
         );
 
-        const result = await plugin(schema, [], {}, { outputFile: '' });
+        try {
+          await plugin(schema, [], {}, { outputFile: '' });
+          throw new Error('Plugin should have raised an exception.');
+        } catch (err) {
+          expect(err.message).toEqual(
+            'Fields on an input object type can not be non-nullable. It seems like the schema was not validated.'
+          );
+        }
+      });
 
+      it('handles extensions properly', async () => {
+        const schema = buildSchema(
+          /* GraphQL */ `
+          input Input @oneOf {
+            int: Int
+          }
+
+          extend input Input {
+            boolean: Boolean
+          }
+
+          type Query {
+            foo(input: Input!): Boolean!
+          }
+        `.concat(oneOfDirectiveDefinition)
+        );
+
+        const result = await plugin(schema, [], {}, { outputFile: '' });
         expect(result.content).toBeSimilarStringTo(`
           export type Input =
-            { int: Scalars['Int']; boolean?: never; }
-            | { int?: never; boolean: Scalars['Boolean']; };
+            { int: InputMaybe<Scalars['Int']>; boolean?: never; }
+            | { int?: never; boolean: InputMaybe<Scalars['Boolean']>; };
+        `);
+      });
+
+      it('handles .isOneOf property on input object types properly', async () => {
+        const schema = buildSchema(
+          /* GraphQL */ `
+          input Input {
+            int: Int
+            boolean: Boolean
+          }
+
+          type Query {
+            foo(input: Input!): Boolean!
+          }
+        `.concat(oneOfDirectiveDefinition)
+        );
+
+        const inputType: Record<'isOneOf', boolean> = schema.getType('Input') as any;
+        inputType.isOneOf = true;
+
+        const result = await plugin(schema, [], {}, { outputFile: '' });
+        expect(result.content).toBeSimilarStringTo(`
+          export type Input =
+            { int: InputMaybe<Scalars['Int']>; boolean?: never; }
+            | { int?: never; boolean: InputMaybe<Scalars['Boolean']>; };
         `);
       });
     });

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2559,7 +2559,7 @@ describe('TypeScript', () => {
 
         expect(result.content).toBeSimilarStringTo(`
           export type Input =
-            { int: InputMaybe<Scalars['Int']>; };
+            { int: Scalars['Int']; };
         `);
       });
 
@@ -2581,8 +2581,8 @@ describe('TypeScript', () => {
 
         expect(result.content).toBeSimilarStringTo(`
           export type Input =
-            { int: InputMaybe<Scalars['Int']>; boolean?: never; }
-            | { int?: never; boolean: InputMaybe<Scalars['Boolean']>; };
+            { int: Scalars['Int']; boolean?: never; }
+            | { int?: never; boolean: Scalars['Boolean']; };
         `);
       });
 
@@ -2630,8 +2630,8 @@ describe('TypeScript', () => {
         const result = await plugin(schema, [], {}, { outputFile: '' });
         expect(result.content).toBeSimilarStringTo(`
           export type Input =
-            { int: InputMaybe<Scalars['Int']>; boolean?: never; }
-            | { int?: never; boolean: InputMaybe<Scalars['Boolean']>; };
+            { int: Scalars['Int']; boolean?: never; }
+            | { int?: never; boolean: Scalars['Boolean']; };
         `);
       });
 
@@ -2655,8 +2655,8 @@ describe('TypeScript', () => {
         const result = await plugin(schema, [], {}, { outputFile: '' });
         expect(result.content).toBeSimilarStringTo(`
           export type Input =
-            { int: InputMaybe<Scalars['Int']>; boolean?: never; }
-            | { int?: never; boolean: InputMaybe<Scalars['Boolean']>; };
+            { int: Scalars['Int']; boolean?: never; }
+            | { int?: never; boolean: Scalars['Boolean']; };
         `);
       });
     });

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2559,7 +2559,7 @@ describe('TypeScript', () => {
 
         expect(result.content).toBeSimilarStringTo(`
           export type Input =
-            { int?: InputMaybe<Scalars['Int']>; };
+            { int: InputMaybe<Scalars['Int']>; };
         `);
       });
 
@@ -2581,8 +2581,8 @@ describe('TypeScript', () => {
 
         expect(result.content).toBeSimilarStringTo(`
           export type Input =
-            { int?: InputMaybe<Scalars['Int']>; boolean?: never; }
-            | { int?: never; boolean?: InputMaybe<Scalars['Boolean']>; };
+            { int: InputMaybe<Scalars['Int']>; boolean?: never; }
+            | { int?: never; boolean: InputMaybe<Scalars['Boolean']>; };
         `);
       });
 

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2581,8 +2581,8 @@ describe('TypeScript', () => {
 
         expect(result.content).toBeSimilarStringTo(`
           export type Input =
-            { int?: InputMaybe<Scalars['Int']>; }
-            | { boolean?: InputMaybe<Scalars['Boolean']>; };
+            { int?: InputMaybe<Scalars['Int']>; boolean?: never; }
+            | { int?: never; boolean?: InputMaybe<Scalars['Boolean']>; };
         `);
       });
 
@@ -2604,8 +2604,8 @@ describe('TypeScript', () => {
 
         expect(result.content).toBeSimilarStringTo(`
           export type Input =
-            { int: Scalars['Int']; }
-            | { boolean: Scalars['Boolean']; };
+            { int: Scalars['Int']; boolean?: never; }
+            | { int?: never; boolean: Scalars['Boolean']; };
         `);
       });
     });


### PR DESCRIPTION
Support for the `@oneOf` directive on input object types.

Things to consider:

- Should we make this available behind a flag?
  
  `@onOf` is still in the RFC stage and the behavior could change slightly. Should we, therefore, make this opt-in?

____

References:
- https://github.com/graphql/graphql-js/pull/3513#issuecomment-1137703851
- https://github.com/graphql/graphql-spec/pull/825