### PR TITLE
Add `noSilentErrors` option to the config type

### DIFF
--- a/.changeset/large-wombats-beam.md
+++ b/.changeset/large-wombats-beam.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/plugin-helpers': patch
+---
+
+add noSilentErrors option to the config type

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -543,6 +543,10 @@ export namespace Types {
      * For more details: https://graphql-code-generator.com/docs/config-reference/lifecycle-hooks
      */
     hooks?: Partial<LifecycleHooksDefinition>;
+    /**
+     * @description Alows to raise errors if any matched files are not valid GraphQL. Default: false.
+     */
+    noSilentErrors?: boolean;
   }
 
   export type ComplexPluginOutput = { content: string; prepend?: string[]; append?: string[] };

--- a/website/public/config.schema.json
+++ b/website/public/config.schema.json
@@ -96,6 +96,10 @@
         "hooks": {
           "$ref": "#/definitions/Partial",
           "description": "Specifies scripts to run when events are happening in the codegen core.\nHooks defined on that level will effect all output files.\n\nFor more details: https://graphql-code-generator.com/docs/config-reference/lifecycle-hooks"
+        },
+        "noSilentErrors": {
+          "description": "Alows to raise errors if any matched files are not valid GraphQL. Default: false.",
+          "type": "boolean"
         }
       }
     },


### PR DESCRIPTION
## Description

Related #9515

The `noSilentErrors` option has already been implemented but not in the config type.

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

(The "Bug fix" above is about fixing the type error.)

## Screenshots/Sandbox (if appropriate/relevant):

Sandbox: https://github.com/tnyo43/graphql-code-generator-issue-sandbox-no-silent-error

You will see that the `noSilentErrors` option works but is not included in the config type if you follow the example in the README.

<img width="1093" alt="Screenshot 2023-07-01 at 21 54 33" src="https://github.com/dotansimha/graphql-code-generator/assets/11014018/3931a9c7-cb2c-4702-a94c-e99bff609926">

## How Has This Been Tested?

1. prepare this repository
  1.1. clone this repository and checkout to this branch (tnyo43:add-no-silent-errors-option-in-config-type)
  1.2. update line 47 in "packages/graphql-codegen-cli/package.json" as `"@graphql-codegen/plugin-helpers": "file:../utils/plugins-helpers",`.
  1.3. run `yarn build`.
2. prepare the sandbox
  2.1. clone the sandbox (https://github.com/tnyo43/graphql-code-generator-issue-sandbox-no-silent-error).
  2.2. update line 10 in "package.json" to use the local @graphql-codegen/cli (ex `"@graphql-codegen/cli": "file:../graphql-code-generator/packages/graphql-codegen-cli",`).
3. In the sandbox, add `noSilentErrors` option in "codegen.ts". You will see no type errors.

<img width="529" alt="Screenshot 2023-07-01 at 21 34 50" src="https://github.com/dotansimha/graphql-code-generator/assets/11014018/5f872931-7f35-457a-aaa9-2c2e24af6d95">


**Test Environment**:

- OS:macOS v13.3.1
- `@graphql-codegen/...`:
- NodeJS:v18.16.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A