### PR TITLE
docs: fix highlights in `client-preset`

### DIFF
--- a/website/src/pages/plugins/presets/preset-client.mdx
+++ b/website/src/pages/plugins/presets/preset-client.mdx
@@ -182,7 +182,7 @@ export default Film
 `useFragment()` can be used without following React's rules of hooks.
 To avoid any issue with ESLint, we recommend changing its naming to `getFragmentData()` by setting the proper `unmaskFunctionName` value:
 
-```ts filename="codegen.ts" {10-12}
+```ts filename="codegen.ts" {9-11}
 import { CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {
@@ -310,7 +310,7 @@ describe('<ProfileName />', () => {
 
 `client-preset`'s Fragment Masking can be disabled as follow:
 
-```ts filename="codegen.ts" {10-12}
+```ts filename="codegen.ts" {9-11}
 import { type CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {
@@ -341,7 +341,7 @@ It is also commonly used to reduce the size of the client bundle as well as to i
 
 Persisted documents can be enabled by setting the `persistedDocuments` option to `true`:
 
-```ts filename="codegen.ts" {10-12}
+```ts filename="codegen.ts" {9-11}
 import { type CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {


### PR DESCRIPTION
## Description

I noticed some highlights on `client-preset` were a little bit off, let's fix this.

## Type of change

Documentation / Website.

## Screenshots/Sandbox (if appropriate/relevant):

| Before | After |
| - | - |
| <img width="849" alt="Screenshot 2023-04-24 at 9 12 27 AM" src="https://user-images.githubusercontent.com/7189823/234008050-0ef85269-2325-496f-baee-40413e41362f.png"> | <img width="843" alt="Screenshot 2023-04-24 at 9 13 42 AM" src="https://user-images.githubusercontent.com/7189823/234008234-a582eeac-75e6-44b8-9a70-ae3038d55ac1.png"> |
| <img width="851" alt="Screenshot 2023-04-24 at 9 12 36 AM" src="https://user-images.githubusercontent.com/7189823/234008048-43c6e036-7793-4961-8d6c-f6fa60f2daba.png"> | <img width="846" alt="Screenshot 2023-04-24 at 9 13 51 AM" src="https://user-images.githubusercontent.com/7189823/234008232-a18d351f-be83-425a-bcce-f38daec80a55.png"> |
| <img width="847" alt="Screenshot 2023-04-24 at 9 12 47 AM" src="https://user-images.githubusercontent.com/7189823/234008034-f403e971-0746-4889-b83b-c8d7269e8733.png"> | <img width="847" alt="Screenshot 2023-04-24 at 9 14 00 AM" src="https://user-images.githubusercontent.com/7189823/234008215-5452b9ed-473d-4169-9e4e-69eae1fd7cf6.png"> |

## How Has This Been Tested?

^ See screenshots.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules