### PR TITLE
feat(schema-ast): support gql extension name for schema-ast output

### DIFF
--- a/packages/plugins/other/schema-ast/src/index.ts
+++ b/packages/plugins/other/schema-ast/src/index.ts
@@ -130,8 +130,12 @@ export const validate: PluginValidateFn<any> = async (
 ) => {
   const singlePlugin = allPlugins.length === 1;
 
-  if (singlePlugin && extname(outputFile) !== '.graphql') {
-    throw new Error(`Plugin "schema-ast" requires extension to be ".graphql"!`);
+  const allowedExtensions = ['.graphql', '.gql'];
+  const isAllowedExtension = allowedExtensions.includes(extname(outputFile));
+
+  if (singlePlugin && !isAllowedExtension) {
+    const allowedExtensionsOutput = allowedExtensions.map(extension => `"${extension}"`).join(' or ');
+    throw new Error(`Plugin "schema-ast" requires extension to be ${allowedExtensionsOutput}!`);
   }
 };
 

--- a/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
+++ b/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
@@ -23,7 +23,7 @@ describe('Schema AST', () => {
         throw new Error(SHOULD_THROW_ERROR);
       } catch (e) {
         expect(e.message).not.toBe(SHOULD_THROW_ERROR);
-        expect(e.message).toBe('Plugin "schema-ast" requires extension to be ".graphql"!');
+        expect(e.message).toBe('Plugin "schema-ast" requires extension to be ".graphql" or ".gql"!');
       }
     });
 
@@ -45,8 +45,23 @@ describe('Schema AST', () => {
       }
     });
 
-    it('Should allow graphql extension when its the only plugin', async () => {
+    it('Should allow .graphql extension when its the only plugin', async () => {
       const fileName = 'output.graphql';
+      const plugins: Types.ConfiguredPlugin[] = [
+        {
+          'schema-ast': {},
+        },
+      ];
+
+      try {
+        await validate(null, null, null, fileName, plugins);
+      } catch (e) {
+        expect(true).toBeFalsy();
+      }
+    });
+
+    it('Should allow .gql extension when its the only plugin', async () => {
+      const fileName = 'output.gql';
       const plugins: Types.ConfiguredPlugin[] = [
         {
           'schema-ast': {},


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Adds support for using the `.gql` file extension for the `schema-ast` plugin output file.

Related #8711

## Type of change

- [✅] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

[codesandbox.io/s/serene-breeze-lk67d8?file=/codegen.ts](https://codesandbox.io/s/serene-breeze-lk67d8?file=/codegen.ts)

## How Has This Been Tested?

Plugin spec updated with relevant tests

**Test Environment**:

- OS: macOS
- `@graphql-codegen/...`: 2.13.12
- NodeJS: 16.15.0

## Checklist:

- [✅] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [✅] I have added tests that prove my fix is effective or that my feature works
- [✅] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
