### PR TITLE
fix: top level ts-node registration bug

### DIFF
--- a/.changeset/silent-singers-cover.md
+++ b/.changeset/silent-singers-cover.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': major
+---
+
+register TypeScriptLoader when needed

--- a/.changeset/silent-singers-cover.md
+++ b/.changeset/silent-singers-cover.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-codegen/cli': major
+'@graphql-codegen/cli': minor
 ---
 
 register TypeScriptLoader when needed

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -21,9 +21,6 @@ import { createHash } from 'crypto';
 
 const { lstat } = promises;
 
-// #8437: conflict with `graphql-config` also using TypeScriptLoader(), causing a double `ts-node` register.
-const tsLoader = TypeScriptLoader({ transpileOnly: true });
-
 export type CodegenConfig = Types.Config;
 
 export type YamlCliFlags = {
@@ -77,6 +74,8 @@ function customLoader(ext: 'json' | 'yaml' | 'js' | 'ts') {
     }
 
     if (ext === 'ts') {
+      // #8437: conflict with `graphql-config` also using TypeScriptLoader(), causing a double `ts-node` register.
+      const tsLoader = TypeScriptLoader({ transpileOnly: true });
       return tsLoader(filepath, content);
     }
   }


### PR DESCRIPTION
## Description

This PR simply averts from using a top level variable for the `TypeScriptLoader` to prevent the unnecessary early registration of `ts-node`

Related #8588

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
