### PR TITLE
Add `generateIntermediaryTypes` parameter

### DIFF
--- a/.changeset/fast-poets-appear.md
+++ b/.changeset/fast-poets-appear.md
@@ -1,4 +1,5 @@
 ---
+'@graphql-codegen/visitor-plugin-common': minor
 '@graphql-codegen/typescript-operations': minor
 ---
 

--- a/.changeset/tasty-rings-boil.md
+++ b/.changeset/tasty-rings-boil.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-operations': minor
+---
+
+Add `generateIntermediateTypes` option

--- a/.changeset/tasty-rings-boil.md
+++ b/.changeset/tasty-rings-boil.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/typescript-operations': minor
 ---
 
-Add `generateIntermediateTypes` option
+Add `generateIntermediaryTypes` option

--- a/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
@@ -266,8 +266,9 @@ export class BaseDocumentsVisitor<
       fragmentSuffix,
       this._declarationBlockConfig
     );
+    const prerequisites = this._selectionSetToObject.flushIntermediaryTypeDeclarations(this._declarationBlockConfig);
     return [
-      this._selectionSetToObject.flushIntermediaryTypeDeclarations(this._declarationBlockConfig),
+      prerequisites,
       fragmentResult,
       this.config.experimentalFragmentVariables
         ? new DeclarationBlock({

--- a/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
@@ -39,7 +39,7 @@ export interface ParsedDocumentsConfig extends ParsedTypesConfig {
   skipTypeNameForRoot: boolean;
   experimentalFragmentVariables: boolean;
   mergeFragmentTypes: boolean;
-  generateIntermediateTypes: boolean;
+  generateIntermediaryTypes: boolean;
 }
 
 export interface RawDocumentsConfig extends RawTypesConfig {
@@ -159,7 +159,7 @@ export interface RawDocumentsConfig extends RawTypesConfig {
    *      'path/to/file.ts': {
    *        plugins: ['typescript-operations'],
    *        config: {
-   *          generateIntermediateTypes: true
+   *          generateIntermediaryTypes: true
    *        },
    *      },
    *    },
@@ -167,7 +167,7 @@ export interface RawDocumentsConfig extends RawTypesConfig {
    *  export default config;
    * ```
    */
-  generateIntermediateTypes?: boolean;
+  generateIntermediaryTypes?: boolean;
 
   // The following are internal, and used by presets
   /**

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -667,15 +667,15 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       return this.getUnknownType();
     }
     if (this._config.generateIntermediateTypes && this._name) {
-      const currentFieldPath = this._buildPath(prefix);
+      const baseTypeName = this._formatCurrentPath(prefix, '_');
       const groupedEntries = Object.entries(grouped);
       if (groupedEntries.length == 1) {
         // if the field is only of one possible type there is no need to suffix the generated entry with the type
         const [declaredTypeName, values] = groupedEntries[0];
-        this.pushIntermediaryDeclaration(currentFieldPath, values.join(' & '));
+        this.pushIntermediaryDeclaration(baseTypeName, values.join(' & '));
         return this.processGroupedSelection(
           {
-            [declaredTypeName]: [currentFieldPath],
+            [declaredTypeName]: [baseTypeName],
           },
           mustAddEmptyObject
         );
@@ -687,7 +687,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
           if (relevant.length === 0) {
             return result;
           }
-          const typeName = `${currentFieldPath}_${declaredTypeName}`;
+          const typeName = `${baseTypeName}_${declaredTypeName}`;
           this.pushIntermediaryDeclaration(typeName, relevant.join(' & '));
           result[declaredTypeName] = [typeName];
           return result;
@@ -717,12 +717,12 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     );
   }
 
-  protected _buildPath(base = ''): string | undefined {
+  protected _formatCurrentPath(base = '', separator = '_'): string | undefined {
     const path = this._path();
     if (path) {
-      const relativePath = path.join('_');
+      const relativePath = path.join(separator);
       if (base) {
-        return `${base}_${relativePath}`;
+        return `${base}${separator}${relativePath}`;
       }
       return relativePath;
     }

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -106,9 +106,16 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     );
   }
 
-  protected pushIntermediaryDeclaration(typeName: string, contents: string) {
+  /**
+   * We push intermediary declarations to the top most element.
+   *
+   * @param typeName the intermediary declaration to push
+   * @param contents the contents for the intermediary declaration
+   * @protected
+   */
+  protected _pushIntermediaryDeclaration(typeName: string, contents: string) {
     if (this._parent) {
-      return this._parent.pushIntermediaryDeclaration(typeName, contents);
+      return this._parent._pushIntermediaryDeclaration(typeName, contents);
     }
     this._intermediaryDeclarations ||= {};
     this._intermediaryDeclarations[typeName] = contents;
@@ -672,7 +679,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       if (groupedEntries.length == 1) {
         // if the field is only of one possible type there is no need to suffix the generated entry with the type
         const [declaredTypeName, values] = groupedEntries[0];
-        this.pushIntermediaryDeclaration(baseTypeName, values.join(' & '));
+        this._pushIntermediaryDeclaration(baseTypeName, values.join(' & '));
         return this.processGroupedSelection(
           {
             [declaredTypeName]: [baseTypeName],
@@ -688,7 +695,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
             return result;
           }
           const typeName = `${baseTypeName}_${declaredTypeName}`;
-          this.pushIntermediaryDeclaration(typeName, relevant.join(' & '));
+          this._pushIntermediaryDeclaration(typeName, relevant.join(' & '));
           result[declaredTypeName] = [typeName];
           return result;
         }, {}),

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -673,7 +673,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     if (Object.keys(grouped).length === 0) {
       return this.getUnknownType();
     }
-    if (this._config.generateIntermediateTypes && this._name) {
+    if (this._config.generateIntermediaryTypes && this._name) {
       const baseTypeName = this._formatCurrentPath(prefix, '_');
       const groupedEntries = Object.entries(grouped);
       if (groupedEntries.length == 1) {

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -39,6 +39,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
         avoidOptionals: normalizeAvoidOptionals(getConfigValue(config.avoidOptionals, false)),
         immutableTypes: getConfigValue(config.immutableTypes, false),
         nonOptionalTypename: getConfigValue(config.nonOptionalTypename, false),
+        generateIntermediateTypes: getConfigValue(config.generateIntermediateTypes, false),
         preResolveTypes: getConfigValue(config.preResolveTypes, true),
         mergeFragmentTypes: getConfigValue(config.mergeFragmentTypes, false),
       } as TypeScriptDocumentsParsedConfig,

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -39,7 +39,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
         avoidOptionals: normalizeAvoidOptionals(getConfigValue(config.avoidOptionals, false)),
         immutableTypes: getConfigValue(config.immutableTypes, false),
         nonOptionalTypename: getConfigValue(config.nonOptionalTypename, false),
-        generateIntermediateTypes: getConfigValue(config.generateIntermediateTypes, false),
+        generateIntermediaryTypes: getConfigValue(config.generateIntermediaryTypes, false),
         preResolveTypes: getConfigValue(config.preResolveTypes, true),
         mergeFragmentTypes: getConfigValue(config.mergeFragmentTypes, false),
       } as TypeScriptDocumentsParsedConfig,

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -6602,10 +6602,10 @@ export type LoginMutation = { __typename?: 'Mutation', login?: LoginMutation_log
       });
 
       expect(content).toBeSimilarStringTo(`
-export type UserFields_profile = { __typename?: 'Profile', age?: number | null };
+export type UserFieldsFragment_profile = { __typename?: 'Profile', age?: number | null };
 
 
-export type UserFieldsFragment = { __typename?: 'User', id: string, username: string, profile?: UserFields_profile | null };
+export type UserFieldsFragment = { __typename?: 'User', id: string, username: string, profile?: UserFieldsFragment_profile | null };
       `);
       await validate(content, config);
     });
@@ -6667,7 +6667,7 @@ export type LoginMutation = (
       });
 
       expect(content).toBeSimilarStringTo(`
-export type UserFields_profile = (
+export type UserFieldsFragment_profile = (
   { __typename?: 'Profile' }
   & Pick<Profile, 'age'>
 );
@@ -6676,7 +6676,7 @@ export type UserFields_profile = (
 export type UserFieldsFragment = (
   { __typename?: 'User' }
   & Pick<User, 'id' | 'username'>
-  & { profile?: Maybe<UserFields_profile> }
+  & { profile?: Maybe<UserFieldsFragment_profile> }
 );
       `);
       await validate(content, config);

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -6567,7 +6567,7 @@ function test(q: GetEntityBrandDataQuery): void {
           }
         }
       `);
-      const config = { generateIntermediateTypes: true };
+      const config = { generateIntermediaryTypes: true };
       const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
@@ -6596,7 +6596,7 @@ export type LoginMutation = { __typename?: 'Mutation', login?: LoginMutation_log
           }
         }
       `);
-      const config = { generateIntermediateTypes: true };
+      const config = { generateIntermediaryTypes: true };
       const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
@@ -6622,7 +6622,7 @@ export type UserFieldsFragment = { __typename?: 'User', id: string, username: st
           }
         }
       `);
-      const config = { generateIntermediateTypes: true, preResolveTypes: false };
+      const config = { generateIntermediaryTypes: true, preResolveTypes: false };
       const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });
@@ -6661,7 +6661,7 @@ export type LoginMutation = (
           }
         }
       `);
-      const config = { generateIntermediateTypes: true, preResolveTypes: false };
+      const config = { generateIntermediaryTypes: true, preResolveTypes: false };
       const { content } = await plugin(schema, [{ location: 'test-file.ts', document: ast }], config, {
         outputFile: '',
       });


### PR DESCRIPTION
## Description

The idea here is to be able, when generating fragment / operation related code, to introduce explicit intermediary types instead of necessarily inlining them.

This is trying to tackle https://github.com/dotansimha/graphql-code-generator/issues/8827

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

By adding new unit tests to make sure it has the expected impacts.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
