### PR TITLE
Make @parcel/watcher optional

### DIFF
--- a/.changeset/five-spies-impress.md
+++ b/.changeset/five-spies-impress.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': major
+---
+
+Make @parcel/watcher optional

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -55,7 +55,6 @@
     "@graphql-tools/prisma-loader": "^8.0.0",
     "@graphql-tools/url-loader": "^8.0.0",
     "@graphql-tools/utils": "^10.0.0",
-    "@parcel/watcher": "^2.1.0",
     "@whatwg-node/fetch": "^0.8.0",
     "chalk": "^4.1.0",
     "cosmiconfig": "^8.1.3",
@@ -78,6 +77,7 @@
   },
   "devDependencies": {
     "@graphql-tools/merge": "9.0.0",
+    "@parcel/watcher": "^2.1.0",
     "@types/debounce": "1.2.1",
     "@types/inquirer": "8.2.6",
     "@types/is-glob": "4.0.2",
@@ -92,7 +92,13 @@
     "prettier": "2.8.8"
   },
   "peerDependencies": {
+    "@parcel/watcher": "^2.1.0",
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@parcel/watcher": {
+      "optional": true
+    }
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/graphql-codegen-cli/src/utils/watcher.ts
+++ b/packages/graphql-codegen-cli/src/utils/watcher.ts
@@ -60,7 +60,17 @@ export const createWatcher = (
   const runWatcher = async (abortSignal: AbortSignal) => {
     const watchDirectory = await findHighestCommonDirectory(allAffirmativePatterns);
 
-    const parcelWatcher = await import('@parcel/watcher');
+    // Try to load the parcel watcher, but don't fail if it's not available.
+    let parcelWatcher: typeof import('@parcel/watcher');
+    try {
+      parcelWatcher = await import('@parcel/watcher');
+    } catch (err) {
+      log(
+        `Parcel watcher not found. To use this feature, please make sure to provide @parcel/watcher as a peer dependency.`
+      );
+      return;
+    }
+
     debugLog(`[Watcher] Parcel watcher loaded...`);
 
     let isShutdown = false;

--- a/website/route-lockfile.txt
+++ b/website/route-lockfile.txt
@@ -57,6 +57,7 @@
 /docs/integrations/vscode
 /docs/migration/from-0-13
 /docs/migration/from-0-18
+/docs/migration/from-4-0
 /docs/plugins -> /plugins
 /docs/plugins/c-sharp -> /plugins/c-sharp/c-sharp-operations
 /docs/plugins/client-note -> /plugins

--- a/website/src/pages/docs/getting-started/development-workflow.mdx
+++ b/website/src/pages/docs/getting-started/development-workflow.mdx
@@ -2,6 +2,8 @@
 description: How to integrate GraphQL Code Generator into your development workflow. Learn how to run it in watch mode, or as part of your CI flow.
 ---
 
+import { Callout } from '@theguild/components'
+
 # Development workflow
 
 GraphQL Code Generator should be integrated as part of your development workflow.
@@ -27,6 +29,13 @@ This way, the codegen generates the output according to your configuration befor
 It's also helpful to run the codegen during your continuous integration flow and ensure that your code continually compiles with the generated output; this way, you can detect breaking changes in your GraphQL schema and GraphQL documents.
 
 ## Watch Mode
+
+<Callout type="info">
+Watch mode was made optional to reduce install size in CI and prevent build errors in certain environments.
+
+To use watch mode, make sure to provide `@parcel/watcher` as a peer dependency.
+
+</Callout>
 
 If you wish to run the codegen in watch mode, you can specify `--watch` (or `-w`) when running it.
 

--- a/website/src/pages/docs/getting-started/installation.mdx
+++ b/website/src/pages/docs/getting-started/installation.mdx
@@ -14,6 +14,12 @@ npm i graphql
 npm i -D typescript @graphql-codegen/cli
 ```
 
+If you want [watch mode](/docs/getting-started/development-workflow#watch-mode) support you need to add `@parcel/watcher` as well:
+
+```sh npm2yarn
+npm i -D @parcel/watcher
+```
+
 ## Global Installation
 
 <Callout type="warning">

--- a/website/src/pages/docs/migration/_meta.json
+++ b/website/src/pages/docs/migration/_meta.json
@@ -1,5 +1,6 @@
 {
   "graphql-cli": "GraphQL-CLI Deprecation",
   "from-0-18": "v0.18 -> v1.0",
-  "from-0-13": "v0.13 -> v0.17"
+  "from-0-13": "v0.13 -> v0.17",
+  "from-4-0": "v4.0 -> v5.0"
 }

--- a/website/src/pages/docs/migration/from-4-0.mdx
+++ b/website/src/pages/docs/migration/from-4-0.mdx
@@ -1,0 +1,95 @@
+---
+description: Migrating to 5.0.0. What has changed? How to migrate? What are the new features?
+---
+
+import { Tabs, Tab } from '@theguild/components'
+
+# Migration to 5.0.0
+
+## What has changed?
+
+There was an outstanding issue with `@parcel/watcher` which prevented it to be installed in certain environments, or needed an extra amount of dependencies to be built.
+This release focuses on improving the usage of `@graphql-codegen/cli` in those environments by making it an optional peer dependency.
+NPM (or Yarn) will not emit errors when an optional peer dependency is missing.
+
+## How to migrate?
+
+To use `@graphql-codegen/cli`'s watch mode (based on @parcel/watcher) you need to provide it in a package that uses `@graphql-codegen/cli` from now on.
+
+Start by updating your package.json
+
+<Tabs items={['Before', 'After']}>
+<Tab>
+```json filename="package.json"
+{
+  "devDependencies": {
+    "@graphql-codegen/cli": "^1.0.0",
+    "@graphql-codegen/typescript": "^1.0.0",
+    "@graphql-codegen/typescript-operations": "^1.0.0"
+  }
+}
+```
+</Tab>
+
+<Tab>
+```json filename="package.json"
+{
+  "devDependencies": {
+    "@graphql-codegen/cli": "^1.0.0",
+    "@graphql-codegen/typescript": "^1.0.0",
+    "@graphql-codegen/typescript-operations": "^1.0.0",
+    "@parcel/watcher": "^2.1.0"
+  }
+}
+```
+</Tab>
+</Tabs>
+
+If you had issues with `@parcel/watcher` previously, you can make NPM and Yarn silently discard any build errors, by using `optionalDependencies` instead:
+
+<Tabs items={['Before', 'After', 'After (Alternative)']}>
+<Tab>
+```json filename="package.json"
+{
+  "devDependencies": {
+    "@graphql-codegen/cli": "^1.0.0",
+    "@graphql-codegen/typescript": "^1.0.0",
+    "@graphql-codegen/typescript-operations": "^1.0.0"
+  }
+}
+```
+</Tab>
+
+<Tab>
+```json filename="package.json"
+{
+  "devDependencies": {
+    "@graphql-codegen/cli": "^1.0.0",
+    "@graphql-codegen/typescript": "^1.0.0",
+    "@graphql-codegen/typescript-operations": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "@parcel/watcher": "^2.1.0"
+  }
+}
+```
+</Tab>
+
+<Tab>
+```json filename="package.json"
+{
+  "devDependencies": {
+    "@graphql-codegen/cli": "^1.0.0",
+    "@graphql-codegen/typescript": "^1.0.0",
+    "@graphql-codegen/typescript-operations": "^1.0.0",
+    "@parcel/watcher": "^2.1.0"
+  },
+  "dependenciesMeta": {
+    "@parcel/watcher": {
+      "optional": true
+    }
+  }
+}
+```
+</Tab>
+</Tabs>


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

This is a new attempt to fix #9320. 
`@parcel/watcher` needs a whole lot of build dependencies on the system. Normally, it will just pull prebuilt binaries for your system. But currently there are no prebuilt binaries for linux on arm64: https://github.com/parcel-bundler/watcher/issues/130
In those environments, it tries to build it from source which means it needs python etc.
This makes `@parcel/watcher` optional, which should prevent these issues. The user is free to choose if they want to include `@parcel/watcher` as a dev dependency or take additional measures such as marking it optional (to ignore build errors)

The tests still run and `@parcel/watcher` should be pulled in via the `devDependencies` for the tests.
I assumed this would be a breaking change and included a major changeset and a migration guide.

Related #9320

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update



## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This is the proposed way laid out in the [yarn docs](https://yarnpkg.com/configuration/manifest/#optionalDependencies). The previous PR just moved `@parcel/watcher` into `optionalDependencies`. Yarn says using an optional peer dependency might be better.