### PR TITLE
chore(parse-mapper): Add extra test for using a custom generic mapper

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/tests/parse-mapper.spec.ts
+++ b/packages/plugins/other/visitor-plugin-common/tests/parse-mapper.spec.ts
@@ -10,6 +10,15 @@ describe('parseMapper', () => {
     });
   });
 
+  it('Should support a custom mapper with no imports', () => {
+    const result = parseMapper('CustomMergeTypeMapper<SomeType, SomeOtherType>', 'SomeType');
+
+    expect(result).toEqual({
+      isExternal: false,
+      type: 'CustomMergeTypeMapper<SomeType, SomeOtherType>',
+    });
+  });
+
   it('Should return the correct values for a external named mapper', () => {
     const result = parseMapper('file#MyType');
 


### PR DESCRIPTION
## Description

This adds an additional test to how mapper strings are parsed 

Related #8050

## Type of change

Adds new unit test

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

N/A - ran `yarn test-and-build`

**Test Environment**:

- OS:
- `@graphql-codegen/visitor-plugin-common`:2.12.1
- NodeJS: v18.7.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
As discussed with @n1ru4l  - this just adds an extra test to prevent regression on using custom generics inside mappers, because it felt to me like I was hacking codegen.
