### PR TITLE
Avoid enforcing return/get the complete object

### DIFF
--- a/.changeset/shiny-cameras-reply.md
+++ b/.changeset/shiny-cameras-reply.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-urql-graphcache": patch
+---
+
+Avoid enforcing return/get the complete object

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -1047,7 +1047,7 @@ export default {
     directives: [],
   },
 } as unknown as IntrospectionQuery;
-export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Comment?: (data: WithTypename<Comment>) => null | string;

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -243,7 +243,7 @@ export const plugin: PluginFunction<UrqlGraphCacheConfig, Types.ComplexPluginOut
   return {
     prepend: [imports],
     content: [
-      `export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };`,
+      `export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };`,
 
       keys,
 

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`urql graphcache Should correctly name GraphCacheResolvers & GraphCacheOptimisticUpdaters with nonstandard mutationType names 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
-export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Todo?: (data: WithTypename<Todo>) => null | string
@@ -44,7 +44,7 @@ export type GraphCacheConfig = {
 exports[`urql graphcache Should correctly output GraphCacheOptimisticUpdaters when there are no mutations 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
-export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Todo?: (data: WithTypename<Todo>) => null | string
@@ -81,7 +81,7 @@ export type GraphCacheConfig = {
 exports[`urql graphcache Should output the cache-generic correctly (with interfaces) 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
-export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Author?: (data: WithTypename<Author>) => null | string,
@@ -133,7 +133,7 @@ export type GraphCacheConfig = {
 exports[`urql graphcache Should output the cache-generic correctly (with typesPrefix and typesSuffix) 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
-export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Author?: (data: WithTypename<PrefixAuthorSuffix>) => null | string,
@@ -190,7 +190,7 @@ export type GraphCacheConfig = {
 exports[`urql graphcache Should output the cache-generic correctly (with unions) 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
-export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Book?: (data: WithTypename<Book>) => null | string,
@@ -237,7 +237,7 @@ export type GraphCacheConfig = {
 exports[`urql graphcache Should output the cache-generic correctly 1`] = `
 "import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter } from '@urql/exchange-graphcache';
 import { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast';
-export type WithTypename<T extends { __typename?: any }> = T & { __typename: NonNullable<T['__typename']> };
+export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {
   Author?: (data: WithTypename<Author>) => null | string,


### PR DESCRIPTION
## Description

This issue was detected in https://github.com/FormidableLabs/urql/issues/2502 which seems to link to https://github.com/dotansimha/graphql-code-generator/pull/7681 the change there looks good but introduces a subtile difference, we remove the `?` which was appended after the property-key. This PR adds onto that change by adding `Partial<>` which should have the same affect as what we were doing with `{ [K in Exclude<keyof T, '__typename'>]?: T[K] }`.

Related # (issue)

Fixes https://github.com/FormidableLabs/urql/issues/2502

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Creating a testable scenario 😅 

Did a quick test in the `dev-test/githunt/urql.types` that looked like:

```ts
const config: GraphCacheConfig = {
  optimistic: {
    submitComment: (vars) => ({
      __typename: 'Comment',
      repoName: vars.repoFullName,
    })
  }
}
```

Which before this change would error that this is not allowed

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
