### PR TITLE
fix: handle undefined namedType for introspection

### DIFF
--- a/.changeset/eighty-trees-confess.md
+++ b/.changeset/eighty-trees-confess.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript': major
+---
+
+handle undefined namedType when including introspection type definitions

--- a/packages/plugins/typescript/typescript/src/index.ts
+++ b/packages/plugins/typescript/typescript/src/index.ts
@@ -65,7 +65,7 @@ export function includeIntrospectionTypesDefinitions(
     Field() {
       const type = getNamedType(typeInfo.getType());
 
-      if (isIntrospectionType(type) && !usedTypes.includes(type)) {
+      if (type && isIntrospectionType(type) && !usedTypes.includes(type)) {
         usedTypes.push(type);
       }
     },


### PR DESCRIPTION
## Description

This PR handles instances where the namedType is undefined and prevents it from being passed to the `isIntrospectionType` function which would result in a crash as outlined in  #8389

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I've ran and ensured that the existing tests pass

**Test Environment**:

- Operating System: `Linux`
- Node Version:     `v14.19.1`
- Package Manager:  `yarn@1.22.19`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

