### PR TITLE
fix(cli): prevent early returning on init cmd

### DIFF
--- a/.changeset/curly-clocks-warn.md
+++ b/.changeset/curly-clocks-warn.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Prevent cli from early returning when run init command.

--- a/packages/graphql-codegen-cli/src/cli.ts
+++ b/packages/graphql-codegen-cli/src/cli.ts
@@ -8,7 +8,7 @@ export async function runCli(cmd: string): Promise<number> {
   await ensureGraphQlPackage();
 
   if (cmd === 'init') {
-    init();
+    await init();
     return 0;
   }
 


### PR DESCRIPTION
## Description

When I run `yarn graphql-codegen init`, it just print some options and is ended immediately. So I add `await` operator to prevent it from early returning.

Related #8162 

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

`yarn graphql-codegen init`

<img width="984" alt="스크린샷 2022-07-31 오전 12 18 15" src="https://user-images.githubusercontent.com/17957593/181920849-45f0e448-2c6f-442d-84ca-16c60db6a313.png">

## How Has This Been Tested?

I haven't tested this. But if it is needed tell me how I can test.

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules