### PR TITLE
improve life cycle hooks typings

### DIFF
--- a/.changeset/plenty-bottles-prove.md
+++ b/.changeset/plenty-bottles-prove.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/cli': patch
+'@graphql-codegen/plugin-helpers': patch
+---
+
+improve typings for life cycle hooks

--- a/.changeset/plenty-bottles-prove.md
+++ b/.changeset/plenty-bottles-prove.md
@@ -1,6 +1,6 @@
 ---
 '@graphql-codegen/cli': patch
-'@graphql-codegen/plugin-helpers': patch
+'@graphql-codegen/plugin-helpers': major
 ---
 
 improve typings for life cycle hooks

--- a/packages/graphql-codegen-cli/src/hooks.ts
+++ b/packages/graphql-codegen-cli/src/hooks.ts
@@ -15,6 +15,40 @@ const DEFAULT_HOOKS: Types.LifecycleHooksDefinition = {
   beforeAllFileWrite: [],
 };
 
+function normalizeHooks(_hooks: Partial<Types.LifecycleHooksDefinition>): {
+  [key in keyof Types.LifecycleHooksDefinition]: (string | Types.HookFunction)[];
+} {
+  const keys = Object.keys({
+    ...DEFAULT_HOOKS,
+    ..._hooks,
+  });
+
+  return keys.reduce(
+    (prev: { [key in keyof Types.LifecycleHooksDefinition]: (string | Types.HookFunction)[] }, hookName: string) => {
+      if (typeof _hooks[hookName] === 'string') {
+        return {
+          ...prev,
+          [hookName]: [_hooks[hookName]] as string[],
+        };
+      }
+      if (typeof _hooks[hookName] === 'function') {
+        return {
+          ...prev,
+          [hookName]: [_hooks[hookName]],
+        };
+      }
+      if (Array.isArray(_hooks[hookName])) {
+        return {
+          ...prev,
+          [hookName]: _hooks[hookName] as string[],
+        };
+      }
+      return prev;
+    },
+    {} as { [key in keyof Types.LifecycleHooksDefinition]: (string | Types.HookFunction)[] }
+  );
+}
+
 function execShellCommand(cmd: string): Promise<string> {
   return new Promise((resolve, reject) => {
     exec(
@@ -60,10 +94,7 @@ async function executeHooks(
 }
 
 export const lifecycleHooks = (_hooks: Partial<Types.LifecycleHooksDefinition> = {}) => {
-  const hooks = {
-    ...DEFAULT_HOOKS,
-    ..._hooks,
-  };
+  const hooks = normalizeHooks(_hooks);
 
   return {
     afterStart: async (): Promise<void> => executeHooks('afterStart', hooks.afterStart),

--- a/packages/graphql-codegen-cli/src/hooks.ts
+++ b/packages/graphql-codegen-cli/src/hooks.ts
@@ -4,7 +4,7 @@ import { exec } from 'child_process';
 import { delimiter, sep } from 'path';
 import { quote } from 'shell-quote';
 
-const DEFAULT_HOOKS: Types.LifecycleHooksDefinition<string[]> = {
+const DEFAULT_HOOKS: Types.LifecycleHooksDefinition = {
   afterStart: [],
   beforeDone: [],
   onWatchTriggered: [],
@@ -14,37 +14,6 @@ const DEFAULT_HOOKS: Types.LifecycleHooksDefinition<string[]> = {
   beforeOneFileWrite: [],
   beforeAllFileWrite: [],
 };
-
-function normalizeHooks(
-  _hooks: Partial<Types.LifecycleHooksDefinition>
-): Types.LifecycleHooksDefinition<(string | Types.HookFunction)[]> {
-  const keys = Object.keys({
-    ...DEFAULT_HOOKS,
-    ..._hooks,
-  });
-
-  return keys.reduce((prev: Types.LifecycleHooksDefinition<(string | Types.HookFunction)[]>, hookName: string) => {
-    if (typeof _hooks[hookName] === 'string') {
-      return {
-        ...prev,
-        [hookName]: [_hooks[hookName]] as string[],
-      };
-    }
-    if (typeof _hooks[hookName] === 'function') {
-      return {
-        ...prev,
-        [hookName]: [_hooks[hookName]],
-      };
-    }
-    if (Array.isArray(_hooks[hookName])) {
-      return {
-        ...prev,
-        [hookName]: _hooks[hookName] as string[],
-      };
-    }
-    return prev;
-  }, {} as Types.LifecycleHooksDefinition<(string | Types.HookFunction)[]>);
-}
 
 function execShellCommand(cmd: string): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -72,10 +41,11 @@ function execShellCommand(cmd: string): Promise<string> {
 
 async function executeHooks(
   hookName: string,
-  scripts: (string | Types.HookFunction)[] = [],
+  _scripts: Types.LifeCycleHookValue = [],
   args: string[] = []
 ): Promise<void> {
   debugLog(`Running lifecycle hook "${hookName}" scripts...`);
+  const scripts = Array.isArray(_scripts) ? _scripts : [_scripts];
 
   const quotedArgs = quote(args);
   for (const script of scripts) {
@@ -90,7 +60,10 @@ async function executeHooks(
 }
 
 export const lifecycleHooks = (_hooks: Partial<Types.LifecycleHooksDefinition> = {}) => {
-  const hooks = normalizeHooks(_hooks);
+  const hooks = {
+    ...DEFAULT_HOOKS,
+    ..._hooks,
+  };
 
   return {
     afterStart: async (): Promise<void> => executeHooks('afterStart', hooks.afterStart),

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -524,50 +524,52 @@ export namespace Types {
   export type PluginOutput = string | ComplexPluginOutput;
   export type HookFunction = (...args: any[]) => void | Promise<void>;
 
+  export type LifeCycleHookValue = string | HookFunction | (string | HookFunction)[];
+
   /**
    * @description All available lifecycle hooks
    * @additionalProperties false
    */
-  export type LifecycleHooksDefinition<T = string | HookFunction | (string | HookFunction)[]> = {
+  export type LifecycleHooksDefinition = {
     /**
      * @description Triggered with no arguments when the codegen starts (after the `codegen.yml` has beed parsed).
      *
      * Specify a shell command to run.
      */
-    afterStart: T;
+    afterStart: LifeCycleHookValue;
     /**
      * @description Triggered with no arguments, right before the codegen closes, or when watch mode is stopped.
      *
      * Specify a shell command to run.
      */
-    beforeDone: T;
+    beforeDone: LifeCycleHookValue;
     /**
      * @description Triggered every time a file changes when using watch mode.
      * Triggered with two arguments: the type of the event (for example, `changed`) and the path of the file.
      */
-    onWatchTriggered: T;
+    onWatchTriggered: LifeCycleHookValue;
     /**
      * @description Triggered in case of a general error in the codegen. The argument is a string containing the error.
      */
-    onError: T;
+    onError: LifeCycleHookValue;
     /**
      * @description Triggered after a file is written to the file-system. Executed with the path for the file.
      * If the content of the file hasn't changed since last execution - this hooks won't be triggered.
      *
      * > This is a very useful hook, you can use it for integration with Prettier or other linters.
      */
-    afterOneFileWrite: T;
+    afterOneFileWrite: LifeCycleHookValue;
     /**
      * @description Executed after writing all the files to the file-system.
      * Triggered with multiple arguments - paths for all files.
      */
-    afterAllFileWrite: T;
+    afterAllFileWrite: LifeCycleHookValue;
     /**
      * @description Triggered before a file is written to the file-system. Executed with the path for the file.
      *
      * If the content of the file hasn't changed since last execution - this hooks won't be triggered.
      */
-    beforeOneFileWrite: T;
+    beforeOneFileWrite: LifeCycleHookValue;
     /**
      * @description Executed after the codegen has done creating the output and before writing the files to the file-system.
      *
@@ -575,7 +577,7 @@ export namespace Types {
      *
      * > Not all the files will be actually written to the file-system, because this is triggered before checking if the file has changed since last execution.
      */
-    beforeAllFileWrite: T;
+    beforeAllFileWrite: LifeCycleHookValue;
   };
 
   export type SkipDocumentsValidationOptions =


### PR DESCRIPTION
## Description

I would like to prepare a PR for #8643.  
Right now the life cycle hooks are using generics and reducers which kind of blocks an easy implementation.

Therefore I removed the reducer and the generic type.

Related #8643

## Type of change

Please delete options that are not relevant.

- [x] Internal Typings


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules