### PR TITLE
Features/improved before one file write hook

### DIFF
--- a/.changeset/curvy-pens-watch.md
+++ b/.changeset/curvy-pens-watch.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/cli': minor
+'@graphql-codegen/plugin-helpers': minor
+---
+
+the life cycle hook beforeOneFileWrite is now able to modify the generated content

--- a/packages/graphql-codegen-cli/tests/generate-and-save.spec.ts
+++ b/packages/graphql-codegen-cli/tests/generate-and-save.spec.ts
@@ -213,4 +213,28 @@ describe('generate-and-save', () => {
     // makes sure it doesn't write a new file
     expect(writeSpy).toHaveBeenCalled();
   });
+  test('should allow to alter the content with the beforeOneFileWrite hook', async () => {
+    const filename = 'modify.ts';
+    const writeSpy = jest.spyOn(fs, 'writeFile').mockImplementation();
+
+    const output = await generate(
+      {
+        schema: SIMPLE_TEST_SCHEMA,
+        generates: {
+          [filename]: {
+            plugins: ['typescript'],
+            hooks: {
+              beforeOneFileWrite: [() => 'new content'],
+            },
+          },
+        },
+      },
+      true
+    );
+
+    expect(output.length).toBe(1);
+    expect(output[0].content).toMatch('new content');
+    // makes sure it doesn't write a new file
+    expect(writeSpy).toHaveBeenCalled();
+  });
 });

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -523,8 +523,14 @@ export namespace Types {
   export type ComplexPluginOutput = { content: string; prepend?: string[]; append?: string[] };
   export type PluginOutput = string | ComplexPluginOutput;
   export type HookFunction = (...args: any[]) => void | Promise<void>;
+  export type HookAlterFunction = (...args: any[]) => void | string | Promise<void | string>;
 
   export type LifeCycleHookValue = string | HookFunction | (string | HookFunction)[];
+  export type LifeCycleAlterHookValue =
+    | string
+    | HookFunction
+    | HookAlterFunction
+    | (string | HookFunction | HookAlterFunction)[];
 
   /**
    * @description All available lifecycle hooks
@@ -565,11 +571,14 @@ export namespace Types {
      */
     afterAllFileWrite: LifeCycleHookValue;
     /**
-     * @description Triggered before a file is written to the file-system. Executed with the path for the file.
+     * @description Triggered before a file is written to the file-system.
+     * Executed with the path and content for the file.
+     *
+     * Returning a string will override the content of the file.
      *
      * If the content of the file hasn't changed since last execution - this hooks won't be triggered.
      */
-    beforeOneFileWrite: LifeCycleHookValue;
+    beforeOneFileWrite: LifeCycleAlterHookValue;
     /**
      * @description Executed after the codegen has done creating the output and before writing the files to the file-system.
      *


### PR DESCRIPTION
## Description

Allow to modify content from `beforeOneFileWrite` for faster and more efficient post modifications.  
See entire discussion in #8643.

<s>This PR should not be merged before #8652 and #8661 as this PR builds ontop of a refactoring introduced in those PRs.</s>  
Update: #8652 and #8661 have been merged.

Related #8643

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] On my machine
- [x] New unit test

**Test Environment**:

- OS: MacOS 13

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
