### PR TITLE
Pass options type to declare function in babel preset

### DIFF
--- a/packages/presets/client/src/babel.ts
+++ b/packages/presets/client/src/babel.ts
@@ -9,7 +9,11 @@ import { buildSchema, parse } from 'graphql';
 
 const noopSchema = buildSchema(`type Query { _: Int }`);
 
-export default declare((api, opts): PluginObj => {
+type ClientBabelPresetOptions = {
+  artifactDirectory?: string;
+  gqlTagName?: string;
+};
+export default declare<ClientBabelPresetOptions>((api, opts): PluginObj => {
   const visitor = new ClientSideBaseVisitor(noopSchema, [], {}, {});
 
   const artifactDirectory = opts['artifactDirectory'] ?? '';


### PR DESCRIPTION
Disclaimer: it's a very very very small improvement.

In order to prepare a talk on TypeScript performance, I was playing with random repositories trying to find some interesting stuff. So there was one hot spot in this repo — in the `babel.ts` file:

<img width="1276" alt="CleanShot 2023-04-27 at 11 12 38@2x" src="https://user-images.githubusercontent.com/9019397/234819343-33629525-f42c-40b4-8cf3-cb2e2273c451.png">

<img width="529" alt="CleanShot 2023-04-27 at 11 12 05@2x" src="https://user-images.githubusercontent.com/9019397/234819483-5d97edf0-434f-4edd-a407-3e6f518abeed.png">

I passed an options type to generic `declare` to remove the hot spot.

<img width="916" alt="CleanShot 2023-04-27 at 11 10 43@2x" src="https://user-images.githubusercontent.com/9019397/234820276-90fce39f-cdcd-4cb3-87c3-09994dec169f.png">

It may not be a significant difference, but it's something.

Before:

<img width="438" alt="CleanShot 2023-04-27 at 11 27 00@2x" src="https://user-images.githubusercontent.com/9019397/234820507-bd24fc0f-607c-4c1c-8524-13dc8c381cd9.png">

After — check time got better:

<img width="395" alt="CleanShot 2023-04-27 at 11 27 38@2x" src="https://user-images.githubusercontent.com/9019397/234820642-d612d76e-73bc-4ebc-b6ac-4ac89ada79a9.png">




