### PR TITLE
avoid namespace imports for enums

### DIFF
--- a/.changeset/loud-crews-itch.md
+++ b/.changeset/loud-crews-itch.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+avoid using TypeScript namespace imports for enums

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -796,13 +796,17 @@ export class BaseTypesVisitor<
     sourceIdentifier: string | null,
     sourceFile: string | null
   ): string[] {
-    const importStatement = this._buildTypeImport(importIdentifier || sourceIdentifier, sourceFile);
-
-    if (importIdentifier !== sourceIdentifier || sourceIdentifier !== typeIdentifier) {
-      return [importStatement, `import ${typeIdentifier} = ${sourceIdentifier};`];
+    if (importIdentifier !== sourceIdentifier) {
+      // use namespace import to dereference nested enum
+      // { enumValues: { MyEnum: './my-file#NS.NestedEnum' } }
+      return [
+        this._buildTypeImport(importIdentifier || sourceIdentifier, sourceFile),
+        `import ${typeIdentifier} = ${sourceIdentifier};`,
+      ];
+    } else if (sourceIdentifier !== typeIdentifier) {
+      return [this._buildTypeImport(`${sourceIdentifier} as ${typeIdentifier}`, sourceFile)];
     }
-
-    return [importStatement];
+    return [this._buildTypeImport(importIdentifier || sourceIdentifier, sourceFile)];
   }
 
   public getEnumsImports(): string[] {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -3308,7 +3308,7 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
-    it('Should build enum correctly with custom imported enum from namspace with different name', async () => {
+    it('Should build enum correctly with custom imported enum from namespace with different name', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
       const result = (await plugin(
         schema,
@@ -3325,7 +3325,7 @@ describe('TypeScript', () => {
       validateTs(result);
     });
 
-    it('Should build enum correctly with custom imported enum from namspace with same name', async () => {
+    it('Should build enum correctly with custom imported enum from namespace with same name', async () => {
       const schema = buildSchema(`enum MyEnum { A, B, C }`);
       const result = (await plugin(
         schema,
@@ -3352,8 +3352,7 @@ describe('TypeScript', () => {
       )) as Types.ComplexPluginOutput;
 
       expect(result.content).not.toContain(`export enum MyEnum`);
-      expect(result.prepend).toContain(`import { MyCustomEnum } from './my-file';`);
-      expect(result.prepend).toContain(`import MyEnum = MyCustomEnum;`);
+      expect(result.prepend).toContain(`import { MyCustomEnum as MyEnum } from './my-file';`);
       expect(result.content).toContain(`export { MyEnum };`);
 
       validateTs(result);
@@ -3387,7 +3386,7 @@ describe('TypeScript', () => {
 
       expect(result.content).toContain(`export { MyEnum };`);
       expect(result.content).toContain(`export { MyEnum2 };`);
-      expect(result.prepend).toContain(`import MyEnum2 = MyEnum2X;`);
+      expect(result.prepend).toContain(`import { MyEnum2X as MyEnum2 } from './my-file';`);
 
       validateTs(result);
     });
@@ -3401,6 +3400,8 @@ describe('TypeScript', () => {
         { outputFile: '' }
       )) as Types.ComplexPluginOutput;
 
+      expect(result.prepend).toContain(`import { MyEnum } from './my-file';`);
+      expect(result.prepend).toContain(`import { MyEnum2 } from './my-file';`);
       expect(result.content).toContain(`export { MyEnum };`);
       expect(result.content).toContain(`export { MyEnum2 };`);
 


### PR DESCRIPTION
## Description

This PR slightly modifies TypeScript code-generation to use idiomatic ES6-style imports (where possible) when importing custom `enumValues`.  

Currently, the following config:

```ts
{ enumValues: { MyEnum: './my-file#MyCustomEnum' } }
```

will produce

```ts
import { MyCustomEnum } from './my-file';
import MyEnum = MyCustomEnum;
export { MyEnum };
```

The namespace import (on the second line above) is a fairly unusual bit of TypeScript syntax.  Some third-party parsers (such as Babel) have difficulty parsing it.  In this scenario, the namespace import is also entirely unnecessary, as we can specify our alias in the original import statement.  

---

After this PR, the output becomes:

```ts
import { MyCustomEnum as MyEnum } from './my-file';
export { MyEnum };
```

This output should be equivalent in terms of functionality, is slightly more readable and compact, and should be better-tolerated by tools that do not understand TypeScript namespaces. 

`MyCustomEnum` is no longer available as a variable in the generated file, although I would not imagine that any reasonable person would expect it to be.  (If anything, this change slightly reduces the odds of unintentional naming collisions)

---

This PR does **not** attempt to resolve this issue for deeply-nested imports such as:

```ts
{ enumValues: { MyEnum: './my-file#NS.MyEnum' } },
```

```ts
import { NS } from './my-file';
import MyEnum = NS.MyEnum;
export { MyEnum };
```     

I'm less confident in my ability to write 100%-equivalent code here that does not utilize namespace imports, and I would also imagine that this scenario is considerably less common.  

Related #4236

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## How Has This Been Tested?

This functionality is covered by existing unit tests, which have been modified to reflect the new expected output.  

Changes to the generated code should be no more complicated than the example described above.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules