### PR TITLE
[website-docs] Update server with preset guide for v0.4 usage

### DIFF
--- a/website/src/pages/docs/guides/graphql-server-apollo-yoga-with-server-preset.mdx
+++ b/website/src/pages/docs/guides/graphql-server-apollo-yoga-with-server-preset.mdx
@@ -64,7 +64,7 @@ type Book {
 
 #### 2. Install Server Preset
 
-<PackageCmd packages={['-D @eddeee888/gcg-typescript-resolver-files']} />
+<PackageCmd packages={['-D @graphql-codegen/cli @eddeee888/gcg-typescript-resolver-files']} />
 
 #### 3. Configure Codegen Config
 
@@ -72,14 +72,12 @@ Create or update your `codegen.ts` as follows:
 
 ```ts filename="codegen.ts"
 import type { CodegenConfig } from '@graphql-codegen/cli'
-import { preset } from '@eddeee888/gcg-typescript-resolver-files'
+import { defineConfig } from '@eddeee888/gcg-typescript-resolver-files'
 
 const config: CodegenConfig = {
   schema: '**/schema.graphql',
   generates: {
-    'src/schema': {
-      preset
-    }
+    'src/schema': defineConfig()
   }
 }
 export default config

--- a/website/src/pages/docs/guides/graphql-server-apollo-yoga-with-server-preset.mdx
+++ b/website/src/pages/docs/guides/graphql-server-apollo-yoga-with-server-preset.mdx
@@ -68,7 +68,11 @@ type Book {
 
 #### 3. Configure Codegen Config
 
-Create or update your `codegen.ts` as follows:
+Create or update your Codegen config as follows:
+
+<Tabs items={['codegen.ts','codegen.yml']}>
+
+<Tab>
 
 ```ts filename="codegen.ts"
 import type { CodegenConfig } from '@graphql-codegen/cli'
@@ -82,6 +86,22 @@ const config: CodegenConfig = {
 }
 export default config
 ```
+
+</Tab>
+
+<Tab>
+
+```yml filename="codegen.yml"
+schema: '**/schema.graphql'
+generates:
+  src/schema:
+    preset: '@eddeee888/gcg-typescript-resolver-files'
+    watchPattern: '**/*.mappers.ts'
+```
+
+</Tab>
+
+</Tabs>
 
 <Callout type="info">
 
@@ -138,21 +158,22 @@ We can use generated files in GraphQL API implementation:
 <Tabs items={['GraphQL Yoga','Apollo Server']}>
 
 <Tab>
+
 ```ts filename="src/server.ts"
-import { createYoga, createSchema } from 'graphql-yoga';
-import { createServer } from 'http';
+import { createYoga, createSchema } from 'graphql-yoga'
+import { createServer } from 'http'
 import { typeDefs } from './schema/typeDefs.generated'
 import { resolvers } from './schema/resolvers.generated'
 
 const yoga = createYoga({ schema: createSchema({ typeDefs, resolvers }) })
 const server = createServer(yoga)
 server.listen(3000)
-
-````
+```
 
 </Tab>
 
 <Tab>
+
 ```ts filename="src/server.ts"
 import { ApolloServer } from 'apollo-server'
 import { typeDefs } from './schema/typeDefs.generated'
@@ -164,8 +185,7 @@ const server = new ApolloServer({ typeDefs, resolvers })
 server.listen().then(({ url }) => {
   console.log(`🚀 Server ready at ${url}`)
 })
-
-````
+```
 
 </Tab>
 


### PR DESCRIPTION
## Description

This PR updates the server with preset guide with `defineConfig` available in server preset v0.4.

Blocked by https://github.com/eddeee888/graphql-code-generator-plugins/pull/92

## Type of change

- [x] Update one of the guides on the website

## Screenshots/Sandbox (if appropriate/relevant):

| Description | Screenshot |
| -- | -- |
| `codegen.ts` | ![Screenshot 2023-04-07 at 9 56 57 am](https://user-images.githubusercontent.com/33769523/230514478-fae348e6-e21c-4ff9-9535-ffd554c7ad3c.png) |
| `codegen.yml` |  ![Screenshot 2023-04-07 at 9 57 03 am](https://user-images.githubusercontent.com/33769523/230514463-20004c76-f5f3-49bb-951a-541c1c465867.png) |

## How Has This Been Tested?

- [x] Ran the website locally and took screenshot

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules