### PR TITLE
fix: ignoreNoDocuments option usage when using graphql configs

### DIFF
--- a/.changeset/quiet-rocks-sin.md
+++ b/.changeset/quiet-rocks-sin.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Fixed option ignoreNoDocuments when using graphql configs

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -274,10 +274,20 @@ export async function executeCodegen(input: CodegenContext | Types.Config): Prom
 
                           const hash = JSON.stringify(documentPointerMap);
                           const result = await cache('documents', hash, async () => {
-                            const documents = await context.loadDocuments(documentPointerMap);
-                            return {
-                              documents,
-                            };
+                            try {
+                              const documents = await context.loadDocuments(documentPointerMap);
+                              return {
+                                documents,
+                              };
+                            } catch (error) {
+                              if (config.ignoreNoDocuments) {
+                                return {
+                                  documents: [],
+                                };
+                              }
+
+                              throw error;
+                            }
                           });
 
                           outputDocuments = result.documents;

--- a/packages/graphql-codegen-cli/tests/generate-and-save.spec.ts
+++ b/packages/graphql-codegen-cli/tests/generate-and-save.spec.ts
@@ -3,6 +3,7 @@ import { Types } from '@graphql-codegen/plugin-helpers';
 import { useMonorepo } from '@graphql-codegen/testing';
 import makeDir from 'make-dir';
 import { generate } from '../src/generate-and-save.js';
+import { createContext } from '../src/config.js';
 import * as fs from '../src/utils/file-system.js';
 
 const SIMPLE_TEST_SCHEMA = `type MyType { f: String } type Query { f: String }`;
@@ -74,6 +75,22 @@ describe('generate-and-save', () => {
     expect(fileReadSpy).toHaveBeenCalledWith(filename);
     // makes sure it doesn't write a new file
     expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  test('should not error when there is ignoreNoDocuments config option is present', async () => {
+    jest.spyOn(fs, 'writeFile').mockImplementation();
+    const config = await createContext({
+      config: './tests/test-files/graphql.config.json',
+      project: undefined,
+      errorsOnly: true,
+      overwrite: true,
+      profile: true,
+      require: [],
+      silent: false,
+      watch: false,
+    });
+
+    await generate(config, false);
   });
 
   test('should use global overwrite option and write a file', async () => {

--- a/packages/graphql-codegen-cli/tests/generate-and-save.spec.ts
+++ b/packages/graphql-codegen-cli/tests/generate-and-save.spec.ts
@@ -77,7 +77,7 @@ describe('generate-and-save', () => {
     expect(writeSpy).not.toHaveBeenCalled();
   });
 
-  test('should not error when there is ignoreNoDocuments config option is present', async () => {
+  test('should not error when ignoreNoDocuments config option is present', async () => {
     jest.spyOn(fs, 'writeFile').mockImplementation();
     const config = await createContext({
       config: './tests/test-files/graphql.config.json',

--- a/packages/graphql-codegen-cli/tests/test-files/graphql.config.json
+++ b/packages/graphql-codegen-cli/tests/test-files/graphql.config.json
@@ -1,0 +1,14 @@
+{
+  "schema": ["../test-documents/schema.graphql"],
+  "documents": ["../test-documents/empty.graphql"],
+  "extensions": {
+    "codegen": {
+      "ignoreNoDocuments": true,
+      "generates": {
+        "./gql/": {
+          "preset": "client"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

When using general graphql configs (eg. graphql.config.json) instead of codegen configs (eg. codegen.ts), `ignoreNoDocuments` option and CLI flag are not working. Additional guard was added when loading documents to not throw error when `ignoreNoDocuments` option is needed.

Related # (issue)
#9368

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

added additional test

**Test Environment**:

- OS: MacOS
- `@graphql-codegen/...`: @latest
- NodeJS: 18

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
