### PR TITLE
fix(typescript-msw): use dedupeOperationSuffix option

### DIFF
--- a/packages/plugins/typescript/msw/tests/__snapshots__/msw.spec.ts.snap
+++ b/packages/plugins/typescript/msw/tests/__snapshots__/msw.spec.ts.snap
@@ -117,6 +117,48 @@ Array [
 ]
 `;
 
+exports[`msw Should use the "dedupeOperationSuffix" setting: content 1`] = `
+"
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockUserQuery((req, res, ctx) => {
+ *   return res(
+ *     ctx.data({ name })
+ *   )
+ * })
+ */
+export const mockUserQuery = (resolver: ResponseResolver<GraphQLRequest<UserQueryVariables>, GraphQLContext<UserQuery>, any>) =>
+  graphql.query<UserQuery, UserQueryVariables>(
+    'UserQuery',
+    resolver
+  )
+
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockUpdateUserMutation((req, res, ctx) => {
+ *   return res(
+ *     ctx.data({ name })
+ *   )
+ * })
+ */
+export const mockUpdateUserMutation = (resolver: ResponseResolver<GraphQLRequest<UpdateUserMutationVariables>, GraphQLContext<UpdateUserMutation>, any>) =>
+  graphql.mutation<UpdateUserMutation, UpdateUserMutationVariables>(
+    'UpdateUserMutation',
+    resolver
+  )
+"
+`;
+
+exports[`msw Should use the "dedupeOperationSuffix" setting: imports 1`] = `
+Array [
+  "import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'",
+]
+`;
+
 exports[`msw Should use the "importOperationTypesFrom" setting: content with types configured via importOperationTypesFrom 1`] = `
 "
 /**

--- a/packages/plugins/typescript/msw/tests/msw.spec.ts
+++ b/packages/plugins/typescript/msw/tests/msw.spec.ts
@@ -85,4 +85,28 @@ describe('msw', () => {
 
     expect(result.content).toMatchSnapshot('content with types configured via importOperationTypesFrom');
   });
+
+  it('Should use the "dedupeOperationSuffix" setting', async () => {
+    const queryNameWithOperation = 'UserQuery';
+    const mutationNameWithOperation = 'UpdateUserMutation';
+    const documentsWithDupes = [
+      { document: parse(`query ${queryNameWithOperation} { name }`) },
+      { document: parse(`mutation ${mutationNameWithOperation} { name }`) },
+    ];
+
+    const result = await plugin(null, documentsWithDupes, { dedupeOperationSuffix: true });
+
+    // handler function names
+    expect(result.content).toContain(`mock${queryNameWithOperation}`);
+    expect(result.content).not.toContain(`mock${queryNameWithOperation}Query`);
+    expect(result.content).toContain(`mock${mutationNameWithOperation}`);
+    expect(result.content).not.toContain(`mock${mutationNameWithOperation}Mutation`);
+
+    // handler strings
+    expect(result.content).toContain(`'${queryNameWithOperation}',`);
+    expect(result.content).toContain(`'${mutationNameWithOperation}',`);
+
+    expect(result.prepend).toMatchSnapshot('imports');
+    expect(result.content).toMatchSnapshot('content');
+  });
 });


### PR DESCRIPTION
## Description

Implements support for the `dedupeOperationSuffix` config option in the `@graphql-codegen/typescript-msw` plugin. Related issue: https://github.com/dotansimha/graphql-code-generator-community/issues/221

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):



## How Has This Been Tested?

New unit tests added in `typescript-msw` plugin to check for the expected behaviour of `dedupeOperationSuffix`.

**Test Environment**:

- OS:  MacOS 12.6
- `@graphql-codegen/cli`: 2.13.1
- NodeJS: 16

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

Decided to follow a similar pattern to other plugins, such as `ts-document` and `react-apollo`, by having a function that gets the operation suffix and provides an empty string(`''`) if the `dedupeOperationSuffix` is available.

Also, consolidated all the `handlerName` logic into one function - following existing patterns in other plugins as well.
