### PR TITLE
refactor: Remove typename when not needed for combine (resolve #8320)

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -552,7 +552,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       this._config.skipTypeNameForRoot
     );
     const transformed: ProcessResult = [
-      ...(typeInfoField && this.needsTypenameField(fragmentsSpreadUsages, typeInfoField)
+      ...(typeInfoField && this.needsTypenameField(fragmentsSpreadUsages)
         ? this._processor.transformTypenameField(typeInfoField.type, typeInfoField.name)
         : []),
       ...this._processor.transformPrimitiveFields(
@@ -601,17 +601,13 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
 
   /**
    * When masking the fragments, typename will always be added.
-   * When combining the fragments, typename will be added only if all
-   * fragments don't have the same type as the main typename.
+   * When combining the fragments, typename will be added only if there
+   * are no fragments.
    * When merging fragments, we need to wait until we know all the involved
    * typenames, so we don't add the typename field.
    */
-  private needsTypenameField(fragmentsSpreadUsages: FragmentSpreadUsage[], typeInfoField: TypenameField) {
-    if (
-      this._config.inlineFragmentTypes === 'combine' &&
-      fragmentsSpreadUsages.length > 0 &&
-      fragmentsSpreadUsages.every(({ onType }) => `'${onType}'` === typeInfoField.type)
-    ) {
+  private needsTypenameField(fragmentsSpreadUsages: FragmentSpreadUsage[]) {
+    if (this._config.inlineFragmentTypes === 'combine' && fragmentsSpreadUsages.length > 0) {
       return false;
     }
 

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -51,6 +51,11 @@ type FragmentSpreadUsage = {
   selectionNodes: Array<SelectionNode>;
 };
 
+type TypenameField = {
+  name: string;
+  type: string;
+};
+
 function isMetadataFieldName(name: string) {
   return ['__schema', '__type'].includes(name);
 }
@@ -434,7 +439,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     let requireTypename = false;
 
     // usages via fragment typescript type
-    const fragmentsSpreadUsages: { name: string; onType: string }[] = [];
+    const fragmentsSpreadUsages: FragmentSpreadUsage[] = [];
 
     // ensure we mutate no function params
     selectionNodes = [...selectionNodes];
@@ -494,7 +499,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       }
 
       if (this._config.inlineFragmentTypes === 'combine' || this._config.inlineFragmentTypes === 'mask') {
-        fragmentsSpreadUsages.push({ name: selectionNode.typeName, onType: selectionNode.onType });
+        fragmentsSpreadUsages.push(selectionNode);
         continue;
       }
 
@@ -546,15 +551,10 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       requireTypename,
       this._config.skipTypeNameForRoot
     );
-    const transformedTypenameFields =
-      !this._config.mergeFragmentTypes || this._config.inlineFragmentTypes === 'mask'
-        ? this._processor.transformTypenameField(typeInfoField.type, typeInfoField.name)
-        : [];
     const transformed: ProcessResult = [
-      // Only add the typename field if we're not merging fragment
-      // types. If we are merging, we need to wait until we know all
-      // the involved typenames.
-      ...transformedTypenameFields,
+      ...(this.needsTypenameField(fragmentsSpreadUsages, typeInfoField)
+        ? this._processor.transformTypenameField(typeInfoField.type, typeInfoField.name)
+        : []),
       ...this._processor.transformPrimitiveFields(
         parentSchemaType,
         Array.from(primitiveFields.values()).map(field => ({
@@ -586,22 +586,36 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
 
     if (fragmentsSpreadUsages.length) {
       if (this._config.inlineFragmentTypes === 'combine') {
-        fields.push(...fragmentsSpreadUsages.map(({ name }) => name));
-
-        // Remove the typename field if all fragments already contain it
-        const allOnSameType = fragmentsSpreadUsages.every(({ onType }) => onType === typeInfoField.type);
-        const stringTypenames = transformedTypenameFields.filter((field): field is string => typeof field === 'string');
-        if (allOnSameType && stringTypenames.length === 1) {
-          fields.splice(fields.indexOf(stringTypenames[0]), 1);
-        }
+        fields.push(...fragmentsSpreadUsages.map(({ typeName }) => typeName));
       } else if (this._config.inlineFragmentTypes === 'mask') {
         fields.push(
-          `{ ' $fragmentRefs': { ${fragmentsSpreadUsages.map(({ name }) => `'${name}': ${name}`).join(`;`)} } }`
+          `{ ' $fragmentRefs': { ${fragmentsSpreadUsages
+            .map(({ typeName }) => `'${typeName}': ${typeName}`)
+            .join(`;`)} } }`
         );
       }
     }
 
     return { typeInfo: typeInfoField, fields };
+  }
+
+  /**
+   * When masking the fragments, typename will always be added.
+   * When combining the fragments, typename will be added only if all
+   * fragments don't have the same type as the main typename.
+   * When merging fragments, we need to wait until we know all the involved
+   * typenames, so we don't add the typename field.
+   */
+  private needsTypenameField(fragmentsSpreadUsages: FragmentSpreadUsage[], typeInfoField: TypenameField) {
+    if (
+      this._config.inlineFragmentTypes === 'combine' &&
+      fragmentsSpreadUsages.length > 0 &&
+      fragmentsSpreadUsages.every(({ onType }) => onType === typeInfoField.type)
+    ) {
+      return false;
+    }
+
+    return !this._config.mergeFragmentTypes || this._config.inlineFragmentTypes === 'mask';
   }
 
   protected buildTypeNameField(
@@ -610,7 +624,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     addTypename: boolean = this._config.addTypename,
     queriedForTypename: boolean = this._queriedForTypename,
     skipTypeNameForRoot: boolean = this._config.skipTypeNameForRoot
-  ): { name: string; type: string } {
+  ): TypenameField {
     const rootTypes = getRootTypes(this._schema);
     if (rootTypes.has(type) && skipTypeNameForRoot && !queriedForTypename) {
       return null;

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -552,7 +552,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       this._config.skipTypeNameForRoot
     );
     const transformed: ProcessResult = [
-      ...(this.needsTypenameField(fragmentsSpreadUsages, typeInfoField)
+      ...(typeInfoField && this.needsTypenameField(fragmentsSpreadUsages, typeInfoField)
         ? this._processor.transformTypenameField(typeInfoField.type, typeInfoField.name)
         : []),
       ...this._processor.transformPrimitiveFields(
@@ -624,7 +624,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     addTypename: boolean = this._config.addTypename,
     queriedForTypename: boolean = this._queriedForTypename,
     skipTypeNameForRoot: boolean = this._config.skipTypeNameForRoot
-  ): TypenameField {
+  ): TypenameField | null {
     const rootTypes = getRootTypes(this._schema);
     if (rootTypes.has(type) && skipTypeNameForRoot && !queriedForTypename) {
       return null;

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -610,7 +610,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     if (
       this._config.inlineFragmentTypes === 'combine' &&
       fragmentsSpreadUsages.length > 0 &&
-      fragmentsSpreadUsages.every(({ onType }) => onType === typeInfoField.type)
+      fragmentsSpreadUsages.every(({ onType }) => `'${onType}'` === typeInfoField.type)
     ) {
       return false;
     }

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -6364,6 +6364,23 @@ function test(q: GetEntityBrandDataQuery): void {
         fragment UserFragment on User {
           id
         }
+
+        query {
+          me {
+            id
+          }
+        }
+
+        query {
+          search(term: "test") {
+            ...UserFragment
+            ...NotifFragment
+          }
+        }
+        fragment NotifFragment on TextNotification {
+          id
+          text
+        }
       `);
       const result = await plugin(
         schema,
@@ -6375,12 +6392,21 @@ function test(q: GetEntityBrandDataQuery): void {
         export type Unnamed_1_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type Unnamed_1_Query = { __typename?: 'Query', me?: (
-            { __typename?: 'User' }
-            & UserFragmentFragment
-          ) | null };
+        export type Unnamed_1_Query = { __typename?: 'Query', me?: UserFragmentFragment | null };
 
         export type UserFragmentFragment = { __typename?: 'User', id: string };
+
+        export type Unnamed_2_QueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type Unnamed_2_Query = { __typename?: 'Query', me?: { __typename?: 'User', id: string } | null };
+
+        export type Unnamed_3_QueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type Unnamed_3_Query = { __typename?: 'Query', search: Array<NotifFragmentFragment | { __typename?: 'ImageNotification' } | UserFragmentFragment> };
+
+        export type NotifFragmentFragment = { __typename?: 'TextNotification', id: string, text: string };
       `);
     });
 


### PR DESCRIPTION
## Description

Related #8320. See the issue for a detailed explanation.

## Type of change

- New feature (non-breaking change which adds functionality)

(_One could say this is a bug fix and not a feature, depends on how you look at it_)

## Screenshots/Sandbox (if appropriate/relevant):

See #8320 for screenshots

## How Has This Been Tested?

By updating and improving the existing test case for `inlineFragmentTypes: combine`. There are basically 3 possible combinations:

- Some fragments on a single type query: _Avoid extra `__typename`_
- No fragments on a query: _Preserve the behavior and make sure `__typename` is added_
- Some fragments on a union type query: _Avoid extra `__typename` for types that are covered by a fragment_

**Test Environment**:

- OS: macOS Monterey 12.5
- NodeJS: v16.16.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- (_N/A_) I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- (_N/A_) Any dependent changes have been merged and published in downstream modules

## Further comments

None.
