### PR TITLE
fix: add makeValidEnumIdentifier for enumsAsConst

### DIFF
--- a/.changeset/clean-files-begin.md
+++ b/.changeset/clean-files-begin.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript': patch
+---
+
+Properly escape enum identifiers when enumsAsConst is used

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -426,10 +426,12 @@ export class TsVisitor<
         .withBlock(
           node.values
             .map(enumOption => {
-              const optionName = this.convertName(enumOption, {
-                useTypesPrefix: false,
-                transformUnderscore: true,
-              });
+              const optionName = this.makeValidEnumIdentifier(
+                this.convertName(enumOption, {
+                  useTypesPrefix: false,
+                  transformUnderscore: true,
+                })
+              );
               const comment = transformComment(enumOption.description as any as string, 1);
               const name = enumOption.name as unknown as string;
               const enumValue: string | number = getValueFromConfig(name) ?? name;

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -209,6 +209,7 @@ describe('TypeScript', () => {
           X_Y_Z
           _TEST
           My_Value
+          _123
         }
       `);
       const result = (await plugin(
@@ -223,7 +224,8 @@ describe('TypeScript', () => {
         ABC: 'A_B_C',
         XYZ: 'X_Y_Z',
         Test: '_TEST',
-        MyValue: 'My_Value'
+        MyValue: 'My_Value',
+        '123': '_123'
       } as const;
       export type MyEnum = typeof MyEnum[keyof typeof MyEnum];`);
     });


### PR DESCRIPTION
## Description

Properly escape enum identifiers when enumsAsConst is used

Related #9149 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested change locally using a basic enum like

```
enum SomeType {
  _401K
  Other
}
```

**Test Environment**:

- OS: macOS

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

