### PR TITLE
URQL GraphCache creates type error when there are no mutations

### DIFF
--- a/.changeset/long-mice-cross.md
+++ b/.changeset/long-mice-cross.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-urql-graphcache': patch
+---
+
+Fixed a bug where the generated type file causes a type error when the GraphQL schema includes no mutations

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -257,9 +257,8 @@ export const plugin: PluginFunction<UrqlGraphCacheConfig, Types.ComplexPluginOut
 
       'export type GraphCacheResolvers = {\n' + resolvers.join(',\n') + '\n};',
 
-      'export type GraphCacheOptimisticUpdaters = {\n  ' +
-        (optimisticUpdaters ? optimisticUpdaters.join(',\n  ') : '{}') +
-        '\n};',
+      'export type GraphCacheOptimisticUpdaters = ' +
+        (optimisticUpdaters ? '{\n  ' + optimisticUpdaters.join(',\n  ') + '\n};' : '{};'),
 
       'export type GraphCacheUpdaters = {\n' +
         '  Mutation?: ' +

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -41,6 +41,43 @@ export type GraphCacheConfig = {
 };"
 `;
 
+exports[`urql graphcache Should correctly output GraphCacheOptimisticUpdaters when there are no mutations 1`] = `
+"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
+import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
+export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
+
+export type GraphCacheKeysConfig = {
+  Todo?: (data: WithTypename<Todo>) => null | string
+}
+
+export type GraphCacheResolvers = {
+  Query_Root?: {
+    todos?: GraphCacheResolver<WithTypename<Query_Root>, Record<string, never>, Array<WithTypename<Todo> | string>>
+  },
+  Todo?: {
+    id?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['ID'] | string>,
+    text?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['String'] | string>,
+    complete?: GraphCacheResolver<WithTypename<Todo>, Record<string, never>, Scalars['Boolean'] | string>
+  }
+};
+
+export type GraphCacheOptimisticUpdaters = {};
+
+export type GraphCacheUpdaters = {
+  Mutation?: {},
+  Subscription?: {},
+};
+
+export type GraphCacheConfig = {
+  schema?: IntrospectionData,
+  updates?: GraphCacheUpdaters,
+  keys?: GraphCacheKeysConfig,
+  optimistic?: GraphCacheOptimisticUpdaters,
+  resolvers?: GraphCacheResolvers,
+  storage?: GraphCacheStorageAdapter
+};"
+`;
+
 exports[`urql graphcache Should output the cache-generic correctly (with interfaces) 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
@@ -76,9 +113,7 @@ export type GraphCacheResolvers = {
   }
 };
 
-export type GraphCacheOptimisticUpdaters = {
-  {}
-};
+export type GraphCacheOptimisticUpdaters = {};
 
 export type GraphCacheUpdaters = {
   Mutation?: {},

--- a/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
@@ -193,4 +193,24 @@ import type { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast
     const result = mergeOutputs([await plugin(schema, [], {})]);
     expect(result).toMatchSnapshot();
   });
+
+  it('Should correctly output GraphCacheOptimisticUpdaters when there are no mutations', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      schema {
+        query: Query_Root
+      }
+
+      type Query_Root {
+        todos: [Todo]
+      }
+
+      type Todo {
+        id: ID
+        text: String
+        complete: Boolean
+      }
+    `);
+    const result = mergeOutputs([await plugin(schema, [], {})]);
+    expect(result).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Description

The `typescript-urql-graphcache` plugin causes a typescript error in the generated type file for the type `GraphCacheOptimisticUpdaters` if the schema has no mutations.

Related Issue: https://github.com/dotansimha/graphql-code-generator/issues/7910

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- A test has a schema with no GraphQL mutations to cover this edge case

## Check list
- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules