### PR TITLE
chore: add `build/` to `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ dev-test/githunt-invalid/invalid.graphql
 packages/graphql-codegen-cli/tests/test-documents/invalid-schema.graphql
 packages/presets/gql-tag-operations/tests/fixtures/crlf-operation.ts
 dist/
+build/
 .next/
 .bob
 CHANGELOG.md


### PR DESCRIPTION
## Description

I noticed that Prettier was executed on `build` folders of generated examples, e.g.: `examples/react/apollo-client/build`.

We don't need to run Prettier on the generated builds from generated examples, especially since they are ignored by git.