### PR TITLE
fix(cli): properly print error that occurred during hook execution

### DIFF
--- a/.changeset/violet-sloths-sparkle.md
+++ b/.changeset/violet-sloths-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+CLI: properly print error that occurred during hook execution

--- a/packages/graphql-codegen-cli/src/hooks.ts
+++ b/packages/graphql-codegen-cli/src/hooks.ts
@@ -58,6 +58,8 @@ function execShellCommand(cmd: string): Promise<string> {
       (error, stdout, stderr) => {
         if (error) {
           reject(error);
+          // eslint-disable-next-line no-console
+          console.error(error);
         } else {
           debugLog(stdout || stderr);
           resolve(stdout || stderr);


### PR DESCRIPTION
Related to https://github.com/dotansimha/graphql-code-generator/issues/8382