### PR TITLE
emitLegacyCommonJSImports in graphqlmodulespreset

### DIFF
--- a/packages/presets/graphql-modules/src/index.ts
+++ b/packages/presets/graphql-modules/src/index.ts
@@ -71,7 +71,7 @@ export const preset: Types.OutputPreset<ModulesConfig> = {
       schemaAst: options.schemaAst!,
     };
 
-    const baseTypesFilename = baseTypesPath.replace(/\.(js|ts|d.ts)$/, '');
+    const baseTypesFilename = baseTypesPath.replace(/\.(js|ts|d.ts)$/, options.config.emitLegacyCommonJSImports ? '' : '.js');
     const baseTypesDir = stripFilename(baseOutput.filename);
 
     // One file per each module


### PR DESCRIPTION
emitLegacyCommonJSImports is not been considered in graphql-modules preset.