### PR TITLE
remove skipDocumentsValidation from near-operation-file

### DIFF
--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -268,7 +268,6 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
         config,
         schema: options.schema,
         schemaAst: schemaObject,
-        skipDocumentsValidation: true,
       });
     }
 

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -681,23 +681,6 @@ describe('near-operation-file preset', () => {
     ]);
   });
 
-  it('Should skip the duplicate documents validation', async () => {
-    const result = await executePreset({
-      baseOutputDir: './src/',
-      config: {},
-      presetConfig: {
-        baseTypesPath: 'types.ts',
-      },
-      schema: schemaDocumentNode,
-      schemaAst: schemaNode,
-      documents: testDocuments,
-      plugins: [],
-      pluginMap: {},
-    });
-
-    expect(result[0].skipDocumentsValidation).toBeTruthy();
-  });
-
   it('Should allow to customize output extension', async () => {
     const result = await executePreset({
       baseOutputDir: './src/',


### PR DESCRIPTION
This field is no longer needed as the proper fix was introduced in
7c60e5accb.

## Description


In 2019 #2143 lead to 1559ab6820. This resulted in typechecking being disabled for near-operation-file presets.
Since that change the ability to toggle this setting was introduced in: [7c60e5accb](https://github.com/dotansimha/graphql-code-generator/pull/6825).
Running the same tests from #2143 it should now be possible to remove the default disable of typechecking for near-operation-file preset. 
Typechecking is important and should be enabled by default. 

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related #8221


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- This has been tested using the following repo to run the tests here: https://github.com/klyve/graphql-codegen-preset-test
 

**Test Environment**:

- OS: macOS
- NodeJS: 16.16.0
- @graphql-codegen/near-operation-file-preset: 2.4.1 + change

- @graphql-codegen/cli: 2.11.5
- @graphql-codegen/introspection: 2.2.1
- @graphql-codegen/typescript: 2.7.3
- @graphql-codegen/typescript-operations: 2.5.3
- @graphql-codegen/typescript-react-apollo: 3.3.3

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

