### PR TITLE
fix missing config in @graphql-codegen/client-preset

### DIFF
--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -175,6 +175,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
         pluginMap,
         schema: options.schema,
         config: {
+          ...options.config,
           inlineFragmentTypes: isMaskingFragments ? 'mask' : options.config['inlineFragmentTypes'],
           useTypeImports: options.config.useTypeImports,
         },


### PR DESCRIPTION
## Description

Pass down config in client-preset config.

Related #8435

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Confirmed it fixes #8435 in local

**Test Environment**:

Same as in #8435

