### PR TITLE
Fixed emitLegacyCommonJSImports in getImports adding JS when truthy r…

### DIFF
--- a/.changeset/unlucky-suits-pay.md
+++ b/.changeset/unlucky-suits-pay.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Fix issue where visitor-plugin-common emitted ESM imports for Operations when emitLegacyCommonJSImports is true

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -532,7 +532,7 @@ export class ClientSideBaseVisitor<
         if (this._collectedOperations.length > 0) {
           if (this.config.importDocumentNodeExternallyFrom === 'near-operation-file' && this._documents.length === 1) {
             let documentPath = `./${this.clearExtension(basename(this._documents[0].location))}`;
-            if (this.config.emitLegacyCommonJSImports) {
+            if (!this.config.emitLegacyCommonJSImports) {
               documentPath += '.js';
             }
 

--- a/packages/plugins/other/visitor-plugin-common/tests/client-side-base-visitor.spec.ts
+++ b/packages/plugins/other/visitor-plugin-common/tests/client-side-base-visitor.spec.ts
@@ -1,0 +1,85 @@
+import { buildSchema, OperationDefinitionNode, parse } from 'graphql';
+import { ClientSideBaseVisitor, DocumentMode } from '../src/client-side-base-visitor.js';
+
+describe('getImports', () => {
+  describe('when documentMode "external", importDocumentNodeExternallyFrom is "near-operation-file"', () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        a: A
+      }
+
+      type A {
+        foo: String
+        bar: String
+      }
+    `);
+
+    describe('when emitLegacyCommonJSImports is true', () => {
+      it('does not append `.js` to Operations import path', () => {
+        const fileName = 'fooBarQuery';
+        const importPath = `src/queries/${fileName}`;
+
+        const document = parse(
+          `query fooBarQuery {
+            a {
+              foo
+              bar
+            }
+          }
+        `
+        );
+
+        const visitor = new ClientSideBaseVisitor(
+          schema,
+          [],
+          {
+            emitLegacyCommonJSImports: true,
+            importDocumentNodeExternallyFrom: 'near-operation-file',
+            documentMode: DocumentMode.external,
+          },
+          {},
+          [{ document, location: importPath }]
+        );
+
+        visitor.OperationDefinition(document.definitions[0] as OperationDefinitionNode);
+
+        const imports = visitor.getImports();
+        expect(imports[0]).toBe(`import * as Operations from './${fileName}';`);
+      });
+    });
+
+    describe('when emitLegacyCommonJSImports is false', () => {
+      it('appends `.js` to Operations import path', () => {
+        const fileName = 'fooBarQuery';
+        const importPath = `src/queries/${fileName}`;
+
+        const document = parse(
+          `query fooBarQuery {
+            a {
+              foo
+              bar
+            }
+          }
+        `
+        );
+
+        const visitor = new ClientSideBaseVisitor(
+          schema,
+          [],
+          {
+            emitLegacyCommonJSImports: false,
+            importDocumentNodeExternallyFrom: 'near-operation-file',
+            documentMode: DocumentMode.external,
+          },
+          {},
+          [{ document, location: importPath }]
+        );
+
+        visitor.OperationDefinition(document.definitions[0] as OperationDefinitionNode);
+
+        const imports = visitor.getImports();
+        expect(imports[0]).toBe(`import * as Operations from './${fileName}.js';`);
+      });
+    });
+  });
+});

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -91,7 +91,7 @@ export default withGuildDocs({
       '/docs/custom-codegen/using-handlebars': '/docs/custom-codegen',
       '/plugins/presets/near-operation-file': '/plugins/presets/near-operation-file-preset',
       '/plugins/typescript/near-operation-file': '/plugins/presets/near-operation-file-preset',
-      '/typescript/typescript-resolvers': '/plugins/typescript/typescript-resolvers'
+      '/typescript/typescript-resolvers': '/plugins/typescript/typescript-resolvers',
     })
       .concat(PLUGINS_REDIRECTS)
       .map(([from, to]) => ({


### PR DESCRIPTION
**Related #8815**

## Description

Whenever generating hooks with `@graphql-codegen/typescript-react-apollo` and the following config options:

```yaml
emitLegacyCommonJSImports: true
documentMode: "external"
importDocumentNodeExternallyFrom: "near-operation-file"
```

It's appending `.js` to the Operations import like so (but it shouldn't):
```ts
import type * as Types from '../../../../shared/types/graphqlGenerated.d';

import * as Operations from './Foobar.query.js';
```

The issue originates in `@graphql-codegen/visitor-plugin-common` specifically [this line](https://github.com/dotansimha/graphql-code-generator/blob/5c66efc2d29a2ba1c054141773a80b0818e628be/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts#L535) where the condition checking if `emitLegacyCommonJSImports` should be inverted according to other examples within the codebase [like here](https://github.com/dotansimha/graphql-code-generator/blob/5ea74e32048f9705dd14a0b06bf42748c6e9244c/packages/presets/gql-tag-operations/src/index.ts#L214). 

The solution here is to just append a `!` to the condition such that it adds the `.js` only when `emitLegacyCommonJSImports` is false.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I've included specs with this path, these can be used to confirm that there's a bug in `visitor-plugin-common` currently where a condition checking `emitLegacyCommonJSImports` just needs to be inverted.

**Test Environment**:

See linked issue if you want more information.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ (N/A)
- [] ~~I have made corresponding changes to the documentation~~ (N/A)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Super simple change, I didn't create a reproduction here because in the linked issue, I reference locations in the codebase where the code is correct and how it differs from this specific location.