### PR TITLE
fix optional input type fields for graphql-input

### DIFF
--- a/.changeset/large-poets-yell.md
+++ b/.changeset/large-poets-yell.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-type-graphql": patch
+---
+
+Ensure optional fields are marked as optional in TypeScript

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -408,7 +408,12 @@ export class TypeGraphQLVisitor<
 
     typeString = this.fixDecorator(type, typeString);
 
-    return decorator + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${node.name}!: ${typeString};`);
+    return (
+      decorator +
+      indent(
+        `${this.config.immutableTypes ? 'readonly ' : ''}${node.name}${type.isNullable ? '?' : '!'}: ${typeString};`
+      )
+    );
   }
 
   InputValueDefinition(
@@ -451,7 +456,12 @@ export class TypeGraphQLVisitor<
       ? this.buildTypeString(type)
       : this.fixDecorator(type, rawType as string);
 
-    return decorator + indent(`${this.config.immutableTypes ? 'readonly ' : ''}${nameString}!: ${typeString};`);
+    return (
+      decorator +
+      indent(
+        `${this.config.immutableTypes ? 'readonly ' : ''}${nameString}${type.isNullable ? '?' : '!'}: ${typeString};`
+      )
+    );
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): string {

--- a/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
+++ b/packages/plugins/typescript/type-graphql/tests/type-graphql.spec.ts
@@ -91,31 +91,31 @@ describe('type-graphql', () => {
       export class A {
         __typename?: 'A';
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
-        id!: Maybe<Scalars['ID']>;
+        id?: Maybe<Scalars['ID']>;
         @TypeGraphQL.Field(type => TypeGraphQL.ID)
         mandatoryId!: Scalars['ID'];
         @TypeGraphQL.Field(type => String, { nullable: true })
-        str!: Maybe<Scalars['String']>;
+        str?: Maybe<Scalars['String']>;
         @TypeGraphQL.Field(type => String)
         mandatoryStr!: Scalars['String'];
         @TypeGraphQL.Field(type => Boolean, { nullable: true })
-        bool!: Maybe<Scalars['Boolean']>;
+        bool?: Maybe<Scalars['Boolean']>;
         @TypeGraphQL.Field(type => Boolean)
         mandatoryBool!: Scalars['Boolean'];
         @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
-        int!: Maybe<Scalars['Int']>;
+        int?: Maybe<Scalars['Int']>;
         @TypeGraphQL.Field(type => TypeGraphQL.Int)
         mandatoryInt!: Scalars['Int'];
         @TypeGraphQL.Field(type => TypeGraphQL.Float, { nullable: true })
-        float!: Maybe<Scalars['Float']>;
+        float?: Maybe<Scalars['Float']>;
         @TypeGraphQL.Field(type => TypeGraphQL.Float)
         mandatoryFloat!: Scalars['Float'];
         @TypeGraphQL.Field(type => B, { nullable: true })
-        b!: Maybe<B>;
+        b?: Maybe<B>;
         @TypeGraphQL.Field(type => B)
         mandatoryB!: FixDecorator<B>;
         @TypeGraphQL.Field(type => [String], { nullable: true })
-        arr!: Maybe<Array<Scalars['String']>>;
+        arr?: Maybe<Array<Scalars['String']>>;
         @TypeGraphQL.Field(type => [String])
         mandatoryArr!: Array<Scalars['String']>;
       }
@@ -140,7 +140,7 @@ describe('type-graphql', () => {
       export class Test extends ITest {
         __typename?: 'Test';
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
-        id!: Maybe<Scalars['ID']>;
+        id?: Maybe<Scalars['ID']>;
         @TypeGraphQL.Field(type => String)
         mandatoryStr!: Scalars['String'];
       }
@@ -151,7 +151,7 @@ describe('type-graphql', () => {
       export abstract class ITest {
 
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
-        id!: Maybe<Scalars['ID']>;
+        id?: Maybe<Scalars['ID']>;
       }
     `);
   });
@@ -186,43 +186,43 @@ describe('type-graphql', () => {
       export class A {
 
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
-        id!: Maybe<Scalars['ID']>;
+        id?: Maybe<Scalars['ID']>;
 
         @TypeGraphQL.Field(type => TypeGraphQL.ID)
         mandatoryId!: Scalars['ID'];
 
         @TypeGraphQL.Field(type => String, { nullable: true })
-        str!: Maybe<Scalars['String']>;
+        str?: Maybe<Scalars['String']>;
 
         @TypeGraphQL.Field(type => String)
         mandatoryStr!: Scalars['String'];
 
         @TypeGraphQL.Field(type => Boolean, { nullable: true })
-        bool!: Maybe<Scalars['Boolean']>;
+        bool?: Maybe<Scalars['Boolean']>;
 
         @TypeGraphQL.Field(type => Boolean)
         mandatoryBool!: Scalars['Boolean'];
 
         @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
-        int!: Maybe<Scalars['Int']>;
+        int?: Maybe<Scalars['Int']>;
 
         @TypeGraphQL.Field(type => TypeGraphQL.Int)
         mandatoryInt!: Scalars['Int'];
 
         @TypeGraphQL.Field(type => TypeGraphQL.Float, { nullable: true })
-        float!: Maybe<Scalars['Float']>;
+        float?: Maybe<Scalars['Float']>;
 
         @TypeGraphQL.Field(type => TypeGraphQL.Float)
         mandatoryFloat!: Scalars['Float'];
 
         @TypeGraphQL.Field(type => B, { nullable: true })
-        b!: Maybe<B>;
+        b?: Maybe<B>;
 
         @TypeGraphQL.Field(type => B)
         mandatoryB!: FixDecorator<B>;
 
         @TypeGraphQL.Field(type => [String], { nullable: true })
-        arr!: Maybe<Array<Scalars['String']>>;
+        arr?: Maybe<Array<Scalars['String']>>;
 
         @TypeGraphQL.Field(type => [String])
         mandatoryArr!: Array<Scalars['String']>;
@@ -263,43 +263,43 @@ describe('type-graphql', () => {
       export class MutationTestArgs {
 
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
-        id!: Maybe<Scalars['ID']>;
+        id?: Maybe<Scalars['ID']>;
 
         @TypeGraphQL.Field(type => TypeGraphQL.ID)
         mandatoryId!: Scalars['ID'];
 
         @TypeGraphQL.Field(type => String, { nullable: true })
-        str!: Maybe<Scalars['String']>;
+        str?: Maybe<Scalars['String']>;
 
         @TypeGraphQL.Field(type => String)
         mandatoryStr!: Scalars['String'];
 
         @TypeGraphQL.Field(type => Boolean, { nullable: true })
-        bool!: Maybe<Scalars['Boolean']>;
+        bool?: Maybe<Scalars['Boolean']>;
 
         @TypeGraphQL.Field(type => Boolean)
         mandatoryBool!: Scalars['Boolean'];
 
         @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
-        int!: Maybe<Scalars['Int']>;
+        int?: Maybe<Scalars['Int']>;
 
         @TypeGraphQL.Field(type => TypeGraphQL.Int)
         mandatoryInt!: Scalars['Int'];
 
         @TypeGraphQL.Field(type => TypeGraphQL.Float, { nullable: true })
-        float!: Maybe<Scalars['Float']>;
+        float?: Maybe<Scalars['Float']>;
 
         @TypeGraphQL.Field(type => TypeGraphQL.Float)
         mandatoryFloat!: Scalars['Float'];
 
         @TypeGraphQL.Field(type => B, { nullable: true })
-        b!: Maybe<B>;
+        b?: Maybe<B>;
 
         @TypeGraphQL.Field(type => B)
         mandatoryB!: FixDecorator<B>;
 
         @TypeGraphQL.Field(type => [String], { nullable: true })
-        arr!: Maybe<Array<Scalars['String']>>;
+        arr?: Maybe<Array<Scalars['String']>>;
 
         @TypeGraphQL.Field(type => [String])
         mandatoryArr!: Array<Scalars['String']>;
@@ -330,7 +330,7 @@ describe('type-graphql', () => {
         export class Test {
           __typename?: 'Test';
           @TypeGraphQL.Bar(type => TypeGraphQL.ID, { nullable: true })
-          id!: Maybe<Scalars['ID']>;
+          id?: Maybe<Scalars['ID']>;
           @TypeGraphQL.Bar(type => String)
           mandatoryStr!: Scalars['String'];
         }
@@ -340,7 +340,7 @@ describe('type-graphql', () => {
         export abstract class ITest {
 
           @TypeGraphQL.Bar(type => TypeGraphQL.ID, { nullable: true })
-          id!: Maybe<Scalars['ID']>;
+          id?: Maybe<Scalars['ID']>;
         }
       `);
   });
@@ -367,7 +367,7 @@ describe('type-graphql', () => {
       export class A {
         __typename?: 'A';
         @TypeGraphQL.Field(type => Date, { nullable: true })
-        date!: Maybe<Scalars['DateTime']>;
+        date?: Maybe<Scalars['DateTime']>;
         @TypeGraphQL.Field(type => Date)
         mandatoryDate!: Scalars['DateTime'];
       }
@@ -431,7 +431,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => String, { nullable: true })
-      str1!: Maybe<Scalars['String']>;
+      str1?: Maybe<Scalars['String']>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -441,7 +441,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [String], { nullable: 'itemsAndList' })
-      strArr1!: Maybe<Array<Maybe<Scalars['String']>>>;
+      strArr1?: Maybe<Array<Maybe<Scalars['String']>>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -451,7 +451,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [String], { nullable: true })
-      strArr3!: Maybe<Array<Scalars['String']>>;
+      strArr3?: Maybe<Array<Scalars['String']>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -461,7 +461,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
-      int1!: Maybe<Scalars['Int']>;
+      int1?: Maybe<Scalars['Int']>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -471,7 +471,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: 'itemsAndList' })
-      intArr1!: Maybe<Array<Maybe<Scalars['Int']>>>;
+      intArr1?: Maybe<Array<Maybe<Scalars['Int']>>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -481,7 +481,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: true })
-      intArr3!: Maybe<Array<Scalars['Int']>>;
+      intArr3?: Maybe<Array<Scalars['Int']>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -491,7 +491,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => MyType2, { nullable: true })
-      custom1!: Maybe<MyType2>;
+      custom1?: Maybe<MyType2>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -501,7 +501,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [MyType2], { nullable: 'itemsAndList' })
-      customArr1!: Maybe<Array<Maybe<MyType2>>>;
+      customArr1?: Maybe<Array<Maybe<MyType2>>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -511,7 +511,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [MyType2], { nullable: true })
-      customArr3!: Maybe<Array<MyType2>>;
+      customArr3?: Maybe<Array<MyType2>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -521,7 +521,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => String, { nullable: true })
-      inputStr1!: Maybe<Scalars['String']>;
+      inputStr1?: Maybe<Scalars['String']>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -531,7 +531,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [String], { nullable: 'itemsAndList' })
-      inputStrArr1!: Maybe<Array<Maybe<Scalars['String']>>>;
+      inputStrArr1?: Maybe<Array<Maybe<Scalars['String']>>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -541,7 +541,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [String], { nullable: true })
-      inputStrArr3!: Maybe<Array<Scalars['String']>>;
+      inputStrArr3?: Maybe<Array<Scalars['String']>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -551,7 +551,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => TypeGraphQL.Int, { nullable: true })
-      inputInt1!: Maybe<Scalars['Int']>;
+      inputInt1?: Maybe<Scalars['Int']>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -561,7 +561,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: 'itemsAndList' })
-      inputIntArr1!: Maybe<Array<Maybe<Scalars['Int']>>>;
+      inputIntArr1?: Maybe<Array<Maybe<Scalars['Int']>>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -571,7 +571,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [TypeGraphQL.Int], { nullable: true })
-      inputIntArr3!: Maybe<Array<Scalars['Int']>>;
+      inputIntArr3?: Maybe<Array<Scalars['Int']>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -581,7 +581,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => MyType2, { nullable: true })
-      inputCustom1!: Maybe<MyType2>;
+      inputCustom1?: Maybe<MyType2>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -591,7 +591,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [MyType2], { nullable: 'itemsAndList' })
-      inputCustomArr1!: Maybe<Array<Maybe<MyType2>>>;
+      inputCustomArr1?: Maybe<Array<Maybe<MyType2>>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -601,7 +601,7 @@ describe('type-graphql', () => {
 
     expect(result.content).toBeSimilarStringTo(`
       @TypeGraphQL.Field(type => [MyType2], { nullable: true })
-      inputCustomArr3!: Maybe<Array<MyType2>>;
+      inputCustomArr3?: Maybe<Array<MyType2>>;
     `);
 
     expect(result.content).toBeSimilarStringTo(`
@@ -654,7 +654,7 @@ describe('type-graphql', () => {
       export class Test extends ITest {
         __typename?: 'Test';
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { description: 'id field description\\ninside Test class', nullable: true })
-        id!: Maybe<Scalars['ID']>;
+        id?: Maybe<Scalars['ID']>;
         @TypeGraphQL.Field(type => String, { description: 'mandatoryStr field description' })
         mandatoryStr!: Scalars['String'];
       }
@@ -665,7 +665,7 @@ describe('type-graphql', () => {
       export abstract class ITest {
 
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { description: 'id field description\\ninside ITest interface', nullable: true })
-        id!: Maybe<Scalars['ID']>;
+        id?: Maybe<Scalars['ID']>;
       }
     `);
 
@@ -674,7 +674,7 @@ describe('type-graphql', () => {
       export class TestInput {
 
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
-        id!: Maybe<Scalars['ID']>;
+        id?: Maybe<Scalars['ID']>;
       }
     `);
   });
@@ -755,7 +755,7 @@ describe('type-graphql', () => {
       @TypeGraphQL.InterfaceType()
       export abstract class ITypeGraphQlInterfaceType {
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
-        id!: Maybe<Scalars['ID']>;
+        id?: Maybe<Scalars['ID']>;
       }`
     );
 
@@ -771,7 +771,7 @@ describe('type-graphql', () => {
       export class TypeGraphQlType {
         __typename?: 'TypeGraphQLType';
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
-        id!: Maybe<Scalars['ID']>;
+        id?: Maybe<Scalars['ID']>;
       }`
     );
 
@@ -785,7 +785,7 @@ describe('type-graphql', () => {
       `@TypeGraphQL.InputType()
       export class TypeGraphQlInputType {
         @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
-        id!: Maybe<Scalars['ID']>;
+        id?: Maybe<Scalars['ID']>;
       }`
     );
 
@@ -808,7 +808,7 @@ describe('type-graphql', () => {
          mandatoryId!: Scalars['ID'];
 
          @TypeGraphQL.Field(type => TypeGraphQL.ID, { nullable: true })
-         optionalId!: Maybe<Scalars['ID']>;
+         optionalId?: Maybe<Scalars['ID']>;
        };`);
   });
 });


### PR DESCRIPTION
## Description

When using typescript-type-graphql, the optional fields from an input are not optional

Related #8001 

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Environment**:

- OS: [Linux]
- NodeJS: [16.15.1]
- graphql version: [15.3.0]
- @graphql-codegen/cli version(s): [ 2.6.2]
- @graphql-codegen/typescript-type-graphql version(s): [ 2.2.14]

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
