### PR TITLE
[cli] Add watchPattern to generates config

### DIFF
--- a/.changeset/brave-papayas-shout.md
+++ b/.changeset/brave-papayas-shout.md
@@ -3,4 +3,39 @@
 '@graphql-codegen/cli': minor
 ---
 
-Add watchFile config for generates config
+Add `watchPattern` config option for `generates` sections.
+
+By default, `watch` mode automatically watches all GraphQL schema and document files. This means when a change is detected, Codegen CLI is run.
+
+A user may want to run Codegen CLI when non-schema and non-document files are changed. Each `generates` section now has a `watchPattern` option to allow more file patterns to be added to the list of patterns to watch.
+
+In the example below, mappers are exported from `schema.mappers.ts` files. We want to re-run Codegen if the content of `*.mappers.ts` files change because they change the generated types file. To solve this, we can add mapper file patterns to watch using the glob pattern used for schema and document files.
+
+```ts
+// codegen.ts
+const config: CodegenConfig = {
+  schema: 'src/schema/**/*.graphql',
+  generates: {
+    'src/schema/types.ts': {
+      plugins: ['typescript', 'typescript-resolvers'],
+      config: {
+        mappers: {
+          User: './user/schema.mappers#UserMapper',
+          Book: './book/schema.mappers#BookMapper',
+        },
+      }
+      watchPattern: 'src/schema/**/*.mappers.ts', // Watches mapper files in `watch` mode. Use an array for multiple patterns e.g. `['src/*.pattern1.ts','src/*.pattern2.ts']`
+    },
+  },
+};
+```
+
+Then, run Codegen CLI in `watch` mode:
+
+```shell
+yarn graphql-codegen --watch
+```
+
+Now, updating `*.mappers.ts` files re-runs Codegen! 🎉
+
+Note: `watchPattern` is only used in `watch` mode i.e. running CLI with `--watch` flag.

--- a/.changeset/brave-papayas-shout.md
+++ b/.changeset/brave-papayas-shout.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/plugin-helpers': minor
+'@graphql-codegen/cli': minor
+---
+
+Add watchFile config for generates config

--- a/packages/graphql-codegen-cli/src/utils/watcher.ts
+++ b/packages/graphql-codegen-cli/src/utils/watcher.ts
@@ -37,6 +37,7 @@ export const createWatcher = (
     .forEach(conf => {
       schemas.push(...normalizeInstanceOrArray<Types.Schema>(conf.schema));
       documents.push(...normalizeInstanceOrArray<Types.OperationDocument>(conf.documents));
+      files.push(...normalizeInstanceOrArray(conf.watchPattern));
     });
 
   if (documents) {

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -321,6 +321,10 @@ export namespace Types {
      * @description DocumentTransform changes documents before executing plugins.
      */
     documentTransforms?: OutputDocumentTransform[];
+    /**
+     * @description: Additional file pattern to watch when using watch mode
+     */
+    watchPattern?: string | string[];
   }
 
   /* Output Builder Preset */


### PR DESCRIPTION
## Description

This PR allows each `generates` config to declare additional file pattern to watch using `watchPattern`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Tested `watchPattern` in this repo PR: https://github.com/eddeee888/poc-gcg-watch-pattern/pull/1

**Test Environment**:

- OS: MacOS
- `@graphql-codegen/cli`: `3.3.0-alpha-20230311001721-c93af8a64`
- NodeJS: 18

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
