### PR TITLE
improve generation performance

### DIFF
--- a/.changeset/odd-files-train.md
+++ b/.changeset/odd-files-train.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+faster type generation

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -69,7 +69,6 @@
     "json-to-pretty-yaml": "^1.2.2",
     "listr2": "^4.0.5",
     "log-symbols": "^4.0.0",
-    "mkdirp": "^1.0.4",
     "shell-quote": "^1.7.3",
     "string-env-interpolation": "^1.0.1",
     "ts-log": "^2.2.3",

--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -153,8 +153,12 @@ function isConfiguredOutput(output: any): output is Types.ConfiguredOutput {
 async function hashFile(filePath: string): Promise<string | null> {
   try {
     return hash(await readFile(filePath));
-  } catch (e) {
-    // return null if file does not exist
-    return null;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      // return null if file does not exist
+      return null;
+    }
+    // rethrow unexpected errors
+    throw err;
   }
 }

--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -2,8 +2,7 @@ import { lifecycleHooks } from './hooks.js';
 import { Types } from '@graphql-codegen/plugin-helpers';
 import { executeCodegen } from './codegen.js';
 import { createWatcher } from './utils/watcher.js';
-import { fileExists, readFile, writeFile, unlinkFile } from './utils/file-system.js';
-import mkdirp from 'mkdirp';
+import { readFile, writeFile, unlinkFile, mkdirp } from './utils/file-system.js';
 import { dirname, join, isAbsolute } from 'path';
 import { debugLog } from './utils/debugging.js';
 import { CodegenContext, ensureContext } from './config.js';
@@ -57,7 +56,13 @@ export async function generate(
       () =>
         Promise.all(
           generationResult.map(async (result: Types.FileOutput) => {
-            const exists = await fileExists(result.filename);
+            const previousHash = recentOutputHash.get(result.filename) || (await hashFile(result.filename));
+            const exists = previousHash !== null;
+
+            // Store previous hash to avoid reading from disk again
+            if (previousHash) {
+              recentOutputHash.set(result.filename, previousHash);
+            }
 
             if (!shouldOverwrite(config, result.filename) && exists) {
               return;
@@ -65,33 +70,34 @@ export async function generate(
 
             const content = result.content || '';
             const currentHash = hash(content);
-            let previousHash = recentOutputHash.get(result.filename);
-
-            if (!previousHash && exists) {
-              previousHash = hash(await readFile(result.filename));
-            }
 
             if (previousHash && currentHash === previousHash) {
               debugLog(`Skipping file (${result.filename}) writing due to indentical hash...`);
               return;
-            } else if (context.checkMode) {
+            }
+
+            // skip updating file in dry mode
+            if (context.checkMode) {
               context.checkModeStaleFiles.push(result.filename);
-              return; // skip updating file in dry mode
+              return;
             }
 
             if (content.length === 0) {
               return;
             }
 
-            recentOutputHash.set(result.filename, currentHash);
-            const basedir = dirname(result.filename);
             await lifecycleHooks(result.hooks).beforeOneFileWrite(result.filename);
             await lifecycleHooks(config.hooks).beforeOneFileWrite(result.filename);
+
+            const basedir = dirname(result.filename);
             await mkdirp(basedir);
             const absolutePath = isAbsolute(result.filename)
               ? result.filename
               : join(input.cwd || process.cwd(), result.filename);
-            await writeFile(absolutePath, result.content);
+
+            await writeFile(absolutePath, content);
+            recentOutputHash.set(result.filename, currentHash);
+
             await lifecycleHooks(result.hooks).afterOneFileWrite(result.filename);
             await lifecycleHooks(config.hooks).afterOneFileWrite(result.filename);
           })
@@ -142,4 +148,13 @@ function shouldOverwrite(config: Types.Config, outputPath: string): boolean {
 
 function isConfiguredOutput(output: any): output is Types.ConfiguredOutput {
   return typeof output.plugins !== 'undefined';
+}
+
+async function hashFile(filePath: string): Promise<string | null> {
+  try {
+    return hash(await readFile(filePath));
+  } catch (e) {
+    // return null if file does not exist
+    return null;
+  }
 }

--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -89,11 +89,12 @@ export async function generate(
             await lifecycleHooks(result.hooks).beforeOneFileWrite(result.filename);
             await lifecycleHooks(config.hooks).beforeOneFileWrite(result.filename);
 
-            const basedir = dirname(result.filename);
-            await mkdirp(basedir);
             const absolutePath = isAbsolute(result.filename)
               ? result.filename
               : join(input.cwd || process.cwd(), result.filename);
+
+            const basedir = dirname(absolutePath);
+            await mkdirp(basedir);
 
             await writeFile(absolutePath, content);
             recentOutputHash.set(result.filename, currentHash);

--- a/packages/graphql-codegen-cli/src/utils/file-system.ts
+++ b/packages/graphql-codegen-cli/src/utils/file-system.ts
@@ -1,5 +1,5 @@
 import { unlink as fsUnlink, promises } from 'fs';
-const { writeFile: fsWriteFile, readFile: fsReadFile, stat: fsStat } = promises;
+const { writeFile: fsWriteFile, readFile: fsReadFile, mkdir } = promises;
 
 export function writeFile(filepath: string, content: string) {
   return fsWriteFile(filepath, content);
@@ -9,14 +9,10 @@ export function readFile(filepath: string) {
   return fsReadFile(filepath, 'utf-8');
 }
 
-export async function fileExists(filePath: string): Promise<boolean> {
-  try {
-    return (await fsStat(filePath)).isFile();
-  } catch (err) {
-    return false;
-  }
-}
-
 export function unlinkFile(filePath: string, cb?: (err?: Error) => any): void {
   fsUnlink(filePath, cb);
+}
+
+export function mkdirp(filePath: string) {
+  return mkdir(filePath, { recursive: true });
 }

--- a/packages/graphql-codegen-cli/tests/generate-and-save.spec.ts
+++ b/packages/graphql-codegen-cli/tests/generate-and-save.spec.ts
@@ -49,8 +49,8 @@ describe('generate-and-save', () => {
     const filename = 'overwrite.ts';
     const writeSpy = jest.spyOn(fs, 'writeFile').mockImplementation();
     // forces file to exist
-    const fileExistsSpy = jest.spyOn(fs, 'fileExists');
-    fileExistsSpy.mockImplementation(async file => file === filename);
+    const fileReadSpy = jest.spyOn(fs, 'readFile');
+    fileReadSpy.mockImplementation(async () => '');
 
     const output = await generate(
       {
@@ -71,7 +71,7 @@ describe('generate-and-save', () => {
 
     expect(output.length).toBe(1);
     // makes sure it checks if file is there
-    expect(fileExistsSpy).toHaveBeenCalledWith(filename);
+    expect(fileReadSpy).toHaveBeenCalledWith(filename);
     // makes sure it doesn't write a new file
     expect(writeSpy).not.toHaveBeenCalled();
   });
@@ -105,8 +105,8 @@ describe('generate-and-save', () => {
     const filename = 'overwrite.ts';
     const writeSpy = jest.spyOn(fs, 'writeFile').mockImplementation();
     // forces file to exist
-    const fileExistsSpy = jest.spyOn(fs, 'fileExists');
-    fileExistsSpy.mockImplementation(async file => file === filename);
+    const fileReadSpy = jest.spyOn(fs, 'readFile');
+    fileReadSpy.mockImplementation(async () => '');
 
     const output = await generate(
       {
@@ -126,7 +126,7 @@ describe('generate-and-save', () => {
 
     expect(output.length).toBe(1);
     // makes sure it checks if file is there
-    expect(fileExistsSpy).toHaveBeenCalledWith(filename);
+    expect(fileReadSpy).toHaveBeenCalledWith(filename);
     // makes sure it doesn't write a new file
     expect(writeSpy).not.toHaveBeenCalled();
   });
@@ -136,9 +136,6 @@ describe('generate-and-save', () => {
     const writeSpy = jest.spyOn(fs, 'writeFile').mockImplementation();
     const readSpy = jest.spyOn(fs, 'readFile').mockImplementation();
     readSpy.mockImplementation(async _f => '');
-    // forces file to exist
-    const fileExistsSpy = jest.spyOn(fs, 'fileExists');
-    fileExistsSpy.mockImplementation(async file => file === filename);
 
     const output = await generate(
       {


### PR DESCRIPTION
## Description

`graphql-codegen-cli/src/generate-and-save.ts` has more filesystem than neccessary:

1.  Checking for existence before reading. (from the [official nodejs docs](https://nodejs.org/docs/latest-v14.x/api/fs.html#fs_fs_exists_path_callback)):
> Using fs.exists() to check for the existence of a file before calling fs.open(), fs.readFile() or fs.writeFile() is not recommended.

2. After reading the file from disk and generating the hash, the hash is not stored.  
So if the `previousHash` matches the `currentHash` the file will be read again from disk.

3. `mkdirp` is now [built into node](https://nodejs.org/docs/latest-v14.x/api/fs.html#fs_fspromises_mkdir_path_options)

This PR improves all three cases and in addition fixes a bug where `input.cwd` is not passed to `mkdirp`.

## How Has This Been Tested?

All unit tests + tested on my machine - would love to get feedback from a windows user.

**Test Environment**:

- OS: MacOs 13
- `@graphql-codegen/...`:
- NodeJS: 16

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules