### PR TITLE
Avoid wrapping args with partial when avoiding optionals

### DIFF
--- a/.changeset/late-olives-pull.md
+++ b/.changeset/late-olives-pull.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-resolvers': patch
+---
+
+Respect avoidOptionals when all arguments are optional

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1401,6 +1401,11 @@ export class BaseResolversVisitor<
           )
         : null;
 
+      const avoidInputsOptionals =
+        typeof this.config.avoidOptionals === 'object'
+          ? this.config.avoidOptionals?.inputValue
+          : this.config.avoidOptionals === true;
+
       if (argsType !== null) {
         const argsToForceRequire = original.arguments.filter(
           arg => !!arg.defaultValue || arg.type.kind === 'NonNullType'
@@ -1408,7 +1413,7 @@ export class BaseResolversVisitor<
 
         if (argsToForceRequire.length > 0) {
           argsType = this.applyRequireFields(argsType, argsToForceRequire);
-        } else if (original.arguments.length > 0) {
+        } else if (original.arguments.length > 0 && avoidInputsOptionals !== true) {
           argsType = this.applyOptionalFields(argsType, original.arguments);
         }
       }
@@ -1428,7 +1433,7 @@ export class BaseResolversVisitor<
 
       const resolverType = isSubscriptionType ? 'SubscriptionResolver' : directiveMappings[0] ?? 'Resolver';
 
-      const avoidOptionals =
+      const avoidResolverOptionals =
         typeof this.config.avoidOptionals === 'object'
           ? this.config.avoidOptionals?.resolvers
           : this.config.avoidOptionals === true;
@@ -1439,7 +1444,7 @@ export class BaseResolversVisitor<
         genericTypes: string[];
       } = {
         name: node.name as any,
-        modifier: avoidOptionals ? '' : '?',
+        modifier: avoidResolverOptionals ? '' : '?',
         type: resolverType,
         genericTypes: [mappedTypeKey, parentTypeSignature, contextType, argsType].filter(f => f),
       };


### PR DESCRIPTION
## Description

Makes it so arguments don't get wrapped with a `Partial` when configured to avoid optionals for input values. Without this change, `avoidOptionals = true` ends up being inconsistent since it will still use optional input values in the case there is only nullable arguments.

Related #9438

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added a test that avoid optionals does not wrap the arguments with a partial when configured.

- [x] #9438 - avoidOptionals should not wrap arguments with partial

**Test Environment**:

- OS: macOS
- `@graphql-codegen/typescript-resolvers`: 4.0.1
- NodeJS: 16.x

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I think this should be fairly uncontroversial since it is preserving the intention of the avoid optionals config. 
