### PR TITLE
feat: implement `getFragmentName`

### DIFF
--- a/dev-test/gql-tag-operations/graphql/fragment-masking.ts
+++ b/dev-test/gql-tag-operations/graphql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/persisted-documents/src/gql/fragment-masking.ts
+++ b/examples/persisted-documents/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/react/apollo-client/src/gql/fragment-masking.ts
+++ b/examples/react/apollo-client/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/react/babel-optimized/src/gql/fragment-masking.ts
+++ b/examples/react/babel-optimized/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/react/graphql-request/src/gql/fragment-masking.ts
+++ b/examples/react/graphql-request/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/react/nextjs-swr/gql/fragment-masking.ts
+++ b/examples/react/nextjs-swr/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/react/tanstack-react-query/src/gql/fragment-masking.ts
+++ b/examples/react/tanstack-react-query/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/react/urql/src/gql/fragment-masking.ts
+++ b/examples/react/urql/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/typescript-esm/src/gql/fragment-masking.ts
+++ b/examples/typescript-esm/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/typescript-graphql-request/src/gql/fragment-masking.ts
+++ b/examples/typescript-graphql-request/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/vue/apollo-composable/src/gql/fragment-masking.ts
+++ b/examples/vue/apollo-composable/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import type { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import type { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/vue/urql/src/gql/fragment-masking.ts
+++ b/examples/vue/urql/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import type { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import type { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/vue/villus/src/gql/fragment-masking.ts
+++ b/examples/vue/villus/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import type { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import type { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }

--- a/examples/yoga-tests/src/gql/fragment-masking.ts
+++ b/examples/yoga-tests/src/gql/fragment-masking.ts
@@ -1,13 +1,21 @@
 import { ResultOf, TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+
+export type FragmentName<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
+  infer TType,
+  any
+>
+  ? TType extends { ' $fragmentName'?: infer TKey }
+    ? TKey
+    : never
+  : never;
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<
   infer TType,
   any
 >
-  ? TType extends { ' $fragmentName'?: infer TKey }
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-      : never
+  ? FragmentName<TDocumentType> extends string
+    ? { ' $fragmentRefs'?: { [key in FragmentName<TDocumentType>]: TType } }
     : never
   : never;
 
@@ -47,4 +55,16 @@ export function makeFragmentData<F extends DocumentNode, FT extends ResultOf<F>>
   _fragment: F
 ): FragmentType<F> {
   return data as FragmentType<F>;
+}
+
+export function getFragmentName<TType>(doc: DocumentNode<TType>): FragmentName<DocumentNode<TType, any>> {
+  const fragmentName = doc.definitions
+    .filter((definition): definition is FragmentDefinitionNode => definition.kind === 'FragmentDefinition')
+    .map(definition => definition.name.value as FragmentName<DocumentNode<TType, any>>)[0];
+
+  if (!fragmentName) {
+    throw new Error(`Could not find a fragment name for the provided document: ${doc}`);
+  }
+
+  return fragmentName;
 }


### PR DESCRIPTION
## Description

> **Warning**: 🚧 WIP 🚧 I still need to update the documentation.

Related #9055

Currently, there's no way to easily extract the name of a generated fragment.

This pull request adds the implementation for a helper function: `getFragmentName` to extract the fragment's name from the `DocumentNode` object via some AST utils.

It returns the name of the generated fragment as a string literal so we can compose fragments or queries with it:

```tsx
import { graphql, getFragmentName } from './gql';

export const FilmFragment = graphql(/* GraphQL */ `
  fragment FilmItem on Film {
    id
    title
    releaseDate
    producers
  }
`);

const fragmentName = getFragmentName(FilmFragment); // 'FilmItemFragment'
//    ^? const fragmentName = "FilmItemFragment"
```

There are two implementations introduced here:

First, we have the function itself to traverse the AST object and return the name of the `FragmentDefinitionNode`.

Then there's a specific TypeScript implementation so we could statically infer the fragment's name as a string literal from ` $fragmentName` field on the type. One advantage of that is that returning a `string` type isn't helpful, I would like to be able to have the fragment's name directly in my IDE (string literal) without having to open the generated code. To achieve this, I split `FragmentType` into a new type: `FragmentName` which is reused by `FragmentType` and the new helper function.

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

The code snippet above was tested in a generated example.

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
