### PR TITLE
Add eslint-disable comment to fragment-masking.ts

### DIFF
--- a/.changeset/silly-glasses-thank.md
+++ b/.changeset/silly-glasses-thank.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/client-preset': patch
+---
+
+Add eslint-disable comment to fragment-masking.ts

--- a/dev-test/gql-tag-operations-masking/gql/fragment-masking.ts
+++ b/dev-test/gql-tag-operations-masking/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql.js';

--- a/dev-test/gql-tag-operations-urql/gql/fragment-masking.ts
+++ b/dev-test/gql-tag-operations-urql/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql.js';

--- a/dev-test/gql-tag-operations/gql/fragment-masking.ts
+++ b/dev-test/gql-tag-operations/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql.js';

--- a/dev-test/gql-tag-operations/graphql/fragment-masking.ts
+++ b/dev-test/gql-tag-operations/graphql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql.js';

--- a/examples/persisted-documents-string-mode/src/gql/fragment-masking.ts
+++ b/examples/persisted-documents-string-mode/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration } from '@graphql-typed-document-node/core';
 import { Incremental, TypedDocumentString } from './graphql';
 

--- a/examples/persisted-documents/src/gql/fragment-masking.ts
+++ b/examples/persisted-documents/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql';

--- a/examples/react/apollo-client-defer/src/gql/fragment-masking.ts
+++ b/examples/react/apollo-client-defer/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql';

--- a/examples/react/apollo-client-swc-plugin/src/gql/fragment-masking.ts
+++ b/examples/react/apollo-client-swc-plugin/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql';

--- a/examples/react/apollo-client/src/gql/fragment-masking.ts
+++ b/examples/react/apollo-client/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql';

--- a/examples/react/http-executor/src/gql/fragment-masking.ts
+++ b/examples/react/http-executor/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql';

--- a/examples/react/nextjs-swr/gql/fragment-masking.ts
+++ b/examples/react/nextjs-swr/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql';

--- a/examples/react/tanstack-react-query/src/gql/fragment-masking.ts
+++ b/examples/react/tanstack-react-query/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration } from '@graphql-typed-document-node/core';
 import { Incremental, TypedDocumentString } from './graphql';
 

--- a/examples/react/urql/src/gql/fragment-masking.ts
+++ b/examples/react/urql/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration } from '@graphql-typed-document-node/core';
 import { Incremental, TypedDocumentString } from './graphql';
 

--- a/examples/typescript-esm/src/gql/fragment-masking.ts
+++ b/examples/typescript-esm/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql.js';

--- a/examples/typescript-graphql-request/src/gql/fragment-masking.ts
+++ b/examples/typescript-graphql-request/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration } from '@graphql-typed-document-node/core';
 import { Incremental, TypedDocumentString } from './graphql';
 

--- a/examples/vite/vite-react-cts/src/gql/fragment-masking.ts
+++ b/examples/vite/vite-react-cts/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql';

--- a/examples/vite/vite-react-mts/src/gql/fragment-masking.ts
+++ b/examples/vite/vite-react-mts/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql';

--- a/examples/vite/vite-react-ts/src/gql/fragment-masking.ts
+++ b/examples/vite/vite-react-ts/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql';

--- a/examples/vue/apollo-composable/src/gql/fragment-masking.ts
+++ b/examples/vue/apollo-composable/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import type { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import type { FragmentDefinitionNode } from 'graphql';
 import type { Incremental } from './graphql';

--- a/examples/vue/urql/src/gql/fragment-masking.ts
+++ b/examples/vue/urql/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import type { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import type { FragmentDefinitionNode } from 'graphql';
 import type { Incremental } from './graphql';

--- a/examples/vue/villus/src/gql/fragment-masking.ts
+++ b/examples/vue/villus/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import type { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import type { FragmentDefinitionNode } from 'graphql';
 import type { Incremental } from './graphql';

--- a/examples/yoga-tests/src/gql/fragment-masking.ts
+++ b/examples/yoga-tests/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql';

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -243,9 +243,11 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       fragmentMaskingFileGenerateConfig = {
         filename: `${options.baseOutputDir}fragment-masking${fragmentMaskingArtifactFileExtension}`,
         pluginMap: {
+          [`add`]: addPlugin,
           [`fragment-masking`]: fragmentMaskingPlugin,
         },
         plugins: [
+          { [`add`]: { content: `/* eslint-disable */` } },
           {
             [`fragment-masking`]: {},
           },

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -754,7 +754,8 @@ export * from "./gql";`);
       expect(result).toHaveLength(4);
       const gqlFile = result.find(file => file.filename === 'out1/fragment-masking.ts');
       expect(gqlFile.content).toMatchInlineSnapshot(`
-        "import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
+        "/* eslint-disable */
+        import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
         import { FragmentDefinitionNode } from 'graphql';
         import { Incremental } from './graphql';
 


### PR DESCRIPTION
## Description

Related #8819

- As discussed in #8819, using `add` plugin by user side is not helpful in this case.
- For consistency with other generated files by client preset.
  - We can add fragment-masking.ts to .eslintignore but it is not consistent with other files. 
  - https://github.com/dotansimha/graphql-code-generator/blob/7ba9d0ec129609cf013f9786cf150b4aa3c59c51/packages/presets/client/src/index.ts#L211
  - https://github.com/dotansimha/graphql-code-generator/blob/7ba9d0ec129609cf013f9786cf150b4aa3c59c51/packages/presets/client/src/index.ts#L224

## Type of change

- [x] New feature (non-breaking change which adds functionality)

I think this is a trivial change. 🤔

## How Has This Been Tested?

- [x] Run updated unit test

**Test Environment**:

- OS: macOS 13.4.1
- `@graphql-codegen/...`: 
- NodeJS: v18.16.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
