### PR TITLE
Stop importing fragments that are now unused

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -604,50 +604,6 @@ export class ClientSideBaseVisitor<
         break;
     }
 
-    if (!options.excludeFragments && !this.config.globalNamespace) {
-      const { documentMode, fragmentImports } = this.config;
-      if (
-        documentMode === DocumentMode.graphQLTag ||
-        documentMode === DocumentMode.string ||
-        documentMode === DocumentMode.documentNodeImportFragments
-      ) {
-        // keep track of what imports we've already generated so we don't try
-        // to import the same identifier twice
-        const alreadyImported = new Map<string, Set<string>>();
-
-        const deduplicatedImports = fragmentImports
-          .map(fragmentImport => {
-            const { path, identifiers } = fragmentImport.importSource;
-            if (!alreadyImported.has(path)) {
-              alreadyImported.set(path, new Set<string>());
-            }
-
-            const alreadyImportedForPath = alreadyImported.get(path);
-            const newIdentifiers = identifiers.filter(identifier => !alreadyImportedForPath.has(identifier.name));
-            newIdentifiers.forEach(newIdentifier => alreadyImportedForPath.add(newIdentifier.name));
-
-            // filter the set of identifiers in this fragment import to only
-            // the ones we haven't already imported from this path
-            return {
-              ...fragmentImport,
-              importSource: {
-                ...fragmentImport.importSource,
-                identifiers: newIdentifiers,
-              },
-              emitLegacyCommonJSImports: this.config.emitLegacyCommonJSImports,
-            };
-          })
-          // remove any imports that now have no identifiers in them
-          .filter(fragmentImport => fragmentImport.importSource.identifiers.length > 0);
-
-        deduplicatedImports.forEach(fragmentImport => {
-          if (fragmentImport.outputPath !== fragmentImport.importSource.path) {
-            this._imports.add(generateFragmentImportStatement(fragmentImport, 'document'));
-          }
-        });
-      }
-    }
-
     return Array.from(this._imports);
   }
 


### PR DESCRIPTION
## Description

After this change: https://github.com/dotansimha/graphql-code-generator/pull/8971, we see that fragments are still imported but now unused, resulting in a TS error.

Related # (issue): https://github.com/dotansimha/graphql-code-generator-community/issues/289

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] [Test A](https://codesandbox.io/s/gql-code-generator-without-dedup-fragments-forked-35lp34?file=/src/user.fragment.generated.tsx)
- [ ] Test B => same sandbox pointing to fork

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
