### PR TITLE
Document custom merge driver to solve merge conflicts

### DIFF
--- a/website/src/pages/docs/getting-started/development-workflow.mdx
+++ b/website/src/pages/docs/getting-started/development-workflow.mdx
@@ -65,6 +65,28 @@ const config: CodegenConfig = {
 export default config
 ```
 
+## Handle Merge Conflicts
+
+If you check generated files under source control, you'll probably end up dealing with merge conflicts. Those conflicts are easy to resolve because all you have to do is to generate those files again, but still, having to resolve those conflicts manually could be quite disruptive.
+
+To avoid that, you can define a [custom merge driver](https://git-scm.com/docs/gitattributes#_defining_a_custom_merge_driver) and let Git handle it for you!
+
+The first thing we need to do, is to define a custom merge driver in your `.gitconfig` file. Ideally, we would like also to install fresh dependencies to make sure we're using the latest version of the codegen, so we'll use `yarn install` (or your alternative command) as part of the merge driver, then the command used to generate the files, in this context: `yarn generate`:
+
+```ini filename=".gitconfig"
+[merge "graphql-codegen"]
+    name = "graphql codegen merge driver"
+    driver = yarn install && yarn generate
+```
+
+Finally, we need to associate the merge driver with the generated files. We can do that by adding the following to your `.gitattributes` file:
+
+```ini filename=".gitattributes"
+__generated_graphql_types__/** merge=graphql-codegen
+```
+
+From now on, every time Git encounter a merge conflict related to the generated files, it will run our custom merge driver behind the scene. You won't even notice it anymore!
+
 ## Monorepo and Yarn Workspaces
 
 If you are using a monorepo structure, with tools such as [Yarn Workspaces](https://yarnpkg.com/lang/en/docs/workspaces) or [Lerna](https://github.com/lerna/lerna), we recommend installing the codegen in the root of your monorepo.


### PR DESCRIPTION
Related to https://github.com/dotansimha/graphql-code-generator/discussions/4253.

Add documentation on using a [custom merge driver](https://git-scm.com/docs/gitattributes#_defining_a_custom_merge_driver) to automatically solve merge conflicts related to generated files.

The rationale behind this is that solving those merge conflicts is quite easy because all we have to do is to regenerate them, but it could be quite tedious as your application is growing and types & fields are often created on the same lines and conflicting. We can't simply use a `union` merge strategy, we really need to regenerate files to make sure they are valid. So let's automate this behind the scene so we don't realize conflict happened.

<img width="1407" alt="Screenshot 2023-06-23 at 2 52 34 PM" src="https://github.com/dotansimha/graphql-code-generator/assets/7189823/381cef82-ec40-4d59-b9ef-579552f8244e">


