### PR TITLE
add prettier as optional feature to the codegen

### DIFF
--- a/.changeset/violet-eggs-jog.md
+++ b/.changeset/violet-eggs-jog.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/cli': minor
+'@graphql-codegen/plugin-helpers': patch
+---
+
+add prettier as optional feature to the codegen

--- a/packages/graphql-codegen-cli/src/prettify.ts
+++ b/packages/graphql-codegen-cli/src/prettify.ts
@@ -1,0 +1,34 @@
+import { debugLog } from './utils/debugging.js';
+
+/**
+ * Try to prettify the output.
+ * Will skip if prettier is not installed.
+ */
+export async function prettify(content: string, fileName: string) {
+  let prettier: typeof import('prettier');
+  try {
+    // prettier is an optional dependency
+    /* eslint-disable import/no-extraneous-dependencies */
+    prettier = await import('prettier');
+  } catch (e) {
+    debugLog(`Skipping prettier formatting as the prettier npm module is not installed`);
+    return content;
+  }
+  const { format, resolveConfig } = prettier;
+  let config: Awaited<ReturnType<typeof resolveConfig>>;
+  try {
+    config = await resolveConfig(fileName);
+  } catch (e) {
+    debugLog(`Could not resolve config for ${fileName}`);
+    config = {};
+  }
+  try {
+    return format(content, {
+      ...config,
+      filepath: fileName,
+    });
+  } catch (e) {
+    debugLog(`Could not prettify ${fileName}`);
+    return content;
+  }
+}

--- a/packages/graphql-codegen-cli/tests/prettify.spec.ts
+++ b/packages/graphql-codegen-cli/tests/prettify.spec.ts
@@ -1,0 +1,19 @@
+import { prettify } from '../src/prettify.js';
+
+describe('prettify', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('prettify content', async () => {
+    const result = await prettify(
+      `
+      export
+          default
+            42
+      `,
+      './demo.js'
+    );
+    expect(result).toBe('export default 42;\n');
+  });
+});

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -512,6 +512,10 @@ export namespace Types {
       globalIdentifier?: string;
     };
     /**
+     * @description A flag to prettify generated files before save. Works only if the prettier npm package is installed.
+     */
+    prettier?: boolean;
+    /**
      * @description Specifies scripts to run when events are happening in the codegen core.
      * Hooks defined on that level will effect all output files.
      *


### PR DESCRIPTION
## Description

This is a more of a proposal than a feature complete PR.

It adds first class prettier support **without** creating a dependency on prettier.

I believe adding prettier as first class feature would provide multiple benefits:

- consistent generated code style for all plugins and contrib plugins
- smarter change detection for less file writes
- easier to setup than lifecycle hooks

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

A new unit test. (`packages/graphql-codegen-cli/tests/prettify.spec.ts`)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If you like I can also turn this PR into a discussion.