### PR TITLE
Remove extension from operations file import

### DIFF
--- a/.changeset/beige-buckets-sleep.md
+++ b/.changeset/beige-buckets-sleep.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/visitor-plugin-common": patch
+---
+
+Remove extension from operations file import

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -483,9 +483,12 @@ export class ClientSideBaseVisitor<
       case DocumentMode.external: {
         if (this._collectedOperations.length > 0) {
           if (this.config.importDocumentNodeExternallyFrom === 'near-operation-file' && this._documents.length === 1) {
-            this._imports.add(
-              `import * as Operations from './${this.clearExtension(basename(this._documents[0].location))}';`
-            );
+            let documentPath = `./${this.clearExtension(basename(this._documents[0].location))}`;
+            if (this.config.emitLegacyCommonJSImports) {
+              documentPath += '.js';
+            }
+
+            this._imports.add(`import * as Operations from '${documentPath}';`);
           } else {
             if (!this.config.importDocumentNodeExternallyFrom) {
               // eslint-disable-next-line no-console

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -484,7 +484,7 @@ export class ClientSideBaseVisitor<
         if (this._collectedOperations.length > 0) {
           if (this.config.importDocumentNodeExternallyFrom === 'near-operation-file' && this._documents.length === 1) {
             this._imports.add(
-              `import * as Operations from './${this.clearExtension(basename(this._documents[0].location))}.js';`
+              `import * as Operations from './${this.clearExtension(basename(this._documents[0].location))}';`
             );
           } else {
             if (!this.config.importDocumentNodeExternallyFrom) {


### PR DESCRIPTION
## Description

#7978 added `.js` extensions all over the place. But this one seems wrong. In a typescript project, it will for example generate
`import * as Operations from './UserSelection.gql.js';` resulting in a bunch of errors because the files aren't there (they are `.ts` files)

#8370 #8331

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)