### PR TITLE
feat: add support for metadata and persisted operations in client preset

### DIFF
--- a/.changeset/@graphql-codegen_client-preset-8757-dependencies.md
+++ b/.changeset/@graphql-codegen_client-preset-8757-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/client-preset": patch
+---
+dependencies updates:
+  - Added dependency [`@graphql-tools/documents@^0.1.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/documents/v/0.1.0) (to `dependencies`)

--- a/.changeset/lemon-zebras-hunt.md
+++ b/.changeset/lemon-zebras-hunt.md
@@ -1,0 +1,52 @@
+---
+'@graphql-codegen/client-preset': minor
+---
+
+Add support for persisted documents.
+
+You can now generate and embed a persisted documents hash for the executable documents.
+
+```ts
+/** codegen.ts */
+import { CodegenConfig } from '@graphql-codegen/cli'
+
+const config: CodegenConfig = {
+  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  documents: ['src/**/*.tsx'],
+  ignoreNoDocuments: true, // for better experience with the watcher
+  generates: {
+    './src/gql/': {
+      preset: 'client',
+      plugins: [],
+      presetConfig: {
+        persistedOperations: true,
+      }
+    }
+  }
+}
+
+export default config
+```
+
+This will generate `./src/gql/persisted-documents.json` (dictionary of hashes with their operation string).
+
+In addition to that each generated document node will have a `__meta__.hash` property.
+
+```ts
+import { gql } from './gql.js'
+
+const allFilmsWithVariablesQueryDocument = graphql(/* GraphQL */ `
+  query allFilmsWithVariablesQuery($first: Int!) {
+    allFilms(first: $first) {
+      edges {
+        node {
+          ...FilmItem
+        }
+      }
+    }
+  }
+`)
+
+console.log((allFilmsWithVariablesQueryDocument as any)["__meta__"]["hash"])
+```
+

--- a/.changeset/tasty-adults-doubt.md
+++ b/.changeset/tasty-adults-doubt.md
@@ -1,0 +1,54 @@
+---
+'@graphql-codegen/client-preset': minor
+---
+
+Add support for embedding metadata in the document AST.
+
+It is now possible to embed metadata (e.g. for your GraphQL client within the emitted code).
+
+```ts
+/** codegen.ts */
+import { CodegenConfig } from '@graphql-codegen/cli'
+
+const config: CodegenConfig = {
+  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  documents: ['src/**/*.tsx'],
+  ignoreNoDocuments: true, // for better experience with the watcher
+  generates: {
+    './src/gql/': {
+      preset: 'client',
+      plugins: [],
+      presetConfig: {
+        onExecutableDocumentNode(documentNode) {
+          return {
+            operation: documentNode.definitions[0].operation,
+            name: documentNode.definitions[0].name.value
+          }
+        }
+      }
+    }
+  }
+}
+
+export default config
+```
+
+You can then access the metadata via the `__meta__` property on the document node.
+
+```ts
+import { gql } from './gql.js'
+
+const allFilmsWithVariablesQueryDocument = graphql(/* GraphQL */ `
+  query allFilmsWithVariablesQuery($first: Int!) {
+    allFilms(first: $first) {
+      edges {
+        node {
+          ...FilmItem
+        }
+      }
+    }
+  }
+`)
+
+console.log((allFilmsWithVariablesQueryDocument as any)["__meta__"])
+```

--- a/packages/plugins/other/visitor-plugin-common/package.json
+++ b/packages/plugins/other/visitor-plugin-common/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@graphql-tools/optimize": "^1.3.0",
     "@graphql-codegen/plugin-helpers": "^3.1.2",
-    "@graphql-tools/documents": "0.1.0-alpha-20230109070251-4be4b310",
     "@graphql-tools/relay-operation-optimizer": "^6.5.0",
     "@graphql-tools/utils": "^9.0.0",
     "auto-bind": "~4.0.0",

--- a/packages/plugins/other/visitor-plugin-common/package.json
+++ b/packages/plugins/other/visitor-plugin-common/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@graphql-tools/optimize": "^1.3.0",
     "@graphql-codegen/plugin-helpers": "^3.1.2",
+    "@graphql-tools/documents": "0.1.0-alpha-20230109070251-4be4b310",
     "@graphql-tools/relay-operation-optimizer": "^6.5.0",
     "@graphql-tools/utils": "^9.0.0",
     "auto-bind": "~4.0.0",

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -360,7 +360,15 @@ export class ClientSideBaseVisitor<
     return documentStr;
   }
 
-  private _generateDocumentNodeHash(definitions: ReadonlyArray<DefinitionNode>, fragmentNames: Array<string>): string {
+  private _generateDocumentNodeHash(
+    definitions: ReadonlyArray<DefinitionNode>,
+    fragmentNames: Array<string>
+  ): string | undefined {
+    // If the document does not contain any executable operation, we don't need to hash it
+    if (definitions.every(def => def.kind !== Kind.OPERATION_DEFINITION)) {
+      return undefined;
+    }
+
     const allDefinitions = [...definitions];
 
     for (const fragment of fragmentNames) {

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -4,6 +4,7 @@ import { optimizeDocumentNode } from '@graphql-tools/optimize';
 import autoBind from 'auto-bind';
 import { pascalCase } from 'change-case-all';
 import { DepGraph } from 'dependency-graph';
+import * as crypto from 'node:crypto';
 import {
   FragmentDefinitionNode,
   FragmentSpreadNode,
@@ -18,7 +19,6 @@ import { BaseVisitor, ParsedConfig, RawConfig } from './base-visitor.js';
 import { generateFragmentImportStatement } from './imports.js';
 import { LoadedFragment, ParsedImport } from './types.js';
 import { buildScalarsFromConfig, getConfigValue } from './utils.js';
-import * as crypto from 'node:crypto';
 
 gqlTag.enableExperimentalFragmentVariables();
 

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import { basename, extname } from 'path';
 import { oldVisit, Types } from '@graphql-codegen/plugin-helpers';
 import { printExecutableGraphQLDocument } from '@graphql-tools/documents';
@@ -5,15 +6,14 @@ import { optimizeDocumentNode } from '@graphql-tools/optimize';
 import autoBind from 'auto-bind';
 import { pascalCase } from 'change-case-all';
 import { DepGraph } from 'dependency-graph';
-import * as crypto from 'node:crypto';
 import {
+  DefinitionNode,
   FragmentDefinitionNode,
   FragmentSpreadNode,
   GraphQLSchema,
   Kind,
   OperationDefinitionNode,
   print,
-  DefinitionNode,
   visit,
 } from 'graphql';
 import gqlTag from 'graphql-tag';

--- a/packages/presets/client/package.json
+++ b/packages/presets/client/package.json
@@ -27,6 +27,7 @@
     "@graphql-codegen/plugin-helpers": "^3.1.2",
     "@graphql-codegen/visitor-plugin-common": "^2.13.7",
     "@graphql-typed-document-node/core": "3.1.1",
+    "@graphql-tools/documents": "0.1.0-alpha-20230109070251-4be4b310",
     "@graphql-tools/utils": "^9.0.0",
     "tslib": "~2.4.0"
   },

--- a/packages/presets/client/package.json
+++ b/packages/presets/client/package.json
@@ -27,7 +27,7 @@
     "@graphql-codegen/plugin-helpers": "^3.1.2",
     "@graphql-codegen/visitor-plugin-common": "^2.13.7",
     "@graphql-typed-document-node/core": "3.1.1",
-    "@graphql-tools/documents": "0.1.0-alpha-20230109070251-4be4b310",
+    "@graphql-tools/documents": "^0.1.0",
     "@graphql-tools/utils": "^9.0.0",
     "tslib": "~2.4.0"
   },

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -129,17 +129,13 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       [`typescript-operations`]: typescriptOperationPlugin,
       [`typed-document-node`]: {
         ...typedDocumentNodePlugin,
-        ...(isPersistedOperations
-          ? {
-              plugin: async (...args: Parameters<PluginFunction>) => {
-                try {
-                  return await typedDocumentNodePlugin.plugin(...args);
-                } finally {
-                  tdnFinished.resolve();
-                }
-              },
-            }
-          : {}),
+        plugin: async (...args: Parameters<PluginFunction>) => {
+          try {
+            return await typedDocumentNodePlugin.plugin(...args);
+          } finally {
+            tdnFinished.resolve();
+          }
+        },
       },
       [`gen-dts`]: gqlTagPlugin,
     };

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -66,7 +66,7 @@ export type ClientPresetConfig = {
   /**
    * Generate metadata for a executable document node and embed it in the emitted code.
    */
-  onDocumentNode?: (documentNode: DocumentNode) => void | Record<string, unknown>;
+  onExecutableDocumentNode?: (documentNode: DocumentNode) => void | Record<string, unknown>;
   /** Persisted operations configuration. */
   persistedOperations?:
     | boolean
@@ -130,7 +130,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       fragmentMaskingConfig = {};
     }
 
-    const onDocumentNodeHook = options.presetConfig.onDocumentNode ?? null;
+    const onExecutableDocumentNodeHook = options.presetConfig.onExecutableDocumentNode ?? null;
     const isMaskingFragments = fragmentMaskingConfig != null;
 
     const persistedOperations = options.presetConfig.persistedOperations
@@ -174,8 +174,9 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       [`gen-dts`]: gqlTagPlugin,
     };
 
-    function onDocumentNode(documentNode: DocumentNode) {
-      const meta = onDocumentNodeHook?.(documentNode);
+    function onExecutableDocumentNode(documentNode: DocumentNode) {
+      const meta = onExecutableDocumentNodeHook?.(documentNode);
+
       if (persistedOperations) {
         const documentString = normalizeAndPrintDocumentNode(documentNode);
         const hash = generateDocumentHash(documentString);
@@ -196,7 +197,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       { [`typescript-operations`]: {} },
       {
         [`typed-document-node`]: {
-          unstable_onDocumentNode: onDocumentNode,
+          unstable_onExecutableDocumentNode: onExecutableDocumentNode,
           unstable_omitDefinitions: persistedOperations?.omitDefinitions ?? false,
         },
       },

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -67,7 +67,7 @@ export type ClientPresetConfig = {
    * Generate metadata for a executable document node and embed it in the emitted code.
    */
   onDocumentNode?: (documentNode: DocumentNode) => void | Record<string, unknown>;
-  /** Persisted operations */
+  /** Persisted operations configuration. */
   persistedOperations?:
     | boolean
     | {

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -1,6 +1,6 @@
 import * as addPlugin from '@graphql-codegen/add';
 import * as gqlTagPlugin from '@graphql-codegen/gql-tag-operations';
-import type { Types, PluginFunction } from '@graphql-codegen/plugin-helpers';
+import type { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
 import * as typedDocumentNodePlugin from '@graphql-codegen/typed-document-node';
 import * as typescriptPlugin from '@graphql-codegen/typescript';
 import * as typescriptOperationPlugin from '@graphql-codegen/typescript-operations';
@@ -94,6 +94,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       );
     }
 
+    // eslint-disable-next-line no-implicit-coercion
     const isPersistedOperations = !!options.presetConfig?.persistedOperations ?? false;
 
     const reexports: Array<string> = [];

--- a/packages/presets/client/src/persisted-documents.ts
+++ b/packages/presets/client/src/persisted-documents.ts
@@ -1,0 +1,38 @@
+import * as crypto from 'crypto';
+import { printExecutableGraphQLDocument } from '@graphql-tools/documents';
+import { type DocumentNode, Kind, visit } from 'graphql';
+
+/**
+ * This function generates a hash from a document node.
+ */
+export function generateDocumentHash(operation: string): string {
+  const shasum = crypto.createHash('sha1');
+  shasum.update(operation);
+  return shasum.digest('hex');
+}
+
+/**
+ * Normalizes and prints a document node.
+ */
+export function normalizeAndPrintDocumentNode(documentNode: DocumentNode): string {
+  /**
+   * This removes all client specific directives/fields from the document
+   * that the server does not know about.
+   * In a future version this should be more configurable.
+   * If you look at this and want to customize it.
+   * Send a PR :)
+   */
+  const sanitizedDocument = visit(documentNode, {
+    [Kind.FIELD](field) {
+      if (field.directives?.some(directive => directive.name.value === 'client')) {
+        return null;
+      }
+    },
+    [Kind.DIRECTIVE](directive) {
+      if (directive.name.value === 'connection') {
+        return null;
+      }
+    },
+  });
+  return printExecutableGraphQLDocument(sanitizedDocument);
+}

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -1100,7 +1100,7 @@ export * from "./fragment-masking.js";`);
           preset,
           plugins: [],
           presetConfig: {
-            onDocumentNode(node) {
+            onExecutableDocumentNode(node) {
               return {
                 cacheKeys: [node.definitions[0].name.value],
               };
@@ -1419,7 +1419,7 @@ export * from "./fragment-masking.js";`);
             plugins: [],
             presetConfig: {
               persistedOperations: true,
-              onDocumentNode(node) {
+              onExecutableDocumentNode(node) {
                 return {
                   cacheKeys: [node.definitions[0].name.value],
                 };

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -1072,7 +1072,7 @@ export * from "./fragment-masking.js";`);
   });
 
   describe('persisted operations', () => {
-    it('can generate persisted documents json file', async () => {
+    it('apply default settings', async () => {
       const result = await executeCodegen({
         schema: [
           /* GraphQL */ `
@@ -1102,9 +1102,9 @@ export * from "./fragment-masking.js";`);
 
       expect(persistedDocuments.content).toMatchInlineSnapshot(`
         "{
-          "0f7ebe7dd4065f092a50eb072800a61bd4ff812b": "query A {\\n  a\\n}",
-          "2d0e30c7c6652379b404709ccc8eca2ceb420572": "query B {\\n  b\\n}",
-          "5d4fb2f872591b281d45519b6beec6fc0bb5bd3e": "fragment C on Query {\\n  c\\n}"
+          "b61b879c1eb0040bce65d70c8adfb1ae9360f52f": "query A { a }",
+          "c3ea9f3f937d47d72c70055ea55c7cf88a35e608": "query B { b }",
+          "e8d0fab85de43b2634f10801ec2a3f94a2850dc1": "fragment C on Query { c }"
         }"
       `);
 
@@ -1145,9 +1145,171 @@ export * from "./fragment-masking.js";`);
 
         export type CFragment = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragment' };
 
-        export const CFragmentDoc = {"__hash":"5d4fb2f872591b281d45519b6beec6fc0bb5bd3e","kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
-        export const ADocument = {"__hash":"0f7ebe7dd4065f092a50eb072800a61bd4ff812b","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
-        export const BDocument = {"__hash":"2d0e30c7c6652379b404709ccc8eca2ceb420572","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
+        export const CFragmentDoc = {"__hash":"e8d0fab85de43b2634f10801ec2a3f94a2850dc1","kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
+        export const ADocument = {"__hash":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
+        export const BDocument = {"__hash":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
+      `);
+    });
+
+    it('mode="replaceDocumentWithHash"', async () => {
+      const result = await executeCodegen({
+        schema: [
+          /* GraphQL */ `
+            type Query {
+              a: String
+              b: String
+              c: String
+            }
+          `,
+        ],
+        documents: path.join(__dirname, 'fixtures/simple-uppercase-operation-name.ts'),
+        generates: {
+          'out1/': {
+            preset,
+            plugins: [],
+            presetConfig: {
+              persistedOperations: {
+                mode: 'replaceDocumentWithHash',
+              },
+            },
+          },
+        },
+        emitLegacyCommonJSImports: false,
+      });
+
+      expect(result).toHaveLength(5);
+
+      const persistedDocuments = result.find(file => file.filename === 'out1/persisted-documents.json');
+
+      expect(persistedDocuments.content).toMatchInlineSnapshot(`
+        "{
+          "b61b879c1eb0040bce65d70c8adfb1ae9360f52f": "query A { a }",
+          "c3ea9f3f937d47d72c70055ea55c7cf88a35e608": "query B { b }",
+          "e8d0fab85de43b2634f10801ec2a3f94a2850dc1": "fragment C on Query { c }"
+        }"
+      `);
+
+      const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
+      expect(graphqlFile.content).toMatchInlineSnapshot(`
+        "/* eslint-disable */
+        import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+        export type Maybe<T> = T | null;
+        export type InputMaybe<T> = Maybe<T>;
+        export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+        export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+        export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+        /** All built-in and custom scalars, mapped to their actual values */
+        export type Scalars = {
+          ID: string;
+          String: string;
+          Boolean: boolean;
+          Int: number;
+          Float: number;
+        };
+
+        export type Query = {
+          __typename?: 'Query';
+          a?: Maybe<Scalars['String']>;
+          b?: Maybe<Scalars['String']>;
+          c?: Maybe<Scalars['String']>;
+        };
+
+        export type AQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type AQuery = { __typename?: 'Query', a?: string | null };
+
+        export type BQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type BQuery = { __typename?: 'Query', b?: string | null };
+
+        export type CFragment = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragment' };
+
+        export const CFragmentDoc = {"__hash":"e8d0fab85de43b2634f10801ec2a3f94a2850dc1"} as unknown as DocumentNode<CFragment, unknown>;
+        export const ADocument = {"__hash":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f"} as unknown as DocumentNode<AQuery, AQueryVariables>;
+        export const BDocument = {"__hash":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608"} as unknown as DocumentNode<BQuery, BQueryVariables>;"
+      `);
+    });
+
+    it('hashPropertyName="custom_property_name"', async () => {
+      const result = await executeCodegen({
+        schema: [
+          /* GraphQL */ `
+            type Query {
+              a: String
+              b: String
+              c: String
+            }
+          `,
+        ],
+        documents: path.join(__dirname, 'fixtures/simple-uppercase-operation-name.ts'),
+        generates: {
+          'out1/': {
+            preset,
+            plugins: [],
+            presetConfig: {
+              persistedOperations: {
+                hashPropertyName: 'custom_property_name',
+              },
+            },
+          },
+        },
+        emitLegacyCommonJSImports: false,
+      });
+
+      expect(result).toHaveLength(5);
+
+      const persistedDocuments = result.find(file => file.filename === 'out1/persisted-documents.json');
+
+      expect(persistedDocuments.content).toMatchInlineSnapshot(`
+        "{
+          "b61b879c1eb0040bce65d70c8adfb1ae9360f52f": "query A { a }",
+          "c3ea9f3f937d47d72c70055ea55c7cf88a35e608": "query B { b }",
+          "e8d0fab85de43b2634f10801ec2a3f94a2850dc1": "fragment C on Query { c }"
+        }"
+      `);
+
+      const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
+      expect(graphqlFile.content).toMatchInlineSnapshot(`
+        "/* eslint-disable */
+        import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+        export type Maybe<T> = T | null;
+        export type InputMaybe<T> = Maybe<T>;
+        export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+        export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+        export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+        /** All built-in and custom scalars, mapped to their actual values */
+        export type Scalars = {
+          ID: string;
+          String: string;
+          Boolean: boolean;
+          Int: number;
+          Float: number;
+        };
+
+        export type Query = {
+          __typename?: 'Query';
+          a?: Maybe<Scalars['String']>;
+          b?: Maybe<Scalars['String']>;
+          c?: Maybe<Scalars['String']>;
+        };
+
+        export type AQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type AQuery = { __typename?: 'Query', a?: string | null };
+
+        export type BQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type BQuery = { __typename?: 'Query', b?: string | null };
+
+        export type CFragment = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragment' };
+
+        export const CFragmentDoc = {"custom_property_name":"e8d0fab85de43b2634f10801ec2a3f94a2850dc1","kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
+        export const ADocument = {"custom_property_name":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
+        export const BDocument = {"custom_property_name":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
       `);
     });
   });

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -917,6 +917,7 @@ export * from "./fragment-masking";`);
         }
         `,
       ]);
+
       validateTs(content, undefined, false, true, [`Duplicate identifier 'DocumentNode'.`], true);
     });
   });
@@ -1145,8 +1146,8 @@ export * from "./fragment-masking.js";`);
         export type CFragment = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragment' };
 
         export const CFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
-        export const ADocument = {"__hash":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
-        export const BDocument = {"__hash":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
+        export const ADocument = {"__meta__":{"hash":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
+        export const BDocument = {"__meta__":{"hash":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
       `);
     });
 
@@ -1225,8 +1226,8 @@ export * from "./fragment-masking.js";`);
         export type CFragment = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragment' };
 
         export const CFragmentDoc = {} as unknown as DocumentNode<CFragment, unknown>;
-        export const ADocument = {"__hash":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f"} as unknown as DocumentNode<AQuery, AQueryVariables>;
-        export const BDocument = {"__hash":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608"} as unknown as DocumentNode<BQuery, BQueryVariables>;"
+        export const ADocument = {"__meta__":{"hash":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f"}} as unknown as DocumentNode<AQuery, AQueryVariables>;
+        export const BDocument = {"__meta__":{"hash":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608"}} as unknown as DocumentNode<BQuery, BQueryVariables>;"
       `);
     });
 
@@ -1305,8 +1306,8 @@ export * from "./fragment-masking.js";`);
         export type CFragment = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragment' };
 
         export const CFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
-        export const ADocument = {"custom_property_name":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
-        export const BDocument = {"custom_property_name":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
+        export const ADocument = {"__meta__":{"custom_property_name":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
+        export const BDocument = {"__meta__":{"custom_property_name":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
       `);
     });
   });

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -535,49 +535,49 @@ export * from "./fragment-masking";`);
     expect(result.length).toBe(4);
     const gqlFile = result.find(file => file.filename === 'out1/gql.ts');
     expect(gqlFile.content).toMatchInlineSnapshot(`
-    "/* eslint-disable */
-    import * as types from './graphql';
-    import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+          "/* eslint-disable */
+          import * as types from './graphql';
+          import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
-    /**
-     * Map of all GraphQL operations in the project.
-     *
-     * This map has several performance disadvantages:
-     * 1. It is not tree-shakeable, so it will include all operations in the project.
-     * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
-     * 3. It does not support dead code elimination, so it will add unused operations.
-     *
-     * Therefore it is highly recommended to use the babel-plugin for production.
-     */
-    const documents = {
-        "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
-    };
+          /**
+           * Map of all GraphQL operations in the project.
+           *
+           * This map has several performance disadvantages:
+           * 1. It is not tree-shakeable, so it will include all operations in the project.
+           * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+           * 3. It does not support dead code elimination, so it will add unused operations.
+           *
+           * Therefore it is highly recommended to use the babel-plugin for production.
+           */
+          const documents = {
+              "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
+          };
 
-    /**
-     * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-     *
-     *
-     * @example
-     * \`\`\`ts
-     * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
-     * \`\`\`
-     *
-     * The query argument is unknown!
-     * Please regenerate the types.
-     */
-    export function graphql(source: string): unknown;
+          /**
+           * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+           *
+           *
+           * @example
+           * \`\`\`ts
+           * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+           * \`\`\`
+           *
+           * The query argument is unknown!
+           * Please regenerate the types.
+           */
+          export function graphql(source: string): unknown;
 
-    /**
-     * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-     */
-    export function graphql(source: "\\n  query a {\\n    a\\n  }\\n"): (typeof documents)["\\n  query a {\\n    a\\n  }\\n"];
+          /**
+           * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+           */
+          export function graphql(source: "\\n  query a {\\n    a\\n  }\\n"): (typeof documents)["\\n  query a {\\n    a\\n  }\\n"];
 
-    export function graphql(source: string) {
-      return (documents as any)[source] ?? {};
-    }
+          export function graphql(source: string) {
+            return (documents as any)[source] ?? {};
+          }
 
-    export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
-    `);
+          export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
+        `);
     const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
     expect(graphqlFile.content).toMatchInlineSnapshot(`
       "/* eslint-disable */
@@ -647,59 +647,59 @@ export * from "./fragment-masking";`);
       expect(indexFile.content).toMatchInlineSnapshot(`"export * from "./gql";"`);
       const gqlFile = result.find(file => file.filename === 'out1/gql.ts');
       expect(gqlFile.content).toMatchInlineSnapshot(`
-      "/* eslint-disable */
-      import * as types from './graphql';
-      import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+              "/* eslint-disable */
+              import * as types from './graphql';
+              import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
-      /**
-       * Map of all GraphQL operations in the project.
-       *
-       * This map has several performance disadvantages:
-       * 1. It is not tree-shakeable, so it will include all operations in the project.
-       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
-       * 3. It does not support dead code elimination, so it will add unused operations.
-       *
-       * Therefore it is highly recommended to use the babel-plugin for production.
-       */
-      const documents = {
-          "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
-          "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
-          "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
-      };
+              /**
+               * Map of all GraphQL operations in the project.
+               *
+               * This map has several performance disadvantages:
+               * 1. It is not tree-shakeable, so it will include all operations in the project.
+               * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+               * 3. It does not support dead code elimination, so it will add unused operations.
+               *
+               * Therefore it is highly recommended to use the babel-plugin for production.
+               */
+              const documents = {
+                  "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
+                  "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
+                  "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
+              };
 
-      /**
-       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-       *
-       *
-       * @example
-       * \`\`\`ts
-       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
-       * \`\`\`
-       *
-       * The query argument is unknown!
-       * Please regenerate the types.
-       */
-      export function graphql(source: string): unknown;
+              /**
+               * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+               *
+               *
+               * @example
+               * \`\`\`ts
+               * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+               * \`\`\`
+               *
+               * The query argument is unknown!
+               * Please regenerate the types.
+               */
+              export function graphql(source: string): unknown;
 
-      /**
-       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-       */
-      export function graphql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
-      /**
-       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-       */
-      export function graphql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
-      /**
-       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-       */
-      export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
+              /**
+               * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+               */
+              export function graphql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
+              /**
+               * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+               */
+              export function graphql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
+              /**
+               * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+               */
+              export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
-      export function graphql(source: string) {
-        return (documents as any)[source] ?? {};
-      }
+              export function graphql(source: string) {
+                return (documents as any)[source] ?? {};
+              }
 
-      export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
-    `);
+              export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
+          `);
     });
 
     it('fragmentMasking: {}', async () => {
@@ -1072,6 +1072,85 @@ export * from "./fragment-masking.js";`);
     });
   });
 
+  it('embed metadata in executable document node', async () => {
+    const result = await executeCodegen({
+      schema: [
+        /* GraphQL */ `
+          type Query {
+            a: String
+            b: String
+            c: String
+          }
+        `,
+      ],
+      documents: [
+        /* GraphQL */ `
+          query aaa {
+            a
+          }
+        `,
+        /* GraphQL */ `
+          query bbb {
+            b
+          }
+        `,
+      ],
+      generates: {
+        'out1/': {
+          preset,
+          plugins: [],
+          presetConfig: {
+            onDocumentNode(node) {
+              return {
+                cacheKeys: [node.definitions[0].name.value],
+              };
+            },
+          },
+        },
+      },
+      emitLegacyCommonJSImports: false,
+    });
+    const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
+    expect(graphqlFile.content).toMatchInlineSnapshot(`
+      "/* eslint-disable */
+      import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+      export type Maybe<T> = T | null;
+      export type InputMaybe<T> = Maybe<T>;
+      export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+      export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+      export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+      /** All built-in and custom scalars, mapped to their actual values */
+      export type Scalars = {
+        ID: string;
+        String: string;
+        Boolean: boolean;
+        Int: number;
+        Float: number;
+      };
+
+      export type Query = {
+        __typename?: 'Query';
+        a?: Maybe<Scalars['String']>;
+        b?: Maybe<Scalars['String']>;
+        c?: Maybe<Scalars['String']>;
+      };
+
+      export type BbbQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+      export type BbbQuery = { __typename?: 'Query', b?: string | null };
+
+      export type AaaQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+      export type AaaQuery = { __typename?: 'Query', a?: string | null };
+
+
+      export const BbbDocument = {"__meta__":{"cacheKeys":["bbb"]},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"bbb"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BbbQuery, BbbQueryVariables>;
+      export const AaaDocument = {"__meta__":{"cacheKeys":["aaa"]},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"aaa"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AaaQuery, AaaQueryVariables>;"
+    `);
+  });
+
   describe('persisted operations', () => {
     it('apply default settings', async () => {
       const result = await executeCodegen({
@@ -1308,6 +1387,86 @@ export * from "./fragment-masking.js";`);
         export const CFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
         export const ADocument = {"__meta__":{"custom_property_name":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
         export const BDocument = {"__meta__":{"custom_property_name":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
+      `);
+    });
+
+    it('embed metadata in executable document node', async () => {
+      const result = await executeCodegen({
+        schema: [
+          /* GraphQL */ `
+            type Query {
+              a: String
+              b: String
+              c: String
+            }
+          `,
+        ],
+        documents: [
+          /* GraphQL */ `
+            query aaa {
+              a
+            }
+          `,
+          /* GraphQL */ `
+            query bbb {
+              b
+            }
+          `,
+        ],
+        generates: {
+          'out1/': {
+            preset,
+            plugins: [],
+            presetConfig: {
+              persistedOperations: true,
+              onDocumentNode(node) {
+                return {
+                  cacheKeys: [node.definitions[0].name.value],
+                };
+              },
+            },
+          },
+        },
+        emitLegacyCommonJSImports: false,
+      });
+      const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
+      expect(graphqlFile.content).toMatchInlineSnapshot(`
+        "/* eslint-disable */
+        import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+        export type Maybe<T> = T | null;
+        export type InputMaybe<T> = Maybe<T>;
+        export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+        export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+        export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+        /** All built-in and custom scalars, mapped to their actual values */
+        export type Scalars = {
+          ID: string;
+          String: string;
+          Boolean: boolean;
+          Int: number;
+          Float: number;
+        };
+
+        export type Query = {
+          __typename?: 'Query';
+          a?: Maybe<Scalars['String']>;
+          b?: Maybe<Scalars['String']>;
+          c?: Maybe<Scalars['String']>;
+        };
+
+        export type AaaQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type AaaQuery = { __typename?: 'Query', a?: string | null };
+
+        export type BbbQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type BbbQuery = { __typename?: 'Query', b?: string | null };
+
+
+        export const AaaDocument = {"__meta__":{"cacheKeys":["aaa"],"hash":"682f60dea844320c05fcb4fb6c4118015902c9a8"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"aaa"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AaaQuery, AaaQueryVariables>;
+        export const BbbDocument = {"__meta__":{"cacheKeys":["bbb"],"hash":"2a8e0849914b13ebc13b112ba5a502678d757511"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"bbb"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BbbQuery, BbbQueryVariables>;"
       `);
     });
   });

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -1103,8 +1103,7 @@ export * from "./fragment-masking.js";`);
       expect(persistedDocuments.content).toMatchInlineSnapshot(`
         "{
           "b61b879c1eb0040bce65d70c8adfb1ae9360f52f": "query A { a }",
-          "c3ea9f3f937d47d72c70055ea55c7cf88a35e608": "query B { b }",
-          "e8d0fab85de43b2634f10801ec2a3f94a2850dc1": "fragment C on Query { c }"
+          "c3ea9f3f937d47d72c70055ea55c7cf88a35e608": "query B { b }"
         }"
       `);
 
@@ -1145,7 +1144,7 @@ export * from "./fragment-masking.js";`);
 
         export type CFragment = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragment' };
 
-        export const CFragmentDoc = {"__hash":"e8d0fab85de43b2634f10801ec2a3f94a2850dc1","kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
+        export const CFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
         export const ADocument = {"__hash":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
         export const BDocument = {"__hash":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
       `);
@@ -1184,8 +1183,7 @@ export * from "./fragment-masking.js";`);
       expect(persistedDocuments.content).toMatchInlineSnapshot(`
         "{
           "b61b879c1eb0040bce65d70c8adfb1ae9360f52f": "query A { a }",
-          "c3ea9f3f937d47d72c70055ea55c7cf88a35e608": "query B { b }",
-          "e8d0fab85de43b2634f10801ec2a3f94a2850dc1": "fragment C on Query { c }"
+          "c3ea9f3f937d47d72c70055ea55c7cf88a35e608": "query B { b }"
         }"
       `);
 
@@ -1226,7 +1224,7 @@ export * from "./fragment-masking.js";`);
 
         export type CFragment = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragment' };
 
-        export const CFragmentDoc = {"__hash":"e8d0fab85de43b2634f10801ec2a3f94a2850dc1"} as unknown as DocumentNode<CFragment, unknown>;
+        export const CFragmentDoc = {} as unknown as DocumentNode<CFragment, unknown>;
         export const ADocument = {"__hash":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f"} as unknown as DocumentNode<AQuery, AQueryVariables>;
         export const BDocument = {"__hash":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608"} as unknown as DocumentNode<BQuery, BQueryVariables>;"
       `);
@@ -1265,8 +1263,7 @@ export * from "./fragment-masking.js";`);
       expect(persistedDocuments.content).toMatchInlineSnapshot(`
         "{
           "b61b879c1eb0040bce65d70c8adfb1ae9360f52f": "query A { a }",
-          "c3ea9f3f937d47d72c70055ea55c7cf88a35e608": "query B { b }",
-          "e8d0fab85de43b2634f10801ec2a3f94a2850dc1": "fragment C on Query { c }"
+          "c3ea9f3f937d47d72c70055ea55c7cf88a35e608": "query B { b }"
         }"
       `);
 
@@ -1307,7 +1304,7 @@ export * from "./fragment-masking.js";`);
 
         export type CFragment = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragment' };
 
-        export const CFragmentDoc = {"custom_property_name":"e8d0fab85de43b2634f10801ec2a3f94a2850dc1","kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
+        export const CFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
         export const ADocument = {"custom_property_name":"b61b879c1eb0040bce65d70c8adfb1ae9360f52f","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
         export const BDocument = {"custom_property_name":"c3ea9f3f937d47d72c70055ea55c7cf88a35e608","kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
       `);

--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -516,21 +516,60 @@ The `client` preset allows the following `config` options:
 
 ## Appendix I: React Query with a custom fetcher setup
 
-The use of `@tanstack/react-query` along with `graphql-request@^5` is highly recommended due to GraphQL Code Generator integration with `graphql-request@^5`:
+The use of `@tanstack/react-query` along with `graphql-request@^5` is highly recommended due to GraphQL Code Generator integration with `graphql-request@^5`.
 
-```ts
-// `data` is properly typed, inferred from `allFilmsWithVariablesQueryDocument` type
-const { data } = useQuery(['films'], async () =>
-  request(
-    'https://swapi-graphql.netlify.app/.netlify/functions/index',
+Create a file with the following helper function within your project:
+
+```ts filename="useGraphQL helper function"
+import request from 'graphql-request'
+import { type TypedDocumentNode } from '@graphql-typed-document-node/core'
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+
+export function useGraphQL<TResult, TVariables>(
+  document: TypedDocumentNode<TResult, TVariables>,
+  ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
+): UseQueryResult<TResult> {
+  return useQuery([(document.definitions[0] as any).name.value, variables], async ({ queryKey }) =>
+    request(
+      'https://swapi-graphql.netlify.app/.netlify/functions/index',
+      document,
+      queryKey[1] ? queryKey[1] : undefined
+    )
+  )
+}
+```
+
+Then write type-safe code like the following:
+
+```ts filename="Application Code"
+import { useGraphQL } from './use-graphql.js'
+import { gql } from './generated/grahql.js'
+
+const allFilmsWithVariablesQueryDocument = gql(/* GraphQL */ `
+  query allFilmsWithVariablesQuery($first: Int!) {
+    allFilms(first: $first) {
+      edges {
+        node {
+          title
+        }
+      }
+    }
+  }
+`)
+
+function App() {
+  // `data` is properly typed, inferred from `allFilmsWithVariablesQueryDocument` type
+  const { data } = useGraphQL(
     allFilmsWithVariablesQueryDocument,
     // variables are also properly type-checked.
     { first: 10 }
   )
-)
+
+  // ... further component code
+}
 ```
 
-In order to infer the result type from a given GraphQL document, we added to `graphql-request@^5` the support for `TypedDocumentNode` documents, an enhanced version of `graphql`'s `DocumentNode` type.
+In case you do not want to use `graphql-request` with `@tanstack/react-query`, you can write and type your own custom fetcher function.
 
 GraphQL Code Generator, via the `client` preset, generates GraphQL documents similar to the following:
 
@@ -546,23 +585,73 @@ A `TypedDocumentNode<R, V>` type carry 2 Generic arguments: the type of the Grap
 
 To implement your own React Query fetcher while preserving the GraphQL document type inference, it should implement a function signature that extract the result type and use it as a return type, as showcased below:
 
-```ts
-const query: TypedDocumentNode<{ greetings: string }, never | Record<any, never>> = parse(/* GraphQL */ `
-  query greetings {
-    greetings
+```ts filename="Custom fetcher function and useGraphQL hook implementation"
+import { type TypedDocumentNode } from '@graphql-typed-document-node/core'
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { print, type ExecutionResult } from 'graphql'
+
+/** Your custom fetcher function */
+async function customFetcher<TResult, TVariables>(
+  url: string,
+  document: TypedDocumentNode<TResult, TVariables>,
+  ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
+): Promise<TResult> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      query: print(document),
+      variables
+    })
+  })
+  if (response.status !== 200) {
+    throw new Error(`Failed to fetch: ${response.statusText}. Body: ${await response.text()}`)
+  }
+
+  return await response.json()
+}
+
+export function useGraphQL<TResult, TVariables>(
+  document: TypedDocumentNode<TResult, TVariables>,
+  ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
+): UseQueryResult<ExecutionResult<TResult>> {
+  return useQuery([(document.definitions[0] as any).name.value, variables], () =>
+    customFetcher('https://swapi-graphql.netlify.app/.netlify/functions/index', document, variables)
+  )
+}
+```
+
+Then write type-safe code like the following:
+
+```ts filename="Application Code"
+import { useGraphQL } from './use-graphql.js'
+import { gql } from './generated/grahql.js'
+
+const allFilmsWithVariablesQueryDocument = gql(/* GraphQL */ `
+  query allFilmsWithVariablesQuery($first: Int!) {
+    allFilms(first: $first) {
+      edges {
+        node {
+          title
+        }
+      }
+    }
   }
 `)
 
-const myFetcher = <D, V>(document: TypedDocumentNode<D, V>): D => {
-  // ... parses the document and fetches the data ...
+function App() {
+  // `data` is properly typed, inferred from `allFilmsWithVariablesQueryDocument` type
+  const { data } = useGraphQL(
+    allFilmsWithVariablesQueryDocument,
+    // variables are also properly type-checked.
+    { first: 10 }
+  )
+
+  // ... further component code
 }
-
-const { data } = useQuery(['greetings'], () => myFetcher(query))
 ```
-
-The type-checking on variables arguments can be added to your custom React Query fetcher by following the same inference principles.
-
-Feel free [to reach out on GitHub discussions](https://github.com/dotansimha/graphql-code-generator/discussions) if you need any help in typing a custom React Query fetcher.
 
 <br />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,6 +2128,14 @@
     tslib "~2.4.0"
     value-or-promise "1.0.11"
 
+"@graphql-tools/documents@0.1.0-alpha-20230109070251-4be4b310":
+  version "0.1.0-alpha-20230109070251-4be4b310"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/documents/-/documents-0.1.0-alpha-20230109070251-4be4b310.tgz#665fbab63aaaaa6929f68c0b4a6b3dff054e5d59"
+  integrity sha512-Shd7yrIYp1ox1SD1HjuhFbQxiAUoD0247wlGzA4Tc3fTEeg/Ok9mmuD/0tH5bwTTAZj7jyqrwatPf5CUZbRKww==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tslib "^2.4.0"
+
 "@graphql-tools/executor-graphql-ws@0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-0.0.5.tgz#eb81fb72ef1eb095be1b2d377b846bff6bf6d102"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,10 +2128,10 @@
     tslib "~2.4.0"
     value-or-promise "1.0.11"
 
-"@graphql-tools/documents@0.1.0-alpha-20230109070251-4be4b310":
-  version "0.1.0-alpha-20230109070251-4be4b310"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/documents/-/documents-0.1.0-alpha-20230109070251-4be4b310.tgz#665fbab63aaaaa6929f68c0b4a6b3dff054e5d59"
-  integrity sha512-Shd7yrIYp1ox1SD1HjuhFbQxiAUoD0247wlGzA4Tc3fTEeg/Ok9mmuD/0tH5bwTTAZj7jyqrwatPf5CUZbRKww==
+"@graphql-tools/documents@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/documents/-/documents-0.1.0.tgz#9c27faea5a17ab271dbd99edd8d52eee0e43573e"
+  integrity sha512-1WQeovHv5S1M3xMzQxbSrG3yl6QOnsq2JUBnlg5/0aMM5R4GNMx6Ms+ROByez/dnuA81kstRuSK+2qpe+GaRIw==
   dependencies:
     lodash.sortby "^4.7.0"
     tslib "^2.4.0"


### PR DESCRIPTION
Closes https://github.com/dotansimha/graphql-code-generator/issues/8756
Closes https://github.com/dotansimha/graphql-code-generator/issues/8822

This implementation is very ugly IMHO, but I could not see a different way in how things are structured right now. 🥲