### PR TITLE
Fix config.schema.json TypeGraphQLPluginConfig.decorateTypes type

### DIFF
--- a/website/public/config.schema.json
+++ b/website/public/config.schema.json
@@ -965,7 +965,8 @@
         },
         "decorateTypes": {
           "description": "Specifies the objects that will have TypeGraphQL decorators prepended to them, by name. Non-matching types will still be output, but without decorators. If not set, all types will be decorated.",
-          "type": "string[]"
+          "type": "array",
+          "items": { "type": "string" }
         },
         "avoidOptionals": {
           "description": "This will cause the generator to avoid using TypeScript optionals (`?`) on types,\nso the following definition: `type A { myField: String }` will output `myField: Maybe<string>`\ninstead of `myField?: Maybe<string>`.\nDefault value: \"false\"",


### PR DESCRIPTION
## Description

Fix invalid type in the config.schema.json file for TypeGraphQLPluginConfig.decorateTypes
`string[]` is not a valid json schema type.

Closes #8215
Closes #8209

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update

