### PR TITLE
improve autogenerated jsdocs

### DIFF
--- a/.changeset/thick-ravens-try.md
+++ b/.changeset/thick-ravens-try.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/gql-tag-operations': patch
+---
+
+provide jsdoc comments for better IDE support

--- a/dev-test/gql-tag-operations-masking-star-wars/gql/gql.ts
+++ b/dev-test/gql-tag-operations-masking-star-wars/gql/gql.ts
@@ -42,7 +42,7 @@ export function gql(
  * ```
  *
  * The query argument is unknown!
- * Please regenerate the types or restart the typescript language server.
+ * Please regenerate the types.
  **/
 export function gql(source: string): unknown;
 

--- a/dev-test/gql-tag-operations-masking-star-wars/gql/gql.ts
+++ b/dev-test/gql-tag-operations-masking-star-wars/gql/gql.ts
@@ -2,6 +2,16 @@
 import * as types from './graphql.js';
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+/**
+ * Map of all GraphQL operations in the project.
+ *
+ * This map has several performance disadvantages:
+ * 1. It is not tree-shakeable, so it will include all operations in the project.
+ * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+ * 3. It does not support dead code elimination, so it will add unused operations.
+ *
+ * Therefore it is highly recommended to use the babel-plugin for production.
+ */
 const documents = {
   '\n  query HeroDetailsWithFragment($episode: Episode) {\n    hero(episode: $episode) {\n      ...HeroDetails\n    }\n  }\n':
     types.HeroDetailsWithFragmentDocument,
@@ -9,14 +19,33 @@ const documents = {
     types.HeroDetailsFragmentDoc,
 };
 
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function gql(
   source: '\n  query HeroDetailsWithFragment($episode: Episode) {\n    hero(episode: $episode) {\n      ...HeroDetails\n    }\n  }\n'
 ): typeof documents['\n  query HeroDetailsWithFragment($episode: Episode) {\n    hero(episode: $episode) {\n      ...HeroDetails\n    }\n  }\n'];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function gql(
   source: '\n  fragment HeroDetails on Character {\n    __typename\n    name\n    ... on Human {\n      height\n    }\n    ... on Droid {\n      primaryFunction\n    }\n  }\n'
 ): typeof documents['\n  fragment HeroDetails on Character {\n    __typename\n    name\n    ... on Human {\n      height\n    }\n    ... on Droid {\n      primaryFunction\n    }\n  }\n'];
 
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ *
+ *
+ * @example
+ * ```ts
+ * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * ```
+ *
+ * The query argument is unknown!
+ * Please regenerate the types or restart the typescript language server.
+ **/
 export function gql(source: string): unknown;
+
 export function gql(source: string) {
   return (documents as any)[source] ?? {};
 }

--- a/dev-test/gql-tag-operations-masking/gql/gql.ts
+++ b/dev-test/gql-tag-operations-masking/gql/gql.ts
@@ -2,6 +2,16 @@
 import * as types from './graphql.js';
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+/**
+ * Map of all GraphQL operations in the project.
+ *
+ * This map has several performance disadvantages:
+ * 1. It is not tree-shakeable, so it will include all operations in the project.
+ * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+ * 3. It does not support dead code elimination, so it will add unused operations.
+ *
+ * Therefore it is highly recommended to use the babel-plugin for production.
+ */
 const documents = {
   '\n  fragment TweetFragment on Tweet {\n    id\n    body\n    ...TweetAuthorFragment\n  }\n':
     types.TweetFragmentFragmentDoc,
@@ -12,20 +22,45 @@ const documents = {
   '\n  query TweetAppQuery {\n    ...TweetsFragment\n  }\n': types.TweetAppQueryDocument,
 };
 
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function gql(
   source: '\n  fragment TweetFragment on Tweet {\n    id\n    body\n    ...TweetAuthorFragment\n  }\n'
 ): typeof documents['\n  fragment TweetFragment on Tweet {\n    id\n    body\n    ...TweetAuthorFragment\n  }\n'];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function gql(
   source: '\n  fragment TweetAuthorFragment on Tweet {\n    id\n    author {\n      id\n      username\n    }\n  }\n'
 ): typeof documents['\n  fragment TweetAuthorFragment on Tweet {\n    id\n    author {\n      id\n      username\n    }\n  }\n'];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function gql(
   source: '\n  fragment TweetsFragment on Query {\n    Tweets {\n      id\n      ...TweetFragment\n    }\n  }\n'
 ): typeof documents['\n  fragment TweetsFragment on Query {\n    Tweets {\n      id\n      ...TweetFragment\n    }\n  }\n'];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function gql(
   source: '\n  query TweetAppQuery {\n    ...TweetsFragment\n  }\n'
 ): typeof documents['\n  query TweetAppQuery {\n    ...TweetsFragment\n  }\n'];
 
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ *
+ *
+ * @example
+ * ```ts
+ * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * ```
+ *
+ * The query argument is unknown!
+ * Please regenerate the types or restart the typescript language server.
+ **/
 export function gql(source: string): unknown;
+
 export function gql(source: string) {
   return (documents as any)[source] ?? {};
 }

--- a/dev-test/gql-tag-operations-masking/gql/gql.ts
+++ b/dev-test/gql-tag-operations-masking/gql/gql.ts
@@ -57,7 +57,7 @@ export function gql(
  * ```
  *
  * The query argument is unknown!
- * Please regenerate the types or restart the typescript language server.
+ * Please regenerate the types.
  **/
 export function gql(source: string): unknown;
 

--- a/dev-test/gql-tag-operations-urql/gql/gql.d.ts
+++ b/dev-test/gql-tag-operations-urql/gql/gql.d.ts
@@ -2,12 +2,21 @@
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
 declare module '@urql/core' {
+  /**
+   * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+   */
   export function gql(
     source: '\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n'
   ): typeof import('./graphql.js').FooDocument;
+  /**
+   * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+   */
   export function gql(
     source: '\n  fragment Lel on Tweet {\n    id\n    body\n  }\n'
   ): typeof import('./graphql.js').LelFragmentDoc;
+  /**
+   * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+   */
   export function gql(
     source: '\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n'
   ): typeof import('./graphql.js').BarDocument;

--- a/dev-test/gql-tag-operations/gql/gql.ts
+++ b/dev-test/gql-tag-operations/gql/gql.ts
@@ -47,7 +47,7 @@ export function gql(
  * ```
  *
  * The query argument is unknown!
- * Please regenerate the types or restart the typescript language server.
+ * Please regenerate the types.
  **/
 export function gql(source: string): unknown;
 

--- a/dev-test/gql-tag-operations/gql/gql.ts
+++ b/dev-test/gql-tag-operations/gql/gql.ts
@@ -2,23 +2,55 @@
 import * as types from './graphql.js';
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+/**
+ * Map of all GraphQL operations in the project.
+ *
+ * This map has several performance disadvantages:
+ * 1. It is not tree-shakeable, so it will include all operations in the project.
+ * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+ * 3. It does not support dead code elimination, so it will add unused operations.
+ *
+ * Therefore it is highly recommended to use the babel-plugin for production.
+ */
 const documents = {
   '\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n': types.FooDocument,
   '\n  fragment Lel on Tweet {\n    id\n    body\n  }\n': types.LelFragmentDoc,
   '\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n': types.BarDocument,
 };
 
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function gql(
   source: '\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n'
 ): typeof documents['\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n'];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function gql(
   source: '\n  fragment Lel on Tweet {\n    id\n    body\n  }\n'
 ): typeof documents['\n  fragment Lel on Tweet {\n    id\n    body\n  }\n'];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function gql(
   source: '\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n'
 ): typeof documents['\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n'];
 
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ *
+ *
+ * @example
+ * ```ts
+ * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * ```
+ *
+ * The query argument is unknown!
+ * Please regenerate the types or restart the typescript language server.
+ **/
 export function gql(source: string): unknown;
+
 export function gql(source: string) {
   return (documents as any)[source] ?? {};
 }

--- a/dev-test/gql-tag-operations/graphql/gql.ts
+++ b/dev-test/gql-tag-operations/graphql/gql.ts
@@ -47,7 +47,7 @@ export function graphql(
  * ```
  *
  * The query argument is unknown!
- * Please regenerate the types or restart the typescript language server.
+ * Please regenerate the types.
  **/
 export function graphql(source: string): unknown;
 

--- a/dev-test/gql-tag-operations/graphql/gql.ts
+++ b/dev-test/gql-tag-operations/graphql/gql.ts
@@ -2,23 +2,55 @@
 import * as types from './graphql.js';
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+/**
+ * Map of all GraphQL operations in the project.
+ *
+ * This map has several performance disadvantages:
+ * 1. It is not tree-shakeable, so it will include all operations in the project.
+ * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+ * 3. It does not support dead code elimination, so it will add unused operations.
+ *
+ * Therefore it is highly recommended to use the babel-plugin for production.
+ */
 const documents = {
   '\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n': types.FooDocument,
   '\n  fragment Lel on Tweet {\n    id\n    body\n  }\n': types.LelFragmentDoc,
   '\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n': types.BarDocument,
 };
 
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function graphql(
   source: '\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n'
 ): typeof documents['\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n'];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function graphql(
   source: '\n  fragment Lel on Tweet {\n    id\n    body\n  }\n'
 ): typeof documents['\n  fragment Lel on Tweet {\n    id\n    body\n  }\n'];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function graphql(
   source: '\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n'
 ): typeof documents['\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n'];
 
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ *
+ *
+ * @example
+ * ```ts
+ * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * ```
+ *
+ * The query argument is unknown!
+ * Please regenerate the types or restart the typescript language server.
+ **/
 export function graphql(source: string): unknown;
+
 export function graphql(source: string) {
   return (documents as any)[source] ?? {};
 }

--- a/packages/plugins/typescript/gql-tag-operations/src/index.ts
+++ b/packages/plugins/typescript/gql-tag-operations/src/index.ts
@@ -57,7 +57,16 @@ export const plugin: PluginFunction<{
     code.push(
       [
         `\n`,
+        `/**\n * The ${gqlTagName} function is used to parse GraphQL queries into a document that can be used by GraphQL clients.\n *\n`,
+        ` * \n * @example\n`,
+        ' * ```ts\n',
+        ' * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);\n',
+        ' * ```\n *\n',
+        ` * The query argument is unknown!\n`,
+        ` * Please regenerate the types or restart the typescript language server.\n`,
+        `**/\n`,
         `export function ${gqlTagName}(source: string): unknown;\n`,
+        `\n`,
         `export function ${gqlTagName}(source: string) {\n`,
         `  return (documents as any)[source] ?? {};\n`,
         `}\n`,
@@ -65,7 +74,6 @@ export const plugin: PluginFunction<{
         ...documentTypePartial,
       ].join('')
     );
-
     return code.join('');
   }
 
@@ -89,6 +97,13 @@ export const plugin: PluginFunction<{
 
 function getDocumentRegistryChunk(sourcesWithOperations: Array<SourceWithOperations> = []) {
   const lines = new Set<string>();
+  lines.add(
+    `/**\n * Map of all GraphQL operations in the project.\n *\n * This map has several performance disadvantages:\n`
+  );
+  lines.add(` * 1. It is not tree-shakeable, so it will include all operations in the project.\n`);
+  lines.add(` * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.\n`);
+  lines.add(` * 3. It does not support dead code elimination, so it will add unused operations.\n *\n`);
+  lines.add(` * Therefore it is highly recommended to use the babel-plugin for production. \n */\n`);
   lines.add(`const documents = {\n`);
 
   for (const { operations, ...rest } of sourcesWithOperations) {
@@ -123,7 +138,10 @@ function getGqlOverloadChunk(
         : emitLegacyCommonJSImports
         ? `typeof import('./graphql').${operations[0].initialName}`
         : `typeof import('./graphql.js').${operations[0].initialName}`;
-    lines.add(`export function ${gqlTagName}(source: ${JSON.stringify(originalString)}): ${returnType};\n`);
+    lines.add(
+      `/**\n * The ${gqlTagName} function is used to parse GraphQL queries into a document that can be used by GraphQL clients.\n */\n` +
+        `export function ${gqlTagName}(source: ${JSON.stringify(originalString)}): ${returnType};\n`
+    );
   }
 
   return lines;

--- a/packages/plugins/typescript/gql-tag-operations/src/index.ts
+++ b/packages/plugins/typescript/gql-tag-operations/src/index.ts
@@ -58,12 +58,12 @@ export const plugin: PluginFunction<{
       [
         `\n`,
         `/**\n * The ${gqlTagName} function is used to parse GraphQL queries into a document that can be used by GraphQL clients.\n *\n`,
-        ` * \n * @example\n`,
+        ` *\n * @example\n`,
         ' * ```ts\n',
         ' * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);\n',
         ' * ```\n *\n',
         ` * The query argument is unknown!\n`,
-        ` * Please regenerate the types or restart the typescript language server.\n`,
+        ` * Please regenerate the types.\n`,
         `**/\n`,
         `export function ${gqlTagName}(source: string): unknown;\n`,
         `\n`,
@@ -103,7 +103,7 @@ function getDocumentRegistryChunk(sourcesWithOperations: Array<SourceWithOperati
   lines.add(` * 1. It is not tree-shakeable, so it will include all operations in the project.\n`);
   lines.add(` * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.\n`);
   lines.add(` * 3. It does not support dead code elimination, so it will add unused operations.\n *\n`);
-  lines.add(` * Therefore it is highly recommended to use the babel-plugin for production. \n */\n`);
+  lines.add(` * Therefore it is highly recommended to use the babel-plugin for production.\n */\n`);
   lines.add(`const documents = {\n`);
 
   for (const { operations, ...rest } of sourcesWithOperations) {

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -40,17 +40,49 @@ export * from "./fragment-masking"`);
       import * as types from './graphql';
       import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
       const documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
       };
 
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
       export function graphql(source: string): unknown;
+
       export function graphql(source: string) {
         return (documents as any)[source] ?? {};
       }
@@ -96,17 +128,49 @@ export * from "./fragment-masking"`);
       import * as types from './graphql';
       import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
       const documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query b {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
       };
 
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  query a {\\n    a\\n  }\\n"): (typeof documents)["\\n  query a {\\n    a\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  query b {\\n    b\\n  }\\n"): (typeof documents)["\\n  query b {\\n    b\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
       export function graphql(source: string): unknown;
+
       export function graphql(source: string) {
         return (documents as any)[source] ?? {};
       }
@@ -144,17 +208,49 @@ export * from "./fragment-masking"`);
       import * as types from './graphql';
       import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
       const documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query b {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
       };
 
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  query a {\\n    a\\n  }\\n"): (typeof documents)["\\n  query a {\\n    a\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  query b {\\n    b\\n  }\\n"): (typeof documents)["\\n  query b {\\n    b\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
       export function graphql(source: string): unknown;
+
       export function graphql(source: string) {
         return (documents as any)[source] ?? {};
       }
@@ -193,17 +289,49 @@ export * from "./fragment-masking"`);
       import * as types from './graphql';
       import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
       const documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
       };
 
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
       export function graphql(source: string): unknown;
+
       export function graphql(source: string) {
         return (documents as any)[source] ?? {};
       }
@@ -284,22 +412,48 @@ export * from "./fragment-masking"`);
     expect(result.length).toBe(4);
     const gqlFile = result.find(file => file.filename === 'out1/gql.ts');
     expect(gqlFile.content).toMatchInlineSnapshot(`
-      "/* eslint-disable */
-      import * as types from './graphql';
-      import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+    "/* eslint-disable */
+    import * as types from './graphql';
+    import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
-      const documents = {
-          "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
-      };
+    /**
+     * Map of all GraphQL operations in the project.
+     *
+     * This map has several performance disadvantages:
+     * 1. It is not tree-shakeable, so it will include all operations in the project.
+     * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+     * 3. It does not support dead code elimination, so it will add unused operations.
+     *
+     * Therefore it is highly recommended to use the babel-plugin for production.
+     */
+    const documents = {
+        "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
+    };
 
-      export function graphql(source: "\\n  query a {\\n    a\\n  }\\n"): (typeof documents)["\\n  query a {\\n    a\\n  }\\n"];
+    /**
+     * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+     */
+    export function graphql(source: "\\n  query a {\\n    a\\n  }\\n"): (typeof documents)["\\n  query a {\\n    a\\n  }\\n"];
 
-      export function graphql(source: string): unknown;
-      export function graphql(source: string) {
-        return (documents as any)[source] ?? {};
-      }
+    /**
+     * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+     *
+     *
+     * @example
+     * \`\`\`ts
+     * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+     * \`\`\`
+     *
+     * The query argument is unknown!
+     * Please regenerate the types.
+    **/
+    export function graphql(source: string): unknown;
 
-      export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
+    export function graphql(source: string) {
+      return (documents as any)[source] ?? {};
+    }
+
+    export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
     `);
     const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
     expect(graphqlFile.content).toMatchInlineSnapshot(`
@@ -370,27 +524,59 @@ export * from "./fragment-masking"`);
       expect(indexFile.content).toMatchInlineSnapshot(`"export * from "./gql""`);
       const gqlFile = result.find(file => file.filename === 'out1/gql.ts');
       expect(gqlFile.content).toMatchInlineSnapshot(`
-        "/* eslint-disable */
-        import * as types from './graphql';
-        import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+      "/* eslint-disable */
+      import * as types from './graphql';
+      import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
-        const documents = {
-            "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
-            "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
-            "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
-        };
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
+      const documents = {
+          "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
+          "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
+      };
 
-        export function graphql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
-        export function graphql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
-        export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
+      export function graphql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
+      export function graphql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
+      export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
-        export function graphql(source: string): unknown;
-        export function graphql(source: string) {
-          return (documents as any)[source] ?? {};
-        }
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
+      export function graphql(source: string): unknown;
 
-        export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
-      `);
+      export function graphql(source: string) {
+        return (documents as any)[source] ?? {};
+      }
+
+      export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
+    `);
     });
 
     it('fragmentMasking: {}', async () => {
@@ -639,17 +825,49 @@ export * from "./fragment-masking.js"`);
       import * as types from './graphql.js';
       import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
       const documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
       };
 
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
       export function graphql(source: string): unknown;
+
       export function graphql(source: string) {
         return (documents as any)[source] ?? {};
       }
@@ -697,14 +915,26 @@ export * from "./fragment-masking.js"`);
         import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
         const documents = [];
+        /**
+         * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+         *
+         *
+         * @example
+         * \`\`\`ts
+         * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+         * \`\`\`
+         *
+         * The query argument is unknown!
+         * Please regenerate the types.
+        **/
         export function graphql(source: string): unknown;
+
         export function graphql(source: string) {
           return (documents as any)[source] ?? {};
         }
 
         export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
       `);
-
       // graphql.ts
       const graphqlFile = result.find(file => file.filename === 'out1/gql.ts');
       expect(graphqlFile).toBeDefined();

--- a/packages/presets/gql-tag-operations/tests/gql-tag-operations.spec.ts
+++ b/packages/presets/gql-tag-operations/tests/gql-tag-operations.spec.ts
@@ -39,17 +39,49 @@ describe('gql-tag-operations-preset', () => {
       import * as types from './graphql';
       import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
       const documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
       };
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
       export function gql(source: string): unknown;
+
       export function gql(source: string) {
         return (documents as any)[source] ?? {};
       }
@@ -94,23 +126,55 @@ describe('gql-tag-operations-preset', () => {
       import * as types from './graphql';
       import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
       const documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query b {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
       };
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  query a {\\n    a\\n  }\\n"): (typeof documents)["\\n  query a {\\n    a\\n  }\\n"];
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  query b {\\n    b\\n  }\\n"): (typeof documents)["\\n  query b {\\n    b\\n  }\\n"];
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
       export function gql(source: string): unknown;
+
       export function gql(source: string) {
         return (documents as any)[source] ?? {};
       }
 
       export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
-    `);
+  `);
 
     // graphql.ts
     const graphqlFile = result.find(file => file.filename === 'out1/gql.ts');
@@ -142,17 +206,49 @@ describe('gql-tag-operations-preset', () => {
       import * as types from './graphql';
       import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
       const documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query b {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
       };
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  query a {\\n    a\\n  }\\n"): (typeof documents)["\\n  query a {\\n    a\\n  }\\n"];
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  query b {\\n    b\\n  }\\n"): (typeof documents)["\\n  query b {\\n    b\\n  }\\n"];
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
       export function gql(source: string): unknown;
+
       export function gql(source: string) {
         return (documents as any)[source] ?? {};
       }
@@ -191,17 +287,49 @@ describe('gql-tag-operations-preset', () => {
       import * as types from './graphql';
       import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
       const documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
       };
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
       export function gql(source: string): unknown;
+
       export function gql(source: string) {
         return (documents as any)[source] ?? {};
       }
@@ -286,13 +414,39 @@ describe('gql-tag-operations-preset', () => {
       import * as types from './graphql';
       import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
       const documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
       };
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  query a {\\n    a\\n  }\\n"): (typeof documents)["\\n  query a {\\n    a\\n  }\\n"];
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
       export function gql(source: string): unknown;
+
       export function gql(source: string) {
         return (documents as any)[source] ?? {};
       }
@@ -730,17 +884,49 @@ describe('gql-tag-operations-preset', () => {
       import * as types from './graphql.js';
       import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
       const documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
       };
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
       export function gql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
+      /**
+       * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+      **/
       export function gql(source: string): unknown;
+
       export function gql(source: string) {
         return (documents as any)[source] ?? {};
       }


### PR DESCRIPTION
Related #8632

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

It adds some jsdoc comments to support devs when using the `client-preset`:

![image](https://user-images.githubusercontent.com/4113649/203369684-4470f218-a6bd-46ef-91ba-aff16682d715.png)

In case the generated types are out of sync it provides a hint to regenerate them:

![image](https://user-images.githubusercontent.com/4113649/203369820-2fa31468-7cd3-45b3-96c1-1d283057a185.png)

It explains why the babel-plugin should be used for production:

![image](https://user-images.githubusercontent.com/4113649/203369879-3f298485-415e-439d-b692-0edc84aed3f3.png)


## How Has This Been Tested?

Unfortunately I couldn't update the snapshots on my machine.  
Jest showed the following error:

`Jest: Couldn't locate all inline snapshots. `

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas