### PR TITLE
ci: remove auto ci job to publish rust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,31 +14,6 @@ jobs:
       githubToken: ${{ secrets.GUILD_BOT_TOKEN }}
       npmToken: ${{ secrets.NPM_TOKEN }}
 
-  publish-rust-swc-plugin:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
-          registry-url: 'https://registry.npmjs.org'
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.65.0
-          target: wasm32-wasi
-          override: true
-      - uses: marcopolo/cargo@a527bf4d534717ff4424a84446c5d710f8833139
-        with:
-          working-directory: ./packages/presets/swc-plugin
-          command: build
-          args: --target wasm32-wasi --release
-      - name: Publish SWC plugin
-        working-directory: ./packages/presets/swc-plugin
-        run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   algolia:
     uses: the-guild-org/shared-config/.github/workflows/algolia-publish.yml@main
     secrets:


### PR DESCRIPTION
#9039 I made it such that we have to trigger CI to publish the rust plugin. So we no longer need to run this automatically 


