### PR TITLE
Update scalar input/output related CHANGELOG with new recommended codegen config

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/CHANGELOG.md
+++ b/packages/plugins/other/visitor-plugin-common/CHANGELOG.md
@@ -86,6 +86,27 @@
   };
   ```
 
+  Here's the recommended config when generating server types with `typescript-resolvers`:
+
+  ```ts
+  const config: CodegenConfig = {
+    // ...
+    generates: {
+      'path/to/file': {
+        plugins: ['typescript', 'typescript-resolvers'],
+        config: {
+          scalars: {
+            ID: {
+              input: 'string',
+              output: 'string | number'
+            },
+          }
+        },
+      },
+    },
+  };
+  ```
+
   ***
 
   Config changes:

--- a/packages/plugins/typescript/operations/CHANGELOG.md
+++ b/packages/plugins/typescript/operations/CHANGELOG.md
@@ -86,6 +86,27 @@
   };
   ```
 
+  Here's the recommended config when generating server types with `typescript-resolvers`:
+
+  ```ts
+  const config: CodegenConfig = {
+    // ...
+    generates: {
+      'path/to/file': {
+        plugins: ['typescript', 'typescript-resolvers'],
+        config: {
+          scalars: {
+            ID: {
+              input: 'string',
+              output: 'string | number'
+            },
+          }
+        },
+      },
+    },
+  };
+  ```
+
   ***
 
   Config changes:

--- a/packages/plugins/typescript/resolvers/CHANGELOG.md
+++ b/packages/plugins/typescript/resolvers/CHANGELOG.md
@@ -86,6 +86,27 @@
   };
   ```
 
+  Here's the recommended config when generating server types with `typescript-resolvers`:
+
+  ```ts
+  const config: CodegenConfig = {
+    // ...
+    generates: {
+      'path/to/file': {
+        plugins: ['typescript', 'typescript-resolvers'],
+        config: {
+          scalars: {
+            ID: {
+              input: 'string',
+              output: 'string | number'
+            },
+          }
+        },
+      },
+    },
+  };
+  ```
+
   ***
 
   Config changes:

--- a/packages/plugins/typescript/typescript/CHANGELOG.md
+++ b/packages/plugins/typescript/typescript/CHANGELOG.md
@@ -86,6 +86,27 @@
   };
   ```
 
+  Here's the recommended config when generating server types with `typescript-resolvers`:
+
+  ```ts
+  const config: CodegenConfig = {
+    // ...
+    generates: {
+      'path/to/file': {
+        plugins: ['typescript', 'typescript-resolvers'],
+        config: {
+          scalars: {
+            ID: {
+              input: 'string',
+              output: 'string | number'
+            },
+          }
+        },
+      },
+    },
+  };
+  ```
+
   ***
 
   Config changes:

--- a/website/src/pages/docs/guides/graphql-server-apollo-yoga.mdx
+++ b/website/src/pages/docs/guides/graphql-server-apollo-yoga.mdx
@@ -76,10 +76,16 @@ const config: CodegenConfig = {
   schema: 'schema.graphql',
   generates: {
     './resolvers-types.ts': {
+      plugins: ['typescript', 'typescript-resolvers'],
       config: {
+        scalars: {
+          ID: {
+            input: 'string',
+            output: 'string | number'
+          },
+        },
         useIndexSignature: true,
       },
-      plugins: ['typescript', 'typescript-resolvers'],
     },
   },
 };
@@ -96,6 +102,14 @@ const config: CodegenConfig = {
   generates: {
     './resolvers-types.ts': {
       plugins: ['typescript', 'typescript-resolvers'],
+      config: {
+        scalars: {
+          ID: {
+            input: 'string',
+            output: 'string | number'
+          },
+        },
+      },
     },
   },
 };

--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -130,8 +130,10 @@ export default config
 **Usage with `@tanstack/react-query`**
 
 If you are using `@tanstack/react-query`, we recommend using it with `graphql-request@^5.0.0` to get the best developer experience.
-<br/>
-If you are willing to provide your own fetcher, you can directly jump to the ["Appendix I: React Query with a custom fetcher setup"](#appendix-i-react-query-with-a-custom-fetcher-setup) and continue the guide once React Query is properly setup.
+
+<br />
+If you are willing to provide your own fetcher, you can directly jump to the ["Appendix I: React Query with a custom fetcher
+setup"](#appendix-i-react-query-with-a-custom-fetcher-setup) and continue the guide once React Query is properly setup.
 
 </Callout>
 

--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -131,7 +131,6 @@ export default config
 
 If you are using `@tanstack/react-query`, we recommend using it with `graphql-request@^5.0.0` to get the best developer experience.
 
-<br />
 If you are willing to provide your own fetcher, you can directly jump to the ["Appendix I: React Query with a custom fetcher
 setup"](#appendix-i-react-query-with-a-custom-fetcher-setup) and continue the guide once React Query is properly setup.
 

--- a/website/src/pages/plugins/typescript/typescript-resolvers.mdx
+++ b/website/src/pages/plugins/typescript/typescript-resolvers.mdx
@@ -33,7 +33,7 @@ You can find [a blog post we wrote about using and customizing this plugin here]
 
 </Callout>
 
-Run `graphql-codegen` as usual, with this new plugin:
+Run `graphql-codegen` with `typescript-resolvers` plugin and the following config:
 
 ```ts filename="codegen.ts"
 import type { CodegenConfig } from '@graphql-codegen/cli'
@@ -42,7 +42,16 @@ const config: CodegenConfig = {
   schema: 'schema.json',
   generates: {
     './src/resolvers-types.ts': {
-      plugins: ['typescript', 'typescript-resolvers']
+      plugins: ['typescript', 'typescript-resolvers'],
+      config: {
+        scalars: {
+          // This option is required to match how GraphQL servers handle ID scalar
+          ID: {
+            input: 'string',
+            output: 'string | number'
+          }
+        }
+      }
     }
   }
 }
@@ -79,6 +88,7 @@ const config: CodegenConfig = {
     './resolvers-types.ts': {
       config: {
         useIndexSignature: true
+        // ... other config options
       },
       plugins: ['typescript', 'typescript-resolvers']
     }
@@ -108,6 +118,7 @@ const config: CodegenConfig = {
           User: './models#UserModel',
           Profile: './models#UserProfile'
         }
+        // ... other config options
       },
       plugins: ['typescript', 'typescript-resolvers']
     }
@@ -150,6 +161,7 @@ const config: CodegenConfig = {
         enumValues: {
           Color: './enums#ColorsCode'
         }
+        // ... other config options
       },
       plugins: ['typescript', 'typescript-resolvers']
     }
@@ -196,6 +208,7 @@ const config: CodegenConfig = {
             BLUE: '#0000FF'
           }
         }
+        // ... other config options
       },
       plugins: ['typescript', 'typescript-resolvers']
     }
@@ -217,6 +230,7 @@ const config: CodegenConfig = {
         mappers: {
           Color: './enums#ColorsCode'
         }
+        // ... other config options
       },
       plugins: ['typescript', 'typescript-resolvers']
     }
@@ -249,6 +263,7 @@ const config: CodegenConfig = {
           ...sharedMappers,
           String: 'StringType'
         }
+        // ... other config options
       }
     },
     'resolvers-types-2.ts': {
@@ -258,6 +273,7 @@ const config: CodegenConfig = {
           ...sharedMappers,
           String: 'StringType'
         }
+        // ... other config options
       }
     }
   }


### PR DESCRIPTION
## Description

CHANGELOGs with references to scalar input/output changes do not have clear instruction on how to migrate for `typescript-resolvers` users. 

This PR adds recommended codegen config to CHANGELOGs and `typescript-resolvers` documentation

I'll also update the release to keep things in sync.

## Type of change

- [x] CHANGELOG update for clarification
- [x] Documentation update
