### PR TITLE
Update server preset guide with 0.3.0 mapper behaviour

### DIFF
--- a/website/src/pages/docs/guides/graphql-server-apollo-yoga-with-server-preset.mdx
+++ b/website/src/pages/docs/guides/graphql-server-apollo-yoga-with-server-preset.mdx
@@ -42,6 +42,7 @@ extend type Query {
 type User {
   id: ID!
   fullName: String!
+  isAdmin: Boolean!
 }
 
 # src/schema/book.graphql
@@ -317,10 +318,13 @@ export interface UserMapper {
   id: string
   firstName: string
   lastName: string
+  isAdmin: 'YES' | 'NO'
 }
 ```
 
-Running codegen automatically imports and uses this mapper in schema types:
+Running codegen again does a few things:
+
+1. automatically imports and uses this mapper in schema types
 
 ```ts filename="src/schema/types.generated.ts" {2,6,11}
 // ... other imports
@@ -337,18 +341,35 @@ export type ResolversParentTypes = {
 }
 ```
 
+2. automatically compares schema type and mapper type to create required field resolvers
+
+```ts filename="src/schema/user/resolvers/User.ts" {3-5,7-10}
+import type { UserResolvers } from './../../types.generated'
+export const User: UserResolvers = {
+  fullName: () => {
+    /* User.fullName resolver is required because User.fullName exists but UserMapper.fullName does not */
+  },
+
+  isAdmin: ({ isAdmin }) => {
+    /* User.isAdmin resolver is required because User.isAdmin and UserMapper.isAdmin are not compatible */
+    return isAdmin
+  }
+}
+```
+
 You can now update your resolvers to use the mapper interface:
 
 ```ts
 // src/schema/user/resolvers/Query/user.ts
 import type { QueryResolvers } from './../../../types.generated'
 export const user: NonNullable<QueryResolvers['user']> = async (_parent, _arg, _ctx) => {
-  return { id: '001', firstName: 'Bart', lastName: 'Simpson' }
+  return { id: '001', firstName: 'Bart', lastName: 'Simpson', isAdmin: 'YES' }
 }
 
 // src/schema/user/resolvers/User.ts
 import type { UserResolvers } from './../../types.generated'
 export const User: UserResolvers = {
   fullName: ({ firstName, lastName }) => `${firstName} ${lastName}`
+  isAdmin: ({ isAdmin }) => isAdmin === 'YES'
 }
 ```


### PR DESCRIPTION
## Description

This PR updates the server preset guide with new v0.3.0 mapper behaviours:

- automatically create missing field resolvers
- automatically create incompatible field resolvers

## Screenshots

![Screen Shot 2023-02-24 at 11 13 18 pm](https://user-images.githubusercontent.com/33769523/221176704-b3da68cd-101e-482e-a384-a5701d273f6a.png)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
