### PR TITLE
feat(preset/client): allow use of enumsAsType config option

### DIFF
--- a/.changeset/gold-mirrors-refuse.md
+++ b/.changeset/gold-mirrors-refuse.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/client-preset': patch
+---
+
+The client preset now allows the use of the `enumsAsTypes` config option

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -78,6 +78,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       useTypeImports: options.config.useTypeImports,
       skipTypename: options.config.skipTypename,
       arrayInputCoercion: options.config.arrayInputCoercion,
+      enumsAsTypes: options.config.enumsAsTypes,
     };
 
     const visitor = new ClientSideBaseVisitor(options.schemaAst!, [], options.config, options.config);

--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -484,6 +484,7 @@ The `client` preset allows the following `config` options:
 - [`namingConvention`](/plugins/typescript/typescript#config-api-reference): Available case functions in `change-case-all` are `camelCase`, `capitalCase`, `constantCase`, `dotCase`, `headerCase`, `noCase`, `paramCase`, `pascalCase`, `pathCase`, `sentenceCase`, `snakeCase`, `lowerCase`, `localeLowerCase`, `lowerCaseFirst`, `spongeCase`, `titleCase`, `upperCase`, `localeUpperCase` and `upperCaseFirst`
 - [`useTypeImports`](/plugins/typescript/typescript#config-api-reference): Will use `import type {}` rather than `import {}` when importing only types. This gives compatibility with TypeScript's `"importsNotUsedAsValues": "error"` option.
 - [`skipTypename`](/plugins/typescript/typescript#config-api-reference): Does not add `__typename` to the generated types, unless it was specified in the selection set.
+- [`enumsAsTypes`](/plugins/typescript/typescript#config-api-reference): Generates enum as TypeScript `type` instead of `enum`. Useful if you wish to generate `.d.ts` declaration file instead of `.ts`
 - [`arrayInputCoercion`](/plugins/typescript/typescript-operations#config-api-reference): The [GraphQL spec](https://spec.graphql.org/draft/#sel-FAHjBJFCAACE_Gh7d) allows arrays and a single primitive value for list input. This allows to deactivate that behavior to only accept arrays instead of single values.
 
 <br />


### PR DESCRIPTION
## Description

Related #8471

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Confirmed locally that it resolves #8471

**Test Environment**:

- OS: all
- NodeJS: v14, v16
- `graphql` version: 16.6.0
- `@graphql-codegen/cli`: 2.13.6

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


