### PR TITLE
emitLegacyCommonJSImports IN graphqlmodulespreset

### DIFF
--- a/packages/presets/graphql-modules/src/index.ts
+++ b/packages/presets/graphql-modules/src/index.ts
@@ -71,7 +71,7 @@ export const preset: Types.OutputPreset<ModulesConfig> = {
       schemaAst: options.schemaAst!,
     };
 
-    const baseTypesFilename = baseTypesPath.replace(/\.(js|ts|d.ts)$/, '');
+    const baseTypesFilename = baseTypesPath.replace(/\.(js|ts|d.ts)$/, options.config.emitLegacyCommonJSImports ? '' : '.js');
     const baseTypesDir = stripFilename(baseOutput.filename);
 
     // One file per each module


### PR DESCRIPTION
When emitLegacyCommonJSImports is false, graphql-modules preset is generating imports without ".js" extension.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

