### PR TITLE
Client preset pass through skip documents validation

### DIFF
--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -130,6 +130,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       nonOptionalTypename: options.config.nonOptionalTypename,
       avoidOptionals: options.config.avoidOptionals,
       documentMode: options.config.documentMode,
+      skipDocumentsValidation: options.config.skipDocumentsValidation,
     };
 
     const visitor = new ClientSideBaseVisitor(options.schemaAst!, [], options.config, options.config);

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -2513,4 +2513,41 @@ export * from "./gql.js";`);
       `);
     });
   });
+
+  it('respects skipDocumentsValidation', async () => {
+    // test against a document using urql's @populate directive, which will
+    // fail validation if the ScalarLeafsRule is enabled
+    await expect(
+      executeCodegen({
+        schema: [
+          /* GraphQL */ `
+            type Mutation {
+              saveVideo(id: ID!): Video!
+            }
+
+            type Video {
+              id: ID!
+              title: String!
+              movie: Movie!
+            }
+
+            type Movie implements Video {
+              id: ID!
+              title: String!
+            }
+          `,
+        ],
+        documents: path.join(__dirname, 'fixtures/with-populate.ts'),
+        generates: {
+          'out1/': {
+            preset,
+            config: {
+              documentMode: 'string',
+              skipDocumentsValidation: { ignoreRules: ['ScalarLeafsRule'] },
+            },
+          },
+        },
+      })
+    ).resolves.toBeDefined();
+  });
 });

--- a/packages/presets/client/tests/fixtures/with-populate.ts
+++ b/packages/presets/client/tests/fixtures/with-populate.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+//@ts-ignore
+const videoQueryDocument = gql(/* GraphQL */ `
+  mutation Video($id: ID!) {
+    saveVideo(id: $id) {
+      movie @populate
+    }
+  }
+`);


### PR DESCRIPTION
## Description

Fixes an issue raised in #8562

It appears that this line is necessary for `skipDocumentsValidation` to work when using the `client-preset`, as it is otherwise stripped out without being passed upstream. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I checked in a fixture that uses urql's [`@populate`](https://formidable.com/open-source/urql/docs/advanced/auto-popcompuulate-mutations/) directive, which violates the [ScalarLeafsRule](https://github.com/graphql/graphql-js/blob/b12dcffe83098922dcc6c0ec94eb6fc032bd9772/src/validation/rules/ScalarLeafsRule.ts#L18) validation rule.  

With the changes in this PR, I am able to successfully use the `skipDocumentsValidation` setting (as documented) to intentionally bypass this particular validation.  Without the changes in this PR, the validation (that I asked to be skipped) will cause the codegen to fail when it is used alongside the client-preset. 

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] **N/A** I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] **N/A** Any dependent changes have been merged and published in downstream modules