### PR TITLE
Add `addToSchema` to Document Transform

### DIFF
--- a/.changeset/pretty-peaches-lay.md
+++ b/.changeset/pretty-peaches-lay.md
@@ -1,0 +1,72 @@
+---
+'@graphql-codegen/plugin-helpers': minor
+'@graphql-codegen/core': minor
+'@graphql-codegen/cli': minor
+---
+
+Add `addToSchema` to Document Transform.
+
+Now, before transforming `documents` with a document transform, you can extend a type in the schema using both `documents` and `schema`. With this change, you can generate type information for a local-only field in your document transform, thus avoiding validation errors.
+
+For instance, the following is an example of a document transform that adds a field named `localOnlyFieldForMyTool` when a `@useMyTool` directive is used:
+
+```ts
+const directiveName = 'useMyTool';
+const localOnlyFieldName = 'localOnlyFieldForMyTool
+const documentTransform: Types.DocumentTransformObject = {
+  transform: ({ documents }) => {
+    return documents.map(documentFile => {
+      documentFile.document = visit(documentFile.document, {
+        Field: {
+          leave(fieldNode) {
+            if (!fieldNode.directives) return undefined;
+            const addFieldDirective = fieldNode.directives.find(
+              directive => directive.name.value === directiveName
+            );
+            if (!addFieldDirective) return undefine
+            const localOnlyField: FieldNode = {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: localOnlyFieldName },
+              directives: [{ kind: Kind.DIRECTIVE, name: { kind: Kind.NAME, value: 'client' } }],
+            };
+            return {
+              ...fieldNode,
+              selectionSet: {
+                ...fieldNode.selectionSet!,
+                selections: [...fieldNode.selectionSet!.selections, localOnlyField],
+              },
+            };
+          },
+        },
+      });
+      return documentFile;
+    });
+  },
+  addToSchema: ({ schemaAst, documents }) => {
+    const typeInfo = new TypeInfo(schemaAst);
+    const typeNames = [];
+    visit(
+      concatAST(documents.map(file => file.document)),
+      visitWithTypeInfo(typeInfo, {
+        Field: {
+          leave(fieldNode) {
+            if (!fieldNode.directives) return;
+            const addFieldDirective = fieldNode.directives.find(
+              directive => directive.name.value === directiveName
+            );
+            if (!addFieldDirective) retur
+            const type = typeInfo.getType();
+            if (isNonNullType(type) && isObjectType(type.ofType)) {
+              typeNames.push(type.ofType.name);
+            }
+          },
+        },
+      })
+    );
+    if (typeNames.length > 0) {
+      return typeNames.map(name => `extend type ${name} { ${localOnlyFieldName}: String! }`).j('\n');
+    }
+    return '';
+  },
+};
+```

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -626,8 +626,17 @@ export namespace Types {
     pluginContext?: { [key: string]: any };
   }) => Types.Promisable<Types.DocumentFile[]>;
 
+  export type DocumentTransformAddToSchemaFunction<Config = object> = (options: {
+    documents: Types.DocumentFile[];
+    schema: DocumentNode;
+    schemaAst?: GraphQLSchema;
+    config: Config;
+    pluginContext?: { [key: string]: any };
+  }) => AddToSchemaResult;
+
   export type DocumentTransformObject<T = object> = {
     transform: DocumentTransformFunction<T>;
+    addToSchema?: AddToSchemaResult | DocumentTransformAddToSchemaFunction;
   };
 
   export type DocumentTransformFileName = string;

--- a/website/src/pages/docs/advanced/document-transform.mdx
+++ b/website/src/pages/docs/advanced/document-transform.mdx
@@ -164,3 +164,73 @@ module.exports = {
   }
 }
 ```
+
+## Extending the schema
+
+You can also extend types using `addToSchema`. For example, if you want to add a local-only field that doesn't exist in the schema using a document transform, you can generate the type information for that field.
+
+The following is an example of a document transform that adds a field named `localOnlyFieldForMyTool` when a `@useMyTool` directive is used:
+
+```ts
+import { Kind, visit, TypeInfo, visitWithTypeInfo, concatAST, isNonNullType, isObjectType, FieldNode } from 'graphql'
+import { Types } from '@graphql-codegen/plugin-helpers'
+
+const directiveName = 'useMyTool'
+const localOnlyFieldName = 'localOnlyFieldForMyTool'
+
+const documentTransform: Types.DocumentTransformObject = {
+  transform: ({ documents }) => {
+    return documents.map(documentFile => {
+      documentFile.document = visit(documentFile.document, {
+        Field: {
+          leave(fieldNode) {
+            if (!fieldNode.directives) return undefined
+            const addFieldDirective = fieldNode.directives.find(directive => directive.name.value === directiveName)
+            if (!addFieldDirective) return undefined
+
+            const localOnlyField: FieldNode = {
+              kind: Kind.FIELD,
+              name: { kind: Kind.NAME, value: localOnlyFieldName },
+              directives: [{ kind: Kind.DIRECTIVE, name: { kind: Kind.NAME, value: 'client' } }]
+            }
+
+            return {
+              ...fieldNode,
+              selectionSet: {
+                ...fieldNode.selectionSet!,
+                selections: [...fieldNode.selectionSet!.selections, localOnlyField]
+              }
+            }
+          }
+        }
+      })
+      return documentFile
+    })
+  },
+  addToSchema: ({ schemaAst, documents }) => {
+    const typeInfo = new TypeInfo(schemaAst)
+    const typeNames = []
+    visit(
+      concatAST(documents.map(file => file.document)),
+      visitWithTypeInfo(typeInfo, {
+        Field: {
+          leave(fieldNode) {
+            if (!fieldNode.directives) return
+            const addFieldDirective = fieldNode.directives.find(directive => directive.name.value === directiveName)
+            if (!addFieldDirective) return
+
+            const type = typeInfo.getType()
+            if (isNonNullType(type) && isObjectType(type.ofType)) {
+              typeNames.push(type.ofType.name)
+            }
+          }
+        }
+      })
+    )
+    if (typeNames.length > 0) {
+      return typeNames.map(name => `extend type ${name} { ${localOnlyFieldName}: String! }`).join('\n')
+    }
+    return ''
+  }
+}
+```


### PR DESCRIPTION
## Description
I have added `addToSchema` to Document Transform. This is based on  https://github.com/dotansimha/graphql-code-generator/discussions/8724.

With this change, you can extend a type in the schema using both `documents` and `schema` before transforming `documents` with a document transform.  You can generate type information for a local-only field in your document transform, thus avoiding validation errors.

If you want to learn more about the detailed background or different implementation methods along with their pros and cons, please refer to https://github.com/dotansimha/graphql-code-generator/discussions/8724.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Please see documentation for usage.

## How Has This Been Tested?

I added tests to the spec file.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
