### PR TITLE
fix(watcher): fix watcher unable to find highest common directory on Windows

### DIFF
--- a/.changeset/stupid-onions-tap.md
+++ b/.changeset/stupid-onions-tap.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+fix watcher unable to find highest common directory on Windows

--- a/packages/graphql-codegen-cli/src/utils/watcher.ts
+++ b/packages/graphql-codegen-cli/src/utils/watcher.ts
@@ -229,7 +229,11 @@ const findHighestCommonDirectory = async (files: string[]): Promise<string> => {
   // e.g. mm.scan("/**/foo/bar").base -> "/" ; mm.scan("/foo/bar/**/fizz/*.graphql") -> /foo/bar
   const dirPaths = files
     .map(filePath => (isAbsolute(filePath) ? filePath : resolve(filePath)))
-    .map(patterned => mm.scan(patterned).base);
+    // mm.scan doesn't know how to handle Windows \ path separator
+    .map(patterned => patterned.replace(/\\/g, '/'))
+    .map(patterned => mm.scan(patterned).base)
+    // revert the separators to the platform-supported ones
+    .map(base => base.replace(/\//g, sep));
 
   // Return longest common prefix if it's accessible, otherwise process.cwd()
   return (async (maybeValidPath: string) => {


### PR DESCRIPTION
## Description

A dependency `micromatch`  has a `scan` method used for parsing a given file and returning glob details. This method does not work with Windows path separator (`\`), causing issues with the watcher on a Windows platform where the watcher would not be able to find a highest common directory, and fall back to watching the `process.cwd()` instead.

From my testing, this is the only place where Windows separator is not supported and the watcher works as expected with the change made in this PR, where we temporarily convert the separators to `/`.

Related #9526

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

We have a big monorepo at work in which I verified my changes. It would be useful for someone to verify on MacOS to make sure non-Windows platforms are not affected

**Test Environment**:

- OS: Windows
- `@graphql-codegen/cli`: 5.0.0
- NodeJS: any

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules