### PR TITLE
fix: custom visitor documentation

### DIFF
--- a/website/src/pages/docs/custom-codegen/using-visitor.mdx
+++ b/website/src/pages/docs/custom-codegen/using-visitor.mdx
@@ -52,8 +52,7 @@ module.exports = {
 Then, create your initial visitor, in our case, we would like to transform a `FieldDefinition` and `ObjectTypeDefinition`, so let's create an object with a stub definitions, an use `visit` to run it:
 
 ```js {8-13}
-const { getCachedDocumentNodeFromSchema } = require('@graphql-codegen/plugin-helpers')
-const { visit } = require('graphql')
+const { getCachedDocumentNodeFromSchema, oldVisit } = require('@graphql-codegen/plugin-helpers')
 
 module.exports = {
   plugin(schema, documents, config) {
@@ -67,7 +66,7 @@ module.exports = {
       }
     }
 
-    const result = visit(astNode, { leave: visitor })
+    const result = oldVisit(astNode, { leave: visitor })
 
     return result.definitions.join('\n')
   }
@@ -77,8 +76,7 @@ module.exports = {
 Now, let's implement `ObjectTypeDefinition` and `FieldDefinition`:
 
 ```js {8-15}
-const { getCachedDocumentNodeFromSchema } = require('@graphql-codegen/plugin-helpers')
-const { visit } = require('graphql')
+const { getCachedDocumentNodeFromSchema, oldVisit } = require('@graphql-codegen/plugin-helpers')
 
 module.exports = {
   plugin(schema, documents, config) {
@@ -94,7 +92,7 @@ module.exports = {
       }
     }
 
-    const result = visit(astNode, { leave: visitor })
+    const result = oldVisit(astNode, { leave: visitor })
 
     return result.definitions.join('\n')
   }


### PR DESCRIPTION
## Description

This PR contains an update to the documentation about custom visitors to make use of `oldVisit` instead of `graphql`'s `visit` function which causes issues in graphql@16.

Related #9230

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Updating this Codesandbox in the same way as the documentation to verify this working.

https://codesandbox.io/p/sandbox/headless-cloud-6z6r45

**Test Environment**:

- OS: Windows 10
- NodeJS: 16.20.0

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

A couple of the checkboxes are left unticked because I am not sure how they apply to pure documentation changes like in this case. Let me know if anything is missing!