### PR TITLE
docs: fix `inputMaybeValue` config typo

### DIFF
--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -334,7 +334,7 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    *     'path/to/file.ts': {
    *       plugins: ['typescript'],
    *       config: {
-   *         inputMaybeValue: T | null | undefined
+   *         inputMaybeValue: 'T | null | undefined'
    *       }
    *     }
    *   }


### PR DESCRIPTION
## Description

Fixes a typo in `typescript` plugin documentation.

## Type of change

- [ ] This change requires a documentation update

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
