### PR TITLE
export type to support isolatedModules

### DIFF
--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -342,7 +342,7 @@ export class TsVisitor<
 
     // In case of mapped external enum string
     if (this.config.enumValues[enumName] && this.config.enumValues[enumName].sourceFile) {
-      return `export { ${this.config.enumValues[enumName].typeIdentifier} };\n`;
+      return `export type { ${this.config.enumValues[enumName].typeIdentifier} };\n`;
     }
 
     const getValueFromConfig = (enumValue: string | number) => {


### PR DESCRIPTION


## Description

Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type' 

Related # (issue) 

#6773 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
