### PR TITLE
Operations and fragments must be uniquely named

### DIFF
--- a/website/src/pages/docs/advanced/how-does-it-work.mdx
+++ b/website/src/pages/docs/advanced/how-does-it-work.mdx
@@ -11,6 +11,12 @@ This process, applied to the `@graphql-codegen/typescript` plugin, is illustrate
 
 ![Codegen flow example](../../../../public/assets/illustrations/codegen_flow1.png)
 
+<Callout>
+**Operations and fragments must have unique names**
+
+GraphQL Code Generator checks for this automatically and will let you know if you have any conflicts.
+</Callout>
+
 ## Example with `@graphql-codegen/typescript`
 
 Given the following GraphQL schema:


### PR DESCRIPTION
## Description

As discussed with @n1ru4l, GraphQL Code Generator requires fragments and operations to have unique names, otherwise it will throw an error. Stating this requirement feels sensible.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules