### PR TITLE
doc: add graphql-codegen-typescript-mock-data plugin in doc

### DIFF
--- a/website/src/category-to-packages.mjs
+++ b/website/src/category-to-packages.mjs
@@ -45,6 +45,7 @@ export const CategoryToPackages = {
     'typescript-vue-apollo',
     'typescript-vue-apollo-smart-ops',
     'typescript-vue-urql',
+    'typescript-mock-data',
   ],
   dart: ['flutter-freezed'],
 };

--- a/website/src/lib/plugins.ts
+++ b/website/src/lib/plugins.ts
@@ -291,6 +291,12 @@ export const PACKAGES: Record<
     icon: 'typescript',
     tags: ['plugin', 'typescript'],
   },
+  'typescript-mock-data': {
+    title: 'TypeScript Mock Data',
+    npmPackage: 'graphql-codegen-typescript-mock-data',
+    icon: 'typescript',
+    tags: ['plugin', 'typescript'],
+  },
   'typescript-mongodb': {
     title: 'TypeScript MongoDB',
     npmPackage: '@graphql-codegen/typescript-mongodb',

--- a/website/src/pages/plugins/typescript/_meta.json
+++ b/website/src/pages/plugins/typescript/_meta.json
@@ -25,5 +25,6 @@
   "typescript-validation-schema": "validation-schema",
   "typescript-vue-apollo": "vue-apollo",
   "typescript-vue-apollo-smart-ops": "vue-apollo-smart-ops",
-  "typescript-vue-urql": "vue-urql"
+  "typescript-vue-urql": "vue-urql",
+  "typescript-mock-data": "typescript-mock-data"
 }

--- a/website/src/pages/plugins/typescript/typescript-mock-data.mdx
+++ b/website/src/pages/plugins/typescript/typescript-mock-data.mdx
@@ -1,0 +1,10 @@
+---
+title: typescript-mock-data
+---
+
+import { PluginApiDocs, PluginHeader } from '@/components/plugin'
+import { pluginGetStaticProps } from '@/lib/plugin-get-static-props'
+export const getStaticProps = pluginGetStaticProps(__filename)
+
+<PluginHeader />
+<PluginApiDocs />


### PR DESCRIPTION
## Description

Add [graphql-codegen-typescript-mock-data](https://github.com/ardeois/graphql-codegen-typescript-mock-data) in plugins page. It's a plugin for building mock data based on the schema. Very useful in unit test to avoid manually creating your mocks.

It's not very popular yet, but the plugin is already used by multiple users and I'm maintaining it for now
![CleanShot 2022-09-29 at 15 41 45](https://user-images.githubusercontent.com/1867939/193126910-5948f6e7-493e-4549-a724-44de01c0740c.png)
 I'm considering moving this project to your repo so you can own it, but this will be done later.

Note I didn't create any issue as it's a documentation PR only, but let me know if you prefer me to create an issue

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] ~I have added tests that prove my fix is effective or that my feature works~
- [x] ~New and existing unit tests pass locally with my changes~
- [x] ~Any dependent changes have been merged and published in downstream modules~

