### PR TITLE
:sparkles: NEW: handle global config.useTypeImports in graphql-modules

### DIFF
--- a/.changeset/nine-shrimps-beam.md
+++ b/.changeset/nine-shrimps-beam.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/graphql-modules-preset': patch
+---
+
+handle global config.useTypeImports in graphql-modules

--- a/packages/presets/graphql-modules/src/builder.ts
+++ b/packages/presets/graphql-modules/src/builder.ts
@@ -48,6 +48,7 @@ export function buildModule(
     schema,
     baseVisitor,
     useGraphQLModules,
+    useTypeImports = false,
   }: {
     importNamespace: string;
     importPath: string;
@@ -58,6 +59,7 @@ export function buildModule(
     baseVisitor: BaseVisitor;
     schema?: GraphQLSchema;
     useGraphQLModules: boolean;
+    useTypeImports?: boolean;
   }
 ): string {
   const picks: Record<RegistryKeys, Record<string, string[]>> = createObject(registryKeys, () => ({}));
@@ -118,10 +120,10 @@ export function buildModule(
   //
 
   // An actual output
-  const imports = [`import * as ${importNamespace} from "${importPath}";`];
+  const imports = [`import${useTypeImports ? ' type' : ''} * as ${importNamespace} from "${importPath}";`];
 
   if (useGraphQLModules) {
-    imports.push(`import * as gm from "graphql-modules";`);
+    imports.push(`import${useTypeImports ? ' type' : ''} * as gm from "graphql-modules";`);
   }
 
   let content = [

--- a/packages/presets/graphql-modules/src/index.ts
+++ b/packages/presets/graphql-modules/src/index.ts
@@ -12,6 +12,7 @@ export const preset: Types.OutputPreset<ModulesConfig> = {
     const { baseTypesPath, encapsulateModuleTypes } = options.presetConfig;
     const useGraphQLModules = getConfigValue(options?.presetConfig.useGraphQLModules, true);
     const requireRootResolvers = getConfigValue(options?.presetConfig.requireRootResolvers, false);
+    const useTypeImports = getConfigValue(options?.config.useTypeImports, false) || false;
 
     const cwd = resolve(options.presetConfig.cwd || process.cwd());
     const importTypesNamespace = options.presetConfig.importTypesNamespace || 'Types';
@@ -113,6 +114,7 @@ export const preset: Types.OutputPreset<ModulesConfig> = {
                   schema.getMutationType()?.name,
                   schema.getSubscriptionType()?.name,
                 ].filter(Boolean),
+                useTypeImports,
               }),
           },
         },

--- a/packages/presets/graphql-modules/tests/builder.spec.ts
+++ b/packages/presets/graphql-modules/tests/builder.spec.ts
@@ -163,6 +163,24 @@ test('should include import statement', () => {
   `);
 });
 
+test('should include import type statement', () => {
+  const output = buildModule('test', testDoc, {
+    importPath: '../types',
+    importNamespace: 'core',
+    encapsulate: 'none',
+    requireRootResolvers: false,
+    shouldDeclare: false,
+    rootTypes: ROOT_TYPES,
+    baseVisitor,
+    useGraphQLModules: true,
+    useTypeImports: true,
+  });
+
+  expect(output).toBeSimilarStringTo(`
+    import type * as core from "../types";
+  `);
+});
+
 test('should work with naming conventions', () => {
   const output = buildModule('test', parse(`type query_root { test: ID! } schema { query: query_root }`), {
     importPath: '../types',

--- a/packages/presets/graphql-modules/tests/integration.spec.ts
+++ b/packages/presets/graphql-modules/tests/integration.spec.ts
@@ -89,6 +89,35 @@ describe('Integration', () => {
     expect(output[4].content).toMatch(importStatement);
   });
 
+  test('should import with respect of useTypeImports config correctly', async () => {
+    const output = await executeCodegen({
+      generates: {
+        './tests/test-files/modules': {
+          schema: './tests/test-files/modules/*/types/*.graphql',
+          plugins: ['typescript', 'typescript-resolvers'],
+          preset: 'graphql-modules',
+          presetConfig: {
+            importBaseTypesFrom: '@types',
+            baseTypesPath: 'global-types.ts',
+            filename: 'module-types.ts',
+            encapsulateModuleTypes: 'none',
+          },
+        },
+      },
+      config: {
+        useTypeImports: true,
+      },
+    });
+
+    const importStatement = `import type * as Types from "@types";`;
+
+    expect(output.length).toBe(5);
+    expect(output[1].content).toMatch(importStatement);
+    expect(output[2].content).toMatch(importStatement);
+    expect(output[3].content).toMatch(importStatement);
+    expect(output[4].content).toMatch(importStatement);
+  });
+
   test('should allow to disable graphql-modules', async () => {
     const output = await executeCodegen({
       generates: {


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

This PR take the `config.useTypeImports` into account for the `graphql-modules` plugin.

Related [KitQL issue](https://github.com/jycouet/kitql/issues/234)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] 2 tests has been added for the CI. (and all previous tests are still passing)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~I have made corresponding changes to the documentation~ as it's taking care of a global config (it's not an additional one)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] ~Any dependent changes have been merged and published in downstream modules~