### PR TITLE
docs: use graphql-code-generator in npx example

### DIFF
--- a/website/src/pages/docs/advanced/profiler.mdx
+++ b/website/src/pages/docs/advanced/profiler.mdx
@@ -4,7 +4,9 @@ import { PackageCmd } from '@/components'
 
 GraphQL Code Generator CLI provides a flag that enables the profiler mode, as follows:
 
-<PackageCmd packages={[{ name: 'graphql-code-generator --config graphql-codegen.yml --profile', cmd: 'run', isNpx: true }]} />
+<PackageCmd
+  packages={[{ name: 'graphql-code-generator --config graphql-codegen.yml --profile', cmd: 'run', isNpx: true }]}
+/>
 
 GraphQL Code Generator operates as usual (generating your files) but also generates a `codegen-[timestamp].json` profile file.
 

--- a/website/src/pages/docs/advanced/profiler.mdx
+++ b/website/src/pages/docs/advanced/profiler.mdx
@@ -4,7 +4,7 @@ import { PackageCmd } from '@/components'
 
 GraphQL Code Generator CLI provides a flag that enables the profiler mode, as follows:
 
-<PackageCmd packages={[{ name: 'graphql-codegen --config graphql-codegen.yml --profile', cmd: 'run', isNpx: true }]} />
+<PackageCmd packages={[{ name: 'graphql-code-generator --config graphql-codegen.yml --profile', cmd: 'run', isNpx: true }]} />
 
 GraphQL Code Generator operates as usual (generating your files) but also generates a `codegen-[timestamp].json` profile file.
 

--- a/website/src/pages/docs/config-reference/codegen-config.mdx
+++ b/website/src/pages/docs/config-reference/codegen-config.mdx
@@ -11,7 +11,7 @@ The CLI automatically detects the defined config file and generates code accordi
 
 In addition, you can also define a path to your config file with the `--config` options, like so:
 
-<PackageCmd packages={[{ name: 'graphql-codegen --config ./path/to/config.yml', cmd: 'run', isNpx: true }]} />
+<PackageCmd packages={[{ name: 'graphql-code-generator --config ./path/to/config.yml', cmd: 'run', isNpx: true }]} />
 
 ## Configuration file format
 

--- a/website/src/pages/docs/getting-started/installation.mdx
+++ b/website/src/pages/docs/getting-started/installation.mdx
@@ -35,7 +35,7 @@ Once installed, GraphQL Code Generator CLI can help you configure your project b
 
 <PackageCmd
   packages={[
-    { name: 'graphql-codegen init', cmd: 'run', isNpx: true },
+    { name: 'graphql-code-generator init', cmd: 'run', isNpx: true },
     { name: '# install the chosen plugins', cmd: 'install' }
   ]}
 />

--- a/website/src/pages/plugins/typescript/typescript-oclif.mdx
+++ b/website/src/pages/plugins/typescript/typescript-oclif.mdx
@@ -142,7 +142,7 @@ Breaking that down:
   relative to the generated files (ie here, `src/commands/something/file.graphql`).
   Note that it has no extension.
 
-With that configured, just run `yarn graphql-codegen` or `npx graphql-codegen` to generate all the
+With that configured, just run `yarn graphql-codegen` or `npx graphql-code-generator` to generate all the
 necessary `oclif` command files. With that complete, follow the directions in the
 [oclif guide](https://oclif.io/docs/introduction) to run your new CLI tool.
 


### PR DESCRIPTION
## Description

Based on my research when we try to use `npx graphql-codegen` it resolves to this old package https://www.npmjs.com/package/graphql-codegen and the alias that seems to work is `graphql-code-generator`

Related #8074 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update



