### PR TITLE
[typescript-resolvers] Extract interface types into ResolversInterfaceTypes + add interface to resolversNonOptionalTypename + simplify ResolversUnionTypes

### DIFF
--- a/.changeset/long-pears-peel.md
+++ b/.changeset/long-pears-peel.md
@@ -1,0 +1,8 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-resolvers': minor
+---
+
+Use generic to simplify ResolversUnionTypes
+
+This follows the `ResolversInterfaceTypes`'s approach where the `RefType` generic is used to refer back to `ResolversTypes` or `ResolversParentTypes` in cases of nested Union types

--- a/.changeset/tricky-swans-happen.md
+++ b/.changeset/tricky-swans-happen.md
@@ -1,0 +1,100 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-resolvers': minor
+---
+
+Extract interfaces to ResolversInterfaceTypes and add to resolversNonOptionalTypename
+
+1. `ResolversInterfaceTypes` is a new type that keeps track of a GraphQL interface and its implementing types.
+
+For example, consider this schema:
+
+```graphql
+extend type Query {
+  character(id: ID!): CharacterNode
+}
+
+interface CharacterNode {
+  id: ID!
+}
+
+type Wizard implements CharacterNode {
+  id: ID!
+  screenName: String!
+  spells: [String!]!
+}
+
+type Fighter implements CharacterNode {
+  id: ID!
+  screenName: String!
+  powerLevel: Int!
+}
+```
+
+The generated types will look like this:
+
+```ts
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+  CharacterNode: Fighter | Wizard;
+};
+
+export type ResolversTypes = {
+  // other types...
+  CharacterNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>["CharacterNode"]>;
+  Fighter: ResolverTypeWrapper<Fighter>;
+  Wizard: ResolverTypeWrapper<Wizard>;
+  // other types...
+};
+
+export type ResolversParentTypes = {
+  // other types...
+  CharacterNode: ResolversInterfaceTypes<ResolversParentTypes>["CharacterNode"];
+  Fighter: Fighter;
+  Wizard: Wizard;
+  // other types...
+};
+```
+
+The `RefType` generic is used to reference back to `ResolversTypes` and `ResolversParentTypes` in some cases such as field returning a Union.
+
+2. `resolversNonOptionalTypename` also affects `ResolversInterfaceTypes`
+
+Using the schema above, if we use `resolversNonOptionalTypename` option:
+
+```typescript
+const config: CodegenConfig = {
+  schema: 'src/schema/**/*.graphql',
+  generates: {
+    'src/schema/types.ts': {
+      plugins: ['typescript', 'typescript-resolvers'],
+      config: {
+        resolversNonOptionalTypename: true // Or `resolversNonOptionalTypename: { interfaceImplementingType: true }`
+      }
+    },
+  },
+};
+```
+
+Then, the generated type looks like this:
+
+```ts
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+  CharacterNode: (Fighter & { __typename: "Fighter" }) | (Wizard & { __typename: "Wizard" });
+};
+
+export type ResolversTypes = {
+  // other types...
+  CharacterNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>["CharacterNode"]>;
+  Fighter: ResolverTypeWrapper<Fighter>;
+  Wizard: ResolverTypeWrapper<Wizard>;
+  // other types...
+};
+
+export type ResolversParentTypes = {
+  // other types...
+  CharacterNode: ResolversInterfaceTypes<ResolversParentTypes>["CharacterNode"];
+  Fighter: Fighter;
+  Wizard: Wizard;
+  // other types...
+};
+```

--- a/dev-test/modules/types.ts
+++ b/dev-test/modules/types.ts
@@ -163,12 +163,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 ) => TResult | Promise<TResult>;
 
 /** Mapping of union types */
-export type ResolversUnionTypes = {
-  PaymentOption: CreditCard | Paypal;
-};
-
-/** Mapping of union parent types */
-export type ResolversUnionParentTypes = {
+export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
   PaymentOption: CreditCard | Paypal;
 };
 
@@ -183,7 +178,7 @@ export type ResolversTypes = {
   ID: ResolverTypeWrapper<Scalars['ID']>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
   Mutation: ResolverTypeWrapper<{}>;
-  PaymentOption: ResolverTypeWrapper<ResolversUnionTypes['PaymentOption']>;
+  PaymentOption: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['PaymentOption']>;
   Paypal: ResolverTypeWrapper<Paypal>;
   Query: ResolverTypeWrapper<{}>;
   String: ResolverTypeWrapper<Scalars['String']>;
@@ -203,7 +198,7 @@ export type ResolversParentTypes = {
   ID: Scalars['ID'];
   Int: Scalars['Int'];
   Mutation: {};
-  PaymentOption: ResolversUnionParentTypes['PaymentOption'];
+  PaymentOption: ResolversUnionTypes<ResolversParentTypes>['PaymentOption'];
   Paypal: Paypal;
   Query: {};
   String: Scalars['String'];

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -105,4 +105,5 @@ export interface ParsedImport {
 
 export interface ResolversNonOptionalTypenameConfig {
   unionMember?: boolean;
+  interfaceImplementingType?: boolean;
 }

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -247,6 +247,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   const resolversParentTypeMapping = visitor.buildResolversParentTypes();
   const resolversUnionTypesMapping = visitor.buildResolversUnionTypes();
   const resolversUnionParentTypesMapping = visitor.buildResolversUnionParentTypes();
+  const resolversInterfaceTypesMapping = visitor.buildResolversInterfaceTypes();
   const { getRootResolver, getAllDirectiveResolvers, mappersImports, unusedMappers, hasScalars } = visitor;
 
   if (hasScalars()) {
@@ -286,6 +287,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
       header,
       resolversUnionTypesMapping,
       resolversUnionParentTypesMapping,
+      resolversInterfaceTypesMapping,
       resolversTypeMapping,
       resolversParentTypeMapping,
       ...visitorResult.definitions.filter(d => typeof d === 'string'),

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -246,7 +246,6 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   const resolversTypeMapping = visitor.buildResolversTypes();
   const resolversParentTypeMapping = visitor.buildResolversParentTypes();
   const resolversUnionTypesMapping = visitor.buildResolversUnionTypes();
-  const resolversUnionParentTypesMapping = visitor.buildResolversUnionParentTypes();
   const resolversInterfaceTypesMapping = visitor.buildResolversInterfaceTypes();
   const { getRootResolver, getAllDirectiveResolvers, mappersImports, unusedMappers, hasScalars } = visitor;
 
@@ -286,7 +285,6 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
     content: [
       header,
       resolversUnionTypesMapping,
-      resolversUnionParentTypesMapping,
       resolversInterfaceTypesMapping,
       resolversTypeMapping,
       resolversParentTypeMapping,

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -165,15 +165,9 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 ) => TResult | Promise<TResult>;
 
 /** Mapping of union types */
-export type ResolversUnionTypes = ResolversObject<{
+export type ResolversUnionTypes<RefType extends Record<string, unknown>> = ResolversObject<{
   ChildUnion: ( Child ) | ( MyOtherType );
-  MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> } ) | ( MyOtherType );
-}>;
-
-/** Mapping of union parent types */
-export type ResolversUnionParentTypes = ResolversObject<{
-  ChildUnion: ( Child ) | ( MyOtherType );
-  MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> } ) | ( MyOtherType );
+  MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( MyOtherType );
 }>;
 
 /** Mapping of interface types */
@@ -190,7 +184,7 @@ export type ResolversTypes = ResolversObject<{
   String: ResolverTypeWrapper<Scalars['String']>;
   Child: ResolverTypeWrapper<Child>;
   MyOtherType: ResolverTypeWrapper<MyOtherType>;
-  ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+  ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
   Query: ResolverTypeWrapper<{}>;
   Subscription: ResolverTypeWrapper<{}>;
   Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -201,7 +195,7 @@ export type ResolversTypes = ResolversObject<{
   WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
   AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
   AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-  MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+  MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
   MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -213,7 +207,7 @@ export type ResolversParentTypes = ResolversObject<{
   String: Scalars['String'];
   Child: Child;
   MyOtherType: MyOtherType;
-  ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+  ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
   Query: {};
   Subscription: {};
   Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -224,7 +218,7 @@ export type ResolversParentTypes = ResolversObject<{
   WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
   AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
   AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-  MyUnion: ResolversUnionParentTypes['MyUnion'];
+  MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
   MyScalar: Scalars['MyScalar'];
   Int: Scalars['Int'];
   Boolean: Scalars['Boolean'];
@@ -430,15 +424,9 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 ) => TResult | Promise<TResult>;
 
 /** Mapping of union types */
-export type ResolversUnionTypes = ResolversObject<{
+export type ResolversUnionTypes<RefType extends Record<string, unknown>> = ResolversObject<{
   ChildUnion: ( Types.Child ) | ( Types.MyOtherType );
-  MyUnion: ( Omit<Types.MyType, 'unionChild'> & { unionChild?: Types.Maybe<ResolversTypes['ChildUnion']> } ) | ( Types.MyOtherType );
-}>;
-
-/** Mapping of union parent types */
-export type ResolversUnionParentTypes = ResolversObject<{
-  ChildUnion: ( Types.Child ) | ( Types.MyOtherType );
-  MyUnion: ( Omit<Types.MyType, 'unionChild'> & { unionChild?: Types.Maybe<ResolversParentTypes['ChildUnion']> } ) | ( Types.MyOtherType );
+  MyUnion: ( Omit<Types.MyType, 'unionChild'> & { unionChild?: Types.Maybe<RefType['ChildUnion']> } ) | ( Types.MyOtherType );
 }>;
 
 /** Mapping of interface types */
@@ -455,7 +443,7 @@ export type ResolversTypes = ResolversObject<{
   String: ResolverTypeWrapper<Types.Scalars['String']>;
   Child: ResolverTypeWrapper<Types.Child>;
   MyOtherType: ResolverTypeWrapper<Types.MyOtherType>;
-  ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+  ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
   Query: ResolverTypeWrapper<{}>;
   Subscription: ResolverTypeWrapper<{}>;
   Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -466,7 +454,7 @@ export type ResolversTypes = ResolversObject<{
   WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
   AnotherNodeWithChild: ResolverTypeWrapper<Omit<Types.AnotherNodeWithChild, 'unionChild'> & { unionChild?: Types.Maybe<ResolversTypes['ChildUnion']> }>;
   AnotherNodeWithAll: ResolverTypeWrapper<Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Types.Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-  MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+  MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
   MyScalar: ResolverTypeWrapper<Types.Scalars['MyScalar']>;
   Int: ResolverTypeWrapper<Types.Scalars['Int']>;
   Boolean: ResolverTypeWrapper<Types.Scalars['Boolean']>;
@@ -478,7 +466,7 @@ export type ResolversParentTypes = ResolversObject<{
   String: Types.Scalars['String'];
   Child: Types.Child;
   MyOtherType: Types.MyOtherType;
-  ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+  ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
   Query: {};
   Subscription: {};
   Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -489,7 +477,7 @@ export type ResolversParentTypes = ResolversObject<{
   WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
   AnotherNodeWithChild: Omit<Types.AnotherNodeWithChild, 'unionChild'> & { unionChild?: Types.Maybe<ResolversParentTypes['ChildUnion']> };
   AnotherNodeWithAll: Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Types.Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-  MyUnion: ResolversUnionParentTypes['MyUnion'];
+  MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
   MyScalar: Types.Scalars['MyScalar'];
   Int: Types.Scalars['Int'];
   Boolean: Types.Scalars['Boolean'];
@@ -779,15 +767,9 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 ) => TResult | Promise<TResult>;
 
 /** Mapping of union types */
-export type ResolversUnionTypes = ResolversObject<{
+export type ResolversUnionTypes<RefType extends Record<string, unknown>> = ResolversObject<{
   ChildUnion: ( Child ) | ( MyOtherType );
-  MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> } ) | ( MyOtherType );
-}>;
-
-/** Mapping of union parent types */
-export type ResolversUnionParentTypes = ResolversObject<{
-  ChildUnion: ( Child ) | ( MyOtherType );
-  MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> } ) | ( MyOtherType );
+  MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( MyOtherType );
 }>;
 
 /** Mapping of interface types */
@@ -804,7 +786,7 @@ export type ResolversTypes = ResolversObject<{
   String: ResolverTypeWrapper<Scalars['String']>;
   Child: ResolverTypeWrapper<Child>;
   MyOtherType: ResolverTypeWrapper<MyOtherType>;
-  ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+  ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
   Query: ResolverTypeWrapper<{}>;
   Subscription: ResolverTypeWrapper<{}>;
   Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -815,7 +797,7 @@ export type ResolversTypes = ResolversObject<{
   WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
   AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
   AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-  MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+  MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
   MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -827,7 +809,7 @@ export type ResolversParentTypes = ResolversObject<{
   String: Scalars['String'];
   Child: Child;
   MyOtherType: MyOtherType;
-  ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+  ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
   Query: {};
   Subscription: {};
   Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -838,7 +820,7 @@ export type ResolversParentTypes = ResolversObject<{
   WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
   AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
   AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-  MyUnion: ResolversUnionParentTypes['MyUnion'];
+  MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
   MyScalar: Scalars['MyScalar'];
   Int: Scalars['Int'];
   Boolean: Scalars['Boolean'];

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -176,6 +176,14 @@ export type ResolversUnionParentTypes = ResolversObject<{
   MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> } ) | ( MyOtherType );
 }>;
 
+/** Mapping of interface types */
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = ResolversObject<{
+  Node: ( SomeNode );
+  AnotherNode: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+  WithChild: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+  WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+}>;
+
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = ResolversObject<{
   MyType: ResolverTypeWrapper<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
@@ -185,12 +193,12 @@ export type ResolversTypes = ResolversObject<{
   ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
   Query: ResolverTypeWrapper<{}>;
   Subscription: ResolverTypeWrapper<{}>;
-  Node: ResolversTypes['SomeNode'];
+  Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
   ID: ResolverTypeWrapper<Scalars['ID']>;
   SomeNode: ResolverTypeWrapper<SomeNode>;
-  AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-  WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-  WithChildren: ResolversTypes['AnotherNodeWithAll'];
+  AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+  WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+  WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
   AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
   AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
   MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
@@ -208,12 +216,12 @@ export type ResolversParentTypes = ResolversObject<{
   ChildUnion: ResolversUnionParentTypes['ChildUnion'];
   Query: {};
   Subscription: {};
-  Node: ResolversParentTypes['SomeNode'];
+  Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
   ID: Scalars['ID'];
   SomeNode: SomeNode;
-  AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-  WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-  WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
+  AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+  WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+  WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
   AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
   AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
   MyUnion: ResolversUnionParentTypes['MyUnion'];
@@ -433,6 +441,14 @@ export type ResolversUnionParentTypes = ResolversObject<{
   MyUnion: ( Omit<Types.MyType, 'unionChild'> & { unionChild?: Types.Maybe<ResolversParentTypes['ChildUnion']> } ) | ( Types.MyOtherType );
 }>;
 
+/** Mapping of interface types */
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = ResolversObject<{
+  Node: ( Types.SomeNode );
+  AnotherNode: ( Omit<Types.AnotherNodeWithChild, 'unionChild'> & { unionChild?: Types.Maybe<RefType['ChildUnion']> } ) | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Types.Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+  WithChild: ( Omit<Types.AnotherNodeWithChild, 'unionChild'> & { unionChild?: Types.Maybe<RefType['ChildUnion']> } ) | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Types.Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+  WithChildren: ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Types.Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+}>;
+
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = ResolversObject<{
   MyType: ResolverTypeWrapper<Omit<Types.MyType, 'unionChild'> & { unionChild?: Types.Maybe<ResolversTypes['ChildUnion']> }>;
@@ -442,12 +458,12 @@ export type ResolversTypes = ResolversObject<{
   ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
   Query: ResolverTypeWrapper<{}>;
   Subscription: ResolverTypeWrapper<{}>;
-  Node: ResolversTypes['SomeNode'];
+  Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
   ID: ResolverTypeWrapper<Types.Scalars['ID']>;
   SomeNode: ResolverTypeWrapper<Types.SomeNode>;
-  AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-  WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-  WithChildren: ResolversTypes['AnotherNodeWithAll'];
+  AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+  WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+  WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
   AnotherNodeWithChild: ResolverTypeWrapper<Omit<Types.AnotherNodeWithChild, 'unionChild'> & { unionChild?: Types.Maybe<ResolversTypes['ChildUnion']> }>;
   AnotherNodeWithAll: ResolverTypeWrapper<Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Types.Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
   MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
@@ -465,12 +481,12 @@ export type ResolversParentTypes = ResolversObject<{
   ChildUnion: ResolversUnionParentTypes['ChildUnion'];
   Query: {};
   Subscription: {};
-  Node: ResolversParentTypes['SomeNode'];
+  Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
   ID: Types.Scalars['ID'];
   SomeNode: Types.SomeNode;
-  AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-  WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-  WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
+  AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+  WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+  WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
   AnotherNodeWithChild: Omit<Types.AnotherNodeWithChild, 'unionChild'> & { unionChild?: Types.Maybe<ResolversParentTypes['ChildUnion']> };
   AnotherNodeWithAll: Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Types.Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
   MyUnion: ResolversUnionParentTypes['MyUnion'];
@@ -774,6 +790,14 @@ export type ResolversUnionParentTypes = ResolversObject<{
   MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> } ) | ( MyOtherType );
 }>;
 
+/** Mapping of interface types */
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = ResolversObject<{
+  Node: ( SomeNode );
+  AnotherNode: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+  WithChild: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+  WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+}>;
+
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = ResolversObject<{
   MyType: ResolverTypeWrapper<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
@@ -783,12 +807,12 @@ export type ResolversTypes = ResolversObject<{
   ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
   Query: ResolverTypeWrapper<{}>;
   Subscription: ResolverTypeWrapper<{}>;
-  Node: ResolversTypes['SomeNode'];
+  Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
   ID: ResolverTypeWrapper<Scalars['ID']>;
   SomeNode: ResolverTypeWrapper<SomeNode>;
-  AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-  WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-  WithChildren: ResolversTypes['AnotherNodeWithAll'];
+  AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+  WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+  WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
   AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
   AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
   MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
@@ -806,12 +830,12 @@ export type ResolversParentTypes = ResolversObject<{
   ChildUnion: ResolversUnionParentTypes['ChildUnion'];
   Query: {};
   Subscription: {};
-  Node: ResolversParentTypes['SomeNode'];
+  Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
   ID: Scalars['ID'];
   SomeNode: SomeNode;
-  AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-  WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-  WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
+  AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+  WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+  WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
   AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
   AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
   MyUnion: ResolversUnionParentTypes['MyUnion'];

--- a/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
@@ -20,6 +20,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChild: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       MyType: ResolverTypeWrapper<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
       String: ResolverTypeWrapper<Scalars['String']>;
@@ -28,12 +36,12 @@ describe('ResolversTypes', () => {
       ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
-      Node: ResolversTypes['SomeNode'];
+      Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
       ID: ResolverTypeWrapper<Scalars['ID']>;
       SomeNode: ResolverTypeWrapper<SomeNode>;
-      AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversTypes['AnotherNodeWithAll'];
+      AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+      WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+      WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
       AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
       MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
@@ -51,12 +59,12 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolversUnionParentTypes['ChildUnion'];
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: Scalars['ID'];
         SomeNode: SomeNode;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
         MyUnion: ResolversUnionParentTypes['MyUnion'];
@@ -74,6 +82,7 @@ describe('ResolversTypes', () => {
       {
         mappers: {
           MyType: 'MyTypeDb',
+          AnotherNodeWithChild: 'AnotherNodeWithChildMapper',
           String: 'number',
         },
       },
@@ -93,6 +102,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( AnotherNodeWithChildMapper ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChild: ( AnotherNodeWithChildMapper ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
         MyType: ResolverTypeWrapper<MyTypeDb>;
         String: ResolverTypeWrapper<number>;
@@ -101,13 +118,13 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
         Query: ResolverTypeWrapper<{}>;
         Subscription: ResolverTypeWrapper<{}>;
-        Node: ResolversTypes['SomeNode'];
+        Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
         ID: ResolverTypeWrapper<Scalars['ID']>;
         SomeNode: ResolverTypeWrapper<SomeNode>;
-        AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversTypes['AnotherNodeWithAll'];
-        AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
+        AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+        WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+        WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
+        AnotherNodeWithChild: ResolverTypeWrapper<AnotherNodeWithChildMapper>;
         AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
         MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
         MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
@@ -124,13 +141,13 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolversUnionParentTypes['ChildUnion'];
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: Scalars['ID'];
         SomeNode: SomeNode;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
-        AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
+        AnotherNodeWithChild: AnotherNodeWithChildMapper;
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
         MyUnion: ResolversUnionParentTypes['MyUnion'];
         MyScalar: Scalars['MyScalar'];
@@ -408,6 +425,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( Partial<SomeNode> );
+        AnotherNode: ( Partial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( Partial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> );
+        WithChild: ( Partial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( Partial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> );
+        WithChildren: ( Partial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       MyType: ResolverTypeWrapper<Partial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
       String: ResolverTypeWrapper<Partial<Scalars['String']>>;
@@ -416,12 +441,12 @@ describe('ResolversTypes', () => {
       ChildUnion: Partial<ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
-      Node: ResolversTypes['SomeNode'];
+      Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
       ID: ResolverTypeWrapper<Partial<Scalars['ID']>>;
       SomeNode: ResolverTypeWrapper<Partial<SomeNode>>;
-      AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversTypes['AnotherNodeWithAll'];
+      AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+      WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+      WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<Partial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
       AnotherNodeWithAll: ResolverTypeWrapper<Partial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>>;
       MyUnion: Partial<ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>>;
@@ -438,12 +463,12 @@ describe('ResolversTypes', () => {
         ChildUnion: Partial<ResolversUnionParentTypes['ChildUnion']>;
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: Partial<Scalars['ID']>;
         SomeNode: Partial<SomeNode>;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: Partial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }>;
         AnotherNodeWithAll: Partial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> }>;
         MyUnion: Partial<ResolversUnionParentTypes['MyUnion']>;
@@ -479,6 +504,14 @@ describe('ResolversTypes', () => {
       }
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( CustomPartial<SomeNode> );
+        AnotherNode: ( CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( CustomPartial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> );
+        WithChild: ( CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( CustomPartial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> );
+        WithChildren: ( CustomPartial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       MyType: ResolverTypeWrapper<CustomPartial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
       String: ResolverTypeWrapper<CustomPartial<Scalars['String']>>;
@@ -487,12 +520,12 @@ describe('ResolversTypes', () => {
       ChildUnion: CustomPartial<ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
-      Node: ResolversTypes['SomeNode'];
+      Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
       ID: ResolverTypeWrapper<CustomPartial<Scalars['ID']>>;
       SomeNode: ResolverTypeWrapper<CustomPartial<SomeNode>>;
-      AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversTypes['AnotherNodeWithAll'];
+      AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+      WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+      WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
       AnotherNodeWithAll: ResolverTypeWrapper<CustomPartial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>>;
       MyUnion: CustomPartial<ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>>;
@@ -509,12 +542,12 @@ describe('ResolversTypes', () => {
         ChildUnion: CustomPartial<ResolversUnionParentTypes['ChildUnion']>;
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: CustomPartial<Scalars['ID']>;
         SomeNode: CustomPartial<SomeNode>;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }>;
         AnotherNodeWithAll: CustomPartial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> }>;
         MyUnion: CustomPartial<ResolversUnionParentTypes['MyUnion']>;
@@ -533,6 +566,7 @@ describe('ResolversTypes', () => {
         noSchemaStitching: true,
         mappers: {
           MyType: './my-wrapper#CustomPartial<{T}>',
+          AnotherNodeWithChild: './my-wrapper#CustomPartial<{T}>',
         },
       },
       { outputFile: '' }
@@ -552,6 +586,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChild: ( CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       MyType: ResolverTypeWrapper<CustomPartial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
       String: ResolverTypeWrapper<Scalars['String']>;
@@ -560,13 +602,13 @@ describe('ResolversTypes', () => {
       ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
-      Node: ResolversTypes['SomeNode'];
+      Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
       ID: ResolverTypeWrapper<Scalars['ID']>;
       SomeNode: ResolverTypeWrapper<SomeNode>;
-      AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversTypes['AnotherNodeWithAll'];
-      AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
+      AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+      WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+      WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
+      AnotherNodeWithChild: ResolverTypeWrapper<CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
       AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
       MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
@@ -582,13 +624,13 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolversUnionParentTypes['ChildUnion'];
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: Scalars['ID'];
         SomeNode: SomeNode;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
-        AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
+        AnotherNodeWithChild: CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }>;
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
         MyUnion: ResolversUnionParentTypes['MyUnion'];
         MyScalar: Scalars['MyScalar'];
@@ -679,12 +721,16 @@ describe('ResolversTypes', () => {
         noSchemaStitching: true,
         mappers: {
           MyType: './my-type#MyType as DatabaseMyType',
+          AnotherNodeWithChild: './my-interface#AnotherNodeWithChild as AnotherNodeWithChildMapper',
         },
       },
       { outputFile: '' }
     )) as Types.ComplexPluginOutput;
 
     expect(result.prepend).toContain(`import { MyType as DatabaseMyType } from './my-type';`);
+    expect(result.prepend).toContain(
+      `import { AnotherNodeWithChild as AnotherNodeWithChildMapper } from './my-interface';`
+    );
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversUnionTypes = {
         ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> } ) | ( MyOtherType );
@@ -698,6 +744,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( AnotherNodeWithChildMapper ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChild: ( AnotherNodeWithChildMapper ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       MyType: ResolverTypeWrapper<DatabaseMyType>;
       String: ResolverTypeWrapper<Scalars['String']>;
@@ -706,13 +760,13 @@ describe('ResolversTypes', () => {
       ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
-      Node: ResolversTypes['SomeNode'];
+      Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
       ID: ResolverTypeWrapper<Scalars['ID']>;
       SomeNode: ResolverTypeWrapper<SomeNode>;
-      AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversTypes['AnotherNodeWithAll'];
-      AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
+      AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+      WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+      WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
+      AnotherNodeWithChild: ResolverTypeWrapper<AnotherNodeWithChildMapper>;
       AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
       MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
@@ -728,13 +782,13 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolversUnionParentTypes['ChildUnion'];
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: Scalars['ID'];
         SomeNode: SomeNode;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
-        AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
+        AnotherNodeWithChild: AnotherNodeWithChildMapper;
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
         MyUnion: ResolversUnionParentTypes['MyUnion'];
         MyScalar: Scalars['MyScalar'];
@@ -753,6 +807,8 @@ describe('ResolversTypes', () => {
         mappers: {
           MyOtherType: './my-type#default as DatabaseMyOtherType',
           MyType: './my-type#MyType as DatabaseMyType',
+          AnotherNodeWithChild: './my-interface#default as AnotherNodeWithChildMapper',
+          AnotherNodeWithAll: './my-interface#AnotherNodeWithAll as AnotherNodeWithAllMapper',
         },
       },
       { outputFile: '' }
@@ -772,6 +828,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( AnotherNodeWithChildMapper ) | ( AnotherNodeWithAllMapper );
+        WithChild: ( AnotherNodeWithChildMapper ) | ( AnotherNodeWithAllMapper );
+        WithChildren: ( AnotherNodeWithAllMapper );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       MyType: ResolverTypeWrapper<DatabaseMyType>;
       String: ResolverTypeWrapper<Scalars['String']>;
@@ -780,14 +844,14 @@ describe('ResolversTypes', () => {
       ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
-      Node: ResolversTypes['SomeNode'];
+      Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
       ID: ResolverTypeWrapper<Scalars['ID']>;
       SomeNode: ResolverTypeWrapper<SomeNode>;
-      AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversTypes['AnotherNodeWithAll'];
-      AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
-      AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
+      AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+      WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+      WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
+      AnotherNodeWithChild: ResolverTypeWrapper<AnotherNodeWithChildMapper>;
+      AnotherNodeWithAll: ResolverTypeWrapper<AnotherNodeWithAllMapper>;
       MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
       Int: ResolverTypeWrapper<Scalars['Int']>;
@@ -802,14 +866,14 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolversUnionParentTypes['ChildUnion'];
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: Scalars['ID'];
         SomeNode: SomeNode;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
-        AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
-        AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
+        AnotherNodeWithChild: AnotherNodeWithChildMapper;
+        AnotherNodeWithAll: AnotherNodeWithAllMapper;
         MyUnion: ResolversUnionParentTypes['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
@@ -827,6 +891,8 @@ describe('ResolversTypes', () => {
         mappers: {
           MyOtherType: './my-type#default as DatabaseMyOtherType',
           MyType: './my-type#MyType as DatabaseMyType',
+          AnotherNodeWithChild: './my-interface#default as AnotherNodeWithChildMapper',
+          AnotherNodeWithAll: './my-interface#AnotherNodeWithAll as AnotherNodeWithAllMapper',
         },
         useTypeImports: true,
       },
@@ -835,6 +901,9 @@ describe('ResolversTypes', () => {
 
     expect(result.prepend).toContain(
       `import type { default as DatabaseMyOtherType, MyType as DatabaseMyType } from './my-type';`
+    );
+    expect(result.prepend).toContain(
+      `import type { default as AnotherNodeWithChildMapper, AnotherNodeWithAll as AnotherNodeWithAllMapper } from './my-interface';`
     );
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversUnionTypes = {
@@ -849,6 +918,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( AnotherNodeWithChildMapper ) | ( AnotherNodeWithAllMapper );
+        WithChild: ( AnotherNodeWithChildMapper ) | ( AnotherNodeWithAllMapper );
+        WithChildren: ( AnotherNodeWithAllMapper );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       MyType: ResolverTypeWrapper<DatabaseMyType>;
       String: ResolverTypeWrapper<Scalars['String']>;
@@ -857,14 +934,14 @@ describe('ResolversTypes', () => {
       ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
-      Node: ResolversTypes['SomeNode'];
+      Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
       ID: ResolverTypeWrapper<Scalars['ID']>;
       SomeNode: ResolverTypeWrapper<SomeNode>;
-      AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversTypes['AnotherNodeWithAll'];
-      AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
-      AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
+      AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+      WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+      WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
+      AnotherNodeWithChild: ResolverTypeWrapper<AnotherNodeWithChildMapper>;
+      AnotherNodeWithAll: ResolverTypeWrapper<AnotherNodeWithAllMapper>;
       MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
       Int: ResolverTypeWrapper<Scalars['Int']>;
@@ -879,14 +956,14 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolversUnionParentTypes['ChildUnion'];
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: Scalars['ID'];
         SomeNode: SomeNode;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
-        AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
-        AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
+        AnotherNodeWithChild: AnotherNodeWithChildMapper;
+        AnotherNodeWithAll: AnotherNodeWithAllMapper;
         MyUnion: ResolversUnionParentTypes['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
@@ -911,6 +988,7 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).not.toBeSimilarStringTo(`export type ResolversUnionTypes`);
+    expect(result.content).not.toBeSimilarStringTo(`export type ResolversInterfaceTypes`);
     expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       MyType: ResolverTypeWrapper<MyTypeDb>;
@@ -920,12 +998,12 @@ describe('ResolversTypes', () => {
       ChildUnion: ResolverTypeWrapper<any>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
-      Node: ResolversTypes['SomeNode'];
+      Node: ResolverTypeWrapper<any>;
       ID: ResolverTypeWrapper<any>;
       SomeNode: ResolverTypeWrapper<any>;
-      AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversTypes['AnotherNodeWithAll'];
+      AnotherNode: ResolverTypeWrapper<any>;
+      WithChild: ResolverTypeWrapper<any>;
+      WithChildren: ResolverTypeWrapper<any>;
       AnotherNodeWithChild: ResolverTypeWrapper<any>;
       AnotherNodeWithAll: ResolverTypeWrapper<any>;
       MyUnion: ResolverTypeWrapper<any>;
@@ -942,12 +1020,12 @@ describe('ResolversTypes', () => {
       ChildUnion: any;
       Query: {};
       Subscription: {};
-      Node: ResolversParentTypes['SomeNode'];
+      Node: any;
       ID: any;
       SomeNode: any;
-      AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-      WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
+      AnotherNode: any;
+      WithChild: any;
+      WithChildren: any;
       AnotherNodeWithChild: any;
       AnotherNodeWithAll: any;
       MyUnion: any;
@@ -966,6 +1044,8 @@ describe('ResolversTypes', () => {
         mappers: {
           MyOtherType: './my-module#CustomMyOtherType',
           MyType: 'MyTypeDb',
+          AnotherNodeWithChild: './my-interface#AnotherNodeWithChildMapper',
+          AnotherNodeWithAll: 'AnotherNodeWithAllMapper',
         },
       },
       { outputFile: '' }
@@ -984,6 +1064,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( AnotherNodeWithChildMapper ) | ( AnotherNodeWithAllMapper );
+        WithChild: ( AnotherNodeWithChildMapper ) | ( AnotherNodeWithAllMapper );
+        WithChildren: ( AnotherNodeWithAllMapper );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       MyType: ResolverTypeWrapper<MyTypeDb>;
       String: ResolverTypeWrapper<Scalars['String']>;
@@ -992,14 +1080,14 @@ describe('ResolversTypes', () => {
       ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
-      Node: ResolversTypes['SomeNode'];
+      Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
       ID: ResolverTypeWrapper<Scalars['ID']>;
       SomeNode: ResolverTypeWrapper<SomeNode>;
-      AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversTypes['AnotherNodeWithAll'];
-      AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
-      AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
+      AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+      WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+      WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
+      AnotherNodeWithChild: ResolverTypeWrapper<AnotherNodeWithChildMapper>;
+      AnotherNodeWithAll: ResolverTypeWrapper<AnotherNodeWithAllMapper>;
       MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
       Int: ResolverTypeWrapper<Scalars['Int']>;
@@ -1014,14 +1102,14 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolversUnionParentTypes['ChildUnion'];
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: Scalars['ID'];
         SomeNode: SomeNode;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
-        AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
-        AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
+        AnotherNodeWithChild: AnotherNodeWithChildMapper;
+        AnotherNodeWithAll: AnotherNodeWithAllMapper;
         MyUnion: ResolversUnionParentTypes['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
@@ -1038,6 +1126,7 @@ describe('ResolversTypes', () => {
         noSchemaStitching: true,
         mappers: {
           MyType: 'Partial<{T}>',
+          AnotherNodeWithChild: 'ExtraPartial<{T}>',
         },
       },
       { outputFile: '' }
@@ -1056,6 +1145,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( ExtraPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChild: ( ExtraPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
         MyType: ResolverTypeWrapper<Partial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
         String: ResolverTypeWrapper<Scalars['String']>;
@@ -1064,13 +1161,13 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
         Query: ResolverTypeWrapper<{}>;
         Subscription: ResolverTypeWrapper<{}>;
-        Node: ResolversTypes['SomeNode'];
+        Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
         ID: ResolverTypeWrapper<Scalars['ID']>;
         SomeNode: ResolverTypeWrapper<SomeNode>;
-        AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversTypes['AnotherNodeWithAll'];
-        AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
+        AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+        WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+        WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
+        AnotherNodeWithChild: ResolverTypeWrapper<ExtraPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
         AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
         MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
         MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
@@ -1088,13 +1185,13 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolversUnionParentTypes['ChildUnion'];
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: Scalars['ID'];
         SomeNode: SomeNode;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
-        AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
+        AnotherNodeWithChild: ExtraPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }>;
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
         MyUnion: ResolversUnionParentTypes['MyUnion'];
         MyScalar: Scalars['MyScalar'];
@@ -1593,6 +1690,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChild: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       MyType: ResolverTypeWrapper<Omit<MyType, 'otherType' | 'unionChild'> & { otherType?: Maybe<ResolversTypes['MyOtherType']>, unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
       String: ResolverTypeWrapper<Scalars['String']>;
@@ -1601,12 +1706,12 @@ describe('ResolversTypes', () => {
       ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
-      Node: ResolversTypes['SomeNode'];
+      Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
       ID: ResolverTypeWrapper<Scalars['ID']>;
       SomeNode: ResolverTypeWrapper<SomeNode>;
-      AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversTypes['AnotherNodeWithAll'];
+      AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+      WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+      WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
       AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
       MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
@@ -1623,12 +1728,12 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolversUnionParentTypes['ChildUnion'];
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: Scalars['ID'];
         SomeNode: SomeNode;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
         MyUnion: ResolversUnionParentTypes['MyUnion'];
@@ -1667,6 +1772,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChild: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
     export type ResolversTypes = {
       MyType: ResolverTypeWrapper<MyTypeCustom>;
       String: ResolverTypeWrapper<Scalars['String']>;
@@ -1675,12 +1788,12 @@ describe('ResolversTypes', () => {
       ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
-      Node: ResolversTypes['SomeNode'];
+      Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
       ID: ResolverTypeWrapper<Scalars['ID']>;
       SomeNode: ResolverTypeWrapper<SomeNode>;
-      AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversTypes['AnotherNodeWithAll'];
+      AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+      WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+      WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
       AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
       MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
@@ -1697,12 +1810,12 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolversUnionParentTypes['ChildUnion'];
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
         ID: Scalars['ID'];
         SomeNode: SomeNode;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
         MyUnion: ResolversUnionParentTypes['MyUnion'];
@@ -1722,12 +1835,14 @@ describe('ResolversTypes', () => {
         noSchemaStitching: true,
         mappers: {
           MyOtherType: './my-file#MyNamespace#MyCustomOtherType',
+          AnotherNodeWithChild: './my-interface#InterfaceNamespace#AnotherNodeWithChildMapper',
         },
       },
       { outputFile: '' }
     )) as Types.ComplexPluginOutput;
 
     expect(result.prepend).toContain(`import { MyNamespace } from './my-file';`);
+    expect(result.prepend).toContain(`import { InterfaceNamespace } from './my-interface';`);
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversUnionTypes = {
         ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> } ) | ( MyNamespace.MyCustomOtherType );
@@ -1741,6 +1856,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( InterfaceNamespace.AnotherNodeWithChildMapper ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChild: ( InterfaceNamespace.AnotherNodeWithChildMapper ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
         MyType: ResolverTypeWrapper<Omit<MyType, 'otherType' | 'unionChild'> & { otherType?: Maybe<ResolversTypes['MyOtherType']>, unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
         String: ResolverTypeWrapper<Scalars['String']>;
@@ -1749,13 +1872,13 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
         Query: ResolverTypeWrapper<{}>;
         Subscription: ResolverTypeWrapper<{}>;
-        Node: ResolversTypes['SomeNode'];
+        Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
         ID: ResolverTypeWrapper<Scalars['ID']>;
         SomeNode: ResolverTypeWrapper<SomeNode>;
-        AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversTypes['AnotherNodeWithAll'];
-        AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
+        AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+        WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+        WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
+        AnotherNodeWithChild: ResolverTypeWrapper<InterfaceNamespace.AnotherNodeWithChildMapper>;
         AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
         MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
         MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
@@ -1773,13 +1896,13 @@ describe('ResolversTypes', () => {
       ChildUnion: ResolversUnionParentTypes['ChildUnion'];
       Query: {};
       Subscription: {};
-      Node: ResolversParentTypes['SomeNode'];
+      Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
       ID: Scalars['ID'];
       SomeNode: SomeNode;
-      AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-      WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
-      AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
+      AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+      WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+      WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
+      AnotherNodeWithChild: InterfaceNamespace.AnotherNodeWithChildMapper;
       AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
       MyUnion: ResolversUnionParentTypes['MyUnion'];
       MyScalar: Scalars['MyScalar'];
@@ -1820,6 +1943,7 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { MyNamespace } from './my-file';`);
     expect(result.content).not.toBeSimilarStringTo(`export type ResolversUnionTypes`);
     expect(result.content).not.toBeSimilarStringTo(`export type ResolversParentUnionTypes`);
+    expect(result.content).not.toBeSimilarStringTo(`export type ResolversInterfaceTypes`);
     expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
         MyType: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
@@ -1829,12 +1953,12 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
         Query: ResolverTypeWrapper<{}>;
         Subscription: ResolverTypeWrapper<{}>;
-        Node: ResolversTypes['SomeNode'];
+        Node: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
         ID: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
         SomeNode: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
-        AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversTypes['AnotherNodeWithAll'];
+        AnotherNode: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
+        WithChild: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
+        WithChildren: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
         AnotherNodeWithChild: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
         AnotherNodeWithAll: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
         MyUnion: ResolverTypeWrapper<MyNamespace.MyDefaultMapper>;
@@ -1853,12 +1977,12 @@ describe('ResolversTypes', () => {
         ChildUnion: MyNamespace.MyDefaultMapper;
         Query: {};
         Subscription: {};
-        Node: ResolversParentTypes['SomeNode'];
+        Node: MyNamespace.MyDefaultMapper;
         ID: MyNamespace.MyDefaultMapper;
         SomeNode: MyNamespace.MyDefaultMapper;
-        AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
+        AnotherNode: MyNamespace.MyDefaultMapper;
+        WithChild: MyNamespace.MyDefaultMapper;
+        WithChildren: MyNamespace.MyDefaultMapper;
         AnotherNodeWithChild: MyNamespace.MyDefaultMapper;
         AnotherNodeWithAll: MyNamespace.MyDefaultMapper;
         MyUnion: MyNamespace.MyDefaultMapper;
@@ -1894,6 +2018,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChild: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
         MyType: ResolverTypeWrapper<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
         String: ResolverTypeWrapper<Scalars['String']>;
@@ -1902,12 +2034,12 @@ describe('ResolversTypes', () => {
         ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
         Query: ResolverTypeWrapper<MyNamespace.MyRootType>;
         Subscription: ResolverTypeWrapper<MyNamespace.MyRootType>;
-        Node: ResolversTypes['SomeNode'];
+        Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
         ID: ResolverTypeWrapper<Scalars['ID']>;
         SomeNode: ResolverTypeWrapper<SomeNode>;
-        AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversTypes['AnotherNodeWithAll'];
+        AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+        WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+        WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
         AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
         AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
         MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
@@ -1926,12 +2058,12 @@ describe('ResolversTypes', () => {
       ChildUnion: ResolversUnionParentTypes['ChildUnion'];
       Query: MyNamespace.MyRootType;
       Subscription: MyNamespace.MyRootType;
-      Node: ResolversParentTypes['SomeNode'];
+      Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
       ID: Scalars['ID'];
       SomeNode: SomeNode;
-      AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-      WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
+      AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+      WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+      WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
       AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
       AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
       MyUnion: ResolversUnionParentTypes['MyUnion'];
@@ -1950,6 +2082,7 @@ describe('ResolversTypes', () => {
         defaultMapper: './my-file#MyNamespace#MyDefaultMapper<{T}>',
         mappers: {
           MyType: './my-file#MyNamespace#MyType<{T}>',
+          AnotherNodeWithChild: './my-inteface#InterfaceNamespace#MyInterface<{T}>',
         },
       },
       { outputFile: '' }
@@ -1969,6 +2102,14 @@ describe('ResolversTypes', () => {
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( MyNamespace.MyDefaultMapper<SomeNode> );
+        AnotherNode: ( InterfaceNamespace.MyInterface<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( MyNamespace.MyDefaultMapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> );
+        WithChild: ( InterfaceNamespace.MyInterface<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( MyNamespace.MyDefaultMapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> );
+        WithChildren: ( MyNamespace.MyDefaultMapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> );
+      };
+    `);
+    expect(result.content).toBeSimilarStringTo(`
       export type ResolversTypes = {
         MyType: ResolverTypeWrapper<MyNamespace.MyType<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
         String: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['String']>>;
@@ -1977,13 +2118,13 @@ describe('ResolversTypes', () => {
         ChildUnion: MyNamespace.MyDefaultMapper<ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>>;
         Query: ResolverTypeWrapper<{}>;
         Subscription: ResolverTypeWrapper<{}>;
-        Node: ResolversTypes['SomeNode'];
+        Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
         ID: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['ID']>>;
         SomeNode: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<SomeNode>>;
-        AnotherNode: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChild: ResolversTypes['AnotherNodeWithChild'] | ResolversTypes['AnotherNodeWithAll'];
-        WithChildren: ResolversTypes['AnotherNodeWithAll'];
-        AnotherNodeWithChild: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
+        AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+        WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+        WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
+        AnotherNodeWithChild: ResolverTypeWrapper<InterfaceNamespace.MyInterface<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
         AnotherNodeWithAll: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>>;
         MyUnion: MyNamespace.MyDefaultMapper<ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>>;
         MyScalar: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['MyScalar']>>;
@@ -2000,13 +2141,13 @@ describe('ResolversTypes', () => {
       ChildUnion: MyNamespace.MyDefaultMapper<ResolversUnionParentTypes['ChildUnion']>;
       Query: {};
       Subscription: {};
-      Node: ResolversParentTypes['SomeNode'];
+      Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
       ID: MyNamespace.MyDefaultMapper<Scalars['ID']>;
       SomeNode: MyNamespace.MyDefaultMapper<SomeNode>;
-      AnotherNode: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-      WithChild: ResolversParentTypes['AnotherNodeWithChild'] | ResolversParentTypes['AnotherNodeWithAll'];
-      WithChildren: ResolversParentTypes['AnotherNodeWithAll'];
-      AnotherNodeWithChild: MyNamespace.MyDefaultMapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }>;
+      AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+      WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+      WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
+      AnotherNodeWithChild: InterfaceNamespace.MyInterface<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }>;
       AnotherNodeWithAll: MyNamespace.MyDefaultMapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> }>;
       MyUnion: MyNamespace.MyDefaultMapper<ResolversUnionParentTypes['MyUnion']>;
       MyScalar: MyNamespace.MyDefaultMapper<Scalars['MyScalar']>;

--- a/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
@@ -8,15 +8,9 @@ describe('ResolversTypes', () => {
     const result = await plugin(resolversTestingSchema, [], {}, { outputFile: '' });
 
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
         ChildUnion: ( Child ) | ( MyOtherType );
-        MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> } ) | ( MyOtherType );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Child ) | ( MyOtherType );
-        MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> } ) | ( MyOtherType );
+        MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( MyOtherType );
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
@@ -33,7 +27,7 @@ describe('ResolversTypes', () => {
       String: ResolverTypeWrapper<Scalars['String']>;
       Child: ResolverTypeWrapper<Child>;
       MyOtherType: ResolverTypeWrapper<MyOtherType>;
-      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
       Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -44,7 +38,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
       AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-      MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+      MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
       Int: ResolverTypeWrapper<Scalars['Int']>;
       Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -56,7 +50,7 @@ describe('ResolversTypes', () => {
         String: Scalars['String'];
         Child: Child;
         MyOtherType: MyOtherType;
-        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -67,7 +61,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];
@@ -90,15 +84,9 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        ChildUnion: ( Omit<Child, 'bar' | 'parent'> & { bar: ResolversTypes['String'], parent?: Maybe<ResolversTypes['MyType']> } ) | ( Omit<MyOtherType, 'bar'> & { bar: ResolversTypes['String'] } );
-        MyUnion: ( MyTypeDb ) | ( Omit<MyOtherType, 'bar'> & { bar: ResolversTypes['String'] } );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Omit<Child, 'bar' | 'parent'> & { bar: ResolversParentTypes['String'], parent?: Maybe<ResolversParentTypes['MyType']> } ) | ( Omit<MyOtherType, 'bar'> & { bar: ResolversParentTypes['String'] } );
-        MyUnion: ( MyTypeDb ) | ( Omit<MyOtherType, 'bar'> & { bar: ResolversParentTypes['String'] } );
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+        ChildUnion: ( Omit<Child, 'bar' | 'parent'> & { bar: RefType['String'], parent?: Maybe<RefType['MyType']> } ) | ( Omit<MyOtherType, 'bar'> & { bar: RefType['String'] } );
+        MyUnion: ( MyTypeDb ) | ( Omit<MyOtherType, 'bar'> & { bar: RefType['String'] } );
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
@@ -115,7 +103,7 @@ describe('ResolversTypes', () => {
         String: ResolverTypeWrapper<number>;
         Child: ResolverTypeWrapper<Omit<Child, 'bar' | 'parent'> & { bar: ResolversTypes['String'], parent?: Maybe<ResolversTypes['MyType']> }>;
         MyOtherType: ResolverTypeWrapper<Omit<MyOtherType, 'bar'> & { bar: ResolversTypes['String'] }>;
-        ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+        ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
         Query: ResolverTypeWrapper<{}>;
         Subscription: ResolverTypeWrapper<{}>;
         Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -126,7 +114,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
         AnotherNodeWithChild: ResolverTypeWrapper<AnotherNodeWithChildMapper>;
         AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-        MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+        MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
         MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
         Int: ResolverTypeWrapper<Scalars['Int']>;
         Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -138,7 +126,7 @@ describe('ResolversTypes', () => {
         String: number;
         Child: Omit<Child, 'bar' | 'parent'> & { bar: ResolversParentTypes['String'], parent?: Maybe<ResolversParentTypes['MyType']> };
         MyOtherType: Omit<MyOtherType, 'bar'> & { bar: ResolversParentTypes['String'] };
-        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -149,7 +137,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: AnotherNodeWithChildMapper;
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];
@@ -190,12 +178,7 @@ describe('ResolversTypes', () => {
     const content = mergeOutputs([result]);
 
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        MovieLike: ( MovieEntity ) | ( Book );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
         MovieLike: ( MovieEntity ) | ( Book );
       };
     `);
@@ -205,7 +188,7 @@ describe('ResolversTypes', () => {
         ID: ResolverTypeWrapper<Scalars['ID']>;
         String: ResolverTypeWrapper<Scalars['String']>;
         Book: ResolverTypeWrapper<Book>;
-        MovieLike: ResolverTypeWrapper<ResolversUnionTypes['MovieLike']>;
+        MovieLike: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MovieLike']>;
         NonInterfaceHasNarrative: ResolverTypeWrapper<Omit<NonInterfaceHasNarrative, 'narrative' | 'movie'> & { narrative: ResolversTypes['MovieLike'], movie: ResolversTypes['Movie'] }>;
         Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
       };
@@ -216,7 +199,7 @@ describe('ResolversTypes', () => {
         ID: Scalars['ID'];
         String: Scalars['String'];
         Book: Book;
-        MovieLike: ResolversUnionParentTypes['MovieLike'];
+        MovieLike: ResolversUnionTypes<ResolversParentTypes>['MovieLike'];
         NonInterfaceHasNarrative: Omit<NonInterfaceHasNarrative, 'narrative' | 'movie'> & { narrative: ResolversParentTypes['MovieLike'], movie: ResolversParentTypes['Movie'] };
         Boolean: Scalars['Boolean'];
       };
@@ -265,12 +248,7 @@ describe('ResolversTypes', () => {
     const content = mergeOutputs([result]);
 
     expect(content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        MovieLike: ( MovieEntity ) | ( Book );
-      };
-    `);
-    expect(content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
         MovieLike: ( MovieEntity ) | ( Book );
       };
     `);
@@ -279,7 +257,7 @@ describe('ResolversTypes', () => {
       ID: ResolverTypeWrapper<Scalars['ID']>;
       String: ResolverTypeWrapper<Scalars['String']>;
       Book: ResolverTypeWrapper<Book>;
-      MovieLike: ResolverTypeWrapper<ResolversUnionTypes['MovieLike']>;
+      MovieLike: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MovieLike']>;
       NonInterfaceHasNarrative: ResolverTypeWrapper<Omit<NonInterfaceHasNarrative, 'narrative' | 'movie'> & { narrative: ResolversTypes['MovieLike'], movie: ResolversTypes['Movie'] }>;
       LayerOfIndirection: ResolverTypeWrapper<Omit<LayerOfIndirection, 'movies'> & { movies: Array<ResolversTypes['NonInterfaceHasNarrative']> }>;
       AnotherLayerOfIndirection: ResolverTypeWrapper<Omit<AnotherLayerOfIndirection, 'inner'> & { inner: ResolversTypes['LayerOfIndirection'] }>;
@@ -291,7 +269,7 @@ describe('ResolversTypes', () => {
         ID: Scalars['ID'];
         String: Scalars['String'];
         Book: Book;
-        MovieLike: ResolversUnionParentTypes['MovieLike'];
+        MovieLike: ResolversUnionTypes<ResolversParentTypes>['MovieLike'];
         NonInterfaceHasNarrative: Omit<NonInterfaceHasNarrative, 'narrative' | 'movie'> & { narrative: ResolversParentTypes['MovieLike'], movie: ResolversParentTypes['Movie'] };
         LayerOfIndirection: Omit<LayerOfIndirection, 'movies'> & { movies: Array<ResolversParentTypes['NonInterfaceHasNarrative']> };
         AnotherLayerOfIndirection: Omit<AnotherLayerOfIndirection, 'inner'> & { inner: ResolversParentTypes['LayerOfIndirection'] };
@@ -413,15 +391,9 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
         ChildUnion: ( Partial<Child> ) | ( Partial<MyOtherType> );
-        MyUnion: ( Partial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }> ) | ( Partial<MyOtherType> );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Partial<Child> ) | ( Partial<MyOtherType> );
-        MyUnion: ( Partial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }> ) | ( Partial<MyOtherType> );
+        MyUnion: ( Partial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( Partial<MyOtherType> );
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
@@ -438,7 +410,7 @@ describe('ResolversTypes', () => {
       String: ResolverTypeWrapper<Partial<Scalars['String']>>;
       Child: ResolverTypeWrapper<Partial<Child>>;
       MyOtherType: ResolverTypeWrapper<Partial<MyOtherType>>;
-      ChildUnion: Partial<ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>>;
+      ChildUnion: Partial<ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
       Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -449,7 +421,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<Partial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
       AnotherNodeWithAll: ResolverTypeWrapper<Partial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>>;
-      MyUnion: Partial<ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>>;
+      MyUnion: Partial<ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>>;
       MyScalar: ResolverTypeWrapper<Partial<Scalars['MyScalar']>>;
       Int: ResolverTypeWrapper<Partial<Scalars['Int']>>;
       Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']>>;
@@ -460,7 +432,7 @@ describe('ResolversTypes', () => {
         String: Partial<Scalars['String']>;
         Child: Partial<Child>;
         MyOtherType: Partial<MyOtherType>;
-        ChildUnion: Partial<ResolversUnionParentTypes['ChildUnion']>;
+        ChildUnion: Partial<ResolversUnionTypes<ResolversParentTypes>['ChildUnion']>;
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -471,7 +443,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: Partial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }>;
         AnotherNodeWithAll: Partial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> }>;
-        MyUnion: Partial<ResolversUnionParentTypes['MyUnion']>;
+        MyUnion: Partial<ResolversUnionTypes<ResolversParentTypes>['MyUnion']>;
         MyScalar: Partial<Scalars['MyScalar']>;
         Int: Partial<Scalars['Int']>;
         Boolean: Partial<Scalars['Boolean']>;
@@ -492,15 +464,9 @@ describe('ResolversTypes', () => {
 
     expect(result.prepend).toContain(`import { CustomPartial } from './my-wrapper';`);
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
         ChildUnion: ( CustomPartial<Child> ) | ( CustomPartial<MyOtherType> );
-        MyUnion: ( CustomPartial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }> ) | ( CustomPartial<MyOtherType> );
-      }
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( CustomPartial<Child> ) | ( CustomPartial<MyOtherType> );
-        MyUnion: ( CustomPartial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }> ) | ( CustomPartial<MyOtherType> );
+        MyUnion: ( CustomPartial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( CustomPartial<MyOtherType> );
       }
     `);
     expect(result.content).toBeSimilarStringTo(`
@@ -517,7 +483,7 @@ describe('ResolversTypes', () => {
       String: ResolverTypeWrapper<CustomPartial<Scalars['String']>>;
       Child: ResolverTypeWrapper<CustomPartial<Child>>;
       MyOtherType: ResolverTypeWrapper<CustomPartial<MyOtherType>>;
-      ChildUnion: CustomPartial<ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>>;
+      ChildUnion: CustomPartial<ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
       Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -528,7 +494,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
       AnotherNodeWithAll: ResolverTypeWrapper<CustomPartial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>>;
-      MyUnion: CustomPartial<ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>>;
+      MyUnion: CustomPartial<ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>>;
       MyScalar: ResolverTypeWrapper<CustomPartial<Scalars['MyScalar']>>;
       Int: ResolverTypeWrapper<CustomPartial<Scalars['Int']>>;
       Boolean: ResolverTypeWrapper<CustomPartial<Scalars['Boolean']>>;
@@ -539,7 +505,7 @@ describe('ResolversTypes', () => {
         String: CustomPartial<Scalars['String']>;
         Child: CustomPartial<Child>;
         MyOtherType: CustomPartial<MyOtherType>;
-        ChildUnion: CustomPartial<ResolversUnionParentTypes['ChildUnion']>;
+        ChildUnion: CustomPartial<ResolversUnionTypes<ResolversParentTypes>['ChildUnion']>;
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -550,7 +516,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }>;
         AnotherNodeWithAll: CustomPartial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> }>;
-        MyUnion: CustomPartial<ResolversUnionParentTypes['MyUnion']>;
+        MyUnion: CustomPartial<ResolversUnionTypes<ResolversParentTypes>['MyUnion']>;
         MyScalar: CustomPartial<Scalars['MyScalar']>;
         Int: CustomPartial<Scalars['Int']>;
         Boolean: CustomPartial<Scalars['Boolean']>;
@@ -574,15 +540,9 @@ describe('ResolversTypes', () => {
 
     expect(result.prepend).toContain(`import { CustomPartial } from './my-wrapper';`);
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> } ) | ( MyOtherType );
-        MyUnion: ( CustomPartial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }> ) | ( MyOtherType );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> } ) | ( MyOtherType );
-        MyUnion: ( CustomPartial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }> ) | ( MyOtherType );
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<RefType['MyType']> } ) | ( MyOtherType );
+        MyUnion: ( CustomPartial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( MyOtherType );
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
@@ -599,7 +559,7 @@ describe('ResolversTypes', () => {
       String: ResolverTypeWrapper<Scalars['String']>;
       Child: ResolverTypeWrapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }>;
       MyOtherType: ResolverTypeWrapper<MyOtherType>;
-      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
       Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -610,7 +570,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
       AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-      MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+      MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
       Int: ResolverTypeWrapper<Scalars['Int']>;
       Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -621,7 +581,7 @@ describe('ResolversTypes', () => {
         String: Scalars['String'];
         Child: Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> };
         MyOtherType: MyOtherType;
-        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -632,7 +592,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: CustomPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }>;
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];
@@ -732,14 +692,8 @@ describe('ResolversTypes', () => {
       `import { AnotherNodeWithChild as AnotherNodeWithChildMapper } from './my-interface';`
     );
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> } ) | ( MyOtherType );
-        MyUnion: ( DatabaseMyType ) | ( MyOtherType );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> } ) | ( MyOtherType );
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<RefType['MyType']> } ) | ( MyOtherType );
         MyUnion: ( DatabaseMyType ) | ( MyOtherType );
       };
     `);
@@ -757,7 +711,7 @@ describe('ResolversTypes', () => {
       String: ResolverTypeWrapper<Scalars['String']>;
       Child: ResolverTypeWrapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }>;
       MyOtherType: ResolverTypeWrapper<MyOtherType>;
-      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
       Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -768,7 +722,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<AnotherNodeWithChildMapper>;
       AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-      MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+      MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
       Int: ResolverTypeWrapper<Scalars['Int']>;
       Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -779,7 +733,7 @@ describe('ResolversTypes', () => {
         String: Scalars['String'];
         Child: Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> };
         MyOtherType: MyOtherType;
-        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -790,7 +744,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: AnotherNodeWithChildMapper;
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];
@@ -816,14 +770,8 @@ describe('ResolversTypes', () => {
 
     expect(result.prepend).toContain(`import DatabaseMyOtherType, { MyType as DatabaseMyType } from './my-type';`);
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> } ) | ( DatabaseMyOtherType );
-        MyUnion: ( DatabaseMyType ) | ( DatabaseMyOtherType );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> } ) | ( DatabaseMyOtherType );
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<RefType['MyType']> } ) | ( DatabaseMyOtherType );
         MyUnion: ( DatabaseMyType ) | ( DatabaseMyOtherType );
       };
     `);
@@ -841,7 +789,7 @@ describe('ResolversTypes', () => {
       String: ResolverTypeWrapper<Scalars['String']>;
       Child: ResolverTypeWrapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }>;
       MyOtherType: ResolverTypeWrapper<DatabaseMyOtherType>;
-      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
       Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -852,7 +800,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<AnotherNodeWithChildMapper>;
       AnotherNodeWithAll: ResolverTypeWrapper<AnotherNodeWithAllMapper>;
-      MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+      MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
       Int: ResolverTypeWrapper<Scalars['Int']>;
       Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -863,7 +811,7 @@ describe('ResolversTypes', () => {
         String: Scalars['String'];
         Child: Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> };
         MyOtherType: DatabaseMyOtherType;
-        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -874,7 +822,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: AnotherNodeWithChildMapper;
         AnotherNodeWithAll: AnotherNodeWithAllMapper;
-        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];
@@ -906,14 +854,8 @@ describe('ResolversTypes', () => {
       `import type { default as AnotherNodeWithChildMapper, AnotherNodeWithAll as AnotherNodeWithAllMapper } from './my-interface';`
     );
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> } ) | ( DatabaseMyOtherType );
-        MyUnion: ( DatabaseMyType ) | ( DatabaseMyOtherType );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> } ) | ( DatabaseMyOtherType );
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<RefType['MyType']> } ) | ( DatabaseMyOtherType );
         MyUnion: ( DatabaseMyType ) | ( DatabaseMyOtherType );
       };
     `);
@@ -931,7 +873,7 @@ describe('ResolversTypes', () => {
       String: ResolverTypeWrapper<Scalars['String']>;
       Child: ResolverTypeWrapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }>;
       MyOtherType: ResolverTypeWrapper<DatabaseMyOtherType>;
-      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
       Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -942,7 +884,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<AnotherNodeWithChildMapper>;
       AnotherNodeWithAll: ResolverTypeWrapper<AnotherNodeWithAllMapper>;
-      MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+      MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
       Int: ResolverTypeWrapper<Scalars['Int']>;
       Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -953,7 +895,7 @@ describe('ResolversTypes', () => {
         String: Scalars['String'];
         Child: Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> };
         MyOtherType: DatabaseMyOtherType;
-        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -964,7 +906,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: AnotherNodeWithChildMapper;
         AnotherNodeWithAll: AnotherNodeWithAllMapper;
-        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];
@@ -1052,14 +994,8 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> } ) | ( CustomMyOtherType );
-        MyUnion: ( MyTypeDb ) | ( CustomMyOtherType );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> } ) | ( CustomMyOtherType );
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<RefType['MyType']> } ) | ( CustomMyOtherType );
         MyUnion: ( MyTypeDb ) | ( CustomMyOtherType );
       };
     `);
@@ -1077,7 +1013,7 @@ describe('ResolversTypes', () => {
       String: ResolverTypeWrapper<Scalars['String']>;
       Child: ResolverTypeWrapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }>;
       MyOtherType: ResolverTypeWrapper<CustomMyOtherType>;
-      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
       Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -1088,7 +1024,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<AnotherNodeWithChildMapper>;
       AnotherNodeWithAll: ResolverTypeWrapper<AnotherNodeWithAllMapper>;
-      MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+      MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
       Int: ResolverTypeWrapper<Scalars['Int']>;
       Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -1099,7 +1035,7 @@ describe('ResolversTypes', () => {
         String: Scalars['String'];
         Child: Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> };
         MyOtherType: CustomMyOtherType;
-        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -1110,7 +1046,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: AnotherNodeWithChildMapper;
         AnotherNodeWithAll: AnotherNodeWithAllMapper;
-        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];
@@ -1133,15 +1069,9 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> } ) | ( MyOtherType );
-        MyUnion: ( Partial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }> ) | ( MyOtherType );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> } ) | ( MyOtherType );
-        MyUnion: ( Partial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }> ) | ( MyOtherType );
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<RefType['MyType']> } ) | ( MyOtherType );
+        MyUnion: ( Partial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( MyOtherType );
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
@@ -1158,7 +1088,7 @@ describe('ResolversTypes', () => {
         String: ResolverTypeWrapper<Scalars['String']>;
         Child: ResolverTypeWrapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }>;
         MyOtherType: ResolverTypeWrapper<MyOtherType>;
-        ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+        ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
         Query: ResolverTypeWrapper<{}>;
         Subscription: ResolverTypeWrapper<{}>;
         Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -1169,7 +1099,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
         AnotherNodeWithChild: ResolverTypeWrapper<ExtraPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
         AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-        MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+        MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
         MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
         Int: ResolverTypeWrapper<Scalars['Int']>;
         Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -1182,7 +1112,7 @@ describe('ResolversTypes', () => {
         String: Scalars['String'];
         Child: Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> };
         MyOtherType: MyOtherType;
-        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -1193,7 +1123,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: ExtraPartial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }>;
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];
@@ -1678,15 +1608,9 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> } ) | ( MyOtherTypeCustom );
-        MyUnion: ( Omit<MyType, 'otherType' | 'unionChild'> & { otherType?: Maybe<ResolversTypes['MyOtherType']>, unionChild?: Maybe<ResolversTypes['ChildUnion']> } ) | ( MyOtherTypeCustom );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> } ) | ( MyOtherTypeCustom );
-        MyUnion: ( Omit<MyType, 'otherType' | 'unionChild'> & { otherType?: Maybe<ResolversParentTypes['MyOtherType']>, unionChild?: Maybe<ResolversParentTypes['ChildUnion']> } ) | ( MyOtherTypeCustom );
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<RefType['MyType']> } ) | ( MyOtherTypeCustom );
+        MyUnion: ( Omit<MyType, 'otherType' | 'unionChild'> & { otherType?: Maybe<RefType['MyOtherType']>, unionChild?: Maybe<RefType['ChildUnion']> } ) | ( MyOtherTypeCustom );
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
@@ -1703,7 +1627,7 @@ describe('ResolversTypes', () => {
       String: ResolverTypeWrapper<Scalars['String']>;
       Child: ResolverTypeWrapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }>;
       MyOtherType: ResolverTypeWrapper<MyOtherTypeCustom>;
-      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
       Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -1714,7 +1638,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
       AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-      MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+      MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
       Int: ResolverTypeWrapper<Scalars['Int']>;
       Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -1725,7 +1649,7 @@ describe('ResolversTypes', () => {
         String: Scalars['String'];
         Child: Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> };
         MyOtherType: MyOtherTypeCustom;
-        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -1736,7 +1660,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];
@@ -1760,14 +1684,8 @@ describe('ResolversTypes', () => {
     )) as Types.ComplexPluginOutput;
 
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> } ) | ( MyOtherTypeCustom );
-        MyUnion: ( MyTypeCustom ) | ( MyOtherTypeCustom );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> } ) | ( MyOtherTypeCustom );
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<RefType['MyType']> } ) | ( MyOtherTypeCustom );
         MyUnion: ( MyTypeCustom ) | ( MyOtherTypeCustom );
       };
     `);
@@ -1785,7 +1703,7 @@ describe('ResolversTypes', () => {
       String: ResolverTypeWrapper<Scalars['String']>;
       Child: ResolverTypeWrapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }>;
       MyOtherType: ResolverTypeWrapper<MyOtherTypeCustom>;
-      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+      ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
       Query: ResolverTypeWrapper<{}>;
       Subscription: ResolverTypeWrapper<{}>;
       Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -1796,7 +1714,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
       AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
       AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-      MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+      MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
       MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
       Int: ResolverTypeWrapper<Scalars['Int']>;
       Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -1807,7 +1725,7 @@ describe('ResolversTypes', () => {
         String: Scalars['String'];
         Child: Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> };
         MyOtherType: MyOtherTypeCustom;
-        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -1818,7 +1736,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];
@@ -1844,15 +1762,9 @@ describe('ResolversTypes', () => {
     expect(result.prepend).toContain(`import { MyNamespace } from './my-file';`);
     expect(result.prepend).toContain(`import { InterfaceNamespace } from './my-interface';`);
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> } ) | ( MyNamespace.MyCustomOtherType );
-        MyUnion: ( Omit<MyType, 'otherType' | 'unionChild'> & { otherType?: Maybe<ResolversTypes['MyOtherType']>, unionChild?: Maybe<ResolversTypes['ChildUnion']> } ) | ( MyNamespace.MyCustomOtherType );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> } ) | ( MyNamespace.MyCustomOtherType );
-        MyUnion: ( Omit<MyType, 'otherType' | 'unionChild'> & { otherType?: Maybe<ResolversParentTypes['MyOtherType']>, unionChild?: Maybe<ResolversParentTypes['ChildUnion']> } ) | ( MyNamespace.MyCustomOtherType );
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+        ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<RefType['MyType']> } ) | ( MyNamespace.MyCustomOtherType );
+        MyUnion: ( Omit<MyType, 'otherType' | 'unionChild'> & { otherType?: Maybe<RefType['MyOtherType']>, unionChild?: Maybe<RefType['ChildUnion']> } ) | ( MyNamespace.MyCustomOtherType );
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
@@ -1869,7 +1781,7 @@ describe('ResolversTypes', () => {
         String: ResolverTypeWrapper<Scalars['String']>;
         Child: ResolverTypeWrapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }>;
         MyOtherType: ResolverTypeWrapper<MyNamespace.MyCustomOtherType>;
-        ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+        ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
         Query: ResolverTypeWrapper<{}>;
         Subscription: ResolverTypeWrapper<{}>;
         Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -1880,7 +1792,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
         AnotherNodeWithChild: ResolverTypeWrapper<InterfaceNamespace.AnotherNodeWithChildMapper>;
         AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-        MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+        MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
         MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
         Int: ResolverTypeWrapper<Scalars['Int']>;
         Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -1893,7 +1805,7 @@ describe('ResolversTypes', () => {
       String: Scalars['String'];
       Child: Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> };
       MyOtherType: MyNamespace.MyCustomOtherType;
-      ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+      ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
       Query: {};
       Subscription: {};
       Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -1904,7 +1816,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
       AnotherNodeWithChild: InterfaceNamespace.AnotherNodeWithChildMapper;
       AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-      MyUnion: ResolversUnionParentTypes['MyUnion'];
+      MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
       MyScalar: Scalars['MyScalar'];
       Int: Scalars['Int'];
       Boolean: Scalars['Boolean'];
@@ -2006,15 +1918,9 @@ describe('ResolversTypes', () => {
 
     expect(result.prepend).toContain(`import { MyNamespace } from './my-file';`);
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
         ChildUnion: ( Child ) | ( MyOtherType );
-        MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> } ) | ( MyOtherType );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( Child ) | ( MyOtherType );
-        MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> } ) | ( MyOtherType );
+        MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( MyOtherType );
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
@@ -2031,7 +1937,7 @@ describe('ResolversTypes', () => {
         String: ResolverTypeWrapper<Scalars['String']>;
         Child: ResolverTypeWrapper<Child>;
         MyOtherType: ResolverTypeWrapper<MyOtherType>;
-        ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+        ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
         Query: ResolverTypeWrapper<MyNamespace.MyRootType>;
         Subscription: ResolverTypeWrapper<MyNamespace.MyRootType>;
         Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -2042,7 +1948,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
         AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
         AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-        MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+        MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
         MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
         Int: ResolverTypeWrapper<Scalars['Int']>;
         Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -2055,7 +1961,7 @@ describe('ResolversTypes', () => {
       String: Scalars['String'];
       Child: Child;
       MyOtherType: MyOtherType;
-      ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+      ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
       Query: MyNamespace.MyRootType;
       Subscription: MyNamespace.MyRootType;
       Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -2066,7 +1972,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
       AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
       AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-      MyUnion: ResolversUnionParentTypes['MyUnion'];
+      MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
       MyScalar: Scalars['MyScalar'];
       Int: Scalars['Int'];
       Boolean: Scalars['Boolean'];
@@ -2090,15 +1996,9 @@ describe('ResolversTypes', () => {
 
     expect(result.prepend).toContain(`import { MyNamespace } from './my-file';`);
     expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        ChildUnion: ( MyNamespace.MyDefaultMapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }> ) | ( MyNamespace.MyDefaultMapper<MyOtherType> );
-        MyUnion: ( MyNamespace.MyType<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }> ) | ( MyNamespace.MyDefaultMapper<MyOtherType> );
-      };
-    `);
-    expect(result.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
-        ChildUnion: ( MyNamespace.MyDefaultMapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> }> ) | ( MyNamespace.MyDefaultMapper<MyOtherType> );
-        MyUnion: ( MyNamespace.MyType<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }> ) | ( MyNamespace.MyDefaultMapper<MyOtherType> );
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+        ChildUnion: ( MyNamespace.MyDefaultMapper<Omit<Child, 'parent'> & { parent?: Maybe<RefType['MyType']> }> ) | ( MyNamespace.MyDefaultMapper<MyOtherType> );
+        MyUnion: ( MyNamespace.MyType<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> ) | ( MyNamespace.MyDefaultMapper<MyOtherType> );
       };
     `);
     expect(result.content).toBeSimilarStringTo(`
@@ -2115,7 +2015,7 @@ describe('ResolversTypes', () => {
         String: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['String']>>;
         Child: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }>>;
         MyOtherType: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<MyOtherType>>;
-        ChildUnion: MyNamespace.MyDefaultMapper<ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>>;
+        ChildUnion: MyNamespace.MyDefaultMapper<ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>>;
         Query: ResolverTypeWrapper<{}>;
         Subscription: ResolverTypeWrapper<{}>;
         Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -2126,7 +2026,7 @@ describe('ResolversTypes', () => {
         WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
         AnotherNodeWithChild: ResolverTypeWrapper<InterfaceNamespace.MyInterface<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>>;
         AnotherNodeWithAll: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>>;
-        MyUnion: MyNamespace.MyDefaultMapper<ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>>;
+        MyUnion: MyNamespace.MyDefaultMapper<ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>>;
         MyScalar: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['MyScalar']>>;
         Int: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['Int']>>;
         Boolean: ResolverTypeWrapper<MyNamespace.MyDefaultMapper<Scalars['Boolean']>>;
@@ -2138,7 +2038,7 @@ describe('ResolversTypes', () => {
       String: MyNamespace.MyDefaultMapper<Scalars['String']>;
       Child: MyNamespace.MyDefaultMapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> }>;
       MyOtherType: MyNamespace.MyDefaultMapper<MyOtherType>;
-      ChildUnion: MyNamespace.MyDefaultMapper<ResolversUnionParentTypes['ChildUnion']>;
+      ChildUnion: MyNamespace.MyDefaultMapper<ResolversUnionTypes<ResolversParentTypes>['ChildUnion']>;
       Query: {};
       Subscription: {};
       Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -2149,7 +2049,7 @@ describe('ResolversTypes', () => {
       WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
       AnotherNodeWithChild: InterfaceNamespace.MyInterface<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }>;
       AnotherNodeWithAll: MyNamespace.MyDefaultMapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> }>;
-      MyUnion: MyNamespace.MyDefaultMapper<ResolversUnionParentTypes['MyUnion']>;
+      MyUnion: MyNamespace.MyDefaultMapper<ResolversUnionTypes<ResolversParentTypes>['MyUnion']>;
       MyScalar: MyNamespace.MyDefaultMapper<Scalars['MyScalar']>;
       Int: MyNamespace.MyDefaultMapper<Scalars['Int']>;
       Boolean: MyNamespace.MyDefaultMapper<Scalars['Boolean']>;

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -245,6 +245,14 @@ export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParen
           MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> } & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
         };
       `);
+      expect(result.content).toBeSimilarStringTo(`
+        export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+          Node: ( SomeNode & { __typename: 'SomeNode' } );
+          AnotherNode: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithChild' } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+          WithChild: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithChild' } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+          WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+        };
+      `);
     });
 
     it('resolversNonOptionalTypename - adds non-optional typenames to ResolversUnionTypes', async () => {
@@ -357,6 +365,101 @@ export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParen
 
       expect(result.content).not.toBeSimilarStringTo('export type ResolversUnionTypes');
       expect(result.content).not.toBeSimilarStringTo('export type ResolversUnionParentTypes');
+    });
+
+    it('resolversNonOptionalTypename - adds non-optional typenames to ResolversInterfaceTypes', async () => {
+      const result = await plugin(
+        resolversTestingSchema,
+        [],
+        { resolversNonOptionalTypename: { interfaceImplementingType: true } },
+        { outputFile: '' }
+      );
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+          Node: ( SomeNode & { __typename: 'SomeNode' } );
+          AnotherNode: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithChild' } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+          WithChild: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithChild' } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+          WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+        };
+      `);
+    });
+
+    it('resolversNonOptionalTypename - adds non-optional typenames to ResolversInterfaceTypes for mappers with no placeholder', async () => {
+      const result = await plugin(
+        resolversTestingSchema,
+        [],
+        {
+          resolversNonOptionalTypename: { interfaceImplementingType: true },
+          mappers: { AnotherNodeWithChild: 'AnotherNodeWithChildMapper' },
+        },
+        { outputFile: '' }
+      );
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+          Node: ( SomeNode & { __typename: 'SomeNode' } );
+          AnotherNode: ( AnotherNodeWithChildMapper & { __typename: 'AnotherNodeWithChild' } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+          WithChild: ( AnotherNodeWithChildMapper & { __typename: 'AnotherNodeWithChild' } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+          WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+        };
+      `);
+    });
+
+    it('resolversNonOptionalTypename - adds non-optional typenames to ResolversInterfaceTypes for mappers with placeholder', async () => {
+      const result = await plugin(
+        resolversTestingSchema,
+        [],
+        {
+          resolversNonOptionalTypename: { interfaceImplementingType: true },
+          mappers: { AnotherNodeWithChild: 'Wrapper<{T}>' },
+        },
+        { outputFile: '' }
+      );
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+          Node: ( SomeNode & { __typename: 'SomeNode' } );
+          AnotherNode: ( Wrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> & { __typename: 'AnotherNodeWithChild' } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+          WithChild: ( Wrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> & { __typename: 'AnotherNodeWithChild' } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+          WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } & { __typename: 'AnotherNodeWithAll' } );
+        };
+      `);
+    });
+
+    it('resolversNonOptionalTypename - adds non-optional typenames to ResolversInterfaceTypes for default mappers with placeholder', async () => {
+      const result = await plugin(
+        resolversTestingSchema,
+        [],
+        {
+          resolversNonOptionalTypename: { interfaceImplementingType: true },
+          defaultMapper: 'Partial<{T}>',
+        },
+        { outputFile: '' }
+      );
+
+      expect(result.content).toBeSimilarStringTo(`
+        export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+          Node: ( Partial<SomeNode> & { __typename: 'SomeNode' } );
+          AnotherNode: ( Partial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> & { __typename: 'AnotherNodeWithChild' } ) | ( Partial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> & { __typename: 'AnotherNodeWithAll' } );
+          WithChild: ( Partial<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> & { __typename: 'AnotherNodeWithChild' } ) | ( Partial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> & { __typename: 'AnotherNodeWithAll' } );
+          WithChildren: ( Partial<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> }> & { __typename: 'AnotherNodeWithAll' } );
+        };
+      `);
+    });
+
+    it('resolversNonOptionalTypename - does not create ResolversInterfaceTypes for default mappers with no placeholder', async () => {
+      const result = await plugin(
+        resolversTestingSchema,
+        [],
+        {
+          resolversNonOptionalTypename: { interfaceImplementingType: true },
+          defaultMapper: 'unknown',
+        },
+        { outputFile: '' }
+      );
+
+      expect(result.content).not.toBeSimilarStringTo('export type ResolversInterfaceTypes');
     });
   });
 
@@ -1994,6 +2097,149 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
 
     expect(content.content).not.toBeSimilarStringTo(`export type ResolversUnionTypes`);
     expect(content.content).not.toBeSimilarStringTo(`export type ResolversUnionParentTypes`);
+  });
+
+  it('should generate ResolversInterfaceTypes', async () => {
+    const content = await plugin(resolversTestingSchema, [], {}, { outputFile: 'graphql.ts' });
+
+    expect(content.content).toBeSimilarStringTo(`
+      export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+        Node: ( SomeNode );
+        AnotherNode: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChild: ( Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+      };
+    `);
+
+    expect(content.content).toBeSimilarStringTo(`
+      export type ResolversTypes = {
+        MyType: ResolverTypeWrapper<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
+        String: ResolverTypeWrapper<Scalars['String']>;
+        Child: ResolverTypeWrapper<Child>;
+        MyOtherType: ResolverTypeWrapper<MyOtherType>;
+        ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+        Query: ResolverTypeWrapper<{}>;
+        Subscription: ResolverTypeWrapper<{}>;
+        Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
+        ID: ResolverTypeWrapper<Scalars['ID']>;
+        SomeNode: ResolverTypeWrapper<SomeNode>;
+        AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+        WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+        WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
+        AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
+        AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
+        MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+        Int: ResolverTypeWrapper<Scalars['Int']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+      };
+    `);
+
+    expect(content.content).toBeSimilarStringTo(`
+      export type ResolversParentTypes = {
+        MyType: Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
+        String: Scalars['String'];
+        Child: Child;
+        MyOtherType: MyOtherType;
+        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        Query: {};
+        Subscription: {};
+        Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
+        ID: Scalars['ID'];
+        SomeNode: SomeNode;
+        AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+        WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+        WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
+        AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
+        AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
+        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyScalar: Scalars['MyScalar'];
+        Int: Scalars['Int'];
+        Boolean: Scalars['Boolean'];
+      };
+    `);
+  });
+
+  it('should generate ResolversInterfaceTypes with transformed type names correctly', async () => {
+    const content = await plugin(
+      resolversTestingSchema,
+      [],
+      { typesPrefix: 'I_', typesSuffix: '_Types' },
+      { outputFile: 'graphql.ts' }
+    );
+
+    expect(content.content).toBeSimilarStringTo(`
+      export type I_ResolversInterfaceTypes_Types<RefType extends Record<string, unknown>> = {
+        Node: ( I_SomeNode_Types );
+        AnotherNode: ( Omit<I_AnotherNodeWithChild_Types, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<I_AnotherNodeWithAll_Types, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChild: ( Omit<I_AnotherNodeWithChild_Types, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } ) | ( Omit<I_AnotherNodeWithAll_Types, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+        WithChildren: ( Omit<I_AnotherNodeWithAll_Types, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<RefType['ChildUnion']>, unionChildren: Array<RefType['ChildUnion']> } );
+      };
+    `);
+
+    expect(content.content).toBeSimilarStringTo(`
+      export type I_ResolversTypes_Types = {
+        MyType: ResolverTypeWrapper<Omit<I_MyType_Types, 'unionChild'> & { unionChild?: Maybe<I_ResolversTypes_Types['ChildUnion']> }>;
+        String: ResolverTypeWrapper<Scalars['String']>;
+        Child: ResolverTypeWrapper<I_Child_Types>;
+        MyOtherType: ResolverTypeWrapper<I_MyOtherType_Types>;
+        ChildUnion: ResolverTypeWrapper<I_ResolversUnionTypes_Types['ChildUnion']>;
+        Query: ResolverTypeWrapper<{}>;
+        Subscription: ResolverTypeWrapper<{}>;
+        Node: ResolverTypeWrapper<I_ResolversInterfaceTypes_Types<I_ResolversTypes_Types>['Node']>;
+        ID: ResolverTypeWrapper<Scalars['ID']>;
+        SomeNode: ResolverTypeWrapper<I_SomeNode_Types>;
+        AnotherNode: ResolverTypeWrapper<I_ResolversInterfaceTypes_Types<I_ResolversTypes_Types>['AnotherNode']>;
+        WithChild: ResolverTypeWrapper<I_ResolversInterfaceTypes_Types<I_ResolversTypes_Types>['WithChild']>;
+        WithChildren: ResolverTypeWrapper<I_ResolversInterfaceTypes_Types<I_ResolversTypes_Types>['WithChildren']>;
+        AnotherNodeWithChild: ResolverTypeWrapper<Omit<I_AnotherNodeWithChild_Types, 'unionChild'> & { unionChild?: Maybe<I_ResolversTypes_Types['ChildUnion']> }>;
+        AnotherNodeWithAll: ResolverTypeWrapper<Omit<I_AnotherNodeWithAll_Types, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<I_ResolversTypes_Types['ChildUnion']>, unionChildren: Array<I_ResolversTypes_Types['ChildUnion']> }>;
+        MyUnion: ResolverTypeWrapper<I_ResolversUnionTypes_Types['MyUnion']>;
+        MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
+        Int: ResolverTypeWrapper<Scalars['Int']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+      };
+    `);
+
+    expect(content.content).toBeSimilarStringTo(`
+      export type I_ResolversParentTypes_Types = {
+        MyType: Omit<I_MyType_Types, 'unionChild'> & { unionChild?: Maybe<I_ResolversParentTypes_Types['ChildUnion']> };
+        String: Scalars['String'];
+        Child: I_Child_Types;
+        MyOtherType: I_MyOtherType_Types;
+        ChildUnion: I_ResolversUnionParentTypes_Types['ChildUnion'];
+        Query: {};
+        Subscription: {};
+        Node: I_ResolversInterfaceTypes_Types<I_ResolversParentTypes_Types>['Node'];
+        ID: Scalars['ID'];
+        SomeNode: I_SomeNode_Types;
+        AnotherNode: I_ResolversInterfaceTypes_Types<I_ResolversParentTypes_Types>['AnotherNode'];
+        WithChild: I_ResolversInterfaceTypes_Types<I_ResolversParentTypes_Types>['WithChild'];
+        WithChildren: I_ResolversInterfaceTypes_Types<I_ResolversParentTypes_Types>['WithChildren'];
+        AnotherNodeWithChild: Omit<I_AnotherNodeWithChild_Types, 'unionChild'> & { unionChild?: Maybe<I_ResolversParentTypes_Types['ChildUnion']> };
+        AnotherNodeWithAll: Omit<I_AnotherNodeWithAll_Types, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<I_ResolversParentTypes_Types['ChildUnion']>, unionChildren: Array<I_ResolversParentTypes_Types['ChildUnion']> };
+        MyUnion: I_ResolversUnionParentTypes_Types['MyUnion'];
+        MyScalar: Scalars['MyScalar'];
+        Int: Scalars['Int'];
+        Boolean: Scalars['Boolean'];
+      };
+    `);
+  });
+
+  it('should NOT generate ResolversInterfaceTypes if there is no Interface', async () => {
+    const testSchema = buildSchema(/* GraphQL */ `
+      type Query {
+        user(id: ID!): User
+      }
+
+      type User {
+        id: ID!
+        fullName: String!
+      }
+    `);
+    const content = await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
+
+    expect(content.content).not.toBeSimilarStringTo(`export type ResolversInterfaceTypes`);
   });
 
   it('should use correct value when rootValueType mapped as default', async () => {

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -234,15 +234,9 @@ export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParen
       );
 
       expect(result.content).toBeSimilarStringTo(`
-        export type ResolversUnionTypes = {
+        export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
           ChildUnion: ( Child & { __typename: 'Child' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
-          MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> } & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
-        };
-      `);
-      expect(result.content).toBeSimilarStringTo(`
-        export type ResolversUnionParentTypes = {
-          ChildUnion: ( Child & { __typename: 'Child' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
-          MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> } & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
+          MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
         };
       `);
       expect(result.content).toBeSimilarStringTo(`
@@ -264,15 +258,9 @@ export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParen
       );
 
       expect(result.content).toBeSimilarStringTo(`
-        export type ResolversUnionTypes = {
+        export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
           ChildUnion: ( Child & { __typename: 'Child' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
-          MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> } & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
-        };
-      `);
-      expect(result.content).toBeSimilarStringTo(`
-        export type ResolversUnionParentTypes = {
-          ChildUnion: ( Child & { __typename: 'Child' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
-          MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> } & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
+          MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> } & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
         };
       `);
     });
@@ -289,13 +277,7 @@ export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParen
       );
 
       expect(result.content).toBeSimilarStringTo(`
-        export type ResolversUnionTypes = {
-          ChildUnion: ( ChildMapper & { __typename: 'Child' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
-          MyUnion: ( MyTypeMapper & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
-        };
-      `);
-      expect(result.content).toBeSimilarStringTo(`
-        export type ResolversUnionParentTypes = {
+        export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
           ChildUnion: ( ChildMapper & { __typename: 'Child' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
           MyUnion: ( MyTypeMapper & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
         };
@@ -314,15 +296,9 @@ export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParen
       );
 
       expect(result.content).toBeSimilarStringTo(`
-        export type ResolversUnionTypes = {
-          ChildUnion: ( Wrapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversTypes['MyType']> }> & { __typename: 'Child' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
-          MyUnion: ( MyWrapper<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }> & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
-        };
-      `);
-      expect(result.content).toBeSimilarStringTo(`
-        export type ResolversUnionParentTypes = {
-          ChildUnion: ( Wrapper<Omit<Child, 'parent'> & { parent?: Maybe<ResolversParentTypes['MyType']> }> & { __typename: 'Child' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
-          MyUnion: ( MyWrapper<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }> & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
+        export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+          ChildUnion: ( Wrapper<Omit<Child, 'parent'> & { parent?: Maybe<RefType['MyType']> }> & { __typename: 'Child' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
+          MyUnion: ( MyWrapper<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> & { __typename: 'MyType' } ) | ( MyOtherType & { __typename: 'MyOtherType' } );
         };
       `);
     });
@@ -339,15 +315,9 @@ export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParen
       );
 
       expect(result.content).toBeSimilarStringTo(`
-        export type ResolversUnionTypes = {
+        export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
           ChildUnion: ( Partial<Child> & { __typename: 'Child' } ) | ( Partial<MyOtherType> & { __typename: 'MyOtherType' } );
-          MyUnion: ( Partial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }> & { __typename: 'MyType' } ) | ( Partial<MyOtherType> & { __typename: 'MyOtherType' } );
-        };
-      `);
-      expect(result.content).toBeSimilarStringTo(`
-        export type ResolversUnionParentTypes = {
-          ChildUnion: ( Partial<Child> & { __typename: 'Child' } ) | ( Partial<MyOtherType> & { __typename: 'MyOtherType' } );
-          MyUnion: ( Partial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> }> & { __typename: 'MyType' } ) | ( Partial<MyOtherType> & { __typename: 'MyOtherType' } );
+          MyUnion: ( Partial<Omit<MyType, 'unionChild'> & { unionChild?: Maybe<RefType['ChildUnion']> }> & { __typename: 'MyType' } ) | ( Partial<MyOtherType> & { __typename: 'MyOtherType' } );
         };
       `);
     });
@@ -1680,12 +1650,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     `);
 
     expect(content.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        CCCUnion: ( CccFoo ) | ( CccBar );
-      };
-    `);
-    expect(content.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
         CCCUnion: ( CccFoo ) | ( CccBar );
       };
     `);
@@ -1696,7 +1661,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
       String: ResolverTypeWrapper<Scalars['String']>;
       CCCBar: ResolverTypeWrapper<CccBar>;
       Query: ResolverTypeWrapper<{}>;
-      CCCUnion: ResolverTypeWrapper<ResolversUnionTypes['CCCUnion']>;
+      CCCUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['CCCUnion']>;
       Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
     };
     `);
@@ -1706,7 +1671,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         String: Scalars['String'];
         CCCBar: CccBar;
         Query: {};
-        CCCUnion: ResolversUnionParentTypes['CCCUnion'];
+        CCCUnion: ResolversUnionTypes<ResolversParentTypes>['CCCUnion'];
         Boolean: Scalars['Boolean'];
       };
     `);
@@ -2036,14 +2001,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     const content = await plugin(testSchema, [], {}, { outputFile: 'graphql.ts' });
 
     expect(content.content).toBeSimilarStringTo(`
-      export type ResolversUnionTypes = {
-        UserPayload: ( UserResult ) | ( StandardError );
-        PostsPayload: ( PostsResult ) | ( StandardError );
-      };
-    `);
-
-    expect(content.content).toBeSimilarStringTo(`
-      export type ResolversUnionParentTypes = {
+      export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
         UserPayload: ( UserResult ) | ( StandardError );
         PostsPayload: ( PostsResult ) | ( StandardError );
       };
@@ -2057,10 +2015,10 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         String: ResolverTypeWrapper<Scalars['String']>;
         User: ResolverTypeWrapper<User>;
         UserResult: ResolverTypeWrapper<UserResult>;
-        UserPayload: ResolverTypeWrapper<ResolversUnionTypes['UserPayload']>;
+        UserPayload: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['UserPayload']>;
         Post: ResolverTypeWrapper<Post>;
         PostsResult: ResolverTypeWrapper<PostsResult>;
-        PostsPayload: ResolverTypeWrapper<ResolversUnionTypes['PostsPayload']>;
+        PostsPayload:  ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['PostsPayload']>;
         Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
       };
     `);
@@ -2073,10 +2031,10 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         String: Scalars['String'];
         User: User;
         UserResult: UserResult;
-        UserPayload: ResolversUnionParentTypes['UserPayload'];
+        UserPayload: ResolversUnionTypes<ResolversParentTypes>['UserPayload'];
         Post: Post;
         PostsResult: PostsResult;
-        PostsPayload: ResolversUnionParentTypes['PostsPayload'];
+        PostsPayload: ResolversUnionTypes<ResolversParentTypes>['PostsPayload'];
         Boolean: Scalars['Boolean'];
       };
     `);
@@ -2117,7 +2075,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         String: ResolverTypeWrapper<Scalars['String']>;
         Child: ResolverTypeWrapper<Child>;
         MyOtherType: ResolverTypeWrapper<MyOtherType>;
-        ChildUnion: ResolverTypeWrapper<ResolversUnionTypes['ChildUnion']>;
+        ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
         Query: ResolverTypeWrapper<{}>;
         Subscription: ResolverTypeWrapper<{}>;
         Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
@@ -2128,7 +2086,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
         AnotherNodeWithChild: ResolverTypeWrapper<Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']> }>;
         AnotherNodeWithAll: ResolverTypeWrapper<Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']> }>;
-        MyUnion: ResolverTypeWrapper<ResolversUnionTypes['MyUnion']>;
+        MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
         MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
         Int: ResolverTypeWrapper<Scalars['Int']>;
         Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -2141,7 +2099,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         String: Scalars['String'];
         Child: Child;
         MyOtherType: MyOtherType;
-        ChildUnion: ResolversUnionParentTypes['ChildUnion'];
+        ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
@@ -2152,7 +2110,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
         AnotherNodeWithChild: Omit<AnotherNodeWithChild, 'unionChild'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']> };
         AnotherNodeWithAll: Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']> };
-        MyUnion: ResolversUnionParentTypes['MyUnion'];
+        MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];
@@ -2183,7 +2141,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         String: ResolverTypeWrapper<Scalars['String']>;
         Child: ResolverTypeWrapper<I_Child_Types>;
         MyOtherType: ResolverTypeWrapper<I_MyOtherType_Types>;
-        ChildUnion: ResolverTypeWrapper<I_ResolversUnionTypes_Types['ChildUnion']>;
+        ChildUnion: ResolverTypeWrapper<I_ResolversUnionTypes_Types<I_ResolversTypes_Types>['ChildUnion']>;
         Query: ResolverTypeWrapper<{}>;
         Subscription: ResolverTypeWrapper<{}>;
         Node: ResolverTypeWrapper<I_ResolversInterfaceTypes_Types<I_ResolversTypes_Types>['Node']>;
@@ -2194,7 +2152,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         WithChildren: ResolverTypeWrapper<I_ResolversInterfaceTypes_Types<I_ResolversTypes_Types>['WithChildren']>;
         AnotherNodeWithChild: ResolverTypeWrapper<Omit<I_AnotherNodeWithChild_Types, 'unionChild'> & { unionChild?: Maybe<I_ResolversTypes_Types['ChildUnion']> }>;
         AnotherNodeWithAll: ResolverTypeWrapper<Omit<I_AnotherNodeWithAll_Types, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<I_ResolversTypes_Types['ChildUnion']>, unionChildren: Array<I_ResolversTypes_Types['ChildUnion']> }>;
-        MyUnion: ResolverTypeWrapper<I_ResolversUnionTypes_Types['MyUnion']>;
+        MyUnion: ResolverTypeWrapper<I_ResolversUnionTypes_Types<I_ResolversTypes_Types>['MyUnion']>;
         MyScalar: ResolverTypeWrapper<Scalars['MyScalar']>;
         Int: ResolverTypeWrapper<Scalars['Int']>;
         Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -2207,7 +2165,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         String: Scalars['String'];
         Child: I_Child_Types;
         MyOtherType: I_MyOtherType_Types;
-        ChildUnion: I_ResolversUnionParentTypes_Types['ChildUnion'];
+        ChildUnion: I_ResolversUnionTypes_Types<I_ResolversParentTypes_Types>['ChildUnion'];
         Query: {};
         Subscription: {};
         Node: I_ResolversInterfaceTypes_Types<I_ResolversParentTypes_Types>['Node'];
@@ -2218,7 +2176,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         WithChildren: I_ResolversInterfaceTypes_Types<I_ResolversParentTypes_Types>['WithChildren'];
         AnotherNodeWithChild: Omit<I_AnotherNodeWithChild_Types, 'unionChild'> & { unionChild?: Maybe<I_ResolversParentTypes_Types['ChildUnion']> };
         AnotherNodeWithAll: Omit<I_AnotherNodeWithAll_Types, 'unionChild' | 'unionChildren'> & { unionChild?: Maybe<I_ResolversParentTypes_Types['ChildUnion']>, unionChildren: Array<I_ResolversParentTypes_Types['ChildUnion']> };
-        MyUnion: I_ResolversUnionParentTypes_Types['MyUnion'];
+        MyUnion: I_ResolversUnionTypes_Types<I_ResolversParentTypes_Types>['MyUnion'];
         MyScalar: Scalars['MyScalar'];
         Int: Scalars['Int'];
         Boolean: Scalars['Boolean'];


### PR DESCRIPTION
## Description

### 1. `ResolversInterfaceTypes` is a new type that keeps track of a GraphQL interface and its implementing types

For example, consider this schema:

```graphql
extend type Query {
  character(id: ID!): CharacterNode
}
interface CharacterNode {
  id: ID!
}
type Wizard implements CharacterNode {
  id: ID!
  screenName: String!
  spells: [String!]!
}
type Fighter implements CharacterNode {
  id: ID!
  screenName: String!
  powerLevel: Int!
}
```

The generated types will look like this:

```ts
export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
  CharacterNode: Fighter | Wizard;
};
export type ResolversTypes = {
  // other types...
  CharacterNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>["CharacterNode"]>;
  Fighter: ResolverTypeWrapper<Fighter>;
  Wizard: ResolverTypeWrapper<Wizard>;
  // other types...
};
export type ResolversParentTypes = {
  // other types...
  CharacterNode: ResolversInterfaceTypes<ResolversParentTypes>["CharacterNode"];
  Fighter: Fighter;
  Wizard: Wizard;
  // other types...
};
```

The `RefType` generic is used to reference back to `ResolversTypes` and `ResolversParentTypes` in some cases such as field returning a Union.

### 2. `resolversNonOptionalTypename` affects `ResolversInterfaceTypes`

Using the schema above, if we use `resolversNonOptionalTypename` option:

```typescript
const config: CodegenConfig = {
  schema: 'src/schema/**/*.graphql',
  generates: {
    'src/schema/types.ts': {
      plugins: ['typescript', 'typescript-resolvers'],
      config: {
        resolversNonOptionalTypename: true // Or `resolversNonOptionalTypename: { interfaceImplementingType: true }`
      }
    },
  },
};
```

Then, the generated type looks like this:

```ts
export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
  CharacterNode: (Fighter & { __typename: "Fighter" }) | (Wizard & { __typename: "Wizard" });
};
export type ResolversTypes = {
  // other types...
  CharacterNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>["CharacterNode"]>;
  Fighter: ResolverTypeWrapper<Fighter>;
  Wizard: ResolverTypeWrapper<Wizard>;
  // other types...
};
export type ResolversParentTypes = {
  // other types...
  CharacterNode: ResolversInterfaceTypes<ResolversParentTypes>["CharacterNode"];
  Fighter: Fighter;
  Wizard: Wizard;
  // other types...
};
```

### 3. Simplify `ResolversUnionTypes` and `ResolversUnionParentTypes` with generic

Previously, we create `ResolversUnionTypes` and `ResolversUnionParentTypes` since each nested union member field may refer back to `ResolversTypes` and `ResolversParentTypes` respectively.

This PR simplifies it by using a generic (similar to `ResolversInterfaceTypes`)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

TODO

- [x] Unit test
- [x] Test in a repo: https://github.com/eddeee888/graphql-server-template/pull/3
  - [x] Confirm resolvers can return `Promise<T>  | T`
  - [x]  Confirm the Interface type (`CharacterNode` in the example repo) is `T` i.e. not a promise

**Test Environment**:

- OS: MacOS
- NodeJS: 18

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
