### PR TITLE
Make isFragmentReady function work with enabled noUncheckedIndexedAccess tsc setting

### DIFF
--- a/.changeset/four-buckets-carry.md
+++ b/.changeset/four-buckets-carry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/client-preset': patch
+---
+
+Improve isFragmentReady utility function to work with noUncheckedIndexedAccess TSC setting

--- a/dev-test/gql-tag-operations-masking/gql/fragment-masking.ts
+++ b/dev-test/gql-tag-operations-masking/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/dev-test/gql-tag-operations-urql/gql/fragment-masking.ts
+++ b/dev-test/gql-tag-operations-urql/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/dev-test/gql-tag-operations/gql/fragment-masking.ts
+++ b/dev-test/gql-tag-operations/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/dev-test/gql-tag-operations/graphql/fragment-masking.ts
+++ b/dev-test/gql-tag-operations/graphql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/persisted-documents-string-mode/src/gql/fragment-masking.ts
+++ b/examples/persisted-documents-string-mode/src/gql/fragment-masking.ts
@@ -53,11 +53,10 @@ export function isFragmentReady<TQuery, TFrag>(
   data: FragmentType<TypedDocumentString<Incremental<TFrag>, any>> | null | undefined
 ): data is FragmentType<typeof fragmentNode> {
   const deferredFields = queryNode.__meta__?.deferredFields as Record<string, (keyof TFrag)[]>;
+  const fragName = fragmentNode.__meta__?.fragmentName as string | undefined;
 
-  if (!deferredFields) return true;
+  if (!deferredFields || !fragName) return true;
 
-  const fragName = fragmentNode.__meta__?.fragmentName;
-
-  const fields = (fragName && deferredFields[fragName]) || [];
+  const fields = deferredFields[fragName] ?? [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/persisted-documents-string-mode/src/gql/fragment-masking.ts
+++ b/examples/persisted-documents-string-mode/src/gql/fragment-masking.ts
@@ -58,6 +58,6 @@ export function isFragmentReady<TQuery, TFrag>(
 
   const fragName = fragmentNode.__meta__?.fragmentName;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/persisted-documents/src/gql/fragment-masking.ts
+++ b/examples/persisted-documents/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/programmatic-typescript/src/gql.generated.ts
+++ b/examples/programmatic-typescript/src/gql.generated.ts
@@ -5,6 +5,8 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/examples/react/apollo-client-defer/src/gql/fragment-masking.ts
+++ b/examples/react/apollo-client-defer/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/react/apollo-client-defer/tsconfig.json
+++ b/examples/react/apollo-client-defer/tsconfig.json
@@ -11,7 +11,8 @@
     "esModuleInterop": true,
     "lib": ["ESNext", "DOM"],
     "skipLibCheck": true,
-    "noEmit": true
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/examples/react/apollo-client-swc-plugin/src/gql/fragment-masking.ts
+++ b/examples/react/apollo-client-swc-plugin/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/react/apollo-client/src/gql/fragment-masking.ts
+++ b/examples/react/apollo-client/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/react/http-executor/src/gql/fragment-masking.ts
+++ b/examples/react/http-executor/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/react/nextjs-swr/gql/fragment-masking.ts
+++ b/examples/react/nextjs-swr/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/react/tanstack-react-query/src/gql/fragment-masking.ts
+++ b/examples/react/tanstack-react-query/src/gql/fragment-masking.ts
@@ -53,11 +53,10 @@ export function isFragmentReady<TQuery, TFrag>(
   data: FragmentType<TypedDocumentString<Incremental<TFrag>, any>> | null | undefined
 ): data is FragmentType<typeof fragmentNode> {
   const deferredFields = queryNode.__meta__?.deferredFields as Record<string, (keyof TFrag)[]>;
+  const fragName = fragmentNode.__meta__?.fragmentName as string | undefined;
 
-  if (!deferredFields) return true;
+  if (!deferredFields || !fragName) return true;
 
-  const fragName = fragmentNode.__meta__?.fragmentName;
-
-  const fields = (fragName && deferredFields[fragName]) || [];
+  const fields = deferredFields[fragName] ?? [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/react/tanstack-react-query/src/gql/fragment-masking.ts
+++ b/examples/react/tanstack-react-query/src/gql/fragment-masking.ts
@@ -58,6 +58,6 @@ export function isFragmentReady<TQuery, TFrag>(
 
   const fragName = fragmentNode.__meta__?.fragmentName;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/react/urql/src/gql/fragment-masking.ts
+++ b/examples/react/urql/src/gql/fragment-masking.ts
@@ -53,11 +53,10 @@ export function isFragmentReady<TQuery, TFrag>(
   data: FragmentType<TypedDocumentString<Incremental<TFrag>, any>> | null | undefined
 ): data is FragmentType<typeof fragmentNode> {
   const deferredFields = queryNode.__meta__?.deferredFields as Record<string, (keyof TFrag)[]>;
+  const fragName = fragmentNode.__meta__?.fragmentName as string | undefined;
 
-  if (!deferredFields) return true;
+  if (!deferredFields || !fragName) return true;
 
-  const fragName = fragmentNode.__meta__?.fragmentName;
-
-  const fields = (fragName && deferredFields[fragName]) || [];
+  const fields = deferredFields[fragName] ?? [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/react/urql/src/gql/fragment-masking.ts
+++ b/examples/react/urql/src/gql/fragment-masking.ts
@@ -58,6 +58,6 @@ export function isFragmentReady<TQuery, TFrag>(
 
   const fragName = fragmentNode.__meta__?.fragmentName;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/typescript-esm/src/gql/fragment-masking.ts
+++ b/examples/typescript-esm/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/typescript-graphql-request/src/gql/fragment-masking.ts
+++ b/examples/typescript-graphql-request/src/gql/fragment-masking.ts
@@ -53,11 +53,10 @@ export function isFragmentReady<TQuery, TFrag>(
   data: FragmentType<TypedDocumentString<Incremental<TFrag>, any>> | null | undefined
 ): data is FragmentType<typeof fragmentNode> {
   const deferredFields = queryNode.__meta__?.deferredFields as Record<string, (keyof TFrag)[]>;
+  const fragName = fragmentNode.__meta__?.fragmentName as string | undefined;
 
-  if (!deferredFields) return true;
+  if (!deferredFields || !fragName) return true;
 
-  const fragName = fragmentNode.__meta__?.fragmentName;
-
-  const fields = (fragName && deferredFields[fragName]) || [];
+  const fields = deferredFields[fragName] ?? [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/typescript-graphql-request/src/gql/fragment-masking.ts
+++ b/examples/typescript-graphql-request/src/gql/fragment-masking.ts
@@ -58,6 +58,6 @@ export function isFragmentReady<TQuery, TFrag>(
 
   const fragName = fragmentNode.__meta__?.fragmentName;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/vite/vite-react-cts/src/gql/fragment-masking.ts
+++ b/examples/vite/vite-react-cts/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/vite/vite-react-mts/src/gql/fragment-masking.ts
+++ b/examples/vite/vite-react-mts/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/vite/vite-react-ts/src/gql/fragment-masking.ts
+++ b/examples/vite/vite-react-ts/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/vue/apollo-composable/src/gql/fragment-masking.ts
+++ b/examples/vue/apollo-composable/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/vue/urql/src/gql/fragment-masking.ts
+++ b/examples/vue/urql/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/vue/villus/src/gql/fragment-masking.ts
+++ b/examples/vue/villus/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/examples/yoga-tests/src/gql/fragment-masking.ts
+++ b/examples/yoga-tests/src/gql/fragment-masking.ts
@@ -61,6 +61,6 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }

--- a/packages/presets/client/src/fragment-masking-plugin.ts
+++ b/packages/presets/client/src/fragment-masking-plugin.ts
@@ -86,7 +86,7 @@ export function isFragmentReady<TQuery, TFrag>(
 
   const fragName = fragmentNode.__meta__?.fragmentName;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }
 `;
@@ -105,7 +105,7 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
   const fragName = fragDef?.name?.value;
 
-  const fields = fragName ? deferredFields[fragName] : [];
+  const fields = (fragName && deferredFields[fragName]) || [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }
 `;

--- a/packages/presets/client/src/fragment-masking-plugin.ts
+++ b/packages/presets/client/src/fragment-masking-plugin.ts
@@ -81,12 +81,11 @@ export function isFragmentReady<TQuery, TFrag>(
   data: FragmentType<TypedDocumentString<Incremental<TFrag>, any>> | null | undefined
 ): data is FragmentType<typeof fragmentNode> {
   const deferredFields = queryNode.__meta__?.deferredFields as Record<string, (keyof TFrag)[]>;
+  const fragName = fragmentNode.__meta__?.fragmentName as string | undefined;
 
-  if (!deferredFields) return true;
+  if (!deferredFields || !fragName) return true;
 
-  const fragName = fragmentNode.__meta__?.fragmentName;
-
-  const fields = (fragName && deferredFields[fragName]) || [];
+  const fields = deferredFields[fragName] ?? [];
   return fields.length > 0 && fields.every(field => data && field in data);
 }
 `;

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -817,7 +817,7 @@ export * from "./gql";`);
           const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
           const fragName = fragDef?.name?.value;
 
-          const fields = fragName ? deferredFields[fragName] : [];
+          const fields = (fragName && deferredFields[fragName]) || [];
           return fields.length > 0 && fields.every(field => data && field in data);
         }
         "

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -1654,6 +1654,8 @@ export * from "./gql.js";`);
         export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
         export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
         export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+        export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+        export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
         /** All built-in and custom scalars, mapped to their actual values */
         export type Scalars = {
           ID: string;


### PR DESCRIPTION
Related https://github.com/dotansimha/graphql-code-generator/issues/9383

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
