### PR TITLE
feat: Add `stripIgnoredCharacters` option (visitor-plugin-common)

### DIFF
--- a/.changeset/curly-numbers-turn.md
+++ b/.changeset/curly-numbers-turn.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+---
+
+Add `stripIgnoredCharacters` option


### PR DESCRIPTION
Related #5616

## Description

Adds a new `stripIgnoredCharacters: boolean` option to `client-side-base-visitor` that removes redundant characters (like line-breaks, whitespaces, etc.) from the query strings.

In the linked issue, I originally proposed doing `.replace(/\s+/g, ' ').trim()` on the strings, but that turned out to be an unreliable approach as it would fail to cover a number of cases:
- It doesn't remove extraneous whitespaces that are not consecutive, so like `query ( $var : Int! )` (should become `query ($var: Int!)`) or more commonly `query { foo bar }` (should become `query{foo bar}`).
- If you have a string literal inside the query, that contains more than one consecutive space or line breaks, it removes those but it obviously shouldn't.

This all means a **GraphQL-specific** minifier is actually needed to do this reliably,
Happily I found out there's a built-in function in [`graphql-js`](https://github.com/graphql/graphql-js) for this very task! `stripIgnoredCharacters` — see https://github.com/graphql/graphql-js/issues/1523, which does precisely this.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I actually didn't add tests for this because I didn't know where to add the tests, `client-side-base-visitor` itself didn't include any tests, and I don't really know what tests I should add and more importantly where. I would appreciate if you point me in the right direction.