### PR TITLE
Fix/multi project

### DIFF
--- a/.changeset/fifty-jars-end.md
+++ b/.changeset/fifty-jars-end.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/cli": patch
+---
+
+Fix/multi project

--- a/packages/graphql-codegen-cli/tests/codegen.spec.ts
+++ b/packages/graphql-codegen-cli/tests/codegen.spec.ts
@@ -1,8 +1,8 @@
 import { useMonorepo } from '@graphql-codegen/testing';
-import { GraphQLObjectType, buildSchema, buildASTSchema, parse, print } from 'graphql';
 import { mergeTypeDefs } from '@graphql-tools/merge';
-import { executeCodegen } from '../src';
+import { buildASTSchema, buildSchema, GraphQLObjectType, parse, print } from 'graphql';
 import { join } from 'path';
+import { createContext, executeCodegen } from '../src';
 
 const SHOULD_NOT_THROW_STRING = 'SHOULD_NOT_THROW';
 const SIMPLE_TEST_SCHEMA = `type MyType { f: String } type Query { f: String }`;
@@ -961,6 +961,7 @@ describe('Codegen Executor', () => {
       throw new Error('This should not throw as the invalid file is excluded via glob.');
     }
   });
+
   it('Should allow plugins to extend schema with custom root', async () => {
     try {
       const output = await executeCodegen({
@@ -1066,5 +1067,21 @@ describe('Codegen Executor', () => {
     } catch (error) {
       expect(error.message).toContain('Failed to load schema for "out1.graphql"');
     }
+  });
+
+  it('Should generate documents output even if prj1/documents and prj1/extensions/codegen/generate/xxx/documents are both definded with the same glob files', async () => {
+    const prj1 = await createContext({
+      config: './tests/test-files/graphql.config.js',
+      project: 'prj1',
+      errorsOnly: true,
+      overwrite: true,
+      profile: true,
+      require: [],
+      silent: false,
+      watch: false,
+    });
+    const config = prj1.getConfig();
+    const output = await executeCodegen(config);
+    expect(output[0].content).toContain('DocumentNode<MyQueryQuery, MyQueryQueryVariables>');
   });
 });

--- a/packages/graphql-codegen-cli/tests/test-files/graphql.config.js
+++ b/packages/graphql-codegen-cli/tests/test-files/graphql.config.js
@@ -1,0 +1,21 @@
+/** @type {import('graphql-config').IGraphQLConfig } */
+module.exports = {
+  generates: {},
+  projects: {
+    prj1: {
+      schema: ['**/test-documents/schema.graphql'],
+      documents: ['**/test-documents/valid.graphql'],
+      extensions: {
+        codegen: {
+          generates: {
+            'graphqlTypes.ts': {
+              schema: ['**/test-documents/schema.graphql'],
+              documents: ['**/test-documents/valid.graphql'],
+              plugins: ['typed-document-node'],
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/website/docs/config-reference/codegen-config.mdx
+++ b/website/docs/config-reference/codegen-config.mdx
@@ -151,6 +151,8 @@ The Codegen also supports several CLI flags that allow you to override the defau
 
 - **`--profile`** - Use the profiler to measure performance. _(see "Profiler" in "Advanced Usage")_
 
+- **`--project` (`-p`)** - To generate only one project out of a [Multi Project](multiproject-config) config file.
+
 <p>&nbsp;</p>
 
 ---

--- a/website/docs/config-reference/multiproject-config.mdx
+++ b/website/docs/config-reference/multiproject-config.mdx
@@ -5,7 +5,7 @@ title: 'Multi Project'
 
 In some cases, it's useful to have multiple projects in the same config file.
 
-For example, in a monorepo, vs-code graphql plugin will automatically pick up the right config for the right folder. _It's pretty handy._
+For example, in a monorepo, the VSCode GraphQL plugin will automatically pick up the right config for the right folder.
 
 <p>&nbsp;</p>
 

--- a/website/docs/config-reference/multiproject-config.mdx
+++ b/website/docs/config-reference/multiproject-config.mdx
@@ -1,0 +1,62 @@
+---
+id: multiproject-config
+title: 'Multi Project'
+---
+
+In some cases, it's useful to have multiple projects in the same config file.
+
+For example, in a monorepo, vs-code graphql plugin will automatically pick up the right config for the right folder. _It's pretty handy._
+
+<p>&nbsp;</p>
+
+---
+
+<p>&nbsp;</p>
+
+## Configuration file format
+
+Here's an example for a possible config file `graphql.config.js`:
+
+```js
+/** @type {import('graphql-config').IGraphQLConfig } */
+module.exports = {
+  projects: {
+    prj1: {
+      schema: ['prj1/**/*.graphql'],
+      documents: ['prj1/**/*.gql'],
+      extensions: {
+        codegen: {
+          generates: {
+            'graphqlTypes.ts': {
+              plugins: ['typescript', 'typed-document-node'],
+            },
+          },
+        },
+      },
+    },
+    prj2: {
+      schema: ['prj2/**/*.graphql'],
+      documents: ['prj2/**/*.gql'],
+      extensions: {
+        codegen: {
+          generates: {
+            'graphqlTypes.ts': {
+              plugins: ['typescript', 'typed-document-node'],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+```
+
+<p>&nbsp;</p>
+
+## Command to generate files
+
+With the previous config, you can generate files with the following command:
+
+```bash
+graphql-codegen --config graphql.config.js -project prj1
+```

--- a/website/docs/config-reference/multiproject-config.mdx
+++ b/website/docs/config-reference/multiproject-config.mdx
@@ -28,11 +28,11 @@ module.exports = {
         codegen: {
           generates: {
             'graphqlTypes.ts': {
-              plugins: ['typescript', 'typed-document-node'],
-            },
-          },
-        },
-      },
+              plugins: ['typescript', 'typed-document-node']
+            }
+          }
+        }
+      }
     },
     prj2: {
       schema: ['prj2/**/*.graphql'],
@@ -41,14 +41,14 @@ module.exports = {
         codegen: {
           generates: {
             'graphqlTypes.ts': {
-              plugins: ['typescript', 'typed-document-node'],
-            },
-          },
-        },
-      },
-    },
-  },
-};
+              plugins: ['typescript', 'typed-document-node']
+            }
+          }
+        }
+      }
+    }
+  }
+}
 ```
 
 <p>&nbsp;</p>

--- a/website/routes.ts
+++ b/website/routes.ts
@@ -35,6 +35,7 @@ export function getRoutes(): IRoutes {
           ['require-field', 'require field'],
           ['naming-convention', 'Naming Convention'],
           ['lifecycle-hooks', 'Lifecycle Hooks'],
+          ['multiproject-config', 'Multi Project'],
         ],
       },
       'docs/advanced': {


### PR DESCRIPTION
When a glob document was listed twice, the output was not correct

Related #6282

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update
  - And I did 😁

## How Has This Been Tested?

- [x] Test added: `Should generate documents output even if prj1/documents and prj1/extensions/codegen/generate/xxx/documents are both definded with the same glob files`
  - Was failing before my fix, now it's passing.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Further comments

Nothing to add 