### PR TITLE
Feature/hasura allow list global fragments

### DIFF
--- a/.changeset/eight-peaches-warn.md
+++ b/.changeset/eight-peaches-warn.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/hasura-allow-list": major
+---
+
+added support for global fragments
+breaking: changed config options to camelCase for consistency

--- a/packages/plugins/other/hasura-allow-list/src/config.ts
+++ b/packages/plugins/other/hasura-allow-list/src/config.ts
@@ -11,4 +11,9 @@ export interface HasuraAllowListPluginConfig {
    * The default value _will change_ in the future if/when newer config versions are released.
    */
   config_version?: 2 | 3;
+  /**
+   * @default false
+   * @description Whether to source fragments per-document, or globally. If set, will enforce fragment name uniqueness
+   */
+  global_fragments?: boolean;
 }

--- a/packages/plugins/other/hasura-allow-list/src/config.ts
+++ b/packages/plugins/other/hasura-allow-list/src/config.ts
@@ -15,5 +15,5 @@ export interface HasuraAllowListPluginConfig {
    * @default false
    * @description Whether to source fragments per-document, or globally. If set, will enforce fragment name uniqueness
    */
-  global_fragments?: boolean;
+  globalFragments?: boolean;
 }

--- a/packages/plugins/other/hasura-allow-list/src/config.ts
+++ b/packages/plugins/other/hasura-allow-list/src/config.ts
@@ -3,14 +3,14 @@ export interface HasuraAllowListPluginConfig {
    * @default allowed-queries
    * @description Choose the collection name to be generated. Defaults to allowed-queries
    */
-  collection_name?: string;
+  collectionName?: string;
   /**
    * @default 3
    * @description Target metadata config version. Supported versions are 2 and 3.
    * This is mostly for future proofing, currently has no impact as both versions use the same format.
    * The default value _will change_ in the future if/when newer config versions are released.
    */
-  config_version?: 2 | 3;
+  configVersion?: 2 | 3;
   /**
    * @default false
    * @description Whether to source fragments per-document, or globally. If set, will enforce fragment name uniqueness

--- a/packages/plugins/other/hasura-allow-list/src/index.ts
+++ b/packages/plugins/other/hasura-allow-list/src/index.ts
@@ -109,16 +109,28 @@ export const plugin: PluginFunction<HasuraAllowListPluginConfig> = async (
   documents: Types.DocumentFile[],
   config: HasuraAllowListPluginConfig
 ): Promise<Types.PluginOutput> => {
+  if ('config_version' in config) {
+    throw new Error(
+      `[hasura allow list plugin] Configuration error: configuration property config_version has been renamed configVersion. Please update your configuration accordingly.`
+    );
+  }
+
+  if ('collection_name' in config) {
+    throw new Error(
+      `[hasura allow list plugin] Configuration error: configuration property collection_name has been renamed collectionName. Please update your configuration accordingly.`
+    );
+  }
+
   const queries: { name: string; query: string }[] = [];
 
-  // if config global_fragments is set, get fragments from all documents
-  const globalFragments = !config.global_fragments ? false : getGlobalFragments(documents);
+  // if config globalFragments is set, get fragments from all documents
+  const globalFragments = !config.globalFragments ? false : getGlobalFragments(documents);
 
   for (const document of documents) {
     // filter out anonymous operations
     const documentOperations = document.document.definitions.filter(namedOperationDefinitionFilter);
 
-    // depending on global_fragments settings, either use document level or global level fragments
+    // depending on globalFragments settings, either use document level or global level fragments
     const fragments = globalFragments || getDocumentFragments(document);
 
     // for each operation in the document
@@ -137,7 +149,7 @@ export const plugin: PluginFunction<HasuraAllowListPluginConfig> = async (
 
   return yaml.stringify([
     {
-      name: config.collection_name ?? 'allowed-queries',
+      name: config.collectionName ?? 'allowed-queries',
       definition: {
         queries,
       },


### PR DESCRIPTION
This is a replacement PR for #7701 where I messed up the git history

## Description

Added support for globally defined fragments for the hasura-allow-list plugin.
Previously it was required that fragments be defined in the same document as the operations that use them.
Now, with the global_fragments config set, fragments will be pulled from all documents in the project.

Because this configuration is off by default, this feature does not break previous behavior and is thus not a breaking change.
Related #7700 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Added tests to test suite for the plugin, testing success case and two error cases.
Also built the plugin and tested on a local project to see the desired output.

**Test Environment**:

- OS: Windows
- `@graphql-codegen/cli`: 2.6.0
- NodeJS: 14.17.6

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
