### PR TITLE
Fix TS type error on strictNullChecks: true

### DIFF
--- a/.changeset/purple-eyes-fix.md
+++ b/.changeset/purple-eyes-fix.md
@@ -1,0 +1,29 @@
+---
+'@graphql-codegen/plugin-helpers': patch
+---
+
+Fix TS type error on strictNullChecks: true
+
+Fix the compiler error:
+
+```
+node_modules/@graphql-codegen/plugin-helpers/oldVisit.d.ts:5:75 - error TS2339: Property 'enter' does not exist on type '{ readonly enter?: ASTVisitFn<NameNode> | undefined; readonly leave: ASTReducerFn<NameNode, unknown>; } | { readonly enter?: ASTVisitFn<DocumentNode> | undefined; readonly leave: ASTReducerFn<...>; } | ... 41 more ... | undefined'.
+
+5     enter?: Partial<Record<keyof NewVisitor, NewVisitor[keyof NewVisitor]['enter']>>;
+                                                                            ~~~~~~~
+
+node_modules/@graphql-codegen/plugin-helpers/oldVisit.d.ts:6:75 - error TS2339: Property 'leave' does not exist on type '{ readonly enter?: ASTVisitFn<NameNode> | undefined; readonly leave: ASTReducerFn<NameNode, unknown>; } | { readonly enter?: ASTVisitFn<DocumentNode> | undefined; readonly leave: ASTReducerFn<...>; } | ... 41 more ... | undefined'.
+
+6     leave?: Partial<Record<keyof NewVisitor, NewVisitor[keyof NewVisitor]['leave']>>;
+                                                                            ~~~~~~~
+
+
+Found 2 errors in the same file, starting at: node_modules/@graphql-codegen/plugin-helpers/oldVisit.d.ts:5
+```
+
+Only happens when TS compiler options `strictNullChecks: true` and `skipLibCheck: false`.
+
+`Partial<T>` includes `{}`, therefore `NewVisitor[keyof NewVisitor]` includes `undefined`, and indexing `undefined` is error.
+Eliminate `undefined` by wrapping it inside `NonNullable<...>`.
+
+Related #7519 

--- a/packages/utils/plugins-helpers/src/oldVisit.ts
+++ b/packages/utils/plugins-helpers/src/oldVisit.ts
@@ -3,8 +3,8 @@ import { ASTNode, visit } from 'graphql';
 type VisitFn = typeof visit;
 type NewVisitor = Partial<Parameters<VisitFn>[1]>;
 type OldVisitor = {
-  enter?: Partial<Record<keyof NewVisitor, NewVisitor[keyof NewVisitor]['enter']>>;
-  leave?: Partial<Record<keyof NewVisitor, NewVisitor[keyof NewVisitor]['leave']>>;
+  enter?: Partial<Record<keyof NewVisitor, NonNullable<NewVisitor[keyof NewVisitor]>['enter']>>;
+  leave?: Partial<Record<keyof NewVisitor, NonNullable<NewVisitor[keyof NewVisitor]>['leave']>>;
 } & NewVisitor;
 
 export function oldVisit(


### PR DESCRIPTION
## Description

Fix the compiler error:

```
node_modules/@graphql-codegen/plugin-helpers/oldVisit.d.ts:5:75 - error TS2339: Property 'enter' does not exist on type '{ readonly enter?: ASTVisitFn<NameNode> | undefined; readonly leave: ASTReducerFn<NameNode, unknown>; } | { readonly enter?: ASTVisitFn<DocumentNode> | undefined; readonly leave: ASTReducerFn<...>; } | ... 41 more ... | undefined'.

5     enter?: Partial<Record<keyof NewVisitor, NewVisitor[keyof NewVisitor]['enter']>>;
                                                                            ~~~~~~~

node_modules/@graphql-codegen/plugin-helpers/oldVisit.d.ts:6:75 - error TS2339: Property 'leave' does not exist on type '{ readonly enter?: ASTVisitFn<NameNode> | undefined; readonly leave: ASTReducerFn<NameNode, unknown>; } | { readonly enter?: ASTVisitFn<DocumentNode> | undefined; readonly leave: ASTReducerFn<...>; } | ... 41 more ... | undefined'.

6     leave?: Partial<Record<keyof NewVisitor, NewVisitor[keyof NewVisitor]['leave']>>;
                                                                            ~~~~~~~


Found 2 errors in the same file, starting at: node_modules/@graphql-codegen/plugin-helpers/oldVisit.d.ts:5
```

Only happens when TS compiler options `strictNullChecks: true` and `skipLibCheck: false`.

`Partial<T>` includes `{}`, therefore `NewVisitor[keyof NewVisitor]` includes `undefined`, and indexing `undefined` is error.
Eliminate `undefined` by wrapping it inside `NonNullable<...>`.

Related #7519 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. `git clone https://github.com/dittos/graphql-codegen-ts-strict-repro.git`
2. `npm install`
3. Apply the fix to `node_modules/@graphql-codegen/plugin-helpers/oldVisit.d.ts`
4. `$(npm bin)/tsc`

**Test Environment**:

- OS: Ubuntu 20.04.1 LTS
- @graphql-codegen/plugin-helpers: 2.4.2
- NodeJS: v16.13.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules