### PR TITLE
fix: output directory for init command

### DIFF
--- a/.changeset/tough-bags-hunt.md
+++ b/.changeset/tough-bags-hunt.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+fix the default output directory for init command

--- a/packages/graphql-codegen-cli/src/init/questions.ts
+++ b/packages/graphql-codegen-cli/src/init/questions.ts
@@ -172,7 +172,7 @@ function normalizeTargets(targets: Tags[] | Tags[][]): Tags[] {
 
 export function getOutputDefaultValue(answers: Answers) {
   if (answers.targets.includes(Tags.client)) {
-    return 'src/gql';
+    return 'src/gql/';
   }
   if (answers.plugins.some(plugin => plugin.defaultExtension === '.tsx')) {
     return 'src/generated/graphql.tsx';

--- a/packages/graphql-codegen-cli/tests/__snapshots__/init.spec.ts.snap
+++ b/packages/graphql-codegen-cli/tests/__snapshots__/init.spec.ts.snap
@@ -9,7 +9,7 @@ const config: CodegenConfig = {
   schema: "http://localhost:4000",
   documents: "graphql/*.ts",
   generates: {
-    "src/gql": {
+    "src/gql/": {
       preset: "client",
       plugins: []
     },
@@ -51,7 +51,7 @@ const config: CodegenConfig = {
   schema: "http://localhost:4000",
   documents: "src/**/*.tsx",
   generates: {
-    "src/gql": {
+    "src/gql/": {
       preset: "client",
       plugins: []
     }
@@ -108,7 +108,7 @@ const config: CodegenConfig = {
   schema: "http://localhost:4000",
   documents: "src/**/*.tsx",
   generates: {
-    "src/gql": {
+    "src/gql/": {
       preset: "client",
       plugins: []
     }


### PR DESCRIPTION
we were missing `/` in the default output path, so updating that so it is not broken.

Related #9157 