### PR TITLE
Add directive params to context type

### DIFF
--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -24,6 +24,7 @@ export type Scalars = {
 export type MyType = {
   __typename?: 'MyType';
   foo: Scalars['String']['output'];
+  bar: Scalars['String']['output'];
   otherType?: Maybe<MyOtherType>;
   withArgs?: Maybe<Scalars['String']['output']>;
   unionChild?: Maybe<ChildUnion>;
@@ -234,12 +235,15 @@ export type MyDirectiveDirectiveArgs = {
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
-export type AuthenticatedDirectiveArgs = { };
+export type AuthenticatedDirectiveArgs = {
+  role?: Maybe<Scalars['String']['input']>;
+};
 
 export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type MyTypeResolvers<ContextType = any, ParentType = ResolversParentTypes['MyType']> = ResolversObject<{
   foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
   withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
   unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -493,12 +497,15 @@ export type MyDirectiveDirectiveArgs = {
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
-export type AuthenticatedDirectiveArgs = { };
+export type AuthenticatedDirectiveArgs = {
+  role?: Types.Maybe<Types.Scalars['String']['input']>;
+};
 
 export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = ResolversObject<{
   foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   otherType?: Resolver<Types.Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
   withArgs?: Resolver<Types.Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<Types.MyTypeWithArgsArgs, 'arg2'>>;
   unionChild?: Resolver<Types.Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -628,6 +635,7 @@ export type Scalars = {
 export type MyType = {
   __typename?: 'MyType';
   foo: Scalars['String']['output'];
+  bar: Scalars['String']['output'];
   otherType?: Maybe<MyOtherType>;
   withArgs?: Maybe<Scalars['String']['output']>;
   unionChild?: Maybe<ChildUnion>;
@@ -838,12 +846,15 @@ export type MyDirectiveDirectiveArgs = {
 
 export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
-export type AuthenticatedDirectiveArgs = { };
+export type AuthenticatedDirectiveArgs = {
+  role?: Maybe<Scalars['String']['input']>;
+};
 
 export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = ResolversObject<{
   foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
   withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
   unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;

--- a/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/mapping.spec.ts
@@ -1249,6 +1249,7 @@ describe('ResolversTypes', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1332,6 +1333,7 @@ describe('ResolversTypes', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1413,6 +1415,7 @@ describe('ResolversTypes', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1483,6 +1486,7 @@ describe('ResolversTypes', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1553,6 +1557,7 @@ describe('ResolversTypes', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -1468,7 +1468,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextType>>;
+        foo?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextType, {}>>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1492,7 +1492,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextType>>;
+        foo?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextType, {}>>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1516,7 +1516,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
-        foo?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextTypeOne>>;
+        foo?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextTypeOne, {}>>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -183,6 +183,7 @@ export type ResolverAuthenticated<TResult, TParent = {}, TContext = {}, TArgs = 
       expect(result.content).toBeSimilarStringTo(`
 export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
   foo?: ResolverAuthenticated<ResolversTypes['String'], ParentType, ContextType>;
+  bar?: ResolverAuthenticated<ResolversTypes['String'], ParentType, ContextType>;
   otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
   withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
   unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -485,6 +486,7 @@ export type ResolverAuthenticated<TResult, TParent = {}, TContext = {}, TArgs = 
     expect(result.content).toBeSimilarStringTo(`
 export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
 foo?: ResolverAuthenticated<ResolversTypes['String'], ParentType, ContextType>;
+bar?: ResolverAuthenticated<ResolversTypes['String'], ParentType, ContextType>;
 otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
 withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
 unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -916,6 +918,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -991,6 +994,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1064,6 +1068,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1155,6 +1160,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1230,6 +1236,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1304,6 +1311,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1379,6 +1387,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1440,6 +1449,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, ContextTypeOne>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, SpecialContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1469,6 +1479,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextType, {}>>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextType, {"role":"admin"}>>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1493,6 +1504,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextType, {}>>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextType, {"role":"admin"}>>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
@@ -1517,6 +1529,7 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = {
         foo?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextTypeOne, {}>>;
+        bar?: Resolver<ResolversTypes['String'], ParentType, AuthenticatedContext<ContextType, {"role":"admin"}>>;
         otherType?: Resolver<Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
         withArgs?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<MyTypeWithArgsArgs, 'arg2'>>;
         unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;

--- a/packages/utils/graphql-codegen-testing/src/resolvers-common.ts
+++ b/packages/utils/graphql-codegen-testing/src/resolvers-common.ts
@@ -6,6 +6,7 @@ import { buildSchema } from 'graphql';
 export const resolversTestingSchema = buildSchema(/* GraphQL */ `
   type MyType {
     foo: String! @authenticated
+    bar: String! @authenticated(role: "admin")
     otherType: MyOtherType
     withArgs(arg: String, arg2: String!): String
     unionChild: ChildUnion
@@ -71,7 +72,7 @@ export const resolversTestingSchema = buildSchema(/* GraphQL */ `
   scalar MyScalar
 
   directive @myDirective(arg: Int!, arg2: String!, arg3: Boolean!) on FIELD
-  directive @authenticated on FIELD_DEFINITION
+  directive @authenticated(role: String) on FIELD_DEFINITION
 `);
 
 export const resolversTestingValidate = async (


### PR DESCRIPTION
## Description

This adds any arguments passed to directives to the directiveContextTypes, allowing more for specific context types.

Here is an example:
```GraphQL
directive @auth (
  match: JSONObject
  skip: Boolean
  includes: JSONObject
) on FIELD_DEFINITION

type Mutation {
  createEntity(name: String!): Entity! @auth(match: { cmsCanModifyEntities: true })

  getEntity(name: String!): Entity! @auth(skip: true)
}
```

With this PR we can customize the ContextType of each resolver to adapt to whatever arguments where passed to the @auth directive. 

In our example we can respect both the `skip: true` (i.e. no token in context) as well as `cmsCanModifyEntities: true` (our auth middleware has verified that the token contains this):
```TypeScript
type AuthContextWithToken<TContext, DirectiveArgs extends {
      readonly match?: Record<string, unknown>
      readonly includes?: Record<string, unknown>
      readonly skip?: boolean
    }> = DirectiveArgs['skip'] extends true
      ? Omit<TContext, 'decodedToken' | 'token'>
      : Omit<TContext, 'decodedToken'> & {
        readonly decodedToken: DirectiveArgs['match']
        & Record<keyof DirectiveArgs['includes'], ReadonlyArray<DirectiveArgs['includes']>>
      }
```

Related # (issue)
#9668

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Not 100% sure if we should consider this a breaking change, it expects the directiveContextTypes to accept 2 type parameters instead of 1.

## Screenshots/Sandbox (if appropriate/relevant):

![signal-2023-09-12-143323_004](https://github.com/dotansimha/graphql-code-generator/assets/1467411/4825f5f7-546d-435c-84cb-85a703beca91)
![signal-2023-09-12-143323_003](https://github.com/dotansimha/graphql-code-generator/assets/1467411/ddcd4b0d-5672-4dd9-b5ef-75d074013ad0)
![signal-2023-09-12-143323_002](https://github.com/dotansimha/graphql-code-generator/assets/1467411/507bc0c8-71ab-4e79-82ab-8966e910ad4a)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Used through patch in [readapt](https://github.com/kingstinct/readapt)
- [ ] Test B

**Test Environment**:

- OS: MacOS
- `@graphql-codegen/...`:
- NodeJS: 18

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I seem to get a different data structure from `ObjectFieldNode` in the [readapt](https://github.com/kingstinct/readapt) patch compared to the PR (here it's `name` property is a NameNode which in turns contains the name as a value, there `name` is just a string). I'm guessing the underlying graphql dependency has changed.