### PR TITLE
Preserve .js extension when importDocumentNodeExternallyFrom and emitLegacyCommonJSImports is false

### DIFF
--- a/.changeset/quick-carpets-teach.md
+++ b/.changeset/quick-carpets-teach.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Preserve .js extension when importDocumentNodeExternallyFrom and emitLegacyCommonJSImports is false

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -542,6 +542,10 @@ export class ClientSideBaseVisitor<
   private clearExtension(path: string): string {
     const extension = extname(path);
 
+    if (!this.config.emitLegacyCommonJSImports && extension === '.js') {
+      return path;
+    }
+
     if (EXTENSIONS_TO_REMOVE.includes(extension)) {
       return path.replace(/\.[^/.]+$/, '');
     }

--- a/packages/plugins/other/visitor-plugin-common/tests/client-side-base-visitor.spec.ts
+++ b/packages/plugins/other/visitor-plugin-common/tests/client-side-base-visitor.spec.ts
@@ -82,4 +82,51 @@ describe('getImports', () => {
       });
     });
   });
+
+  describe('when documentMode "external", importDocumentNodeExternallyFrom is relative path', () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        a: A
+      }
+
+      type A {
+        foo: String
+        bar: String
+      }
+    `);
+
+    describe('when emitLegacyCommonJSImports is false', () => {
+      it('preserves `.js` on Operations import path', () => {
+        const fileName = 'fooBarQuery';
+        const importPath = `./src/queries/${fileName}.js`;
+
+        const document = parse(
+          `query fooBarQuery {
+            a {
+              foo
+              bar
+            }
+          }
+        `
+        );
+
+        const visitor = new ClientSideBaseVisitor(
+          schema,
+          [],
+          {
+            emitLegacyCommonJSImports: false,
+            importDocumentNodeExternallyFrom: importPath,
+            documentMode: DocumentMode.external,
+          },
+          {},
+          [{ document, location: importPath }]
+        );
+
+        visitor.OperationDefinition(document.definitions[0] as OperationDefinitionNode);
+
+        const imports = visitor.getImports();
+        expect(imports[0]).toBe(`import * as Operations from '${importPath}';`);
+      });
+    });
+  });
 });


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

These changes skip removing `.js` extensions from import paths when the `emitLegacyCommonJSImports` option is set to `false`

Related # (issue)
#8894 
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added unit test to simulate the input parameters and configuration options. Verify with 

```sh
yarn test  packages/plugins/other/visitor-plugin-common/tests/client-side-base-visitor.spec.ts 
```


**Test Environment**:

OS: macOS
NodeJS: 18.13.0
graphql version: 16.6.0
@graphql-codegen/visitor-plugin-common version(s): 2.13.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

