### PR TITLE
feat: Add stripIgnoredCharacters option (visitor-plugin-common) - continued

### DIFF
--- a/.changeset/nice-gifts-sparkle.md
+++ b/.changeset/nice-gifts-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': major
+---
+
+Add `stripIgnoredCharacters` option

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -7,6 +7,7 @@ import {
   FragmentSpreadNode,
   GraphQLSchema,
   Kind,
+  stripIgnoredCharacters,
 } from 'graphql';
 import { DepGraph } from 'dependency-graph';
 import gqlTag from 'graphql-tag';
@@ -208,6 +209,11 @@ export interface RawClientSideBasePluginConfig extends RawConfig {
    * @description If set to true, it will enable support for parsing variables on fragments.
    */
   experimentalFragmentVariables?: boolean;
+  /**
+   * @default false
+   * @description If set to true, any extraneous whitespace characters, etc. in the strings will be removed — using `graphql-js`'s `stripIgnoredCharacters` function. Has no effect if `documentMode` is set to `documentNode`.
+   */
+  stripIgnoredCharacters?: boolean;
 }
 
 export interface ClientSideBasePluginConfig extends ParsedConfig {
@@ -228,6 +234,7 @@ export interface ClientSideBasePluginConfig extends ParsedConfig {
   pureMagicComment?: boolean;
   optimizeDocumentNode: boolean;
   experimentalFragmentVariables?: boolean;
+  stripIgnoredCharacters?: boolean;
 }
 
 export class ClientSideBaseVisitor<
@@ -269,6 +276,7 @@ export class ClientSideBaseVisitor<
       importDocumentNodeExternallyFrom: getConfigValue(rawConfig.importDocumentNodeExternallyFrom, ''),
       pureMagicComment: getConfigValue(rawConfig.pureMagicComment, false),
       experimentalFragmentVariables: getConfigValue(rawConfig.experimentalFragmentVariables, false),
+      stripIgnoredCharacters: getConfigValue(rawConfig.stripIgnoredCharacters, false),
       ...additionalConfig,
     } as any);
 
@@ -381,12 +389,17 @@ export class ClientSideBaseVisitor<
       return JSON.stringify(gqlObj);
     }
     if (this.config.documentMode === DocumentMode.string) {
-      return '`' + doc + '`';
+      return '`' + (this.config.stripIgnoredCharacters ? stripIgnoredCharacters(doc) : doc) + '`';
     }
 
     const gqlImport = this._parseImport(this.config.gqlImport || 'graphql-tag');
 
-    return (gqlImport.propName || 'gql') + '`' + doc + '`';
+    return (
+      (gqlImport.propName || 'gql') +
+      '`' +
+      (this.config.stripIgnoredCharacters ? stripIgnoredCharacters(doc) : doc) +
+      '`'
+    );
   }
 
   protected _generateFragment(fragmentDocument: FragmentDefinitionNode): string | void {

--- a/packages/plugins/typescript/generic-sdk/src/visitor.ts
+++ b/packages/plugins/typescript/generic-sdk/src/visitor.ts
@@ -29,6 +29,7 @@ function isStreamOperation(operationAST: OperationDefinitionNode) {
 }
 
 export class GenericSdkVisitor extends ClientSideBaseVisitor<RawGenericSdkPluginConfig, GenericSdkPluginConfig> {
+  private _externalImportPrefix: string;
   private _operationsToInclude: {
     node: OperationDefinitionNode;
     documentVariableName: string;
@@ -56,6 +57,7 @@ export class GenericSdkVisitor extends ClientSideBaseVisitor<RawGenericSdkPlugin
     } else if (this.config.rawRequest) {
       this._additionalImports.push(`${importType} { ExecutionResult } from 'graphql';`);
     }
+    this._externalImportPrefix = this.config.importOperationTypesFrom ? `${this.config.importOperationTypesFrom}.` : '';
   }
 
   protected buildOperation(
@@ -84,6 +86,7 @@ export class GenericSdkVisitor extends ClientSideBaseVisitor<RawGenericSdkPlugin
     const usingObservable = !!this.config.usingObservableFrom;
     const allPossibleActions = this._operationsToInclude
       .map(o => {
+        const operationName = o.node.name.value;
         const optionalVariables =
           !o.node.variableDefinitions ||
           o.node.variableDefinitions.length === 0 ||
@@ -92,7 +95,7 @@ export class GenericSdkVisitor extends ClientSideBaseVisitor<RawGenericSdkPlugin
         const resultData = this.config.rawRequest
           ? `ExecutionResult<${o.operationResultType}, E>`
           : o.operationResultType;
-        return `${o.node.name.value}(variables${optionalVariables ? '?' : ''}: ${
+        return `${operationName}(variables${optionalVariables ? '?' : ''}: ${
           o.operationVariablesTypes
         }, options?: C): ${returnType}<${resultData}> {
   return requester<${o.operationResultType}, ${o.operationVariablesTypes}>(${
@@ -100,6 +103,7 @@ export class GenericSdkVisitor extends ClientSideBaseVisitor<RawGenericSdkPlugin
         }, variables, options) as ${returnType}<${resultData}>;
 }`;
       })
+      .filter(Boolean)
       .map(s => indentMultiline(s, 2));
 
     const documentNodeType = this.config.documentMode === DocumentMode.string ? 'string' : 'DocumentNode';

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -3,7 +3,6 @@ import { parse, buildClientSchema, buildSchema } from 'graphql';
 import { plugin } from '../src/index.js';
 import { plugin as tsPlugin } from '../../typescript/src/index.js';
 import { mergeOutputs, Types } from '@graphql-codegen/plugin-helpers';
-import { DocumentMode } from '@graphql-codegen/visitor-plugin-common';
 
 describe('TypeScript Operations Plugin', () => {
   const gitHuntSchema = buildClientSchema(require('../../../../../dev-test/githunt/schema.json'));


### PR DESCRIPTION
## Description

Adds a new stripIgnoredCharacters: boolean option to client-side-base-visitor that removes redundant characters (like line-breaks, whitespaces, etc.) from the query strings.

In the linked issue, I originally proposed doing .replace(/\s+/g, ' ').trim() on the strings, but that turned out to be an unreliable approach as it would fail to cover a number of cases:

- It doesn't remove extraneous whitespaces that are not consecutive, so like `query ( $var : Int! )` (should become `query ($var: Int!)`) or more commonly `query { foo bar }` (should become `query{foo bar}`).
- If you have a string literal inside the query, that contains more than one consecutive space or line breaks, it removes those but it obviously shouldn't.

This all means a GraphQL-specific minifier is actually needed to do this reliably,
Happily I found out there's a built-in function in [graphql-js](https://github.com/graphql/graphql-js) for this very task! stripIgnoredCharacters — see https://github.com/graphql/graphql-js/issues/1523, which does precisely this.

## Related # (issue)

Related to #5616 and continuation of #8322

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I've added a test in `ts-documents.spec.ts`, but I'm not really sure this is the best location. I looked at how other options are tested but it seems there are barely any tests for the client visitor.

**Test Environment**:

- OS: Mac M1
- `@graphql-codegen/...`: latest
- NodeJS: v16.18

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This is the continuation of PR https://github.com/dotansimha/graphql-code-generator/pull/8322 all credits go to @aradalvand