### PR TITLE
Fix json schema for TypeGraphQLPluginConfig

### DIFF
--- a/packages/plugins/typescript/type-graphql/src/config.ts
+++ b/packages/plugins/typescript/type-graphql/src/config.ts
@@ -12,7 +12,6 @@ export interface TypeGraphQLPluginConfig extends TypeScriptPluginConfig {
   /**
    * @name decorateTypes
    * @description Specifies the objects that will have TypeGraphQL decorators prepended to them, by name. Non-matching types will still be output, but without decorators. If not set, all types will be decorated.
-   * @type string[]
    * @example Decorate only type User
    * ```yaml
    * generates:

--- a/website/public/config.schema.json
+++ b/website/public/config.schema.json
@@ -965,7 +965,8 @@
         },
         "decorateTypes": {
           "description": "Specifies the objects that will have TypeGraphQL decorators prepended to them, by name. Non-matching types will still be output, but without decorators. If not set, all types will be decorated.",
-          "type": "string[]"
+          "type": "array",
+          "items": { "type": "string" }
         },
         "avoidOptionals": {
           "description": "This will cause the generator to avoid using TypeScript optionals (`?`) on types,\nso the following definition: `type A { myField: String }` will output `myField: Maybe<string>`\ninstead of `myField?: Maybe<string>`.\nDefault value: \"false\"",


### PR DESCRIPTION
<!--
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

-->

## Description

The definition in `packages/plugins/typescript/type-graphql/src/config.ts` was incorrectly specifying `@type: string[]` in the docs, which was overriding the derived type used by the `typescript-schema-generator`:

> Note that we needed to use @TJS-type instead of just @type because of an [issue with the typescript compiler](https://github.com/Microsoft/TypeScript/issues/13498). ([source](https://www.npmjs.com/package/typescript-json-schema))

Related #8209

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

In our project's `codegen.yml`:

Valid:

```
# yaml-language-server: $schema=https://raw.githubusercontent.com/bbugh/graphql-code-generator/d3ea8db0fcf1b1c783d3c8fc499de23293ee083e/website/public/config.schema.json
schema
```

Invalid:

```
# yaml-language-server: $schema=https://www.graphql-code-generator.com/config.schema.json
overwrite: true
```

**Test Environment**:

- OS: MacOS Monterey 12.4
- NodeJS: v18.2.0

## Checklist:

*(I don't think all of these apply)*

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
