### PR TITLE
fix docs for client-preset

### DIFF
--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -27,7 +27,7 @@ export type ClientPresetConfig = {
    *    documents: ['src/**\/*.tsx', '!src\/gql/**\/*'],
    *    generates: {
    *       './src/gql/': {
-   *          preset: 'front-end',
+   *          preset: 'client',
    *          presetConfig: {
    *            fragmentMasking: false,
    *          }
@@ -51,7 +51,7 @@ export type ClientPresetConfig = {
    *    documents: ['src/**\/*.tsx', '!src\/gql/**\/*'],
    *    generates: {
    *       './src/gql/': {
-   *          preset: 'front-end',
+   *          preset: 'client',
    *          presetConfig: {
    *            gqlTagName: 'gql',
    *          }


### PR DESCRIPTION
According to https://the-guild.dev/graphql/codegen/docs/guides/react-vue the preset name is `client` not `front-end`