### PR TITLE
[typescript-msw] Update typescript-msw to support importOperationTypesFrom

### DIFF
--- a/packages/plugins/typescript/msw/src/visitor.ts
+++ b/packages/plugins/typescript/msw/src/visitor.ts
@@ -17,6 +17,7 @@ export interface MSWPluginConfig extends ClientSideBasePluginConfig {
 }
 
 export class MSWVisitor extends ClientSideBaseVisitor<MSWRawPluginConfig, MSWPluginConfig> {
+  private _externalImportPrefix: string;
   private _operationsToInclude: {
     node: OperationDefinitionNode;
     documentVariableName: string;
@@ -29,6 +30,8 @@ export class MSWVisitor extends ClientSideBaseVisitor<MSWRawPluginConfig, MSWPlu
     super(schema, fragments, rawConfig, { link: getConfigValue(rawConfig.link, undefined) });
 
     autoBind(this);
+
+    this._externalImportPrefix = this.config.importOperationTypesFrom ? `${this.config.importOperationTypesFrom}.` : '';
   }
 
   public getImports(): string[] {
@@ -82,7 +85,16 @@ export const ${handlerName} = (resolver: ResponseResolver<GraphQLRequest<${opera
     return [endpoint, ...operations].join('\n');
   }
 
-  buildOperation(node, documentVariableName, operationType, operationResultType, operationVariablesTypes) {
+  buildOperation(
+    node: OperationDefinitionNode,
+    documentVariableName: string,
+    operationType: string,
+    operationResultType: string,
+    operationVariablesTypes: string
+  ) {
+    operationResultType = this._externalImportPrefix + operationResultType;
+    operationVariablesTypes = this._externalImportPrefix + operationVariablesTypes;
+
     if (node.name == null) {
       throw new Error("Plugin 'msw' cannot generate mocks for unnamed operation.\n\n" + print(node));
     } else {

--- a/packages/plugins/typescript/msw/tests/__snapshots__/msw.spec.ts.snap
+++ b/packages/plugins/typescript/msw/tests/__snapshots__/msw.spec.ts.snap
@@ -116,3 +116,39 @@ Array [
   "import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'",
 ]
 `;
+
+exports[`msw Should use the "importOperationTypesFrom" setting: content with types configured via importOperationTypesFrom 1`] = `
+"
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockUserQuery((req, res, ctx) => {
+ *   return res(
+ *     ctx.data({ name })
+ *   )
+ * })
+ */
+export const mockUserQuery = (resolver: ResponseResolver<GraphQLRequest<Types.UserQueryVariables>, GraphQLContext<Types.UserQuery>, any>) =>
+  graphql.query<Types.UserQuery, Types.UserQueryVariables>(
+    'User',
+    resolver
+  )
+
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockUpdateUserMutation((req, res, ctx) => {
+ *   return res(
+ *     ctx.data({ name })
+ *   )
+ * })
+ */
+export const mockUpdateUserMutation = (resolver: ResponseResolver<GraphQLRequest<Types.UpdateUserMutationVariables>, GraphQLContext<Types.UpdateUserMutation>, any>) =>
+  graphql.mutation<Types.UpdateUserMutation, Types.UpdateUserMutationVariables>(
+    'UpdateUser',
+    resolver
+  )
+"
+`;

--- a/packages/plugins/typescript/msw/tests/msw.spec.ts
+++ b/packages/plugins/typescript/msw/tests/msw.spec.ts
@@ -65,4 +65,24 @@ describe('msw', () => {
     expect(result.content).toContain(`ctx.data({ ${selection} })`);
     expect(result.content).toMatchSnapshot('content with variables and selection JSDoc documentation');
   });
+
+  it('Should use the "importOperationTypesFrom" setting', async () => {
+    const importOperationTypesFrom = 'Types';
+    const result = await plugin(null, documents, { importOperationTypesFrom });
+
+    // handler variable and result type
+    const queryVariablesType = `${importOperationTypesFrom}.${queryName}QueryVariables`;
+    const queryType = `${importOperationTypesFrom}.${queryName}Query`;
+    expect(result.content).toContain(`GraphQLRequest<${queryVariablesType}>`);
+    expect(result.content).toContain(`GraphQLContext<${queryType}>`);
+    expect(result.content).toContain(`graphql.query<${queryType}, ${queryVariablesType}>`);
+
+    const mutationVariablesType = `${importOperationTypesFrom}.${mutationName}MutationVariables`;
+    const mutationType = `${importOperationTypesFrom}.${mutationName}Mutation`;
+    expect(result.content).toContain(`GraphQLRequest<${mutationVariablesType}>`);
+    expect(result.content).toContain(`GraphQLContext<${mutationType}>`);
+    expect(result.content).toContain(`graphql.mutation<${mutationType}, ${mutationVariablesType}>`);
+
+    expect(result.content).toMatchSnapshot('content with types configured via importOperationTypesFrom');
+  });
 });


### PR DESCRIPTION
## Description

This adds support for `importOperationTypesFrom` config option for the `typescript-msw` plugin.

Related https://github.com/dotansimha/graphql-code-generator/issues/8053

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I added tests to the `typescript-msw` package to verify the behavior

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] ~Any dependent changes have been merged and published in downstream modules~
