### PR TITLE
docs: remove duplicate package to install in api-testing.mdx

### DIFF
--- a/website/src/pages/docs/guides/api-testing.mdx
+++ b/website/src/pages/docs/guides/api-testing.mdx
@@ -28,7 +28,7 @@ Install the following development dependencies:
 
 <PackageCmd
   packages={[
-    '-D typescript ts-node @graphql-codegen/cli @graphql-codegen/client-preset jest @babel/core @babel/preset-env @babel/preset-typescript @graphql-codegen/client-preset babel-jest @graphql-typed-document-node/core'
+    '-D typescript ts-node @graphql-codegen/cli @graphql-codegen/client-preset jest @babel/core @babel/preset-env @babel/preset-typescript babel-jest @graphql-typed-document-node/core'
   ]}
 />
 


### PR DESCRIPTION
## Description

`@graphql-codegen/client-preset` is mentioned twice in the installation instructions in [api-testing.mdx](https://github.com/dotansimha/graphql-code-generator/blob/2276708d0ea2aab4942136923651226de4aabe5a/website/src/pages/docs/guides/api-testing.mdx?plain=1#L31)

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [X] This change requires a documentation update

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
