### PR TITLE
[cli/docs]Add GitHub Loader TypeScript type, update usage docs

### DIFF
--- a/.changeset/breezy-rice-retire.md
+++ b/.changeset/breezy-rice-retire.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/plugin-helpers': patch
+---
+
+Update GitHub loader TypeScript type and usage docs

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -184,7 +184,7 @@ export namespace Types {
   }
 
   export interface GitHubSchemaOptions {
-    [githubProtocol: string]: { token: string };
+    [githubProtocol: `github:${string}`]: { token: string };
   }
 
   export type SchemaGlobPath = string;

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -183,6 +183,10 @@ export namespace Types {
     'apollo-engine': ApolloEngineOptions;
   }
 
+  export interface GitHubSchemaOptions {
+    [githubProtocol: string]: { token: string };
+  }
+
   export type SchemaGlobPath = string;
   /**
    * @description A URL to your GraphQL endpoint, a local path to `.graphql` file, a glob pattern to your GraphQL schema files, or a JavaScript file that exports the schema to generate code from. This can also be an array which specifies multiple schemas to generate code from. You can read more about the supported formats [here](schema-field#available-formats).
@@ -191,6 +195,7 @@ export namespace Types {
     | string
     | UrlSchemaWithOptions
     | ApolloEngineSchemaOptions
+    | GitHubSchemaOptions
     | LocalSchemaPathWithOptions
     | SchemaGlobPath
     | SchemaWithLoader

--- a/website/src/pages/docs/config-reference/schema-field.mdx
+++ b/website/src/pages/docs/config-reference/schema-field.mdx
@@ -445,7 +445,33 @@ export default config;
 
 ### GitHub
 
-You can load your schema file from a remote GitHub file, using the following syntax:
+You can load your schema file from a remote GitHub file using one of the following approaches:
+
+#### Provide GitHub token in Codegen Config
+
+Provide the GitHub path to your schema and token using the following syntax:
+
+```ts {4,5,6,7}
+import { CodegenConfig } from '@graphql-codegen/cli';
+
+const config: CodegenConfig = {
+  schema: {
+    'github:user/repo#branchName:path/to/file.graphql':
+      { token: "<YOUR GITHUB TOKEN>" }
+  }
+};
+export default config;
+```
+
+Then, run codegen:
+
+```bash
+yarn graphql-codegen
+```
+
+#### Provide GitHub token via Codegen CLI
+
+Alternatively, you can provide just the GitHub path to your schema:
 
 ```ts {4}
 import { CodegenConfig } from '@graphql-codegen/cli';
@@ -456,6 +482,11 @@ const config: CodegenConfig = {
 export default config;
 ```
 
+Then, provide your GitHub token using the `GITHU_TOKEN` environment variable when running codegen:
+
+```bash
+GITHUB_TOKEN=<YOUR GITHUB TOKEN> yarn graphql-codegen
+```
 
 <Callout>You can load from a JSON file, `.graphql` file, or from a code file containing `gql` tag syntax.</Callout>
 


### PR DESCRIPTION
## Description

This PR improves schema Github Loader doc and TypeScript usability:

- clarifies the two ways of using GitHub Loader in the doc
- updates TypeScript type of GitHub loader

Related: https://github.com/dotansimha/graphql-code-generator/pull/9281

## Type of change

- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

### Preview of updated doc

<img width="670" alt="Screenshot 2023-04-23 at 9 28 44 pm" src="https://user-images.githubusercontent.com/33769523/233837168-d08af3c1-e4f8-409f-96e4-5e0e8b9317a2.png">

### Using token no longer triggers TS errors

<img width="930" alt="Screenshot 2023-04-23 at 9 38 23 pm" src="https://user-images.githubusercontent.com/33769523/233837598-61a7669e-03df-46ab-acd6-2b2b6ce29530.png">



## How Has This Been Tested?

- [x] Use alpha version in a repo

**Test Environment**:

- OS: MacOS
- NodeJS: 18

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
