### PR TITLE
fix: use prefix and suffix for imported enum values

### DIFF
--- a/.changeset/large-horses-divide.md
+++ b/.changeset/large-horses-divide.md
@@ -1,0 +1,7 @@
+---
+"@graphql-codegen/typescript-resolvers": patch
+"@graphql-codegen/typescript": patch
+"@graphql-codegen/visitor-plugin-common": patch
+---
+
+Stop appending configured `typesSuffix` to enum keys

--- a/.changeset/real-shirts-tan.md
+++ b/.changeset/real-shirts-tan.md
@@ -1,0 +1,7 @@
+---
+"@graphql-codegen/typescript-resolvers": patch
+"@graphql-codegen/typescript": patch
+"@graphql-codegen/visitor-plugin-common": patch
+---
+
+Respect `typesPrefix` and `typesSuffix` options for enum names when `enumValues` option is provided.

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -830,7 +830,10 @@ export class BaseResolversVisitor<
       } else if (isEnumType(schemaType) && this.config.enumValues[typeName]) {
         prev[typeName] =
           this.config.enumValues[typeName].sourceIdentifier ||
-          this.convertName(this.config.enumValues[typeName].typeIdentifier);
+          this.convertName(this.config.enumValues[typeName].typeIdentifier, {
+            useTypesPrefix: this.config.enumPrefix,
+            useTypesSuffix: this.config.enumSuffix,
+          });
       } else if (hasDefaultMapper && !hasPlaceholder(this.config.defaultMapper.type)) {
         prev[typeName] = applyWrapper(this.config.defaultMapper.type);
       } else if (isScalar) {

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -853,14 +853,18 @@ export class BaseTypesVisitor<
     return Object.keys(this.config.enumValues)
       .flatMap(enumName => {
         const mappedValue = this.config.enumValues[enumName];
+        const typeIdentifier = this.convertName(enumName, {
+          useTypesPrefix: this.config.enumPrefix,
+          useTypesSuffix: this.config.enumSuffix,
+        });
 
         if (mappedValue.sourceFile) {
           if (mappedValue.isDefault) {
-            return [this._buildTypeImport(mappedValue.typeIdentifier, mappedValue.sourceFile, true)];
+            return [this._buildTypeImport(typeIdentifier, mappedValue.sourceFile, true)];
           }
 
           return this.handleEnumValueMapper(
-            mappedValue.typeIdentifier,
+            typeIdentifier,
             mappedValue.importIdentifier,
             mappedValue.sourceIdentifier,
             mappedValue.sourceFile
@@ -1020,7 +1024,10 @@ export class BaseTypesVisitor<
       return this._getScalar(typeAsString, isVisitingInputType ? 'input' : 'output');
     }
     if (this.config.enumValues[typeAsString]) {
-      return this.config.enumValues[typeAsString].typeIdentifier;
+      return this.convertName(this.config.enumValues[typeAsString].typeIdentifier, {
+        useTypesPrefix: this.config.enumPrefix,
+        useTypesSuffix: this.config.enumSuffix,
+      });
     }
 
     const schemaType = this._schema.getType(node.name as any);

--- a/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-types-visitor.ts
@@ -919,6 +919,7 @@ export class BaseTypesVisitor<
         const optionName = this.makeValidEnumIdentifier(
           this.convertName(enumOption, {
             useTypesPrefix: false,
+            useTypesSuffix: false,
             transformUnderscore: true,
           })
         );

--- a/packages/plugins/other/visitor-plugin-common/src/variables-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/variables-to-object.ts
@@ -101,7 +101,10 @@ export class OperationVariablesToObject {
       } else if (this._scalars[typeName]) {
         typeValue = this.getScalar(typeName);
       } else if (this._enumValues[typeName]?.sourceFile) {
-        typeValue = this._enumValues[typeName].typeIdentifier || this._enumValues[typeName].sourceIdentifier;
+        typeValue = this._convertName(this._enumValues[typeName].typeIdentifier, {
+          useTypesPrefix: this._enumPrefix,
+          useTypesSuffix: this._enumSuffix,
+        });
       } else {
         typeValue = `${prefix}${this._convertName(baseType, {
           useTypesPrefix: this._enumNames.includes(typeName) ? this._enumPrefix : true,

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -2928,7 +2928,7 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
         { outputFile: 'graphql.ts' }
       )) as Types.ComplexPluginOutput;
 
-      expect(output.content).toContain(`export type GqlAuthDirectiveArgs = {\n  role?: Maybe<UserRole>;\n};`);
+      expect(output.content).toContain(`export type GqlAuthDirectiveArgs = {\n  role?: Maybe<GqlUserRole>;\n};`);
       expect(output.content).toContain(
         `export type GqlAuthDirectiveResolver<Result, Parent, ContextType = any, Args = GqlAuthDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;`
       );

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -355,7 +355,10 @@ export class TsVisitor<
 
     // In case of mapped external enum string
     if (this.config.enumValues[enumName]?.sourceFile) {
-      return `export { ${this.config.enumValues[enumName].typeIdentifier} };\n`;
+      return `export { ${this.convertName(this.config.enumValues[enumName].typeIdentifier, {
+        useTypesPrefix: this.config.enumPrefix,
+        useTypesSuffix: this.config.enumSuffix,
+      })} };\n`;
     }
 
     const getValueFromConfig = (enumValue: string | number) => {


### PR DESCRIPTION
## Description

Related to #9520

Fixes a bug in the `typescript` plugin where `typesPrefix` and `typesSuffix` were not used for custom or imported enum values. Not respecting this option is problematic since it causes downstream plugins, such as `typescript-operations`, to not work properly as they'd try to reference types that didn't exist.

Additionally, it also fixes a small issue with enums where keys would be modified when a `typesSuffix` was specified. Since this behavior doesn't exist for prefixes, and suffixes were introduced after prefixes, I assumed that this was unintended behavior that slipped through the cracks. If it is intentional I'd be happy to revert my changes.

> An alternative implementation would have been to ignore these configuration options for imported enums entirely, which would be in the spirit of previous fixes. The issue with that approach is that not all downstream plugins have great support for the `enumValues` option, most importantly the `typescript-operations` plugin. I did also develop a solution in which the `typescript-operations` plugin would properly use that provided option, however when doing so it made the plugin incompatible with the `import-types` preset (it wouldn't import the custom enum types from the `presetConfig.typesPath` nor the path specified in `enumValues`). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

It's not fully clear to me whether this is a breaking change or not. While it does change some functionality, most important being the name of the re-exported types, it's mostly internals that are changing. Considering that it'd already alias some enums if the source and graphql identifiers weren't the same, it feels acceptable that it's now just doing that more often.

Previously some individuals had reported issues along the lines of this one that were fixed in prior PRs (see modified tests here) - every one of those use cases should still produce valid code with these changes.

## How Has This Been Tested?

This PR includes a number of updates to unit tests that demonstrate that this fix works. I've also run a number of local tests with settings similar to those in the unit tests.

**Test Environment**:

- OS: 
- NodeJS: 18.13.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules