### PR TITLE
fix(cli): prevent duplicated error messages on fail (without watcher)

### DIFF
--- a/.changeset/smooth-beans-fetch.md
+++ b/.changeset/smooth-beans-fetch.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/cli": patch
+---
+
+fix(cli): prevent duplicated error messages on fail (without watcher)

--- a/packages/graphql-codegen-cli/src/cli.ts
+++ b/packages/graphql-codegen-cli/src/cli.ts
@@ -16,7 +16,6 @@ export async function runCli(cmd: string): Promise<any> {
     return await generate(context);
   } catch (error) {
     await lifecycleHooks(context.getConfig().hooks).onError(error.toString());
-    throw error;
   }
 }
 


### PR DESCRIPTION
I did a local repro for #7546 that reported duplicated error messages from CLI output.

When watcher is enabled, duplicated error messages don't show because we properly handle promise fail callback:
https://github.com/dotansimha/graphql-code-generator/blob/f2ecf73ff858e091901c7f40df9b00fd8a3a5560/packages/graphql-codegen-cli/src/utils/watcher.ts#L70-L71

The duplicated came from the main `try/catch` that unnecessarily rethrow the error returned by `generate()`.
