### PR TITLE
refactor: remove unnecessary browser check

### DIFF
--- a/.changeset/early-pots-leave.md
+++ b/.changeset/early-pots-leave.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/cli': minor
 ---
 
-Remove unecessary browser check
+Remove unnecessary browser check

--- a/.changeset/early-pots-leave.md
+++ b/.changeset/early-pots-leave.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': minor
+---
+
+Remove unecessary browser check

--- a/packages/graphql-codegen-cli/src/utils/cli-error.ts
+++ b/packages/graphql-codegen-cli/src/utils/cli-error.ts
@@ -1,5 +1,4 @@
 import { DetailedError } from '@graphql-codegen/plugin-helpers';
-import { isBrowser, isNode } from './is-browser';
 
 type CompositeError = Error | DetailedError;
 type ListrError = Error & { errors: CompositeError[] };
@@ -21,9 +20,7 @@ export function cliError(err: any, exitOnError = true) {
   // eslint-disable-next-line no-console
   console.error(msg);
 
-  if (exitOnError && isNode) {
+  if (exitOnError) {
     process.exit(1);
-  } else if (exitOnError && isBrowser) {
-    throw err;
   }
 }

--- a/packages/graphql-codegen-cli/src/utils/is-browser.ts
+++ b/packages/graphql-codegen-cli/src/utils/is-browser.ts
@@ -1,7 +1,0 @@
-declare let window: any, process: any;
-
-const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
-
-const isNode = typeof process !== 'undefined' && process.versions != null && process.versions.node != null;
-
-export { isBrowser, isNode };


### PR DESCRIPTION
not sure why we need the browser or node check. This isn't really meant for browsers and to make it work for browser we need to refactor many things.