### PR TITLE
Add a test case to ensure deduplicated fragments

### DIFF
--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -1043,7 +1043,9 @@ export * from "./gql.js";`);
     } catch {}
     await fs.promises.mkdir(path.join(dir, 'out1'), { recursive: true });
     for (const file of result) {
-      await fs.promises.writeFile(path.join(dir, file.filename), file.content, 'utf-8');
+      if (file.filename === 'out1/graphql.ts') {
+        await fs.promises.writeFile(path.join(dir, file.filename), file.content, 'utf-8');
+      }
     }
 
     const { default: jiti } = await import('jiti');

--- a/packages/presets/client/tests/fixtures/reused-fragment.ts
+++ b/packages/presets/client/tests/fixtures/reused-fragment.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+
+const SharedComponentFragment = graphql(`
+  fragment SharedComponentFragment on User {
+    id
+    username
+  }
+`);
+
+const EventHeaderComponentFragment = graphql(`
+  fragment EventHeaderComponentFragment on Event {
+    owner {
+      ...SharedComponentFragment
+    }
+  }
+`);
+
+const EventQueryDocument = graphql(`
+  query EventQuery($eventId: ID!) {
+    event(id: $eventId) {
+      ...EventHeaderComponentFragment
+      attendees {
+        ...SharedComponentFragment
+      }
+    }
+  }
+`);


### PR DESCRIPTION
## Description

I was looking into [an issue with duplicated fragments](https://github.com/dotansimha/graphql-code-generator/issues/8670) and found out it was fixed in [a recent PR](https://github.com/dotansimha/graphql-code-generator/pull/8971) by always inlining fragments. So this PR only adds a test case to ensure that it works as expected (I followed @saihaj's repros mentioned in the issue).

However, should we revisit the inlining part? It causes [issues with huge files being generated](https://github.com/dotansimha/graphql-code-generator/pull/8971#issuecomment-1451997425).

Related https://github.com/dotansimha/graphql-code-generator/issues/8670

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
