### PR TITLE
getPluginByName fails unexpectedly when plugin is not prefixed with @…

### DIFF
--- a/.changeset/green-dogs-wait.md
+++ b/.changeset/green-dogs-wait.md
@@ -1,0 +1,8 @@
+---
+"@graphql-codegen/cli": patch
+---
+
+getPluginByName fails unexpectedly when plugin is not prefixed with @graphq-codegen in ESM context
+
+MODULE_NOT_FOUND is the error code you receive in a CommonJS context when you require() a module and it does not exist.
+ERR_MODULE_NOT_FOUND is the error code you receive in an ESM context when you import or import() ad module that does not exist.

--- a/packages/graphql-codegen-cli/src/plugins.ts
+++ b/packages/graphql-codegen-cli/src/plugins.ts
@@ -22,7 +22,7 @@ export async function getPluginByName(
     try {
       return await pluginLoader(moduleName);
     } catch (err) {
-      if (err.code !== 'MODULE_NOT_FOUND' || err.code !== 'ERR_MODULE_NOT_FOUND') {
+      if (err.code !== 'MODULE_NOT_FOUND' && err.code !== 'ERR_MODULE_NOT_FOUND') {
         throw new DetailedError(
           `Unable to load template plugin matching ${name}`,
           `

--- a/packages/graphql-codegen-cli/src/plugins.ts
+++ b/packages/graphql-codegen-cli/src/plugins.ts
@@ -22,7 +22,7 @@ export async function getPluginByName(
     try {
       return await pluginLoader(moduleName);
     } catch (err) {
-      if (err.code !== 'MODULE_NOT_FOUND') {
+      if (err.code !== 'MODULE_NOT_FOUND' || err.code !== 'ERR_MODULE_NOT_FOUND') {
         throw new DetailedError(
           `Unable to load template plugin matching ${name}`,
           `


### PR DESCRIPTION
…graphql-codgen/

We've been finding that our error code thrown is not `MODULE_NOT_FOUND` but rather `ERR_MODULE_NOT_FOUND` leading to codegen cli throwing and failing plugin load when trying the first plugin option. Since the error returned isn't `MODULE_NOT_FOUND`. As small double check here by adding the || `ERR_MODULE_NOT_FOUND` should account for that case. 

IMO this is a small but pretty urgent fix as it could be incorrectly throwing in some environments. I don't personally know the cause for the different error code, but our repo is via Vite / Node 17 and is ESM based.

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related # (issue)

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
