### PR TITLE
fix(plugin-generic-sdk): Remove useless E generic when rawRequest is false

### DIFF
--- a/packages/plugins/typescript/generic-sdk/src/visitor.ts
+++ b/packages/plugins/typescript/generic-sdk/src/visitor.ts
@@ -104,10 +104,16 @@ export class GenericSdkVisitor extends ClientSideBaseVisitor<RawGenericSdkPlugin
 
     const documentNodeType = this.config.documentMode === DocumentMode.string ? 'string' : 'DocumentNode';
     const resultData = this.config.rawRequest ? 'ExecutionResult<R, E>' : 'R';
-    const returnType = `Promise<${resultData}> | ${usingObservable ? 'Observable' : 'AsyncIterable'}<${resultData}>`;
+    const requesterTypeName = this.config.rawRequest ? 'Requester<C = {}, E = unknown>' : 'Requester<C = {}>';
+    const requesterReturnType = `Promise<${resultData}> | ${
+      usingObservable ? 'Observable' : 'AsyncIterable'
+    }<${resultData}>`;
+    const getSdkSignature = this.config.rawRequest
+      ? 'getSdk<C, E>(requester: Requester<C, E>)'
+      : 'getSdk<C>(requester: Requester<C>)';
 
-    return `export type Requester<C = {}, E = unknown> = <R, V>(doc: ${documentNodeType}, vars?: V, options?: C) => ${returnType}
-export function getSdk<C, E>(requester: Requester<C, E>) {
+    return `export type ${requesterTypeName} = <R, V>(doc: ${documentNodeType}, vars?: V, options?: C) => ${requesterReturnType}
+export function ${getSdkSignature} {
   return {
 ${allPossibleActions.join(',\n')}
   };

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -237,8 +237,8 @@ export const Feed4Document = gql\`
   }
 }
     \`;
-export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
-export function getSdk<C, E>(requester: Requester<C, E>) {
+export type Requester<C = {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
+export function getSdk<C>(requester: Requester<C>) {
   return {
     feed(variables?: FeedQueryVariables, options?: C): Promise<FeedQuery> {
       return requester<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options) as Promise<FeedQuery>;
@@ -486,8 +486,8 @@ export const FeedLiveDocument = gql\`
   }
 }
     \`;
-export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
-export function getSdk<C, E>(requester: Requester<C, E>) {
+export type Requester<C = {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
+export function getSdk<C>(requester: Requester<C>) {
   return {
     feed(variables?: FeedQueryVariables, options?: C): Promise<FeedQuery> {
       return requester<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options) as Promise<FeedQuery>;
@@ -726,8 +726,8 @@ export const FeedLiveDocument = gql\`
   }
 }
     \`;
-export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | Observable<R>
-export function getSdk<C, E>(requester: Requester<C, E>) {
+export type Requester<C = {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | Observable<R>
+export function getSdk<C>(requester: Requester<C>) {
   return {
     feed(variables?: FeedQueryVariables, options?: C): Promise<FeedQuery> {
       return requester<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options) as Promise<FeedQuery>;
@@ -978,8 +978,8 @@ export const Feed4Document = \`
   }
 }
     \`;
-export type Requester<C = {}, E = unknown> = <R, V>(doc: string, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
-export function getSdk<C, E>(requester: Requester<C, E>) {
+export type Requester<C = {}> = <R, V>(doc: string, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
+export function getSdk<C>(requester: Requester<C>) {
   return {
     feed(variables?: FeedQueryVariables, options?: C): Promise<FeedQuery> {
       return requester<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options) as Promise<FeedQuery>;


### PR DESCRIPTION
## Description

As @JanStevens said, my last PR broke the generated type when `rawRequest: false` is false and `noUnusedParameters: true`.

This fix as simple as possible and remove the unused `E` generic from the function signature when `rawRequest` is false.

Sorry guys I missed that :/ Hope this PR can help 💪 

Related #8175 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

