### PR TITLE
feat(react-query): add @reactQueryKey directive to override generated react-query key

### DIFF
--- a/packages/plugins/typescript/react-query/src/index.ts
+++ b/packages/plugins/typescript/react-query/src/index.ts
@@ -41,6 +41,10 @@ export const plugin: PluginFunction<ReactQueryRawPluginConfig, Types.ComplexPlug
   };
 };
 
+export const addToSchema = /* GraphQL */ `
+  directive @reactQueryKey(key: [String]!) on QUERY
+`;
+
 export const validate: PluginValidateFn<any> = async (
   schema: GraphQLSchema,
   documents: Types.DocumentFile[],

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -1,4 +1,4 @@
-import { OperationDefinitionNode } from 'graphql';
+import { ListValueNode, OperationDefinitionNode, StringValueNode } from 'graphql';
 
 export function generateQueryVariablesSignature(
   hasRequiredVariables: boolean,
@@ -7,8 +7,14 @@ export function generateQueryVariablesSignature(
   return `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
 }
 export function generateInfiniteQueryKey(node: OperationDefinitionNode, hasRequiredVariables: boolean): string {
-  if (hasRequiredVariables) return `['${node.name.value}.infinite', variables]`;
-  return `variables === undefined ? ['${node.name.value}.infinite'] : ['${node.name.value}.infinite', variables]`;
+  const keyDirective = node.directives?.find(d => d.name.value == 'reactQueryKey');
+  const keyPrefix = keyDirective
+    ? (keyDirective.arguments[0].value as ListValueNode).values
+        .map((v: StringValueNode) => JSON.stringify(v.value))
+        .join(', ')
+    : `'${node.name.value}.infinite'`;
+  if (hasRequiredVariables) return `[${keyPrefix}, variables]`;
+  return `variables === undefined ? [${keyPrefix}] : [${keyPrefix}, variables]`;
 }
 
 export function generateInfiniteQueryKeyMaker(
@@ -25,8 +31,14 @@ export function generateInfiniteQueryKeyMaker(
 }
 
 export function generateQueryKey(node: OperationDefinitionNode, hasRequiredVariables: boolean): string {
-  if (hasRequiredVariables) return `['${node.name.value}', variables]`;
-  return `variables === undefined ? ['${node.name.value}'] : ['${node.name.value}', variables]`;
+  const keyDirective = node.directives?.find(d => d.name.value == 'reactQueryKey');
+  const keyPrefix = keyDirective
+    ? (keyDirective.arguments[0].value as ListValueNode).values
+        .map((v: StringValueNode) => JSON.stringify(v.value))
+        .join(', ')
+    : `'${node.name.value}'`;
+  if (hasRequiredVariables) return `[${keyPrefix}, variables]`;
+  return `variables === undefined ? [${keyPrefix}] : [${keyPrefix}, variables]`;
 }
 
 export function generateQueryKeyMaker(

--- a/website/src/pages/plugins/typescript/typescript-react-query.mdx
+++ b/website/src/pages/plugins/typescript/typescript-react-query.mdx
@@ -314,3 +314,14 @@ export const MyComponent = () => {
   )
 }
 ```
+
+### Customizing Query Key
+
+To customize the query key used by react-query, the `@reactQueryKey` directive
+can be used:
+
+```graphql
+query MyQuery @reactQueryKey(key: ["query", "key", "prefix"]) {
+  # ...
+}
+```


### PR DESCRIPTION
## Description

Adds a `@reactQueryKey` directive on `QUERY` which allows customizing the generated key.

Related dotansimha/graphql-code-generator-community#209

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Adds a test to make sure the generated key is correct.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
