### PR TITLE
fix(react-query) incorrect options type in generated infiniteQuery

### DIFF
--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -48,7 +48,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
     this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.infiniteQuery.hook);
     this.visitor.reactQueryOptionsIdentifiersInUse.add(hookConfig.infiniteQuery.options);
 
-    const options = `options?: ${hookConfig.query.options}<${operationResultType}, TError, TData>`;
+    const options = `options?: ${hookConfig.infiniteQuery.options}<${operationResultType}, TError, TData>`;
 
     return `export const useInfinite${operationName} = <
       TData = ${operationResultType},

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -199,6 +199,21 @@ export const useTestQuery = <
       fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     );
+export const useInfiniteTestQuery = <
+      TData = TTestQuery,
+      TError = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      pageParamKey: keyof TTestQueryVariables,
+      variables?: TTestQueryVariables,
+      options?: UseInfiniteQueryOptions<TTestQuery, TError, TData>
+    ) =>
+    useInfiniteQuery<TTestQuery, TError, TData>(
+      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      (metaData) => fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
+      options
+    );
+
 export const TestDocument = \`
     mutation test($name: String) {
   submitRepository(repoFullName: $name) {


### PR DESCRIPTION
## Description

There is a bug in the `react-query` plugin that generates an incorrect type being used in the generated useInfinite queries.

Related #7897

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

I've implemented a new test case that was missing on this part of the code, and this bugfix validates it.
I also tested this on my personal project and the generated types are now correct.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
