### PR TITLE
fix: use consistent naming convention

### DIFF
--- a/.changeset/lemon-zebras-hunt.md
+++ b/.changeset/lemon-zebras-hunt.md
@@ -19,7 +19,7 @@ const config: CodegenConfig = {
       preset: 'client',
       plugins: [],
       presetConfig: {
-        persistedOperations: true,
+        persistedDocuments: true,
       }
     }
   }

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -1169,7 +1169,7 @@ export * from "./fragment-masking.js";`);
             preset,
             plugins: [],
             presetConfig: {
-              persistedOperations: true,
+              persistedDocuments: true,
             },
           },
         },
@@ -1247,7 +1247,7 @@ export * from "./fragment-masking.js";`);
             preset,
             plugins: [],
             presetConfig: {
-              persistedOperations: {
+              persistedDocuments: {
                 mode: 'replaceDocumentWithHash',
               },
             },
@@ -1327,7 +1327,7 @@ export * from "./fragment-masking.js";`);
             preset,
             plugins: [],
             presetConfig: {
-              persistedOperations: {
+              persistedDocuments: {
                 hashPropertyName: 'custom_property_name',
               },
             },
@@ -1418,7 +1418,7 @@ export * from "./fragment-masking.js";`);
             preset,
             plugins: [],
             presetConfig: {
-              persistedOperations: true,
+              persistedDocuments: true,
               onExecutableDocumentNode(node) {
                 return {
                   cacheKeys: [node.definitions[0].name.value],


### PR DESCRIPTION
let's merge this before the next release. I actually wanted to name these persisted documents but ended up writing persisted operations lol. Since we did not release persisted documents, we can still rename them.