### PR TITLE
chore: sync node versions used by GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@main
         with:
-          nodeVersion: 16
+          nodeVersion: 18
       - name: Prettier Check
         run: yarn prettier:check
   dev-tests-old:
@@ -46,7 +46,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@main
         with:
-          nodeVersion: 16
+          nodeVersion: 18
       - name: Build
         run: yarn build
         env:
@@ -64,7 +64,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@main
         with:
-          nodeVersion: 16
+          nodeVersion: 18
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.65.0
@@ -97,7 +97,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@main
         with:
-          nodeVersion: 16
+          nodeVersion: 18
       - name: Build
         run: yarn build
         env:
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # remove windows to speed up the tests
-        node_version: [14, 16, 18]
+        node_version: [14, 16, 18, 20]
         graphql_version: [15, 16]
         include:
           - node-version: 14


### PR DESCRIPTION
All workflows are using node 18 (LTS), except `main` workflow.

Let's make sure we're also using node LTS to do things on GitHub Actions.

Additionally, node 20 is out as current and will be the active LTS starting in October, let's start testing against it.