### PR TITLE
Fix @oneOf support broken with declaration kind other than type

### DIFF
--- a/.changeset/afraid-maps-complain.md
+++ b/.changeset/afraid-maps-complain.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript': patch
+---
+
+Fix incompatibility between `@oneOf` input types and declaration kind other than `type`

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -624,9 +624,9 @@ export class BaseTypesVisitor<
   }
 
   getInputObjectOneOfDeclarationBlock(node: InputObjectTypeDefinitionNode): DeclarationBlock {
-    // Since oneOf declarations (almost) always result in a
-    // union, we have to force a declaration kind of `type`.
-    const declarationKind = 'type';
+    // As multiple fields always result in a union, we have
+    // to force a declaration kind of `type` in this case
+    const declarationKind = node.fields.length === 1 ? this._parsedConfig.declarationKind.input : 'type';
     return new DeclarationBlock(this._declarationBlockConfig)
       .export()
       .asKind(declarationKind)

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -624,6 +624,8 @@ export class BaseTypesVisitor<
   }
 
   getInputObjectOneOfDeclarationBlock(node: InputObjectTypeDefinitionNode): DeclarationBlock {
+    // Since a oneOf declaration is always a union
+    // we have to force a type declaration kind.
     const declarationKind = 'type';
     return new DeclarationBlock(this._declarationBlockConfig)
       .export()

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -624,9 +624,10 @@ export class BaseTypesVisitor<
   }
 
   getInputObjectOneOfDeclarationBlock(node: InputObjectTypeDefinitionNode): DeclarationBlock {
+    const declarationKind = 'type';
     return new DeclarationBlock(this._declarationBlockConfig)
       .export()
-      .asKind(this._parsedConfig.declarationKind.input)
+      .asKind(declarationKind)
       .withName(this.convertName(node))
       .withComment(node.description as any as string)
       .withContent(`\n` + node.fields.join('\n  |'));

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -624,8 +624,8 @@ export class BaseTypesVisitor<
   }
 
   getInputObjectOneOfDeclarationBlock(node: InputObjectTypeDefinitionNode): DeclarationBlock {
-    // Since a oneOf declaration is always a union
-    // we have to force a type declaration kind.
+    // Since oneOf declarations (almost) always result in a
+    // union, we have to force a declaration kind of `type`.
     const declarationKind = 'type';
     return new DeclarationBlock(this._declarationBlockConfig)
       .export()

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2635,7 +2635,29 @@ describe('TypeScript', () => {
         `);
       });
 
-      it('forces type declaration kind', async () => {
+      it('respects configured declaration kind with single field', async () => {
+        const schema = buildSchema(
+          /* GraphQL */ `
+          input Input @oneOf {
+            int: Int
+          }
+
+          type Query {
+            foo(input: Input!): Boolean!
+          }
+        `.concat(oneOfDirectiveDefinition)
+        );
+
+        const result = await plugin(schema, [], { declarationKind: 'interface' }, { outputFile: '' });
+
+        expect(result.content).toBeSimilarStringTo(`
+          export interface Input {
+            int: Scalars['Int'];
+          }
+        `);
+      });
+
+      it('forces declaration kind of type with multiple fields', async () => {
         const schema = buildSchema(
           /* GraphQL */ `
           input Input @oneOf {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -2635,6 +2635,29 @@ describe('TypeScript', () => {
         `);
       });
 
+      it('forces type declaration kind', async () => {
+        const schema = buildSchema(
+          /* GraphQL */ `
+          input Input @oneOf {
+            int: Int
+            boolean: Boolean
+          }
+
+          type Query {
+            foo(input: Input!): Boolean!
+          }
+        `.concat(oneOfDirectiveDefinition)
+        );
+
+        const result = await plugin(schema, [], { declarationKind: 'interface' }, { outputFile: '' });
+
+        expect(result.content).toBeSimilarStringTo(`
+          export type Input =
+            { int: Scalars['Int']; boolean?: never; }
+            | { int?: never; boolean: Scalars['Boolean']; };
+        `);
+      });
+
       it('raises exception for type with non-optional fields', async () => {
         const schema = buildSchema(
           /* GraphQL */ `


### PR DESCRIPTION
On #8024 it was suggested to remove support for `declarationKind` all together.
Since this is a breaking change and probably won't happen soon and things are currently broken if using a `declarationKind` other than `type`, I would like to propose hard-coding `@oneOf` declarations to `type`, regardless of the configured `declarationKind` as `type` is the only one working.

Fixes #7938