### PR TITLE
docs: generated graphql import example in react-vue.mdx

### DIFF
--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -551,9 +551,9 @@ Then write type-safe code like the following:
 
 ```ts filename="Application Code"
 import { useGraphQL } from './use-graphql.js'
-import { gql } from './generated/graphql.js'
+import { graphql } from './generated/gql.js'
 
-const allFilmsWithVariablesQueryDocument = gql(/* GraphQL */ `
+const allFilmsWithVariablesQueryDocument = graphql(/* GraphQL */ `
   query allFilmsWithVariablesQuery($first: Int!) {
     allFilms(first: $first) {
       edges {
@@ -635,9 +635,9 @@ Then write type-safe code like the following:
 
 ```ts filename="Application Code"
 import { useGraphQL } from './use-graphql.js'
-import { gql } from './generated/graphql.js'
+import { graphql } from './generated/gql.js'
 
-const allFilmsWithVariablesQueryDocument = gql(/* GraphQL */ `
+const allFilmsWithVariablesQueryDocument = graphql(/* GraphQL */ `
   query allFilmsWithVariablesQuery($first: Int!) {
     allFilms(first: $first) {
       edges {


### PR DESCRIPTION
No issue created because this is just a small fix in docs.

## Description

Fixing a mistake in the docs.
The imported function should be `graphql` from the generated `gql.ts` file.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

