### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/algolia-integrity.yml
+++ b/.github/workflows/algolia-integrity.yml
@@ -3,8 +3,14 @@ on:
   pull_request:
     paths:
       - 'website/**'
+permissions:
+  contents: read
+
 jobs:
   algolia-records-check:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: write  # for marocchino/sticky-pull-request-comment to create or update PR comment
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -21,6 +21,9 @@ on:
 
 jobs:
   changes:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: Check Changeset
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Linting Check


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
