### PR TITLE
docs: codegen dependencies

### DIFF
--- a/website/src/pages/docs/guides/graphql-server-apollo-yoga.mdx
+++ b/website/src/pages/docs/guides/graphql-server-apollo-yoga.mdx
@@ -58,7 +58,7 @@ type Query {
 
 **2. Install the `@graphql-codegen/typescript-resolvers` plugin**
 
-<PackageCmd packages={['-D @graphql-codegen/typescript-resolvers @graphql-codegen/typescript']} />
+<PackageCmd packages={['-D @graphql-codegen/cli @graphql-codegen/typescript-resolvers @graphql-codegen/typescript']} />
 
 **3. Configure the plugin**
 


### PR DESCRIPTION
## Description

Updates step 2 of [the guide](https://the-guild.dev/graphql/codegen/docs/guides/graphql-server-apollo-yoga) to include `@graphql-codegen/cli` as a dependency to install, as it's required for steps 3 (Configure the plugin) & 4 (Run the codegen)

![image](https://user-images.githubusercontent.com/656630/217910973-ff30f626-b373-4fea-b21b-88063a254877.png)
