### PR TITLE
Fix options getting swallowed by client preset

### DIFF
--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -116,22 +116,6 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
 
     const reexports: Array<string> = [];
 
-    // the `client` preset is restricting the config options inherited from `typescript`, `typescript-operations` and others.
-    const forwardedConfig = {
-      scalars: options.config.scalars,
-      defaultScalarType: options.config.defaultScalarType,
-      strictScalars: options.config.strictScalars,
-      namingConvention: options.config.namingConvention,
-      useTypeImports: options.config.useTypeImports,
-      skipTypename: options.config.skipTypename,
-      arrayInputCoercion: options.config.arrayInputCoercion,
-      enumsAsTypes: options.config.enumsAsTypes,
-      dedupeFragments: options.config.dedupeFragments,
-      nonOptionalTypename: options.config.nonOptionalTypename,
-      avoidOptionals: options.config.avoidOptionals,
-      documentMode: options.config.documentMode,
-    };
-
     const visitor = new ClientSideBaseVisitor(options.schemaAst!, [], options.config, options.config);
     let fragmentMaskingConfig: FragmentMaskingConfig | null = null;
 
@@ -252,9 +236,8 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
         ],
         schema: options.schema,
         config: {
-          useTypeImports: options.config.useTypeImports,
+          ...options.config,
           unmaskFunctionName: fragmentMaskingConfig.unmaskFunctionName,
-          emitLegacyCommonJSImports: options.config.emitLegacyCommonJSImports,
           isStringDocumentMode: options.config.documentMode === DocumentMode.string,
         },
         documents: [],
@@ -283,7 +266,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
           },
         ],
         schema: options.schema,
-        config: {},
+        config,
         documents: [],
         documentTransforms: options.documentTransforms,
       };
@@ -296,8 +279,8 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
         pluginMap,
         schema: options.schema,
         config: {
+          ...options.config,
           inlineFragmentTypes: isMaskingFragments ? 'mask' : options.config['inlineFragmentTypes'],
-          ...forwardedConfig,
         },
         documents: sources,
         documentTransforms: options.documentTransforms,
@@ -334,7 +317,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
                 },
               },
               schema: options.schema,
-              config: {},
+              config,
               documents: sources,
               documentTransforms: options.documentTransforms,
             },

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -2513,4 +2513,30 @@ export * from "./gql.js";`);
       `);
     });
   });
+
+  // Note: The main test for "dedupeOperationSuffix" happens elsewhere. This is just a regression test to verify that
+  // the preset doesn't fundamentally break it.
+  it('Test for dedupeOperationSuffix', async () => {
+    const result = await executeCodegen({
+      schema: [
+        /* GraphQL */ `
+          type Query {
+            a: String
+          }
+        `,
+      ],
+      documents: path.join(__dirname, 'fixtures/operation-suffix.ts'),
+      generates: {
+        'out1/': {
+          preset,
+          config: {
+            dedupeOperationSuffix: true,
+          },
+        },
+      },
+    });
+
+    const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
+    expect(graphqlFile.content).toContain('export type SomeQuery =');
+  });
 });

--- a/packages/presets/client/tests/fixtures/operation-suffix.ts
+++ b/packages/presets/client/tests/fixtures/operation-suffix.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+//@ts-ignore
+import gql from 'gql-tag';
+
+//@ts-ignore
+const A = gql(/* GraphQL */ `
+  query someQuery {
+    a
+  }
+`);


### PR DESCRIPTION
## Description

This deals with #8576, #8993 and #9104 by passing through _all_ options by default instead of only allowing a small subset with no way to override that behavior. The original code doesn't give a rationale for doing this.

A few computed values are inserted into the config by the preset, and those will keep overriding the user options as of right now, because I assume that they required for the preset to work as expected.

This change should only be noticeable to users that were already passing options that didn't work/exist before. It basically has the same impact as adding a new option.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test` doesn't show additional failures (there were some pre-existing ones before this change though)
- [x] Added a test for using `dedupeOperationSuffix` with the client preset (failed before, passes after)

**Test Environment**:

- OS: Linux 6.3.5-arch1-1 #1 SMP PREEMPT_DYNAMIC Tue, 30 May 2023 13:44:01 +0000 x86_64 GNU/Linux
- `@graphql-codegen/client-preset@4.0.0`
- NodeJS: v20.2.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules