### PR TITLE
Fix swc-plugin package.json

### DIFF
--- a/packages/presets/swc-plugin/package.json
+++ b/packages/presets/swc-plugin/package.json
@@ -11,7 +11,7 @@
   ],
   "main": "swc_plugin.wasm",
   "scripts": {
-    "build-wasm": "cargo build --target wasm32-wasi --release && cp target/wasm32-wasi/release/swc_plugin.wasm ../"
+    "build-wasm": "cargo build --target wasm32-wasi --release && cp target/wasm32-wasi/release/swc_plugin.wasm ./"
   },
   "homepage": "https://the-guild.dev/graphql/codegen/plugins/presets/preset-client",
   "repository": {
@@ -22,5 +22,7 @@
   "bugs": {
     "url": "https://github.com/dotansimha/graphql-code-generator/issues"
   },
-  "files": []
+  "files": [
+    "swc_plugin.wasm"
+  ]
 }


### PR DESCRIPTION
I tried to build the SWC plugin, but I noticed that the wasm file wasn't in the `package.json`'s files array. Besides, the `build-wasm` command copied the file to the wrong place. This fixes it 😄 