### PR TITLE
fix: ensure falsy enum values are still mapped

### DIFF
--- a/.changeset/spotty-waves-whisper.md
+++ b/.changeset/spotty-waves-whisper.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript": patch
+"@graphql-codegen/visitor-plugin-common": patch
+---
+
+Ensure falsy enum values are still mapped

--- a/packages/plugins/other/visitor-plugin-common/src/enum-values.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/enum-values.ts
@@ -24,7 +24,7 @@ export function parseEnumValues({
       for (const enumTypeName of allEnums) {
         const enumType = schema.getType(enumTypeName) as GraphQLEnumType;
         for (const { name, value } of enumType.getValues()) {
-          if (value && value !== name) {
+          if (value !== name) {
             mapOrStr[enumTypeName] = mapOrStr[enumTypeName] || {};
             if (typeof mapOrStr[enumTypeName] !== 'string' && !mapOrStr[enumTypeName][name]) {
               mapOrStr[enumTypeName][name] = typeof value === 'string' ? escapeString(value) : value;

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -637,6 +637,38 @@ describe('TypeScript', () => {
       expect(output).toContain(`SomethingElse = '99'`);
     });
 
+    it('#7898 - falsy enum value set on schema with enumsAsTypes set', async () => {
+      const testSchema = new GraphQLSchema({
+        types: [
+          new GraphQLObjectType({
+            name: 'Query',
+            fields: {
+              test: {
+                type: new GraphQLEnumType({
+                  name: 'MyEnum',
+                  values: {
+                    EnumValueName: {
+                      value: 0,
+                    },
+                  },
+                }),
+              },
+            },
+          }),
+        ],
+      });
+
+      const result = (await plugin(
+        testSchema,
+        [],
+        { enumsAsTypes: true },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+      const output = mergeOutputs([result]);
+      expect(output).not.toContain('EnumValueName');
+      expect(output).toContain('0');
+    });
+
     it('#6532 - numeric enum values with namingConvention', async () => {
       const testSchema = buildSchema(/* GraphQL */ `
         type Query {


### PR DESCRIPTION
## Description

Enums with falsy values were getting generated incorrectly when using enumsAsTypes. The cause was truthyness check on the value before creating the value map.

I've removed the truthy check so instead it only checks if `value !== name`.

I considered adding a `typeof value !== "undefined"` but as far as I'm aware, value is never undefined. For enums without a value map, then the value is the same as the name.

Related #7898

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

[CodeSandbox](https://codesandbox.io/s/intelligent-dubinsky-5rerq2) demonstrating problem

## How Has This Been Tested?

A test has been added in this PR

**Test Environment**:

- OS: Linux
- NodeJS: v16.15.0
```
    "@graphql-codegen/core": "2.5.1",
    "@graphql-codegen/typescript": "2.4.11",
    "graphql": "16.5.0"
```

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
