### PR TITLE
Add useQuery argument generic type

### DIFF
--- a/.changeset/spotty-cherries-drop.md
+++ b/.changeset/spotty-cherries-drop.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-urql": patch
+---
+
+Add useQuery argument generic type

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -445,7 +445,7 @@ export const CommentDocument = gql`
 `;
 
 export function useCommentQuery(options: Omit<Urql.UseQueryArgs<CommentQueryVariables>, 'query'>) {
-  return Urql.useQuery<CommentQuery>({ query: CommentDocument, ...options });
+  return Urql.useQuery<CommentQuery, CommentQueryVariables>({ query: CommentDocument, ...options });
 }
 export const CurrentUserForProfileDocument = gql`
   query CurrentUserForProfile {
@@ -459,7 +459,10 @@ export const CurrentUserForProfileDocument = gql`
 export function useCurrentUserForProfileQuery(
   options?: Omit<Urql.UseQueryArgs<CurrentUserForProfileQueryVariables>, 'query'>
 ) {
-  return Urql.useQuery<CurrentUserForProfileQuery>({ query: CurrentUserForProfileDocument, ...options });
+  return Urql.useQuery<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>({
+    query: CurrentUserForProfileDocument,
+    ...options,
+  });
 }
 export const FeedDocument = gql`
   query Feed($type: FeedType!, $offset: Int, $limit: Int) {
@@ -474,7 +477,7 @@ export const FeedDocument = gql`
 `;
 
 export function useFeedQuery(options: Omit<Urql.UseQueryArgs<FeedQueryVariables>, 'query'>) {
-  return Urql.useQuery<FeedQuery>({ query: FeedDocument, ...options });
+  return Urql.useQuery<FeedQuery, FeedQueryVariables>({ query: FeedDocument, ...options });
 }
 export const SubmitRepositoryDocument = gql`
   mutation submitRepository($repoFullName: String!) {

--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -131,7 +131,7 @@ export function use${operationName}<TData = ${operationResultType}>(options: Omi
 export function use${operationName}(options${
       isVariablesRequired ? '' : '?'
     }: Omit<Urql.Use${operationType}Args<${operationVariablesTypes}>, 'query'>) {
-  return Urql.use${operationType}<${operationResultType}>({ query: ${documentVariableName}, ...options });
+  return Urql.use${operationType}<${operationResultType}, ${operationVariablesTypes}>({ query: ${documentVariableName}, ...options });
 };`;
   }
 

--- a/packages/plugins/typescript/urql/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql/tests/__snapshots__/urql.spec.ts.snap
@@ -25,6 +25,6 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 
 export function useTestQuery(options?: Omit<Urql.UseQueryArgs<Operations.TestQueryVariables>, 'query'>) {
-  return Urql.useQuery<Operations.TestQuery>({ query: Operations.TestDocument, ...options });
+  return Urql.useQuery<Operations.TestQuery, Operations.TestQueryVariables>({ query: Operations.TestDocument, ...options });
 };"
 `;

--- a/packages/plugins/typescript/urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql/tests/urql.spec.ts
@@ -553,7 +553,7 @@ query MyFeed {
 
       expect(content.content).toBeSimilarStringTo(`
 export function useFeedQuery(options?: Omit<Urql.UseQueryArgs<FeedQueryVariables>, 'query'>) {
-  return Urql.useQuery<FeedQuery>({ query: FeedDocument, ...options });
+  return Urql.useQuery<FeedQuery, FeedQueryVariables>({ query: FeedDocument, ...options });
 };`);
 
       expect(content.content).toBeSimilarStringTo(`
@@ -582,7 +582,7 @@ export function useSubmitRepositoryMutation() {
 
       expect(content.content).toBeSimilarStringTo(`
 export function useRequiredArgQuery(options: Omit<Urql.UseQueryArgs<RequiredArgQueryVariables>, 'query'>) {
-  return Urql.useQuery<RequiredArgQuery>({ query: RequiredArgDocument, ...options });
+  return Urql.useQuery<RequiredArgQuery, RequiredArgQueryVariables>({ query: RequiredArgDocument, ...options });
 };`);
       await validateTypeScript(content, schema, docs, {});
     });
@@ -606,7 +606,7 @@ export function useRequiredArgQuery(options: Omit<Urql.UseQueryArgs<RequiredArgQ
 
       expect(content.content).toBeSimilarStringTo(`
 export function useDefaultValueArgQuery(options?: Omit<Urql.UseQueryArgs<DefaultValueArgQueryVariables>, 'query'>) {
-  return Urql.useQuery<DefaultValueArgQuery>({ query: DefaultValueArgDocument, ...options });
+  return Urql.useQuery<DefaultValueArgQuery, DefaultValueArgQueryVariables>({ query: DefaultValueArgDocument, ...options });
 };`);
       await validateTypeScript(content, schema, docs, {});
     });


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Add missing generic type. No dependencies and all information for this is already present, just not wired up.

Related #7976

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

The change is very simple and can be verified by looking at the one line of code which was changed in conjunction with the type signature [of useQuery here](https://github.com/FormidableLabs/urql/blob/main/packages/react-urql/src/hooks/useQuery.ts#L49).

**Test Environment**:

- `@graphql-codegen/typescript-urql` version: 3.5.12

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
