### PR TITLE
 graphql-request: Specify explicit extension when importing dom types

### DIFF
--- a/.changeset/unlucky-windows-arrive.md
+++ b/.changeset/unlucky-windows-arrive.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-graphql-request": patch
+"@graphql-codegen/typescript-react-query": patch
+---
+
+ graphql-request: Specify explicit extension when importing dom types

--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -41,9 +41,10 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
     autoBind(this);
 
     const typeImport = this.config.useTypeImports ? 'import type' : 'import';
+    const fileExtension = this.config.emitLegacyCommonJSImports ? '' : '.js';
 
     this._additionalImports.push(`${typeImport} { GraphQLClient } from 'graphql-request';`);
-    this._additionalImports.push(`${typeImport} * as Dom from 'graphql-request/dist/types.dom';`);
+    this._additionalImports.push(`${typeImport} * as Dom from 'graphql-request/dist/types.dom${fileExtension}';`);
 
     if (this.config.rawRequest && this.config.documentMode !== DocumentMode.string) {
       this._additionalImports.push(`import { print } from 'graphql'`);

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -7,7 +7,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import * as Dom from 'graphql-request/dist/types.dom.js';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -292,7 +292,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import * as Dom from 'graphql-request/dist/types.dom.js';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -571,7 +571,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import * as Dom from 'graphql-request/dist/types.dom.js';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -849,7 +849,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import type { GraphQLClient } from 'graphql-request';
-import type * as Dom from 'graphql-request/dist/types.dom';
+import type * as Dom from 'graphql-request/dist/types.dom.js';
 import { print } from 'graphql'
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
@@ -1133,7 +1133,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import * as Dom from 'graphql-request/dist/types.dom.js';
 import { print } from 'graphql'
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
@@ -1417,7 +1417,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import * as Dom from 'graphql-request/dist/types.dom.js';
 import { print } from 'graphql'
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
@@ -1701,7 +1701,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import type { GraphQLClient } from 'graphql-request';
-import type * as Dom from 'graphql-request/dist/types.dom';
+import type * as Dom from 'graphql-request/dist/types.dom.js';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -1981,7 +1981,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import * as Dom from 'graphql-request/dist/types.dom.js';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -66,8 +66,9 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
     const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
 
     const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
+    const fileExtension = this.visitor.config.emitLegacyCommonJSImports ? '' : '.js';
     this.visitor.imports.add(`${typeImport} { GraphQLClient } from 'graphql-request';`);
-    this.visitor.imports.add(`${typeImport} { RequestInit } from 'graphql-request/dist/types.dom';`);
+    this.visitor.imports.add(`${typeImport} { RequestInit } from 'graphql-request/dist/types.dom${fileExtension}';`);
 
     const hookConfig = this.visitor.queryMethodMap;
     this.visitor.reactQueryHookIdentifiersInUse.add(hookConfig.query.hook);
@@ -134,7 +135,8 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
   ): string {
     const variables = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
     const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
-    this.visitor.imports.add(`${typeImport} { RequestInit } from 'graphql-request/dist/types.dom';`);
+    const fileExtension = this.visitor.config.emitLegacyCommonJSImports ? '' : '.js';
+    this.visitor.imports.add(`${typeImport} { RequestInit } from 'graphql-request/dist/types.dom${fileExtension}';`);
 
     return `\nuse${operationName}.fetcher = (client: GraphQLClient, ${variables}, headers?: RequestInit['headers']) => fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables, headers);`;
   }

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -580,7 +580,7 @@ export const useTestMutation = <
         `import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';`
       );
       expect(out.prepend).toContain(`import { GraphQLClient } from 'graphql-request';`);
-      expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom';`);
+      expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom.js';`);
       expect(out.prepend[3])
         .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variables?: TVariables, headers?: RequestInit['headers']) {
           return async (): Promise<TData> => client.request<TData, TVariables>(query, variables, headers);


### PR DESCRIPTION
This is needed to support "moduleResolution": "nodenext" in typescript


## Description

Related #8022

It looks like the related issue attempted to add `.js` extensions to all imports, but this one got missing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

n/a

## How Has This Been Tested?


- [x] Modified generated code locally, it passes typescript compilation

**Test Environment**:

n/a

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a