### PR TITLE
Fix link in contributing.mdx

### DIFF
--- a/website/src/pages/docs/custom-codegen/contributing.mdx
+++ b/website/src/pages/docs/custom-codegen/contributing.mdx
@@ -9,7 +9,7 @@ import { Callout } from '@theguild/components'
 When your new plugin is ready, you can either:
 
 - maintain it in your repo and npm package
-- contribute and make it part of the GraphQL Code Generator community repo ([`dotansimha/graphql-code-generator-community`](dotansimha/graphql-code-generator-community))
+- contribute and make it part of the GraphQL Code Generator community repo ([`dotansimha/graphql-code-generator-community`](https://github.com/dotansimha/graphql-code-generator-community))
 
 The GraphQL Code Generator community repository contains plugins for all languages and platforms.
 If your plugin could be helpful for others, please consider creating a PR and maintaining it in our repo.


### PR DESCRIPTION
## Description

The current link is working on GitHub's viewer, but broken in the [document page](https://the-guild.dev/graphql/codegen/docs/custom-codegen/contributing).

I skimped to create an issue because this is just a document fix. Please tell me if I should do it.

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Tested that the link keeps working on GitHub UI.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
