### PR TITLE
docs: make `react-query`/`graphql-request` recommendation clearer

### DIFF
--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -129,7 +129,8 @@ export default config
 
 **Usage with `@tanstack/react-query`**
 
-For the best developer experience, we recommend using `@tanstack/react-query` with `graphql-request@^5.0.0`. <br/>
+If you are using `@tanstack/react-query`, we recommend using it with `graphql-request@^5.0.0` to get the best developer experience.
+<br/>
 If you are willing to provide your own fetcher, you can directly jump to the ["Appendix I: React Query with a custom fetcher setup"](#appendix-i-react-query-with-a-custom-fetcher-setup) and continue the guide once React Query is properly setup.
 
 </Callout>


### PR DESCRIPTION

## Description

This rephrases the "Usage with `@tanstack/react-query`" callout to make it clearer that it isn't recommending using `@tanstack/react-query` over other data fetching libraries.

The previous phrasing confused me. See https://github.com/dotansimha/graphql-code-generator/discussions/9482 discussion for context.

Related # (issue)

https://github.com/dotansimha/graphql-code-generator/discussions/9482

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
