### PR TITLE
adding allowUndefinedQueryVariables option to typescript-operations plugin

### DIFF
--- a/.changeset/lazy-laws-brake.md
+++ b/.changeset/lazy-laws-brake.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-operations': minor
+---
+
+Added allowUndefinedQueryVariables as config option

--- a/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
@@ -257,7 +257,7 @@ export class BaseDocumentsVisitor<
       .join('\n\n');
   }
 
-  protected applyVariablesWrapper(variablesBlock: string): string {
+  protected applyVariablesWrapper(variablesBlock: string, _operationType?: string): string {
     return variablesBlock;
   }
 
@@ -288,7 +288,7 @@ export class BaseDocumentsVisitor<
 
     const operationVariables = new DeclarationBlock({
       ...this._declarationBlockConfig,
-      blockTransformer: t => this.applyVariablesWrapper(t),
+      blockTransformer: t => this.applyVariablesWrapper(t, operationType),
     })
       .export()
       .asKind('type')

--- a/packages/plugins/typescript/operations/src/config.ts
+++ b/packages/plugins/typescript/operations/src/config.ts
@@ -267,4 +267,29 @@ export interface TypeScriptDocumentsPluginConfig extends RawDocumentsConfig {
    * ```
    */
   maybeValue?: string;
+
+  /**
+   * @description Adds undefined as a possible type for query variables
+   * @default false
+   *
+   * @exampleMarkdown
+   * ```ts filename="codegen.ts"
+   *  import type { CodegenConfig } from '@graphql-codegen/cli';
+   *
+   *  const config: CodegenConfig = {
+   *    // ...
+   *    generates: {
+   *      'path/to/file.ts': {
+   *        plugins: ['typescript'],
+   *        config: {
+   *          allowUndefinedQueryVariables: true
+   *        },
+   *      },
+   *    },
+   *  };
+   *  export default config;
+   * ```
+   */
+
+  allowUndefinedQueryVariables?: boolean;
 }

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -24,6 +24,7 @@ export interface TypeScriptDocumentsParsedConfig extends ParsedDocumentsConfig {
   immutableTypes: boolean;
   noExport: boolean;
   maybeValue: string;
+  allowUndefinedQueryVariables: boolean;
 }
 
 export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
@@ -41,6 +42,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
         nonOptionalTypename: getConfigValue(config.nonOptionalTypename, false),
         preResolveTypes: getConfigValue(config.preResolveTypes, true),
         mergeFragmentTypes: getConfigValue(config.mergeFragmentTypes, false),
+        allowUndefinedQueryVariables: getConfigValue(config.allowUndefinedQueryVariables, false),
       } as TypeScriptDocumentsParsedConfig,
       schema
     );
@@ -133,9 +135,10 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
     return ';';
   }
 
-  protected applyVariablesWrapper(variablesBlock: string): string {
+  protected applyVariablesWrapper(variablesBlock: string, operationType: string): string {
     const prefix = this.config.namespacedImportName ? `${this.config.namespacedImportName}.` : '';
+    const extraType = this.config.allowUndefinedQueryVariables && operationType === 'Query' ? ' | undefined' : '';
 
-    return `${prefix}Exact<${variablesBlock === '{}' ? `{ [key: string]: never; }` : variablesBlock}>`;
+    return `${prefix}Exact<${variablesBlock === '{}' ? `{ [key: string]: never; }` : variablesBlock}>${extraType}`;
   }
 }

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -383,7 +383,7 @@ describe('TypeScript Operations Plugin', () => {
       `);
     });
 
-    it.only('should add undefined as possible value according to allowUndefinedQueryVariables', async () => {
+    it('should add undefined as possible value according to allowUndefinedQueryVariables', async () => {
       const schema = buildSchema(/* GraphQL */ `
         type Query {
           user: User!

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -382,6 +382,52 @@ describe('TypeScript Operations Plugin', () => {
       export type UserQuery = { __typename?: 'Query', user: { __typename?: 'User', name: string, age?: number | 'specialType', address?: string, nicknames?: Array<string> | 'specialType', parents?: Array<User> } };
       `);
     });
+
+    it.only('should add undefined as possible value according to allowUndefinedQueryVariables', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          user: User!
+        }
+
+        type User {
+          name: String!
+          age: Int
+          address: String!
+          nicknames: [String!]
+          parents: [User!]!
+        }
+      `);
+
+      const fragment = parse(/* GraphQL */ `
+        query user($showProperty: Boolean!) {
+          user {
+            name
+            age
+            address @include(if: $showProperty)
+            nicknames @include(if: $showProperty)
+            parents @include(if: $showProperty)
+          }
+        }
+      `);
+
+      const { content } = await plugin(
+        schema,
+        [{ location: '', document: fragment }],
+        {
+          preResolveTypes: true,
+          allowUndefinedQueryVariables: true,
+        },
+        {
+          outputFile: 'graphql.ts',
+        }
+      );
+
+      expect(content).toBeSimilarStringTo(`
+        export type UserQueryVariables = Exact<{
+          showProperty: Scalars['Boolean']['input'];
+        }> | undefined;
+      `);
+    });
   });
 
   describe('Scalars', () => {


### PR DESCRIPTION
## Description

For libraries like `react-query`, there is the option to disable a query if there is a dependency that hasn't been met. For example:

```
query getAuthUsers($userId: uuid!) {
  authentication_users(where: { uuid: { _eq: $userId } }) {
    uuid
  }
}
```

```
type Props = {
  userId: string | undefined;
}

...

const { data } = useGetAuthUsers({ userId }, { enabled: Boolean(userId) });
```

Unfortunately, this fails typechecking because the variables for the hook are defined as `Exact<{ userId: string>`. I'd like to be able to do something like the following.

```
const { data }  = useGetAuthUsers(userId ? { userId } : undefined, { enabled: Boolean(userId) });
```

This disables the query and maintains type safety.

This PR adds the ability to set `allowUndefinedQueryVariables` (boolean) in a codegen config to add a union to query variable types to allow them to be `undefined`.

Related [#6124](https://github.com/dotansimha/graphql-code-generator/discussions/6124)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added a Jest test to the `typescript-operations` plugin.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
