### PR TITLE
docs(plugins/typescript): exampleMarkdown indentation

### DIFF
--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -202,7 +202,9 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    * @description This will cause the generator to emit types for enums only.
    * @default false
    *
-   * @exampleMarkdown Override all definition types
+   * @exampleMarkdown
+   * ## Override all definition types
+   *
    * ```ts filename="codegen.ts"
    * import type { CodegenConfig } from '@graphql-codegen/cli'
    *
@@ -226,7 +228,9 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    * Interacts well with `preResolveTypes: true`
    * @default false
    *
-   * @exampleMarkdown Override all definition types
+   * @exampleMarkdown
+   * ## Override all definition types
+   *
    * ```ts filename="codegen.ts"
    * import type { CodegenConfig } from '@graphql-codegen/cli'
    *

--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -203,7 +203,7 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    * @default false
    *
    * @exampleMarkdown
-   * ## Override all definition types
+   * Override all definition types
    *
    * ```ts filename="codegen.ts"
    * import type { CodegenConfig } from '@graphql-codegen/cli'
@@ -229,7 +229,7 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    * @default false
    *
    * @exampleMarkdown
-   * ## Override all definition types
+   * Override all definition types
    *
    * ```ts filename="codegen.ts"
    * import type { CodegenConfig } from '@graphql-codegen/cli'


### PR DESCRIPTION
IDK why exactly this fixes the output, but it works.

<img width="1030" alt="Screenshot 2023-02-07 at 15 14 28" src="https://user-images.githubusercontent.com/11807600/217269571-d4a22426-1059-440e-8d9d-da003297e82b.png">
