### PR TITLE
feat(ts-resolvers): Add ability to configure a custom resolver

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -278,6 +278,7 @@ export interface RawResolversConfig extends RawConfig {
    *         inputValue: true
    *         object: true
    *         defaultValue: true
+   * 	       resolvers: true;
    * ```
    */
   avoidOptionals?: boolean | AvoidOptionalsConfig;
@@ -370,6 +371,22 @@ export interface RawResolversConfig extends RawConfig {
    * @ignore
    */
   directiveResolverMappings?: Record<string, string>;
+  /**
+   * @description Allow you to set the visitor class that will be used to traverse the graphql AST to generate
+   * the types.
+   *
+   *
+   * @exampleMarkdown
+   *
+   * ## Custom Visitor
+   *
+   * ```yaml
+   * plugins
+   *   config:
+   *     customVisitor: ./my-custom-visitor#VisitorClass
+   * ```
+   * **/
+  customVisitor?: string;
 }
 
 export type ResolverTypes = { [gqlType: string]: string };
@@ -431,6 +448,7 @@ export class BaseResolversVisitor<
       mappers: transformMappers(rawConfig.mappers || {}, rawConfig.mapperTypeSuffix),
       scalars: buildScalarsFromConfig(_schema, rawConfig, defaultScalars),
       internalResolversPrefix: getConfigValue(rawConfig.internalResolversPrefix, '__'),
+      customVisitor: getConfigValue(rawConfig.customVisitor, null), // If custom visitor is not set, we will use the default one
       ...additionalConfig,
     } as TPluginConfig);
 

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -76,7 +76,18 @@ export type Resolver${capitalizedDirectiveName}WithResolve<TResult, TParent, TCo
   }
 
   const transformedSchema = config.federation ? addFederationReferencesToSchema(schema) : schema;
-  const visitor = new TypeScriptResolversVisitor({ ...config, directiveResolverMappings }, transformedSchema);
+
+  let visitor;
+
+  if (config.customVisitor) {
+    // @TODO: figure out how to use custom-visitor#VisirClass syntax
+    // instead of using default
+    const CustomVistor = require(config.customVisitor).default;
+    visitor = new CustomVistor({ ...config, directiveResolverMappings }, transformedSchema);
+  } else {
+    visitor = new TypeScriptResolversVisitor({ ...config, directiveResolverMappings }, transformedSchema);
+  }
+
   const namespacedImportPrefix = visitor.config.namespacedImportName ? `${visitor.config.namespacedImportName}.` : '';
 
   const astNode = getCachedDocumentNodeFromSchema(transformedSchema);


### PR DESCRIPTION
Draft PR (WIP) - one way to implement the feature described in #8338

## Description
In Redwood, we need the ability to slightly modify how the TypeScriptResolversVisitor works, while keeping all of the other functionality within the typescript-resolvers plugin as is.

I've tried to describe what we're trying to achieve in this recording: https://s.tape.sh/xK6JyeYz?s=1.25

Related #8338

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
This is a draft PR for discussion, I will add tests as advised!

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
