### PR TITLE
Fix issue where selection set flattening uses the wrong parent type

### DIFF
--- a/.changeset/warm-trainers-shout.md
+++ b/.changeset/warm-trainers-shout.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-operations': patch
+---
+
+Fix issue where selection set flattening uses the wrong parent type

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -248,7 +248,8 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
   }
 
   protected flattenSelectionSet(
-    selections: ReadonlyArray<SelectionNode>
+    selections: ReadonlyArray<SelectionNode>,
+    parentSchemaType?: GraphQLObjectType<any, any>
   ): Map<string, Array<SelectionNode | FragmentSpreadUsage>> {
     const selectionNodesByTypeName = new Map<string, Array<SelectionNode | FragmentSpreadUsage>>();
     const inlineFragmentSelections: InlineFragmentNode[] = [];
@@ -270,10 +271,16 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     }
 
     if (fieldNodes.length) {
-      inlineFragmentSelections.push(this._createInlineFragmentForFieldNodes(this._parentSchemaType, fieldNodes));
+      inlineFragmentSelections.push(
+        this._createInlineFragmentForFieldNodes(parentSchemaType ?? this._parentSchemaType, fieldNodes)
+      );
     }
 
-    this._collectInlineFragments(this._parentSchemaType, inlineFragmentSelections, selectionNodesByTypeName);
+    this._collectInlineFragments(
+      parentSchemaType ?? this._parentSchemaType,
+      inlineFragmentSelections,
+      selectionNodesByTypeName
+    );
     const fragmentsUsage = this.buildFragmentSpreadsUsage(fragmentSpreads);
 
     for (const [typeName, records] of Object.entries(fragmentsUsage)) {
@@ -513,7 +520,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
           fragmentType.getTypes().find(objectType => objectType.name === parentSchemaType.name))
       ) {
         // also process fields from fragment that apply for this parentType
-        const flatten = this.flattenSelectionSet(selectionNode.selectionNodes);
+        const flatten = this.flattenSelectionSet(selectionNode.selectionNodes, parentSchemaType);
         const typeNodes = flatten.get(parentSchemaType.name) ?? [];
         selectionNodes.push(...typeNodes);
         for (const iinterface of parentSchemaType.getInterfaces()) {

--- a/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
+++ b/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
@@ -133,6 +133,20 @@ function test(q: QQuery) {
     }"
 `;
 
+exports[`TypeScript Operations Plugin Issues #6874 - generates types when parent type differs from spread fragment member types and preResolveTypes=true 1`] = `
+"export type SnakeQueryQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type SnakeQueryQuery = { __typename?: 'Query', snake: { __typename?: 'Snake', name: string, features: { __typename?: 'SnakeFeatures', color: string, length: number } } | { __typename?: 'Error' } };
+
+type AnimalFragment_Bat_Fragment = { __typename?: 'Bat', features: { __typename?: 'BatFeatures', color: string, wingspan: number } };
+
+type AnimalFragment_Snake_Fragment = { __typename?: 'Snake', features: { __typename?: 'SnakeFeatures', color: string, length: number } };
+
+export type AnimalFragmentFragment = AnimalFragment_Bat_Fragment | AnimalFragment_Snake_Fragment;
+"
+`;
+
 exports[`TypeScript Operations Plugin Selection Set Should generate the correct __typename when using both inline fragment and spread over type 1`] = `
 "export type UserQueryQueryVariables = Exact<{ [key: string]: never; }>;
 


### PR DESCRIPTION
## Description

Related https://github.com/dotansimha/graphql-code-generator/issues/7364 and https://github.com/dotansimha/graphql-code-generator/pull/6874

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Here's a screenshot of how the test fails without the bugfix:
<img width="1200" alt="failing_test" src="https://user-images.githubusercontent.com/4051258/204677829-b3702bdf-049f-4dd4-88b1-e04bb7496786.png">


## How Has This Been Tested?

- I created a new unit test in ts-documents.spec.ts that fails before the fix and succeeds afterwards.
- I plan on testing this on a codebase with a large schema. I'll update this comment when I have verified it works on our codebase.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This is just https://github.com/dotansimha/graphql-code-generator/pull/6874 with a unit test to show what has been fixed 😅 @mvestergaard did all the hard work here

The important features of the schema and query used in the test are:
- The `snake` field returns a `SnakeResult` and all the child fields are within a `... on Snake` inline fragment with a type condition. (I tried having the `snake` field return a type `Snake`, instead, but this did not cause a bug)
- The `Bat` and `Snake` subtypes of `Animal` both have a field named `features`, but they are of a different type.

There might be other test cases that cause the same error because what @cecchi described in https://github.com/dotansimha/graphql-code-generator/issues/7364 seems to be slightly different than the issue I was able to repro.