### PR TITLE
Fix fragment imports for near-operation-file with graphQLTag

### DIFF
--- a/.changeset/big-bottles-bow.md
+++ b/.changeset/big-bottles-bow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Fix fragment imports for near-operation-file with graphQLTag

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -16,7 +16,8 @@ import {
 import gqlTag from 'graphql-tag';
 import { BaseVisitor, ParsedConfig, RawConfig } from './base-visitor.js';
 import { LoadedFragment, ParsedImport } from './types.js';
-import { buildScalarsFromConfig, getConfigValue } from './utils.js';
+import { buildScalarsFromConfig, unique, flatten, getConfigValue, groupBy } from './utils.js';
+import { FragmentImport, ImportDeclaration, generateFragmentImportStatement } from './imports.js';
 
 gqlTag.enableExperimentalFragmentVariables();
 
@@ -568,7 +569,7 @@ export class ClientSideBaseVisitor<
     return path;
   }
 
-  public getImports(): string[] {
+  public getImports(options: { excludeFragments?: boolean } = {}): string[] {
     for (const i of this._additionalImports || []) {
       this._imports.add(i);
     }
@@ -619,6 +620,31 @@ export class ClientSideBaseVisitor<
       }
       default:
         break;
+    }
+
+    const excludeFragments =
+      options.excludeFragments || this.config.globalNamespace || this.config.documentMode !== DocumentMode.graphQLTag;
+
+    if (!excludeFragments) {
+      const deduplicatedImports = Object.values(groupBy(this.config.fragmentImports, fi => fi.importSource.path))
+        .map(
+          (fragmentImports): ImportDeclaration<FragmentImport> => ({
+            ...fragmentImports[0],
+            importSource: {
+              ...fragmentImports[0].importSource,
+              identifiers: unique(
+                flatten(fragmentImports.map(fi => fi.importSource.identifiers)),
+                identifier => identifier.name
+              ),
+            },
+            emitLegacyCommonJSImports: this.config.emitLegacyCommonJSImports,
+          })
+        )
+        .filter(fragmentImport => fragmentImport.outputPath !== fragmentImport.importSource.path);
+
+      for (const fragmentImport of deduplicatedImports) {
+        this._imports.add(generateFragmentImportStatement(fragmentImport, 'document'));
+      }
     }
 
     return Array.from(this._imports);

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -524,3 +524,19 @@ export function isOneOfInputObjectType(
 
   return isOneOfType;
 }
+
+export function groupBy<T>(array: Array<T>, key: (item: T) => string | number): { [key: string]: Array<T> } {
+  return array.reduce<{ [key: string]: Array<T> }>((acc, item) => {
+    const group = (acc[key(item)] ??= []);
+    group.push(item);
+    return acc;
+  }, {});
+}
+
+export function flatten<T>(array: Array<Array<T>>): Array<T> {
+  return ([] as Array<T>).concat(...array);
+}
+
+export function unique<T>(array: Array<T>, key: (item: T) => string | number = item => item.toString()): Array<T> {
+  return Object.values(array.reduce((acc, item) => ({ [key(item)]: item, ...acc }), {}));
+}

--- a/packages/plugins/other/visitor-plugin-common/tests/utils.spec.ts
+++ b/packages/plugins/other/visitor-plugin-common/tests/utils.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from '@jest/globals';
+import { flatten, groupBy, unique } from '../src/utils';
+
+describe('utils', () => {
+  describe('flatten', () => {
+    it('should flatten a nested array', () => {
+      const array = [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ];
+      const actual = flatten(array);
+      const expected = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('groupBy', () => {
+    it('should group by a property', () => {
+      const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+      const actual = groupBy(array, i => i % 2);
+      const expected = { 0: [2, 4, 6, 8, 10], 1: [1, 3, 5, 7, 9] };
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('unique', () => {
+    it('should return unique items when no key selector is passed', () => {
+      const array = [1, 2, 3, 1, 2, 4];
+      const actual = unique(array);
+      const expected = [1, 2, 3, 4];
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return unique items based on key selector', () => {
+      const array = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+        { id: 1, name: 'Alice #2' },
+        { id: 3, name: 'Charlie' },
+      ];
+
+      const actual = unique(array, item => item.id);
+      const expected = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+        { id: 3, name: 'Charlie' },
+      ];
+
+      expect(actual).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
## Description
Fixes a regression issue introduced by a recent change which removes fragment imports entirely.

Related #9293

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I cloned [this minimal reproduction](https://stackblitz.com/edit/graphql-codegen-fragment-issue?file=src/user.query.ts) from the related issue and ran it with the changes.

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

As part of the change I've added 3 one line array utility functions, which make the change code much cleaner and easier to understand.
