### PR TITLE
feat(apollo-client-helpers): optionally generate types for FieldPolicy

### DIFF
--- a/.changeset/new-chairs-whisper.md
+++ b/.changeset/new-chairs-whisper.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-apollo-client-helpers': minor
+---
+
+Optionally generate types for `FieldPolicy` and `FieldReadFunction`

--- a/packages/plugins/typescript/apollo-client-helpers/src/config.ts
+++ b/packages/plugins/typescript/apollo-client-helpers/src/config.ts
@@ -41,4 +41,11 @@ export type ApolloClientHelpersConfig = {
    *
    */
   requirePoliciesForAllTypes?: boolean;
+  /**
+   * @name baseTypesPath
+   * @type string
+   * @description The base schema types file, used to type `FieldPolicy` and `FieldReadFunction`.
+   *
+   */
+  baseTypesPath?: string;
 };

--- a/packages/plugins/typescript/apollo-client-helpers/src/config.ts
+++ b/packages/plugins/typescript/apollo-client-helpers/src/config.ts
@@ -48,4 +48,8 @@ export type ApolloClientHelpersConfig = {
    *
    */
   baseTypesPath?: string;
+  /**
+   * @description A flag to disable adding `.js` extension to the output file. Default: `true`.
+   */
+  emitLegacyCommonJSImports?: boolean;
 };

--- a/packages/plugins/typescript/apollo-client-helpers/src/index.ts
+++ b/packages/plugins/typescript/apollo-client-helpers/src/index.ts
@@ -40,7 +40,13 @@ function generateTypePoliciesSignature(
       );
 
       perTypePolicies.push(`export type ${fieldPolicyVarName} = {
-${fieldsNames.map(fieldName => `\t${fieldName}?: FieldPolicy<any> | FieldReadFunction<any>`).join(',\n')}
+${fieldsNames
+  .map(fieldName =>
+    config.baseTypesPath
+      ? `\t${fieldName}?: FieldPolicy<Types.${typeName}['${fieldName}'], Types.${typeName}['${fieldName}'] | Reference> | FieldReadFunction<Types.${typeName}['${fieldName}'], Types.${typeName}['${fieldName}'] | Reference>`
+      : `\t${fieldName}?: FieldPolicy<any> | FieldReadFunction<any>`
+  )
+  .join(',\n')}
 };`);
 
       return {
@@ -73,10 +79,16 @@ ${fieldsNames.map(fieldName => `\t${fieldName}?: FieldPolicy<any> | FieldReadFun
 
   return {
     prepend: [
+      config.baseTypesPath
+        ? `import ${config.useTypeImports ? 'type ' : ''}{ Reference } from '@apollo/client';`
+        : null,
       `import ${
         config.useTypeImports ? 'type ' : ''
       }{ FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';`,
-    ],
+      config.baseTypesPath
+        ? `import ${config.useTypeImports ? 'type ' : ''}* as Types from './${config.baseTypesPath}';`
+        : null,
+    ].filter(Boolean),
     content: [...perTypePolicies, rootContent].join('\n'),
   };
 }

--- a/packages/plugins/typescript/apollo-client-helpers/src/index.ts
+++ b/packages/plugins/typescript/apollo-client-helpers/src/index.ts
@@ -86,7 +86,9 @@ ${fieldsNames
         config.useTypeImports ? 'type ' : ''
       }{ FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';`,
       config.baseTypesPath
-        ? `import ${config.useTypeImports ? 'type ' : ''}* as Types from './${config.baseTypesPath}';`
+        ? `import ${config.useTypeImports ? 'type ' : ''}* as Types from './${config.baseTypesPath}${
+            config.emitLegacyCommonJSImports ? '' : '.js'
+          }';`
         : null,
     ].filter(Boolean),
     content: [...perTypePolicies, rootContent].join('\n'),

--- a/packages/plugins/typescript/apollo-client-helpers/tests/__snapshots__/apollo-client-helpers.spec.ts.snap
+++ b/packages/plugins/typescript/apollo-client-helpers/tests/__snapshots__/apollo-client-helpers.spec.ts.snap
@@ -24,6 +24,32 @@ export type StrictTypedTypePolicies = {
 export type TypedTypePolicies = StrictTypedTypePolicies & TypePolicies;"
 `;
 
+exports[`apollo-client-helpers Should output typePolicies object with baseTypesPath: gqltypes 1`] = `
+"import { Reference } from '@apollo/client';
+import { FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';
+import * as Types from './gqltypes';
+export type QueryKeySpecifier = ('user' | QueryKeySpecifier)[];
+export type QueryFieldPolicy = {
+	user?: FieldPolicy<Types.Query['user'], Types.Query['user'] | Reference> | FieldReadFunction<Types.Query['user'], Types.Query['user'] | Reference>
+};
+export type UserKeySpecifier = ('id' | 'name' | UserKeySpecifier)[];
+export type UserFieldPolicy = {
+	id?: FieldPolicy<Types.User['id'], Types.User['id'] | Reference> | FieldReadFunction<Types.User['id'], Types.User['id'] | Reference>,
+	name?: FieldPolicy<Types.User['name'], Types.User['name'] | Reference> | FieldReadFunction<Types.User['name'], Types.User['name'] | Reference>
+};
+export type StrictTypedTypePolicies = {
+	Query?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | QueryKeySpecifier | (() => undefined | QueryKeySpecifier),
+		fields?: QueryFieldPolicy,
+	},
+	User?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | UserKeySpecifier | (() => undefined | UserKeySpecifier),
+		fields?: UserFieldPolicy,
+	}
+};
+export type TypedTypePolicies = StrictTypedTypePolicies & TypePolicies;"
+`;
+
 exports[`apollo-client-helpers Should output typePolicies object with requireKeyFields: true 1`] = `
 "import { FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';
 export type QueryKeySpecifier = ('user' | QueryKeySpecifier)[];

--- a/packages/plugins/typescript/apollo-client-helpers/tests/__snapshots__/apollo-client-helpers.spec.ts.snap
+++ b/packages/plugins/typescript/apollo-client-helpers/tests/__snapshots__/apollo-client-helpers.spec.ts.snap
@@ -27,6 +27,32 @@ export type TypedTypePolicies = StrictTypedTypePolicies & TypePolicies;"
 exports[`apollo-client-helpers Should output typePolicies object with baseTypesPath: gqltypes 1`] = `
 "import { Reference } from '@apollo/client';
 import { FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';
+import * as Types from './gqltypes.js';
+export type QueryKeySpecifier = ('user' | QueryKeySpecifier)[];
+export type QueryFieldPolicy = {
+	user?: FieldPolicy<Types.Query['user'], Types.Query['user'] | Reference> | FieldReadFunction<Types.Query['user'], Types.Query['user'] | Reference>
+};
+export type UserKeySpecifier = ('id' | 'name' | UserKeySpecifier)[];
+export type UserFieldPolicy = {
+	id?: FieldPolicy<Types.User['id'], Types.User['id'] | Reference> | FieldReadFunction<Types.User['id'], Types.User['id'] | Reference>,
+	name?: FieldPolicy<Types.User['name'], Types.User['name'] | Reference> | FieldReadFunction<Types.User['name'], Types.User['name'] | Reference>
+};
+export type StrictTypedTypePolicies = {
+	Query?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | QueryKeySpecifier | (() => undefined | QueryKeySpecifier),
+		fields?: QueryFieldPolicy,
+	},
+	User?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | UserKeySpecifier | (() => undefined | UserKeySpecifier),
+		fields?: UserFieldPolicy,
+	}
+};
+export type TypedTypePolicies = StrictTypedTypePolicies & TypePolicies;"
+`;
+
+exports[`apollo-client-helpers Should output typePolicies object with baseTypesPath: gqltypes and emitLegacyCommonJSImports: true 1`] = `
+"import { Reference } from '@apollo/client';
+import { FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';
 import * as Types from './gqltypes';
 export type QueryKeySpecifier = ('user' | QueryKeySpecifier)[];
 export type QueryFieldPolicy = {

--- a/packages/plugins/typescript/apollo-client-helpers/tests/apollo-client-helpers.spec.ts
+++ b/packages/plugins/typescript/apollo-client-helpers/tests/apollo-client-helpers.spec.ts
@@ -56,4 +56,25 @@ describe('apollo-client-helpers', () => {
     expect(result).toContain(`Query?:`);
     expect(result).toMatchSnapshot();
   });
+
+  it('Should output typePolicies object with baseTypesPath: gqltypes', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        user: User!
+      }
+      type User {
+        id: ID!
+        name: String!
+      }
+    `);
+    const result = mergeOutputs([
+      await plugin(schema, [], {
+        baseTypesPath: 'gqltypes',
+      }),
+    ]);
+    expect(result).toContain(
+      `user?: FieldPolicy<Types.Query['user'], Types.Query['user'] | Reference> | FieldReadFunction<Types.Query['user'], Types.Query['user'] | Reference>`
+    );
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/plugins/typescript/apollo-client-helpers/tests/apollo-client-helpers.spec.ts
+++ b/packages/plugins/typescript/apollo-client-helpers/tests/apollo-client-helpers.spec.ts
@@ -77,4 +77,26 @@ describe('apollo-client-helpers', () => {
     );
     expect(result).toMatchSnapshot();
   });
+
+  it('Should output typePolicies object with baseTypesPath: gqltypes and emitLegacyCommonJSImports: true', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        user: User!
+      }
+      type User {
+        id: ID!
+        name: String!
+      }
+    `);
+    const result = mergeOutputs([
+      await plugin(schema, [], {
+        baseTypesPath: 'gqltypes',
+        emitLegacyCommonJSImports: true,
+      }),
+    ]);
+    expect(result).toContain(
+      `user?: FieldPolicy<Types.Query['user'], Types.Query['user'] | Reference> | FieldReadFunction<Types.Query['user'], Types.Query['user'] | Reference>`
+    );
+    expect(result).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

I'm a rebel (I was prototyping if it was possible, and why not open a PR 😅)

## Description

Currently all type policies are typed as `any`, meaning no type safety in custom read functions.

Related # (issue) N/A

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

- In my own project
- Unit test

**Test Environment**:

- OS:
- `@graphql-codegen/...`:  `2.13.7`
- NodeJS: `16.18.0`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

- I'm not sure about the `References` change. It should be allowed as return value, but this now also comes as `existing` to `merge` functions. Might just be a weakness in the Apollo types?
- Client fields are not in my `gqltypes`, not sure how to deal with it 😅 Shouldn't block an initial release, tho.