### PR TITLE
allow mappers config overriding

### DIFF
--- a/.changeset/angry-apples-protect.md
+++ b/.changeset/angry-apples-protect.md
@@ -7,8 +7,8 @@ Introduce `mergeMappers` config flags will allows to reuse mappers across genera
 ```yml
 schema: "schema.graphql"
 documents: src/*.ts
+mergeMappers: true
 config:
-    mergeMappers: true
     mappers:
       ID: IDType
 generates:

--- a/.changeset/angry-apples-protect.md
+++ b/.changeset/angry-apples-protect.md
@@ -1,0 +1,29 @@
+---
+'@graphql-codegen/cli': minor
+---
+
+Introduce `mergeMappers` config flags will allows to reuse mappers across generated files:
+
+```yml
+schema: "schema.graphql"
+documents: src/*.ts
+config:
+    mergeMappers: true
+    mappers:
+      ID: IDType
+generates:
+  resolvers-types-1.ts:
+    plugins:
+      - typescript
+      - typescript-resolvers
+    config:
+      mappers:
+        String: StringType
+  resolvers-types-2.ts:
+    plugins:
+      - typescript
+      - typescript-resolvers
+    config:
+      mappers:
+        String: StringType
+```

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -315,12 +315,16 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
                             ...(typeof outputFileTemplateConfig === 'string'
                               ? { value: outputFileTemplateConfig }
                               : outputFileTemplateConfig),
-                            mappers: {
-                              ...(rootConfig.mappers || {}),
-                              ...(typeof outputFileTemplateConfig === 'string'
-                                ? {}
-                                : outputFileTemplateConfig.mappers || {}),
-                            },
+                            ...(rootConfig.mergeMappers
+                              ? {
+                                  mappers: {
+                                    ...(rootConfig.mappers || {}),
+                                    ...(typeof outputFileTemplateConfig === 'string'
+                                      ? {}
+                                      : outputFileTemplateConfig.mappers || {}),
+                                  },
+                                }
+                              : {}),
                             emitLegacyCommonJSImports: shouldEmitLegacyCommonJSImports(config, filename),
                           };
 

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -315,7 +315,7 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
                             ...(typeof outputFileTemplateConfig === 'string'
                               ? { value: outputFileTemplateConfig }
                               : outputFileTemplateConfig),
-                            ...(rootConfig.mergeMappers
+                            ...(config.mergeMappers
                               ? {
                                   mappers: {
                                     ...(rootConfig.mappers || {}),

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -315,6 +315,12 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
                             ...(typeof outputFileTemplateConfig === 'string'
                               ? { value: outputFileTemplateConfig }
                               : outputFileTemplateConfig),
+                            mappers: {
+                              ...(rootConfig.mappers || {}),
+                              ...(typeof outputFileTemplateConfig === 'string'
+                                ? {}
+                                : outputFileTemplateConfig.mappers || {}),
+                            },
                             emitLegacyCommonJSImports: shouldEmitLegacyCommonJSImports(config, filename),
                           };
 

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -120,6 +120,10 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
           : {
               ...options.config,
               ...pluginConfig,
+              mappers: {
+                ...options.config.mappers,
+                ...pluginConfig.mappers,
+              },
             };
 
       const result = await profiler.run(

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -120,10 +120,6 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
           : {
               ...options.config,
               ...pluginConfig,
-              mappers: {
-                ...options.config.mappers,
-                ...pluginConfig.mappers,
-              },
             };
 
       const result = await profiler.run(

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -442,6 +442,10 @@ export namespace Types {
      */
     emitLegacyCommonJSImports?: boolean;
     /**
+     * @description A flag to enable merging root-level `mappers` with output-level `mappers`
+     */
+    mergeMappers?: boolean;
+    /**
      * @description A flag to suppress printing errors when they occur.
      */
     silent?: boolean;


### PR DESCRIPTION
## Description

When workspaces include multiple GraphQL projects, and graphs share the same core model. In this case, I would like to write the core model mappers only once in the root config and additional mappers per plugin, but that is not currently allowed.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I skipped it because there are no existing tests for config. Please tell me if it requires

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
