### PR TITLE
test: Added a test that fails when a folder contains the

### DIFF
--- a/packages/graphql-codegen-cli/tests/codegen.spec.ts
+++ b/packages/graphql-codegen-cli/tests/codegen.spec.ts
@@ -1086,4 +1086,23 @@ describe('Codegen Executor', () => {
     const output = await executeCodegen(config);
     expect(output[0].content).toContain('DocumentNode<MyQueryQuery, MyQueryQueryVariables>');
   });
+
+  it('Should accept document with = in directory name', async () => {
+    const output = await executeCodegen({
+      schema: SIMPLE_TEST_SCHEMA,
+      documents: ['./tests/test-documents-with-equal-sign/[equal=equal]/query.ts'],
+      generates: {
+        'out1.ts': {
+          plugins: [
+            {
+              'typescript-operations': {},
+            },
+          ],
+        },
+      },
+    });
+
+    expect(output[0].content).toContain('MyQuery');
+    expect(output[0].filename).toEqual('out1.ts');
+  });
 });

--- a/packages/graphql-codegen-cli/tests/test-documents-with-equal-sign/[equal=equal]/query.ts
+++ b/packages/graphql-codegen-cli/tests/test-documents-with-equal-sign/[equal=equal]/query.ts
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag';
+
+export const query = gql`
+  query myQuery {
+    f
+  }
+`;


### PR DESCRIPTION
Add a test for verify the issue https://github.com/dotansimha/graphql-code-generator/issues/8978

## Description

There is a bug with the generator when there is an equals sign in a folder name. All files inside the folder are ignored.
This PR adds a test (which currently fails), to verify that these files are not skipped

Related #8978

## Type of change

Please delete options that are not relevant.

- [x] Add test for a bug
- [ ] Fix the bug 

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
