### PR TITLE
Fix broken website deployment due to typescript-json-schema requirement

### DIFF
--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -188,7 +188,7 @@ export namespace Types {
   }
 
   export interface GitHubSchemaOptions {
-    [githubProtocol: `github:${string}`]: { token: string };
+    [githubProtocol: string]: { token: string };
   }
 
   export type SchemaGlobPath = string;


### PR DESCRIPTION
## Description

This fixes website deployment because `typescript-json-schema` does not work with template literal string in type key

Related discussion: https://github.com/dotansimha/graphql-code-generator/pull/9332#discussion_r1174565990

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
