### PR TITLE
fix: use `gqlTagName` in the autogenerated example

### DIFF
--- a/.changeset/nasty-eggs-rule.md
+++ b/.changeset/nasty-eggs-rule.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/gql-tag-operations': patch
+'@graphql-codegen/client-preset': patch
+---
+
+Use `gqlTagName` for generated examples

--- a/dev-test/gql-tag-operations/graphql/gql.ts
+++ b/dev-test/gql-tag-operations/graphql/gql.ts
@@ -24,7 +24,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/persisted-documents/src/gql/gql.ts
+++ b/examples/persisted-documents/src/gql/gql.ts
@@ -22,7 +22,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/react/apollo-client/src/gql/gql.ts
+++ b/examples/react/apollo-client/src/gql/gql.ts
@@ -25,7 +25,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/react/babel-optimized/src/gql/gql.ts
+++ b/examples/react/babel-optimized/src/gql/gql.ts
@@ -25,7 +25,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/react/graphql-request/src/gql/gql.ts
+++ b/examples/react/graphql-request/src/gql/gql.ts
@@ -25,7 +25,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/react/nextjs-swr/gql/gql.ts
+++ b/examples/react/nextjs-swr/gql/gql.ts
@@ -25,7 +25,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/react/tanstack-react-query/src/gql/gql.ts
+++ b/examples/react/tanstack-react-query/src/gql/gql.ts
@@ -25,7 +25,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/react/urql/src/gql/gql.ts
+++ b/examples/react/urql/src/gql/gql.ts
@@ -25,7 +25,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/typescript-esm/src/gql/gql.ts
+++ b/examples/typescript-esm/src/gql/gql.ts
@@ -25,7 +25,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/typescript-graphql-request/src/gql/gql.ts
+++ b/examples/typescript-graphql-request/src/gql/gql.ts
@@ -25,7 +25,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/vue/apollo-composable/src/gql/gql.ts
+++ b/examples/vue/apollo-composable/src/gql/gql.ts
@@ -25,7 +25,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/vue/urql/src/gql/gql.ts
+++ b/examples/vue/urql/src/gql/gql.ts
@@ -25,7 +25,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/vue/villus/src/gql/gql.ts
+++ b/examples/vue/villus/src/gql/gql.ts
@@ -25,7 +25,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/examples/yoga-tests/src/gql/gql.ts
+++ b/examples/yoga-tests/src/gql/gql.ts
@@ -24,7 +24,7 @@ const documents = {
  *
  * @example
  * ```ts
- * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * const query = graphql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
  * ```
  *
  * The query argument is unknown!

--- a/packages/plugins/typescript/gql-tag-operations/src/index.ts
+++ b/packages/plugins/typescript/gql-tag-operations/src/index.ts
@@ -54,7 +54,7 @@ export const plugin: PluginFunction<{
         `/**\n * The ${gqlTagName} function is used to parse GraphQL queries into a document that can be used by GraphQL clients.\n *\n`,
         ` *\n * @example\n`,
         ' * ```ts\n',
-        ' * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);\n',
+        ` * const query = ${gqlTagName}` + '(`query GetUser($id: ID!) { user(id: $id) { name } }`);\n',
         ' * ```\n *\n',
         ` * The query argument is unknown!\n`,
         ` * Please regenerate the types.\n`,

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -60,7 +60,7 @@ export * from "./gql";`);
        *
        * @example
        * \`\`\`ts
-       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * const query = graphql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
        * \`\`\`
        *
        * The query argument is unknown!
@@ -147,7 +147,7 @@ export * from "./gql";`);
        *
        * @example
        * \`\`\`ts
-       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * const query = graphql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
        * \`\`\`
        *
        * The query argument is unknown!
@@ -226,7 +226,7 @@ export * from "./gql";`);
        *
        * @example
        * \`\`\`ts
-       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * const query = graphql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
        * \`\`\`
        *
        * The query argument is unknown!
@@ -306,7 +306,7 @@ export * from "./gql";`);
        *
        * @example
        * \`\`\`ts
-       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * const query = graphql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
        * \`\`\`
        *
        * The query argument is unknown!
@@ -434,7 +434,7 @@ export * from "./gql";`);
        *
        * @example
        * \`\`\`ts
-       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * const query = graphql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
        * \`\`\`
        *
        * The query argument is unknown!
@@ -529,49 +529,49 @@ export * from "./gql";`);
     expect(result.length).toBe(4);
     const gqlFile = result.find(file => file.filename === 'out1/gql.ts');
     expect(gqlFile.content).toMatchInlineSnapshot(`
-          "/* eslint-disable */
-          import * as types from './graphql';
-          import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+      "/* eslint-disable */
+      import * as types from './graphql';
+      import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
-          /**
-           * Map of all GraphQL operations in the project.
-           *
-           * This map has several performance disadvantages:
-           * 1. It is not tree-shakeable, so it will include all operations in the project.
-           * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
-           * 3. It does not support dead code elimination, so it will add unused operations.
-           *
-           * Therefore it is highly recommended to use the babel-plugin for production.
-           */
-          const documents = {
-              "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
-          };
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel-plugin for production.
+       */
+      const documents = {
+          "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
+      };
 
-          /**
-           * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-           *
-           *
-           * @example
-           * \`\`\`ts
-           * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
-           * \`\`\`
-           *
-           * The query argument is unknown!
-           * Please regenerate the types.
-           */
-          export function graphql(source: string): unknown;
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = graphql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+       */
+      export function graphql(source: string): unknown;
 
-          /**
-           * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-           */
-          export function graphql(source: "\\n  query a {\\n    a\\n  }\\n"): (typeof documents)["\\n  query a {\\n    a\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
+      export function graphql(source: "\\n  query a {\\n    a\\n  }\\n"): (typeof documents)["\\n  query a {\\n    a\\n  }\\n"];
 
-          export function graphql(source: string) {
-            return (documents as any)[source] ?? {};
-          }
+      export function graphql(source: string) {
+        return (documents as any)[source] ?? {};
+      }
 
-          export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
-        `);
+      export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
+    `);
     const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
     expect(graphqlFile.content).toMatchInlineSnapshot(`
       "/* eslint-disable */
@@ -640,59 +640,59 @@ export * from "./gql";`);
       expect(indexFile.content).toMatchInlineSnapshot(`"export * from "./gql";"`);
       const gqlFile = result.find(file => file.filename === 'out1/gql.ts');
       expect(gqlFile.content).toMatchInlineSnapshot(`
-              "/* eslint-disable */
-              import * as types from './graphql';
-              import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+        "/* eslint-disable */
+        import * as types from './graphql';
+        import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
-              /**
-               * Map of all GraphQL operations in the project.
-               *
-               * This map has several performance disadvantages:
-               * 1. It is not tree-shakeable, so it will include all operations in the project.
-               * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
-               * 3. It does not support dead code elimination, so it will add unused operations.
-               *
-               * Therefore it is highly recommended to use the babel-plugin for production.
-               */
-              const documents = {
-                  "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
-                  "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
-                  "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
-              };
+        /**
+         * Map of all GraphQL operations in the project.
+         *
+         * This map has several performance disadvantages:
+         * 1. It is not tree-shakeable, so it will include all operations in the project.
+         * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+         * 3. It does not support dead code elimination, so it will add unused operations.
+         *
+         * Therefore it is highly recommended to use the babel-plugin for production.
+         */
+        const documents = {
+            "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
+            "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
+            "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
+        };
 
-              /**
-               * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-               *
-               *
-               * @example
-               * \`\`\`ts
-               * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
-               * \`\`\`
-               *
-               * The query argument is unknown!
-               * Please regenerate the types.
-               */
-              export function graphql(source: string): unknown;
+        /**
+         * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+         *
+         *
+         * @example
+         * \`\`\`ts
+         * const query = graphql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+         * \`\`\`
+         *
+         * The query argument is unknown!
+         * Please regenerate the types.
+         */
+        export function graphql(source: string): unknown;
 
-              /**
-               * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-               */
-              export function graphql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
-              /**
-               * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-               */
-              export function graphql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
-              /**
-               * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
-               */
-              export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
+        /**
+         * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+         */
+        export function graphql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
+        /**
+         * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+         */
+        export function graphql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
+        /**
+         * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+         */
+        export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
 
-              export function graphql(source: string) {
-                return (documents as any)[source] ?? {};
-              }
+        export function graphql(source: string) {
+          return (documents as any)[source] ?? {};
+        }
 
-              export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
-          `);
+        export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
+      `);
     });
 
     it('fragmentMasking: {}', async () => {
@@ -966,7 +966,7 @@ export * from "./gql.js";`);
        *
        * @example
        * \`\`\`ts
-       * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * const query = graphql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
        * \`\`\`
        *
        * The query argument is unknown!
@@ -1039,7 +1039,7 @@ export * from "./gql.js";`);
          *
          * @example
          * \`\`\`ts
-         * const query = gql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+         * const query = graphql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
          * \`\`\`
          *
          * The query argument is unknown!


### PR DESCRIPTION
## Description

I noticed that the example generated wasn't using `gqlTagName`, and therefore the example said `gql`, but the recent version switched to `graphql`, and it got me confused for a second. I believe we probably want to leverage `gqlTagName` for the example and the other places already relying on it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

See updated snapshots and examples.

## How Has This Been Tested?

- [x] Generated new examples via `yarn generate:examples`
- [x] Updated snapshots 

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
