### PR TITLE
fix: out-of-memory crash (#7720) and significantly improve performance + feat: extracting fields to types

### DIFF
--- a/.changeset/hip-garlics-invent.md
+++ b/.changeset/hip-garlics-invent.md
@@ -1,0 +1,9 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-operations': minor
+---
+
+fix: out-of-memory crash (fixes #7720)
+perf: implement a caching mechanism that makes sure the type originating at the same location is never generated twice, as long as the combination of selected fields and possible types matches
+feat: implement `extractAllFieldsToTypes: boolean`
+feat: implement `printFieldsOnNewLines: boolean`

--- a/dev-test/gatsby/fragments.ts
+++ b/dev-test/gatsby/fragments.ts
@@ -1,0 +1,149 @@
+import gql from 'graphql-tag';
+
+export const WPColumns = gql`
+  fragment WPColumns on WpCoreColumnsBlock {
+    __typename
+    attributes {
+      ... on WpCoreColumnsBlockAttributes {
+        align
+        verticalAlignment
+      }
+    }
+    innerBlocks {
+      ...WpColumnFields
+      ...WpCoreImageBlockFragment
+      ...WpCoreGalleryBlockFragment
+      innerBlocks {
+        __typename
+        ...WpCoreImageBlockForGalleryFragment
+        ...WpCoreGalleryBlockFragment
+        saveContent
+        dynamicContent
+        isDynamic
+        #
+        ... on WpCoreGalleryBlock {
+          __typename
+          ...WpCoreGalleryBlockFragment
+
+          innerBlocks {
+            __typename
+            ...WpCoreImageBlockForGalleryFragment
+          }
+        }
+        ... on WpCoreColumnsBlock {
+          innerBlocks {
+            ...WpColumnFields
+            innerBlocks {
+              ...WpCoreImageBlockFragment
+              ...WpCoreGalleryBlockFragment
+              ... on WpCoreColumnsBlock {
+                innerBlocks {
+                  ...WpColumnFields
+                  innerBlocks {
+                    ...WpCoreImageBlockForGalleryFragment
+                    ...WpCoreGalleryBlockFragment
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const wpColumnFields = gql`
+  fragment WpColumnFields on WpCoreColumnBlock {
+    __typename
+    saveContent
+    dynamicContent
+    isDynamic
+    attributes {
+      __typename
+    }
+  }
+`;
+
+export const WpCoreImageBlockFragment = gql`
+  fragment WpCoreImageBlockFragment on WpCoreImageBlock {
+    __typename
+    saveContent
+    originalContent
+    attributes {
+      __typename
+      ... on WpCoreImageBlockAttributes {
+        id
+        alt
+        caption
+        width
+        title
+        height
+        linkTarget
+        url
+        imageFluid {
+          childImageSharp {
+            gatsbyImageData(quality: 100, layout: FULL_WIDTH)
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const WpCoreImageBlockForGalleryFragment = gql`
+  fragment WpCoreImageBlockForGalleryFragment on WpCoreImageBlock {
+    __typename
+    saveContent
+    attributes {
+      __typename
+      ... on WpCoreImageBlockAttributes {
+        id
+        alt
+        caption
+        width
+        title
+        height
+        linkTarget
+        url
+        imageFluid {
+          childImageSharp {
+            full: gatsbyImageData(quality: 100, layout: FULL_WIDTH)
+            thumbnail: gatsbyImageData(layout: CONSTRAINED)
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const WpCoreParagraphBlockFragment = gql`
+  fragment WpCoreParagraphBlockFragment on WpCoreParagraphBlock {
+    __typename
+    saveContent
+    isDynamic
+    dynamicContent
+  }
+`;
+
+export const WpCoreGalleryBlockFragment = gql`
+  fragment WpCoreGalleryBlockFragment on WpCoreGalleryBlock {
+    dynamicContent
+    attributes {
+      ... on WpCoreGalleryBlockAttributes {
+        align
+        anchor
+        ids
+        caption
+        images {
+          id
+          url
+          link
+          alt
+          caption
+        }
+        className
+      }
+    }
+  }
+`;

--- a/dev-test/gatsby/schema.graphql
+++ b/dev-test/gatsby/schema.graphql
@@ -1,0 +1,22577 @@
+"""
+Define parent-child relations between types. This is used to add `child*` and `children*` convenience fields like `childImageSharp`.
+"""
+directive @childOf(
+  """
+  A list of mime-types this type is a child of. Usually these are the mime-types handled by a transformer plugin.
+  """
+  mimeTypes: [String!]! = []
+
+  """
+  A list of types this type is a child of. Usually these are the types handled by a transformer plugin.
+  """
+  types: [String!]! = []
+) on OBJECT
+
+"""
+Add date formatting options.
+"""
+directive @dateformat(difference: String, formatString: String, fromNow: Boolean, locale: String) on FIELD_DEFINITION
+
+"""
+Do not infer field types from field values.
+"""
+directive @dontInfer on OBJECT
+
+"""
+Link to File node by relative path.
+"""
+directive @fileByRelativePath(from: String) on FIELD_DEFINITION
+
+"""
+Infer field types from field values.
+"""
+directive @infer on OBJECT
+
+"""
+Link to node by foreign-key relation.
+"""
+directive @link(by: String! = "id", from: String, on: String) on FIELD_DEFINITION
+
+"""
+Define the mime-types handled by this type.
+"""
+directive @mimeTypes(
+  """
+  The mime-types handled by this type.
+  """
+  types: [String!]! = []
+) on OBJECT
+
+"""
+DEPRECATED: Use interface inheritance instead, i.e. "interface Foo implements Node".
+
+Adds root query fields for an interface. All implementing types must also implement the Node interface.
+"""
+directive @nodeInterface on INTERFACE
+
+"""
+Proxy resolver from another field.
+"""
+directive @proxy(from: String!, fromNode: Boolean! = false) on FIELD_DEFINITION
+
+input AVIFOptions {
+  lossless: Boolean
+  quality: Int
+  speed: Int
+}
+
+input BlurredOptions {
+  """
+  Force the output format for the low-res preview. Default is to use the same format as the input. You should rarely need to change this
+  """
+  toFormat: ImageFormat
+
+  """
+  Width of the generated low-res preview. Default is 20px
+  """
+  width: Int
+}
+
+input BooleanQueryOperatorInput {
+  eq: Boolean
+  in: [Boolean]
+  ne: Boolean
+  nin: [Boolean]
+}
+
+"""
+A date string, such as 2007-12-03, compliant with the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
+"""
+scalar Date
+
+input DateQueryOperatorInput {
+  eq: Date
+  gt: Date
+  gte: Date
+  in: [Date]
+  lt: Date
+  lte: Date
+  ne: Date
+  nin: [Date]
+}
+
+type Directory implements Node {
+  absolutePath: String!
+  accessTime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  atime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  atimeMs: Float!
+  base: String!
+  birthTime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  birthtime: Date @deprecated(reason: "Use `birthTime` instead")
+  birthtimeMs: Float @deprecated(reason: "Use `birthTime` instead")
+  changeTime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  children: [Node!]!
+  ctime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  ctimeMs: Float!
+  dev: Int!
+  dir: String!
+  ext: String!
+  extension: String!
+  gid: Int!
+  id: ID!
+  ino: Float!
+  internal: Internal!
+  mode: Int!
+  modifiedTime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  mtime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  mtimeMs: Float!
+  name: String!
+  nlink: Int!
+  parent: Node
+  prettySize: String!
+  rdev: Int!
+  relativeDirectory: String!
+  relativePath: String!
+  root: String!
+  size: Int!
+  sourceInstanceName: String!
+  uid: Int!
+}
+
+type DirectoryConnection {
+  distinct(field: DirectoryFieldsEnum!): [String!]!
+  edges: [DirectoryEdge!]!
+  group(field: DirectoryFieldsEnum!, limit: Int, skip: Int): [DirectoryGroupConnection!]!
+  max(field: DirectoryFieldsEnum!): Float
+  min(field: DirectoryFieldsEnum!): Float
+  nodes: [Directory!]!
+  pageInfo: PageInfo!
+  sum(field: DirectoryFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type DirectoryEdge {
+  next: Directory
+  node: Directory!
+  previous: Directory
+}
+
+enum DirectoryFieldsEnum {
+  absolutePath
+  accessTime
+  atime
+  atimeMs
+  base
+  birthTime
+  birthtime
+  birthtimeMs
+  changeTime
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  ctime
+  ctimeMs
+  dev
+  dir
+  ext
+  extension
+  gid
+  id
+  ino
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  mode
+  modifiedTime
+  mtime
+  mtimeMs
+  name
+  nlink
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  prettySize
+  rdev
+  relativeDirectory
+  relativePath
+  root
+  size
+  sourceInstanceName
+  uid
+}
+
+input DirectoryFilterInput {
+  absolutePath: StringQueryOperatorInput
+  accessTime: DateQueryOperatorInput
+  atime: DateQueryOperatorInput
+  atimeMs: FloatQueryOperatorInput
+  base: StringQueryOperatorInput
+  birthTime: DateQueryOperatorInput
+  birthtime: DateQueryOperatorInput
+  birthtimeMs: FloatQueryOperatorInput
+  changeTime: DateQueryOperatorInput
+  children: NodeFilterListInput
+  ctime: DateQueryOperatorInput
+  ctimeMs: FloatQueryOperatorInput
+  dev: IntQueryOperatorInput
+  dir: StringQueryOperatorInput
+  ext: StringQueryOperatorInput
+  extension: StringQueryOperatorInput
+  gid: IntQueryOperatorInput
+  id: StringQueryOperatorInput
+  ino: FloatQueryOperatorInput
+  internal: InternalFilterInput
+  mode: IntQueryOperatorInput
+  modifiedTime: DateQueryOperatorInput
+  mtime: DateQueryOperatorInput
+  mtimeMs: FloatQueryOperatorInput
+  name: StringQueryOperatorInput
+  nlink: IntQueryOperatorInput
+  parent: NodeFilterInput
+  prettySize: StringQueryOperatorInput
+  rdev: IntQueryOperatorInput
+  relativeDirectory: StringQueryOperatorInput
+  relativePath: StringQueryOperatorInput
+  root: StringQueryOperatorInput
+  size: IntQueryOperatorInput
+  sourceInstanceName: StringQueryOperatorInput
+  uid: IntQueryOperatorInput
+}
+
+type DirectoryGroupConnection {
+  distinct(field: DirectoryFieldsEnum!): [String!]!
+  edges: [DirectoryEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: DirectoryFieldsEnum!, limit: Int, skip: Int): [DirectoryGroupConnection!]!
+  max(field: DirectoryFieldsEnum!): Float
+  min(field: DirectoryFieldsEnum!): Float
+  nodes: [Directory!]!
+  pageInfo: PageInfo!
+  sum(field: DirectoryFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input DirectorySortInput {
+  fields: [DirectoryFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+input DuotoneGradient {
+  highlight: String!
+  opacity: Int
+  shadow: String!
+}
+
+type File implements Node {
+  absolutePath: String!
+  accessTime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  atime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  atimeMs: Float!
+  base: String!
+  birthTime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  birthtime: Date @deprecated(reason: "Use `birthTime` instead")
+  birthtimeMs: Float @deprecated(reason: "Use `birthTime` instead")
+  blksize: Int
+  blocks: Int
+  changeTime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+
+  """
+  Returns the first child node of type ImageSharp or null if there are no children of given type on this node
+  """
+  childImageSharp: ImageSharp
+  children: [Node!]!
+
+  """
+  Returns all children nodes filtered by type ImageSharp
+  """
+  childrenImageSharp: [ImageSharp]
+  ctime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  ctimeMs: Float!
+  dev: Int!
+  dir: String!
+  ext: String!
+  extension: String!
+  gid: Int!
+  hash: String
+  id: ID!
+  ino: Float!
+  internal: Internal!
+  mode: Int!
+  modifiedTime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  mtime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date!
+  mtimeMs: Float!
+  name: String!
+  nlink: Int!
+  parent: Node
+  prettySize: String!
+
+  """
+  Copy file to static directory and return public url to it
+  """
+  publicURL: String
+  rdev: Int!
+  relativeDirectory: String!
+  relativePath: String!
+  root: String!
+  size: Int!
+  sourceInstanceName: String!
+  uid: Int!
+}
+
+type FileConnection {
+  distinct(field: FileFieldsEnum!): [String!]!
+  edges: [FileEdge!]!
+  group(field: FileFieldsEnum!, limit: Int, skip: Int): [FileGroupConnection!]!
+  max(field: FileFieldsEnum!): Float
+  min(field: FileFieldsEnum!): Float
+  nodes: [File!]!
+  pageInfo: PageInfo!
+  sum(field: FileFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type FileEdge {
+  next: File
+  node: File!
+  previous: File
+}
+
+enum FileFieldsEnum {
+  absolutePath
+  accessTime
+  atime
+  atimeMs
+  base
+  birthTime
+  birthtime
+  birthtimeMs
+  blksize
+  blocks
+  changeTime
+  childImageSharp___children
+  childImageSharp___children___children
+  childImageSharp___children___children___children
+  childImageSharp___children___children___id
+  childImageSharp___children___id
+  childImageSharp___children___internal___content
+  childImageSharp___children___internal___contentDigest
+  childImageSharp___children___internal___description
+  childImageSharp___children___internal___fieldOwners
+  childImageSharp___children___internal___ignoreType
+  childImageSharp___children___internal___mediaType
+  childImageSharp___children___internal___owner
+  childImageSharp___children___internal___type
+  childImageSharp___children___parent___children
+  childImageSharp___children___parent___id
+  childImageSharp___fixed___aspectRatio
+  childImageSharp___fixed___base64
+  childImageSharp___fixed___height
+  childImageSharp___fixed___originalName
+  childImageSharp___fixed___src
+  childImageSharp___fixed___srcSet
+  childImageSharp___fixed___srcSetWebp
+  childImageSharp___fixed___srcWebp
+  childImageSharp___fixed___tracedSVG
+  childImageSharp___fixed___width
+  childImageSharp___fluid___aspectRatio
+  childImageSharp___fluid___base64
+  childImageSharp___fluid___originalImg
+  childImageSharp___fluid___originalName
+  childImageSharp___fluid___presentationHeight
+  childImageSharp___fluid___presentationWidth
+  childImageSharp___fluid___sizes
+  childImageSharp___fluid___src
+  childImageSharp___fluid___srcSet
+  childImageSharp___fluid___srcSetWebp
+  childImageSharp___fluid___srcWebp
+  childImageSharp___fluid___tracedSVG
+  childImageSharp___gatsbyImageData
+  childImageSharp___id
+  childImageSharp___internal___content
+  childImageSharp___internal___contentDigest
+  childImageSharp___internal___description
+  childImageSharp___internal___fieldOwners
+  childImageSharp___internal___ignoreType
+  childImageSharp___internal___mediaType
+  childImageSharp___internal___owner
+  childImageSharp___internal___type
+  childImageSharp___original___height
+  childImageSharp___original___src
+  childImageSharp___original___width
+  childImageSharp___parent___children
+  childImageSharp___parent___children___children
+  childImageSharp___parent___children___id
+  childImageSharp___parent___id
+  childImageSharp___parent___internal___content
+  childImageSharp___parent___internal___contentDigest
+  childImageSharp___parent___internal___description
+  childImageSharp___parent___internal___fieldOwners
+  childImageSharp___parent___internal___ignoreType
+  childImageSharp___parent___internal___mediaType
+  childImageSharp___parent___internal___owner
+  childImageSharp___parent___internal___type
+  childImageSharp___parent___parent___children
+  childImageSharp___parent___parent___id
+  childImageSharp___resize___aspectRatio
+  childImageSharp___resize___height
+  childImageSharp___resize___originalName
+  childImageSharp___resize___src
+  childImageSharp___resize___tracedSVG
+  childImageSharp___resize___width
+  children
+  childrenImageSharp
+  childrenImageSharp___children
+  childrenImageSharp___children___children
+  childrenImageSharp___children___children___children
+  childrenImageSharp___children___children___id
+  childrenImageSharp___children___id
+  childrenImageSharp___children___internal___content
+  childrenImageSharp___children___internal___contentDigest
+  childrenImageSharp___children___internal___description
+  childrenImageSharp___children___internal___fieldOwners
+  childrenImageSharp___children___internal___ignoreType
+  childrenImageSharp___children___internal___mediaType
+  childrenImageSharp___children___internal___owner
+  childrenImageSharp___children___internal___type
+  childrenImageSharp___children___parent___children
+  childrenImageSharp___children___parent___id
+  childrenImageSharp___fixed___aspectRatio
+  childrenImageSharp___fixed___base64
+  childrenImageSharp___fixed___height
+  childrenImageSharp___fixed___originalName
+  childrenImageSharp___fixed___src
+  childrenImageSharp___fixed___srcSet
+  childrenImageSharp___fixed___srcSetWebp
+  childrenImageSharp___fixed___srcWebp
+  childrenImageSharp___fixed___tracedSVG
+  childrenImageSharp___fixed___width
+  childrenImageSharp___fluid___aspectRatio
+  childrenImageSharp___fluid___base64
+  childrenImageSharp___fluid___originalImg
+  childrenImageSharp___fluid___originalName
+  childrenImageSharp___fluid___presentationHeight
+  childrenImageSharp___fluid___presentationWidth
+  childrenImageSharp___fluid___sizes
+  childrenImageSharp___fluid___src
+  childrenImageSharp___fluid___srcSet
+  childrenImageSharp___fluid___srcSetWebp
+  childrenImageSharp___fluid___srcWebp
+  childrenImageSharp___fluid___tracedSVG
+  childrenImageSharp___gatsbyImageData
+  childrenImageSharp___id
+  childrenImageSharp___internal___content
+  childrenImageSharp___internal___contentDigest
+  childrenImageSharp___internal___description
+  childrenImageSharp___internal___fieldOwners
+  childrenImageSharp___internal___ignoreType
+  childrenImageSharp___internal___mediaType
+  childrenImageSharp___internal___owner
+  childrenImageSharp___internal___type
+  childrenImageSharp___original___height
+  childrenImageSharp___original___src
+  childrenImageSharp___original___width
+  childrenImageSharp___parent___children
+  childrenImageSharp___parent___children___children
+  childrenImageSharp___parent___children___id
+  childrenImageSharp___parent___id
+  childrenImageSharp___parent___internal___content
+  childrenImageSharp___parent___internal___contentDigest
+  childrenImageSharp___parent___internal___description
+  childrenImageSharp___parent___internal___fieldOwners
+  childrenImageSharp___parent___internal___ignoreType
+  childrenImageSharp___parent___internal___mediaType
+  childrenImageSharp___parent___internal___owner
+  childrenImageSharp___parent___internal___type
+  childrenImageSharp___parent___parent___children
+  childrenImageSharp___parent___parent___id
+  childrenImageSharp___resize___aspectRatio
+  childrenImageSharp___resize___height
+  childrenImageSharp___resize___originalName
+  childrenImageSharp___resize___src
+  childrenImageSharp___resize___tracedSVG
+  childrenImageSharp___resize___width
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  ctime
+  ctimeMs
+  dev
+  dir
+  ext
+  extension
+  gid
+  hash
+  id
+  ino
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  mode
+  modifiedTime
+  mtime
+  mtimeMs
+  name
+  nlink
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  prettySize
+  publicURL
+  rdev
+  relativeDirectory
+  relativePath
+  root
+  size
+  sourceInstanceName
+  uid
+}
+
+input FileFilterInput {
+  absolutePath: StringQueryOperatorInput
+  accessTime: DateQueryOperatorInput
+  atime: DateQueryOperatorInput
+  atimeMs: FloatQueryOperatorInput
+  base: StringQueryOperatorInput
+  birthTime: DateQueryOperatorInput
+  birthtime: DateQueryOperatorInput
+  birthtimeMs: FloatQueryOperatorInput
+  blksize: IntQueryOperatorInput
+  blocks: IntQueryOperatorInput
+  changeTime: DateQueryOperatorInput
+  childImageSharp: ImageSharpFilterInput
+  children: NodeFilterListInput
+  childrenImageSharp: ImageSharpFilterListInput
+  ctime: DateQueryOperatorInput
+  ctimeMs: FloatQueryOperatorInput
+  dev: IntQueryOperatorInput
+  dir: StringQueryOperatorInput
+  ext: StringQueryOperatorInput
+  extension: StringQueryOperatorInput
+  gid: IntQueryOperatorInput
+  hash: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  ino: FloatQueryOperatorInput
+  internal: InternalFilterInput
+  mode: IntQueryOperatorInput
+  modifiedTime: DateQueryOperatorInput
+  mtime: DateQueryOperatorInput
+  mtimeMs: FloatQueryOperatorInput
+  name: StringQueryOperatorInput
+  nlink: IntQueryOperatorInput
+  parent: NodeFilterInput
+  prettySize: StringQueryOperatorInput
+  publicURL: StringQueryOperatorInput
+  rdev: IntQueryOperatorInput
+  relativeDirectory: StringQueryOperatorInput
+  relativePath: StringQueryOperatorInput
+  root: StringQueryOperatorInput
+  size: IntQueryOperatorInput
+  sourceInstanceName: StringQueryOperatorInput
+  uid: IntQueryOperatorInput
+}
+
+type FileGroupConnection {
+  distinct(field: FileFieldsEnum!): [String!]!
+  edges: [FileEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: FileFieldsEnum!, limit: Int, skip: Int): [FileGroupConnection!]!
+  max(field: FileFieldsEnum!): Float
+  min(field: FileFieldsEnum!): Float
+  nodes: [File!]!
+  pageInfo: PageInfo!
+  sum(field: FileFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input FileSortInput {
+  fields: [FileFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+input FloatQueryOperatorInput {
+  eq: Float
+  gt: Float
+  gte: Float
+  in: [Float]
+  lt: Float
+  lte: Float
+  ne: Float
+  nin: [Float]
+}
+
+enum GatsbyImageFormat {
+  AUTO
+  AVIF
+  JPG
+  NO_CHANGE
+  PNG
+  WEBP
+}
+
+enum GatsbyImageLayout {
+  CONSTRAINED
+  FIXED
+  FULL_WIDTH
+}
+
+enum GatsbyImagePlaceholder {
+  BLURRED
+  DOMINANT_COLOR
+  NONE
+  TRACED_SVG
+}
+
+input IDQueryOperatorInput {
+  eq: ID
+  in: [ID]
+  ne: ID
+  nin: [ID]
+}
+
+enum ImageCropFocus {
+  ATTENTION
+  CENTER
+  EAST
+  ENTROPY
+  NORTH
+  NORTHEAST
+  NORTHWEST
+  SOUTH
+  SOUTHEAST
+  SOUTHWEST
+  WEST
+}
+
+enum ImageFit {
+  CONTAIN
+  COVER
+  FILL
+  INSIDE
+  OUTSIDE
+}
+
+enum ImageFormat {
+  AUTO
+  AVIF
+  JPG
+  NO_CHANGE
+  PNG
+  WEBP
+}
+
+enum ImageLayout {
+  CONSTRAINED
+  FIXED
+  FULL_WIDTH
+}
+
+enum ImagePlaceholder {
+  BLURRED
+  DOMINANT_COLOR
+  NONE
+  TRACED_SVG
+}
+
+type ImageSharp implements Node {
+  children: [Node!]!
+  fixed(
+    background: String = "rgba(0,0,0,1)"
+    base64Width: Int
+    cropFocus: ImageCropFocus = ATTENTION
+    duotone: DuotoneGradient
+    fit: ImageFit = COVER
+    grayscale: Boolean = false
+    height: Int
+    jpegProgressive: Boolean = true
+    jpegQuality: Int
+    pngCompressionSpeed: Int = 4
+    pngQuality: Int
+    quality: Int
+    rotate: Int = 0
+    toFormat: ImageFormat = AUTO
+    toFormatBase64: ImageFormat = AUTO
+    traceSVG: Potrace
+    trim: Float = 0
+    webpQuality: Int
+    width: Int
+  ): ImageSharpFixed
+  fluid(
+    background: String = "rgba(0,0,0,1)"
+    base64Width: Int
+    cropFocus: ImageCropFocus = ATTENTION
+    duotone: DuotoneGradient
+    fit: ImageFit = COVER
+    grayscale: Boolean = false
+    jpegProgressive: Boolean = true
+    jpegQuality: Int
+    maxHeight: Int
+    maxWidth: Int
+    pngCompressionSpeed: Int = 4
+    pngQuality: Int
+    quality: Int
+    rotate: Int = 0
+    sizes: String = ""
+
+    """
+    A list of image widths to be generated. Example: [ 200, 340, 520, 890 ]
+    """
+    srcSetBreakpoints: [Int] = []
+    toFormat: ImageFormat = AUTO
+    toFormatBase64: ImageFormat = AUTO
+    traceSVG: Potrace
+    trim: Float = 0
+    webpQuality: Int
+  ): ImageSharpFluid
+  gatsbyImageData(
+    """
+    If set along with width or height, this will set the value of the other dimension to match the provided aspect ratio, cropping the image if needed.
+    If neither width or height is provided, height will be set based on the intrinsic width of the source image.
+    """
+    aspectRatio: Float
+
+    """
+    Options to pass to sharp when generating AVIF images.
+    """
+    avifOptions: AVIFOptions
+
+    """
+    Background color applied to the wrapper. Also passed to sharp to use as a background when "letterboxing" an image to another aspect ratio.
+    """
+    backgroundColor: String
+
+    """
+    Options for the low-resolution placeholder image. Set placeholder to "BLURRED" to use this
+    """
+    blurredOptions: BlurredOptions
+
+    """
+    Specifies the image widths to generate. For FIXED and CONSTRAINED images it is better to allow these to be determined automatically,
+    based on the image size. For FULL_WIDTH images this can be used to override the default, which is [750, 1080, 1366, 1920].
+    It will never generate any images larger than the source.
+    """
+    breakpoints: [Int]
+
+    """
+    The image formats to generate. Valid values are "AUTO" (meaning the same format as the source image), "JPG", "PNG", "WEBP" and "AVIF".
+    The default value is [AUTO, WEBP], and you should rarely need to change this. Take care if you specify JPG or PNG when you do
+    not know the formats of the source images, as this could lead to unwanted results such as converting JPEGs to PNGs. Specifying
+    both PNG and JPG is not supported and will be ignored.
+    """
+    formats: [ImageFormat]
+
+    """
+    The display height of the generated image for layout = FIXED, and the maximum display height of the largest image for layout = CONSTRAINED.
+    The image will be cropped if the aspect ratio does not match the source image. If omitted, it is calculated from the supplied width,
+    matching the aspect ratio of the source image.
+    """
+    height: Int
+
+    """
+    Options to pass to sharp when generating JPG images.
+    """
+    jpgOptions: JPGOptions
+
+    """
+    The layout for the image.
+    FIXED: A static image sized, that does not resize according to the screen width
+    FULL_WIDTH: The image resizes to fit its container. Pass a "sizes" option if it isn't going to be the full width of the screen.
+    CONSTRAINED: Resizes to fit its container, up to a maximum width, at which point it will remain fixed in size.
+    """
+    layout: ImageLayout = CONSTRAINED
+
+    """
+    A list of image pixel densities to generate. It will never generate images larger than the source, and will always include a 1x image.
+    Default is [ 1, 2 ] for FIXED images, meaning 1x and 2x and [0.25, 0.5, 1, 2] for CONSTRAINED. In this case, an image with a constrained layout
+    and width = 400 would generate images at 100, 200, 400 and 800px wide. Ignored for FULL_WIDTH images, which use breakpoints instead
+    """
+    outputPixelDensities: [Float]
+
+    """
+    Format of generated placeholder image, displayed while the main image loads.
+    BLURRED: a blurred, low resolution image, encoded as a base64 data URI (default)
+    DOMINANT_COLOR: a solid color, calculated from the dominant color of the image.
+    TRACED_SVG: a low-resolution traced SVG of the image.
+    NONE: no placeholder. Set "background" to use a fixed background color.
+    """
+    placeholder: ImagePlaceholder
+
+    """
+    Options to pass to sharp when generating PNG images.
+    """
+    pngOptions: PNGOptions
+
+    """
+    The default quality. This is overridden by any format-specific options
+    """
+    quality: Int
+
+    """
+    The "sizes" property, passed to the img tag. This describes the display size of the image.
+    This does not affect the generated images, but is used by the browser to decide which images to download.
+    You should usually leave this blank, and a suitable value will be calculated. The exception is if a FULL_WIDTH image
+    does not actually span the full width of the screen, in which case you should pass the correct size here.
+    """
+    sizes: String
+
+    """
+    Options for traced placeholder SVGs. You also should set placeholder to "TRACED_SVG".
+    """
+    tracedSVGOptions: Potrace
+
+    """
+    Options to pass to sharp to control cropping and other image manipulations.
+    """
+    transformOptions: TransformOptions
+
+    """
+    Options to pass to sharp when generating WebP images.
+    """
+    webpOptions: WebPOptions
+
+    """
+    The display width of the generated image for layout = FIXED, and the maximum display width of the largest image for layout = CONSTRAINED.
+    Ignored if layout = FLUID.
+    """
+    width: Int
+  ): JSON!
+  id: ID!
+  internal: Internal!
+  original: ImageSharpOriginal
+  parent: Node
+  resize(
+    background: String = "rgba(0,0,0,1)"
+    base64: Boolean = false
+    cropFocus: ImageCropFocus = ATTENTION
+    duotone: DuotoneGradient
+    fit: ImageFit = COVER
+    grayscale: Boolean = false
+    height: Int
+    jpegProgressive: Boolean = true
+    jpegQuality: Int
+    pngCompressionLevel: Int = 9
+    pngCompressionSpeed: Int = 4
+    pngQuality: Int
+    quality: Int
+    rotate: Int = 0
+    toFormat: ImageFormat = AUTO
+    traceSVG: Potrace
+    trim: Float = 0
+    webpQuality: Int
+    width: Int
+  ): ImageSharpResize
+}
+
+type ImageSharpConnection {
+  distinct(field: ImageSharpFieldsEnum!): [String!]!
+  edges: [ImageSharpEdge!]!
+  group(field: ImageSharpFieldsEnum!, limit: Int, skip: Int): [ImageSharpGroupConnection!]!
+  max(field: ImageSharpFieldsEnum!): Float
+  min(field: ImageSharpFieldsEnum!): Float
+  nodes: [ImageSharp!]!
+  pageInfo: PageInfo!
+  sum(field: ImageSharpFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type ImageSharpEdge {
+  next: ImageSharp
+  node: ImageSharp!
+  previous: ImageSharp
+}
+
+enum ImageSharpFieldsEnum {
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  fixed___aspectRatio
+  fixed___base64
+  fixed___height
+  fixed___originalName
+  fixed___src
+  fixed___srcSet
+  fixed___srcSetWebp
+  fixed___srcWebp
+  fixed___tracedSVG
+  fixed___width
+  fluid___aspectRatio
+  fluid___base64
+  fluid___originalImg
+  fluid___originalName
+  fluid___presentationHeight
+  fluid___presentationWidth
+  fluid___sizes
+  fluid___src
+  fluid___srcSet
+  fluid___srcSetWebp
+  fluid___srcWebp
+  fluid___tracedSVG
+  gatsbyImageData
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  original___height
+  original___src
+  original___width
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  resize___aspectRatio
+  resize___height
+  resize___originalName
+  resize___src
+  resize___tracedSVG
+  resize___width
+}
+
+input ImageSharpFilterInput {
+  children: NodeFilterListInput
+  fixed: ImageSharpFixedFilterInput
+  fluid: ImageSharpFluidFilterInput
+  gatsbyImageData: JSONQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  original: ImageSharpOriginalFilterInput
+  parent: NodeFilterInput
+  resize: ImageSharpResizeFilterInput
+}
+
+input ImageSharpFilterListInput {
+  elemMatch: ImageSharpFilterInput
+}
+
+type ImageSharpFixed {
+  aspectRatio: Float
+  base64: String
+  height: Float!
+  originalName: String
+  src: String!
+  srcSet: String!
+  srcSetWebp: String
+  srcWebp: String
+  tracedSVG: String
+  width: Float!
+}
+
+input ImageSharpFixedFilterInput {
+  aspectRatio: FloatQueryOperatorInput
+  base64: StringQueryOperatorInput
+  height: FloatQueryOperatorInput
+  originalName: StringQueryOperatorInput
+  src: StringQueryOperatorInput
+  srcSet: StringQueryOperatorInput
+  srcSetWebp: StringQueryOperatorInput
+  srcWebp: StringQueryOperatorInput
+  tracedSVG: StringQueryOperatorInput
+  width: FloatQueryOperatorInput
+}
+
+type ImageSharpFluid {
+  aspectRatio: Float!
+  base64: String
+  originalImg: String
+  originalName: String
+  presentationHeight: Int!
+  presentationWidth: Int!
+  sizes: String!
+  src: String!
+  srcSet: String!
+  srcSetWebp: String
+  srcWebp: String
+  tracedSVG: String
+}
+
+input ImageSharpFluidFilterInput {
+  aspectRatio: FloatQueryOperatorInput
+  base64: StringQueryOperatorInput
+  originalImg: StringQueryOperatorInput
+  originalName: StringQueryOperatorInput
+  presentationHeight: IntQueryOperatorInput
+  presentationWidth: IntQueryOperatorInput
+  sizes: StringQueryOperatorInput
+  src: StringQueryOperatorInput
+  srcSet: StringQueryOperatorInput
+  srcSetWebp: StringQueryOperatorInput
+  srcWebp: StringQueryOperatorInput
+  tracedSVG: StringQueryOperatorInput
+}
+
+type ImageSharpGroupConnection {
+  distinct(field: ImageSharpFieldsEnum!): [String!]!
+  edges: [ImageSharpEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: ImageSharpFieldsEnum!, limit: Int, skip: Int): [ImageSharpGroupConnection!]!
+  max(field: ImageSharpFieldsEnum!): Float
+  min(field: ImageSharpFieldsEnum!): Float
+  nodes: [ImageSharp!]!
+  pageInfo: PageInfo!
+  sum(field: ImageSharpFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type ImageSharpOriginal {
+  height: Float
+  src: String
+  width: Float
+}
+
+input ImageSharpOriginalFilterInput {
+  height: FloatQueryOperatorInput
+  src: StringQueryOperatorInput
+  width: FloatQueryOperatorInput
+}
+
+type ImageSharpResize {
+  aspectRatio: Float
+  height: Int
+  originalName: String
+  src: String
+  tracedSVG: String
+  width: Int
+}
+
+input ImageSharpResizeFilterInput {
+  aspectRatio: FloatQueryOperatorInput
+  height: IntQueryOperatorInput
+  originalName: StringQueryOperatorInput
+  src: StringQueryOperatorInput
+  tracedSVG: StringQueryOperatorInput
+  width: IntQueryOperatorInput
+}
+
+input ImageSharpSortInput {
+  fields: [ImageSharpFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+input IntQueryOperatorInput {
+  eq: Int
+  gt: Int
+  gte: Int
+  in: [Int]
+  lt: Int
+  lte: Int
+  ne: Int
+  nin: [Int]
+}
+
+type Internal {
+  content: String
+  contentDigest: String!
+  description: String
+  fieldOwners: [String]
+  ignoreType: Boolean
+  mediaType: String
+  owner: String!
+  type: String!
+}
+
+input InternalFilterInput {
+  content: StringQueryOperatorInput
+  contentDigest: StringQueryOperatorInput
+  description: StringQueryOperatorInput
+  fieldOwners: StringQueryOperatorInput
+  ignoreType: BooleanQueryOperatorInput
+  mediaType: StringQueryOperatorInput
+  owner: StringQueryOperatorInput
+  type: StringQueryOperatorInput
+}
+
+input JPGOptions {
+  progressive: Boolean = true
+  quality: Int
+}
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+
+input JSONQueryOperatorInput {
+  eq: JSON
+  glob: JSON
+  in: [JSON]
+  ne: JSON
+  nin: [JSON]
+  regex: JSON
+}
+
+"""
+Node Interface
+"""
+interface Node {
+  children: [Node!]!
+  id: ID!
+  internal: Internal!
+  parent: Node
+}
+
+input NodeFilterInput {
+  children: NodeFilterListInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  parent: NodeFilterInput
+}
+
+input NodeFilterListInput {
+  elemMatch: NodeFilterInput
+}
+
+input PNGOptions {
+  compressionSpeed: Int = 4
+  quality: Int
+}
+
+type PageInfo {
+  currentPage: Int!
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  itemCount: Int!
+  pageCount: Int!
+  perPage: Int
+  totalCount: Int!
+}
+
+input Potrace {
+  alphaMax: Float
+  background: String
+  blackOnWhite: Boolean
+  color: String
+  optCurve: Boolean
+  optTolerance: Float
+  threshold: Int
+  turdSize: Float
+  turnPolicy: PotraceTurnPolicy
+}
+
+enum PotraceTurnPolicy {
+  TURNPOLICY_BLACK
+  TURNPOLICY_LEFT
+  TURNPOLICY_MAJORITY
+  TURNPOLICY_MINORITY
+  TURNPOLICY_RIGHT
+  TURNPOLICY_WHITE
+}
+
+type Query {
+  allDirectory(filter: DirectoryFilterInput, limit: Int, skip: Int, sort: DirectorySortInput): DirectoryConnection!
+  allFile(filter: FileFilterInput, limit: Int, skip: Int, sort: FileSortInput): FileConnection!
+  allImageSharp(filter: ImageSharpFilterInput, limit: Int, skip: Int, sort: ImageSharpSortInput): ImageSharpConnection!
+  allInternalEvents(
+    filter: internal__eventsFilterInput
+    limit: Int
+    skip: Int
+    sort: internal__eventsSortInput
+  ): internal__eventsConnection!
+  allSite(filter: SiteFilterInput, limit: Int, skip: Int, sort: SiteSortInput): SiteConnection!
+  allSiteBuildMetadata(
+    filter: SiteBuildMetadataFilterInput
+    limit: Int
+    skip: Int
+    sort: SiteBuildMetadataSortInput
+  ): SiteBuildMetadataConnection!
+  allSiteFunction(
+    filter: SiteFunctionFilterInput
+    limit: Int
+    skip: Int
+    sort: SiteFunctionSortInput
+  ): SiteFunctionConnection!
+  allSitePage(filter: SitePageFilterInput, limit: Int, skip: Int, sort: SitePageSortInput): SitePageConnection!
+  allSitePlugin(filter: SitePluginFilterInput, limit: Int, skip: Int, sort: SitePluginSortInput): SitePluginConnection!
+  allWp(filter: WpFilterInput, limit: Int, skip: Int, sort: WpSortInput): WpConnection!
+  allWpBlockEditorContentNode(
+    filter: WpBlockEditorContentNodeFilterInput
+    limit: Int
+    skip: Int
+    sort: WpBlockEditorContentNodeSortInput
+  ): WpBlockEditorContentNodeConnection!
+  allWpBlockEditorPreview(
+    filter: WpBlockEditorPreviewFilterInput
+    limit: Int
+    skip: Int
+    sort: WpBlockEditorPreviewSortInput
+  ): WpBlockEditorPreviewConnection!
+  allWpCategory(filter: WpCategoryFilterInput, limit: Int, skip: Int, sort: WpCategorySortInput): WpCategoryConnection!
+  allWpComment(filter: WpCommentFilterInput, limit: Int, skip: Int, sort: WpCommentSortInput): WpCommentConnection!
+  allWpCommentAuthor(
+    filter: WpCommentAuthorFilterInput
+    limit: Int
+    skip: Int
+    sort: WpCommentAuthorSortInput
+  ): WpCommentAuthorConnection!
+  allWpContentNode(
+    filter: WpContentNodeFilterInput
+    limit: Int
+    skip: Int
+    sort: WpContentNodeSortInput
+  ): WpContentNodeConnection!
+  allWpContentType(
+    filter: WpContentTypeFilterInput
+    limit: Int
+    skip: Int
+    sort: WpContentTypeSortInput
+  ): WpContentTypeConnection!
+  allWpMediaItem(
+    filter: WpMediaItemFilterInput
+    limit: Int
+    skip: Int
+    sort: WpMediaItemSortInput
+  ): WpMediaItemConnection!
+  allWpMenu(filter: WpMenuFilterInput, limit: Int, skip: Int, sort: WpMenuSortInput): WpMenuConnection!
+  allWpMenuItem(filter: WpMenuItemFilterInput, limit: Int, skip: Int, sort: WpMenuItemSortInput): WpMenuItemConnection!
+  allWpPage(filter: WpPageFilterInput, limit: Int, skip: Int, sort: WpPageSortInput): WpPageConnection!
+  allWpPost(filter: WpPostFilterInput, limit: Int, skip: Int, sort: WpPostSortInput): WpPostConnection!
+  allWpPostFormat(
+    filter: WpPostFormatFilterInput
+    limit: Int
+    skip: Int
+    sort: WpPostFormatSortInput
+  ): WpPostFormatConnection!
+  allWpReusableBlock(
+    filter: WpReusableBlockFilterInput
+    limit: Int
+    skip: Int
+    sort: WpReusableBlockSortInput
+  ): WpReusableBlockConnection!
+  allWpTag(filter: WpTagFilterInput, limit: Int, skip: Int, sort: WpTagSortInput): WpTagConnection!
+  allWpTaxonomy(filter: WpTaxonomyFilterInput, limit: Int, skip: Int, sort: WpTaxonomySortInput): WpTaxonomyConnection!
+  allWpTermNode(filter: WpTermNodeFilterInput, limit: Int, skip: Int, sort: WpTermNodeSortInput): WpTermNodeConnection!
+  allWpUser(filter: WpUserFilterInput, limit: Int, skip: Int, sort: WpUserSortInput): WpUserConnection!
+  allWpUserRole(filter: WpUserRoleFilterInput, limit: Int, skip: Int, sort: WpUserRoleSortInput): WpUserRoleConnection!
+  directory(
+    absolutePath: StringQueryOperatorInput
+    accessTime: DateQueryOperatorInput
+    atime: DateQueryOperatorInput
+    atimeMs: FloatQueryOperatorInput
+    base: StringQueryOperatorInput
+    birthTime: DateQueryOperatorInput
+    birthtime: DateQueryOperatorInput
+    birthtimeMs: FloatQueryOperatorInput
+    changeTime: DateQueryOperatorInput
+    children: NodeFilterListInput
+    ctime: DateQueryOperatorInput
+    ctimeMs: FloatQueryOperatorInput
+    dev: IntQueryOperatorInput
+    dir: StringQueryOperatorInput
+    ext: StringQueryOperatorInput
+    extension: StringQueryOperatorInput
+    gid: IntQueryOperatorInput
+    id: StringQueryOperatorInput
+    ino: FloatQueryOperatorInput
+    internal: InternalFilterInput
+    mode: IntQueryOperatorInput
+    modifiedTime: DateQueryOperatorInput
+    mtime: DateQueryOperatorInput
+    mtimeMs: FloatQueryOperatorInput
+    name: StringQueryOperatorInput
+    nlink: IntQueryOperatorInput
+    parent: NodeFilterInput
+    prettySize: StringQueryOperatorInput
+    rdev: IntQueryOperatorInput
+    relativeDirectory: StringQueryOperatorInput
+    relativePath: StringQueryOperatorInput
+    root: StringQueryOperatorInput
+    size: IntQueryOperatorInput
+    sourceInstanceName: StringQueryOperatorInput
+    uid: IntQueryOperatorInput
+  ): Directory
+  file(
+    absolutePath: StringQueryOperatorInput
+    accessTime: DateQueryOperatorInput
+    atime: DateQueryOperatorInput
+    atimeMs: FloatQueryOperatorInput
+    base: StringQueryOperatorInput
+    birthTime: DateQueryOperatorInput
+    birthtime: DateQueryOperatorInput
+    birthtimeMs: FloatQueryOperatorInput
+    blksize: IntQueryOperatorInput
+    blocks: IntQueryOperatorInput
+    changeTime: DateQueryOperatorInput
+    childImageSharp: ImageSharpFilterInput
+    children: NodeFilterListInput
+    childrenImageSharp: ImageSharpFilterListInput
+    ctime: DateQueryOperatorInput
+    ctimeMs: FloatQueryOperatorInput
+    dev: IntQueryOperatorInput
+    dir: StringQueryOperatorInput
+    ext: StringQueryOperatorInput
+    extension: StringQueryOperatorInput
+    gid: IntQueryOperatorInput
+    hash: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    ino: FloatQueryOperatorInput
+    internal: InternalFilterInput
+    mode: IntQueryOperatorInput
+    modifiedTime: DateQueryOperatorInput
+    mtime: DateQueryOperatorInput
+    mtimeMs: FloatQueryOperatorInput
+    name: StringQueryOperatorInput
+    nlink: IntQueryOperatorInput
+    parent: NodeFilterInput
+    prettySize: StringQueryOperatorInput
+    publicURL: StringQueryOperatorInput
+    rdev: IntQueryOperatorInput
+    relativeDirectory: StringQueryOperatorInput
+    relativePath: StringQueryOperatorInput
+    root: StringQueryOperatorInput
+    size: IntQueryOperatorInput
+    sourceInstanceName: StringQueryOperatorInput
+    uid: IntQueryOperatorInput
+  ): File
+  imageSharp(
+    children: NodeFilterListInput
+    fixed: ImageSharpFixedFilterInput
+    fluid: ImageSharpFluidFilterInput
+    gatsbyImageData: JSONQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    original: ImageSharpOriginalFilterInput
+    parent: NodeFilterInput
+    resize: ImageSharpResizeFilterInput
+  ): ImageSharp
+  internalEvents(
+    children: NodeFilterListInput
+    events: internal__eventsEventsFilterListInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    next_rest_url: StringQueryOperatorInput
+    parent: NodeFilterInput
+    previous_rest_url: StringQueryOperatorInput
+    rest_url: StringQueryOperatorInput
+    total: IntQueryOperatorInput
+    total_pages: IntQueryOperatorInput
+  ): internal__events
+  site(
+    buildTime: DateQueryOperatorInput
+    children: NodeFilterListInput
+    host: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    jsxRuntime: StringQueryOperatorInput
+    parent: NodeFilterInput
+    pathPrefix: StringQueryOperatorInput
+    polyfill: BooleanQueryOperatorInput
+    port: IntQueryOperatorInput
+    siteMetadata: SiteSiteMetadataFilterInput
+    trailingSlash: StringQueryOperatorInput
+  ): Site
+  siteBuildMetadata(
+    buildTime: DateQueryOperatorInput
+    children: NodeFilterListInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    parent: NodeFilterInput
+  ): SiteBuildMetadata
+  siteFunction(
+    absoluteCompiledFilePath: StringQueryOperatorInput
+    children: NodeFilterListInput
+    functionRoute: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    matchPath: StringQueryOperatorInput
+    originalAbsoluteFilePath: StringQueryOperatorInput
+    originalRelativeFilePath: StringQueryOperatorInput
+    parent: NodeFilterInput
+    pluginName: StringQueryOperatorInput
+    relativeCompiledFilePath: StringQueryOperatorInput
+  ): SiteFunction
+  sitePage(
+    children: NodeFilterListInput
+    component: StringQueryOperatorInput
+    componentChunkName: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    internalComponentName: StringQueryOperatorInput
+    matchPath: StringQueryOperatorInput
+    pageContext: JSONQueryOperatorInput
+    parent: NodeFilterInput
+    path: StringQueryOperatorInput
+    pluginCreator: SitePluginFilterInput
+  ): SitePage
+  sitePlugin(
+    browserAPIs: StringQueryOperatorInput
+    children: NodeFilterListInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    name: StringQueryOperatorInput
+    nodeAPIs: StringQueryOperatorInput
+    packageJson: JSONQueryOperatorInput
+    parent: NodeFilterInput
+    pluginFilepath: StringQueryOperatorInput
+    pluginOptions: JSONQueryOperatorInput
+    resolve: StringQueryOperatorInput
+    ssrAPIs: StringQueryOperatorInput
+    version: StringQueryOperatorInput
+  ): SitePlugin
+  wp(
+    allSettings: WpSettingsFilterInput
+    children: NodeFilterListInput
+    discussionSettings: WpDiscussionSettingsFilterInput
+    generalSettings: WpGeneralSettingsFilterInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    readingSettings: WpReadingSettingsFilterInput
+    wpGatsby: WpWPGatsbyFilterInput
+    writingSettings: WpWritingSettingsFilterInput
+  ): Wp
+  wpBlockEditorContentNode(
+    blocks: WpBlockFilterListInput
+    blocksJSON: StringQueryOperatorInput
+    children: NodeFilterListInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    previewBlocks: WpBlockFilterListInput
+    previewBlocksJSON: StringQueryOperatorInput
+  ): WpBlockEditorContentNode
+  wpBlockEditorPreview(
+    author: WpNodeWithAuthorToUserConnectionEdgeFilterInput
+    authorDatabaseId: IntQueryOperatorInput
+    authorId: IDQueryOperatorInput
+    blocks: WpBlockFilterListInput
+    blocksJSON: StringQueryOperatorInput
+    children: NodeFilterListInput
+    content: StringQueryOperatorInput
+    contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+    contentTypeName: StringQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    date: DateQueryOperatorInput
+    dateGmt: DateQueryOperatorInput
+    desiredSlug: StringQueryOperatorInput
+    enclosure: StringQueryOperatorInput
+    guid: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+    lastUpdateTime: StringQueryOperatorInput
+    link: StringQueryOperatorInput
+    modified: DateQueryOperatorInput
+    modifiedGmt: DateQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    previewed: WpBlockEditorContentNodeFilterInput
+    previewedDatabaseId: IntQueryOperatorInput
+    previewedParentDatabaseId: IntQueryOperatorInput
+    slug: StringQueryOperatorInput
+    status: StringQueryOperatorInput
+    template: WpContentTemplateFilterInput
+    title: StringQueryOperatorInput
+    uri: StringQueryOperatorInput
+  ): WpBlockEditorPreview
+  wpCategory(
+    ancestors: WpCategoryToAncestorsCategoryConnectionFilterInput
+    children: NodeFilterListInput
+    contentNodes: WpCategoryToContentNodeConnectionFilterInput
+    count: IntQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    description: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    link: StringQueryOperatorInput
+    name: StringQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    parentDatabaseId: IntQueryOperatorInput
+    parentId: IDQueryOperatorInput
+    posts: WpCategoryToPostConnectionFilterInput
+    slug: StringQueryOperatorInput
+    taxonomy: WpCategoryToTaxonomyConnectionEdgeFilterInput
+    taxonomyName: StringQueryOperatorInput
+    termGroupId: IntQueryOperatorInput
+    termTaxonomyId: IntQueryOperatorInput
+    uri: StringQueryOperatorInput
+    wpChildren: WpCategoryToCategoryConnectionFilterInput
+    wpParent: WpCategoryToParentCategoryConnectionEdgeFilterInput
+  ): WpCategory
+  wpComment(
+    agent: StringQueryOperatorInput
+    approved: BooleanQueryOperatorInput
+    author: WpCommentToCommenterConnectionEdgeFilterInput
+    authorIp: StringQueryOperatorInput
+    children: NodeFilterListInput
+    commentedOn: WpCommentToContentNodeConnectionEdgeFilterInput
+    content: StringQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    date: DateQueryOperatorInput
+    dateGmt: DateQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    karma: IntQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    parentDatabaseId: IntQueryOperatorInput
+    parentId: IDQueryOperatorInput
+    replies: WpCommentToCommentConnectionFilterInput
+    type: StringQueryOperatorInput
+    wpParent: WpCommentToParentCommentConnectionEdgeFilterInput
+  ): WpComment
+  wpCommentAuthor(
+    avatar: WpAvatarFilterInput
+    children: NodeFilterListInput
+    databaseId: IntQueryOperatorInput
+    email: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    name: StringQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    url: StringQueryOperatorInput
+  ): WpCommentAuthor
+  wpContentNode(
+    children: NodeFilterListInput
+    contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+    contentTypeName: StringQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    date: DateQueryOperatorInput
+    dateGmt: DateQueryOperatorInput
+    desiredSlug: StringQueryOperatorInput
+    enclosure: StringQueryOperatorInput
+    guid: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+    link: StringQueryOperatorInput
+    modified: DateQueryOperatorInput
+    modifiedGmt: DateQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    slug: StringQueryOperatorInput
+    status: StringQueryOperatorInput
+    template: WpContentTemplateFilterInput
+    uri: StringQueryOperatorInput
+  ): WpContentNode
+  wpContentType(
+    archivePath: StringQueryOperatorInput
+    canExport: BooleanQueryOperatorInput
+    children: NodeFilterListInput
+    connectedTaxonomies: WpContentTypeToTaxonomyConnectionFilterInput
+    contentNodes: WpContentTypeToContentNodeConnectionFilterInput
+    deleteWithUser: BooleanQueryOperatorInput
+    description: StringQueryOperatorInput
+    excludeFromSearch: BooleanQueryOperatorInput
+    graphqlPluralName: StringQueryOperatorInput
+    graphqlSingleName: StringQueryOperatorInput
+    hasArchive: BooleanQueryOperatorInput
+    hierarchical: BooleanQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isFrontPage: BooleanQueryOperatorInput
+    isPostsPage: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    label: StringQueryOperatorInput
+    labels: WpPostTypeLabelDetailsFilterInput
+    menuIcon: StringQueryOperatorInput
+    menuPosition: IntQueryOperatorInput
+    name: StringQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    public: BooleanQueryOperatorInput
+    publiclyQueryable: BooleanQueryOperatorInput
+    restBase: StringQueryOperatorInput
+    restControllerClass: StringQueryOperatorInput
+    showInAdminBar: BooleanQueryOperatorInput
+    showInGraphql: BooleanQueryOperatorInput
+    showInMenu: BooleanQueryOperatorInput
+    showInNavMenus: BooleanQueryOperatorInput
+    showInRest: BooleanQueryOperatorInput
+    showUi: BooleanQueryOperatorInput
+    uri: StringQueryOperatorInput
+  ): WpContentType
+  wpMediaItem(
+    altText: StringQueryOperatorInput
+    ancestors: WpHierarchicalContentNodeToContentNodeAncestorsConnectionFilterInput
+    author: WpNodeWithAuthorToUserConnectionEdgeFilterInput
+    authorDatabaseId: IntQueryOperatorInput
+    authorId: IDQueryOperatorInput
+    caption: StringQueryOperatorInput
+    children: NodeFilterListInput
+    commentCount: IntQueryOperatorInput
+    commentStatus: StringQueryOperatorInput
+    comments: WpMediaItemToCommentConnectionFilterInput
+    contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+    contentTypeName: StringQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    date: DateQueryOperatorInput
+    dateGmt: DateQueryOperatorInput
+    description: StringQueryOperatorInput
+    desiredSlug: StringQueryOperatorInput
+    enclosure: StringQueryOperatorInput
+    fileSize: IntQueryOperatorInput
+    filename: StringQueryOperatorInput
+    filesize: IntQueryOperatorInput
+    gatsbyImage: JSONQueryOperatorInput
+    guid: StringQueryOperatorInput
+    height: IntQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+    link: StringQueryOperatorInput
+    localFile: FileFilterInput
+    mediaDetails: WpMediaDetailsFilterInput
+    mediaItemUrl: StringQueryOperatorInput
+    mediaType: StringQueryOperatorInput
+    mimeType: StringQueryOperatorInput
+    modified: DateQueryOperatorInput
+    modifiedGmt: DateQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    parentDatabaseId: IntQueryOperatorInput
+    parentId: IDQueryOperatorInput
+    publicUrl: StringQueryOperatorInput
+    remoteFile: FileFilterInput
+    resize: RemoteFileResizeFilterInput
+    sizes: StringQueryOperatorInput
+    slug: StringQueryOperatorInput
+    sourceUrl: StringQueryOperatorInput
+    srcSet: StringQueryOperatorInput
+    status: StringQueryOperatorInput
+    template: WpContentTemplateFilterInput
+    title: StringQueryOperatorInput
+    uri: StringQueryOperatorInput
+    width: IntQueryOperatorInput
+    wpChildren: WpHierarchicalContentNodeToContentNodeChildrenConnectionFilterInput
+    wpParent: WpHierarchicalContentNodeToParentContentNodeConnectionEdgeFilterInput
+  ): WpMediaItem
+  wpMenu(
+    children: NodeFilterListInput
+    count: IntQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    locations: WpMenuLocationEnumQueryOperatorInput
+    menuItems: WpMenuToMenuItemConnectionFilterInput
+    name: StringQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    slug: StringQueryOperatorInput
+  ): WpMenu
+  wpMenuItem(
+    childItems: WpMenuItemToMenuItemConnectionFilterInput
+    children: NodeFilterListInput
+    connectedNode: WpMenuItemToMenuItemLinkableConnectionEdgeFilterInput
+    cssClasses: StringQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    description: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    label: StringQueryOperatorInput
+    linkRelationship: StringQueryOperatorInput
+    locations: WpMenuLocationEnumQueryOperatorInput
+    menu: WpMenuItemToMenuConnectionEdgeFilterInput
+    nodeType: StringQueryOperatorInput
+    order: IntQueryOperatorInput
+    parent: NodeFilterInput
+    parentDatabaseId: IntQueryOperatorInput
+    parentId: IDQueryOperatorInput
+    path: StringQueryOperatorInput
+    target: StringQueryOperatorInput
+    title: StringQueryOperatorInput
+    url: StringQueryOperatorInput
+  ): WpMenuItem
+  wpPage(
+    ancestors: WpHierarchicalContentNodeToContentNodeAncestorsConnectionFilterInput
+    author: WpNodeWithAuthorToUserConnectionEdgeFilterInput
+    authorDatabaseId: IntQueryOperatorInput
+    authorId: IDQueryOperatorInput
+    blocks: WpBlockFilterListInput
+    blocksJSON: StringQueryOperatorInput
+    children: NodeFilterListInput
+    commentCount: IntQueryOperatorInput
+    commentStatus: StringQueryOperatorInput
+    comments: WpPageToCommentConnectionFilterInput
+    content: StringQueryOperatorInput
+    contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+    contentTypeName: StringQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    date: DateQueryOperatorInput
+    dateGmt: DateQueryOperatorInput
+    desiredSlug: StringQueryOperatorInput
+    enclosure: StringQueryOperatorInput
+    featuredImage: WpNodeWithFeaturedImageToMediaItemConnectionEdgeFilterInput
+    featuredImageDatabaseId: IntQueryOperatorInput
+    featuredImageId: IDQueryOperatorInput
+    guid: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isFrontPage: BooleanQueryOperatorInput
+    isPostsPage: BooleanQueryOperatorInput
+    isPrivacyPage: BooleanQueryOperatorInput
+    isRevision: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+    link: StringQueryOperatorInput
+    menuOrder: IntQueryOperatorInput
+    modified: DateQueryOperatorInput
+    modifiedGmt: DateQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    parentDatabaseId: IntQueryOperatorInput
+    parentId: IDQueryOperatorInput
+    previewBlocks: WpBlockFilterListInput
+    previewBlocksJSON: StringQueryOperatorInput
+    slug: StringQueryOperatorInput
+    status: StringQueryOperatorInput
+    template: WpContentTemplateFilterInput
+    title: StringQueryOperatorInput
+    uri: StringQueryOperatorInput
+    wpChildren: WpHierarchicalContentNodeToContentNodeChildrenConnectionFilterInput
+    wpParent: WpHierarchicalContentNodeToParentContentNodeConnectionEdgeFilterInput
+  ): WpPage
+  wpPost(
+    author: WpNodeWithAuthorToUserConnectionEdgeFilterInput
+    authorDatabaseId: IntQueryOperatorInput
+    authorId: IDQueryOperatorInput
+    blocks: WpBlockFilterListInput
+    blocksJSON: StringQueryOperatorInput
+    categories: WpPostToCategoryConnectionFilterInput
+    children: NodeFilterListInput
+    commentCount: IntQueryOperatorInput
+    commentStatus: StringQueryOperatorInput
+    comments: WpPostToCommentConnectionFilterInput
+    content: StringQueryOperatorInput
+    contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+    contentTypeName: StringQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    date: DateQueryOperatorInput
+    dateGmt: DateQueryOperatorInput
+    desiredSlug: StringQueryOperatorInput
+    enclosure: StringQueryOperatorInput
+    excerpt: StringQueryOperatorInput
+    featuredImage: WpNodeWithFeaturedImageToMediaItemConnectionEdgeFilterInput
+    featuredImageDatabaseId: IntQueryOperatorInput
+    featuredImageId: IDQueryOperatorInput
+    guid: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isRevision: BooleanQueryOperatorInput
+    isSticky: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+    link: StringQueryOperatorInput
+    modified: DateQueryOperatorInput
+    modifiedGmt: DateQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    pingStatus: StringQueryOperatorInput
+    pinged: StringQueryOperatorInput
+    postFormats: WpPostToPostFormatConnectionFilterInput
+    previewBlocks: WpBlockFilterListInput
+    previewBlocksJSON: StringQueryOperatorInput
+    slug: StringQueryOperatorInput
+    status: StringQueryOperatorInput
+    tags: WpPostToTagConnectionFilterInput
+    template: WpContentTemplateFilterInput
+    terms: WpPostToTermNodeConnectionFilterInput
+    title: StringQueryOperatorInput
+    toPing: StringQueryOperatorInput
+    uri: StringQueryOperatorInput
+  ): WpPost
+  wpPostFormat(
+    children: NodeFilterListInput
+    contentNodes: WpPostFormatToContentNodeConnectionFilterInput
+    count: IntQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    description: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    link: StringQueryOperatorInput
+    name: StringQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    posts: WpPostFormatToPostConnectionFilterInput
+    slug: StringQueryOperatorInput
+    taxonomy: WpPostFormatToTaxonomyConnectionEdgeFilterInput
+    taxonomyName: StringQueryOperatorInput
+    termGroupId: IntQueryOperatorInput
+    termTaxonomyId: IntQueryOperatorInput
+    uri: StringQueryOperatorInput
+  ): WpPostFormat
+  wpReusableBlock(
+    blocks: WpBlockFilterListInput
+    blocksJSON: StringQueryOperatorInput
+    children: NodeFilterListInput
+    content: StringQueryOperatorInput
+    contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+    contentTypeName: StringQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    date: DateQueryOperatorInput
+    dateGmt: DateQueryOperatorInput
+    desiredSlug: StringQueryOperatorInput
+    enclosure: StringQueryOperatorInput
+    guid: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isRevision: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+    link: StringQueryOperatorInput
+    modified: DateQueryOperatorInput
+    modifiedGmt: DateQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    previewBlocks: WpBlockFilterListInput
+    previewBlocksJSON: StringQueryOperatorInput
+    slug: StringQueryOperatorInput
+    status: StringQueryOperatorInput
+    template: WpContentTemplateFilterInput
+    title: StringQueryOperatorInput
+    uri: StringQueryOperatorInput
+  ): WpReusableBlock
+  wpTag(
+    children: NodeFilterListInput
+    contentNodes: WpTagToContentNodeConnectionFilterInput
+    count: IntQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    description: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    link: StringQueryOperatorInput
+    name: StringQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    posts: WpTagToPostConnectionFilterInput
+    slug: StringQueryOperatorInput
+    taxonomy: WpTagToTaxonomyConnectionEdgeFilterInput
+    taxonomyName: StringQueryOperatorInput
+    termGroupId: IntQueryOperatorInput
+    termTaxonomyId: IntQueryOperatorInput
+    uri: StringQueryOperatorInput
+  ): WpTag
+  wpTaxonomy(
+    archivePath: StringQueryOperatorInput
+    children: NodeFilterListInput
+    connectedContentTypes: WpTaxonomyToContentTypeConnectionFilterInput
+    description: StringQueryOperatorInput
+    graphqlPluralName: StringQueryOperatorInput
+    graphqlSingleName: StringQueryOperatorInput
+    hierarchical: BooleanQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    label: StringQueryOperatorInput
+    name: StringQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    public: BooleanQueryOperatorInput
+    restBase: StringQueryOperatorInput
+    restControllerClass: StringQueryOperatorInput
+    showCloud: BooleanQueryOperatorInput
+    showInAdminColumn: BooleanQueryOperatorInput
+    showInGraphql: BooleanQueryOperatorInput
+    showInMenu: BooleanQueryOperatorInput
+    showInNavMenus: BooleanQueryOperatorInput
+    showInQuickEdit: BooleanQueryOperatorInput
+    showInRest: BooleanQueryOperatorInput
+    showUi: BooleanQueryOperatorInput
+  ): WpTaxonomy
+  wpTermNode(
+    children: NodeFilterListInput
+    count: IntQueryOperatorInput
+    databaseId: IntQueryOperatorInput
+    description: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    link: StringQueryOperatorInput
+    name: StringQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+    slug: StringQueryOperatorInput
+    taxonomyName: StringQueryOperatorInput
+    termGroupId: IntQueryOperatorInput
+    termTaxonomyId: IntQueryOperatorInput
+    uri: StringQueryOperatorInput
+  ): WpTermNode
+  wpUser(
+    avatar: WpAvatarFilterInput
+    blockEditorPreviews: WpUserToBlockEditorPreviewConnectionFilterInput
+    capKey: StringQueryOperatorInput
+    capabilities: StringQueryOperatorInput
+    children: NodeFilterListInput
+    comments: WpUserToCommentConnectionFilterInput
+    databaseId: IntQueryOperatorInput
+    description: StringQueryOperatorInput
+    email: StringQueryOperatorInput
+    extraCapabilities: StringQueryOperatorInput
+    firstName: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    isContentNode: BooleanQueryOperatorInput
+    isTermNode: BooleanQueryOperatorInput
+    lastName: StringQueryOperatorInput
+    locale: StringQueryOperatorInput
+    name: StringQueryOperatorInput
+    nicename: StringQueryOperatorInput
+    nickname: StringQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    pages: WpUserToPageConnectionFilterInput
+    parent: NodeFilterInput
+    posts: WpUserToPostConnectionFilterInput
+    registeredDate: StringQueryOperatorInput
+    roles: WpUserToUserRoleConnectionFilterInput
+    slug: StringQueryOperatorInput
+    uri: StringQueryOperatorInput
+    url: StringQueryOperatorInput
+    username: StringQueryOperatorInput
+  ): WpUser
+  wpUserRole(
+    capabilities: StringQueryOperatorInput
+    children: NodeFilterListInput
+    displayName: StringQueryOperatorInput
+    id: StringQueryOperatorInput
+    internal: InternalFilterInput
+    name: StringQueryOperatorInput
+    nodeType: StringQueryOperatorInput
+    parent: NodeFilterInput
+  ): WpUserRole
+}
+
+"""
+Remote Interface
+"""
+interface RemoteFile {
+  filename: String!
+  filesize: Int
+
+  """
+  Data used in the <GatsbyImage /> component. See https://gatsby.dev/img for more info.
+  """
+  gatsbyImage(
+    """
+    If set along with width or height, this will set the value of the other dimension to match the provided aspect ratio, cropping the image if needed.
+    If neither width or height is provided, height will be set based on the intrinsic width of the source image.
+    """
+    aspectRatio: Float
+
+    """
+    Background color applied to the wrapper, or when "letterboxing" an image to another aspect ratio.
+    """
+    backgroundColor: String
+
+    """
+    Specifies the image widths to generate. You should rarely need to change this. For FIXED and CONSTRAINED images it is better to allow these to be determined automatically,
+    based on the image size. For FULL_WIDTH images this can be used to override the default, which is [750, 1080, 1366, 1920].
+    It will never generate any images larger than the source.
+    """
+    breakpoints: [Int] = [750, 1080, 1366, 1920]
+    cropFocus: [RemoteFileCropFocus]
+    fit: RemoteFileFit = COVER
+
+    """
+    The image formats to generate. Valid values are AUTO (meaning the same format as the source image), JPG, PNG, WEBP and AVIF.
+    The default value is [AUTO, WEBP, AVIF], and you should rarely need to change this. Take care if you specify JPG or PNG when you do
+    not know the formats of the source images, as this could lead to unwanted results such as converting JPEGs to PNGs. Specifying
+    both PNG and JPG is not supported and will be ignored.
+    """
+    formats: [RemoteFileFormat!] = [AUTO, WEBP, AVIF]
+
+    """
+    If set, the height of the generated image. If omitted, it is calculated from the supplied width, matching the aspect ratio of the source image.
+    """
+    height: Int
+
+    """
+    The layout for the image.
+    FIXED: A static image sized, that does not resize according to the screen width
+    FULL_WIDTH: The image resizes to fit its container. Pass a "sizes" option if it isn't going to be the full width of the screen.
+    CONSTRAINED: Resizes to fit its container, up to a maximum width, at which point it will remain fixed in size.
+    """
+    layout: RemoteFileLayout = CONSTRAINED
+
+    """
+    A list of image pixel densities to generate for FIXED and CONSTRAINED images. You should rarely need to change this. It will never generate images larger than the source, and will always include a 1x image.
+    Default is [ 1, 2 ] for fixed images, meaning 1x, 2x, and [0.25, 0.5, 1, 2] for fluid. In this case, an image with a fluid layout and width = 400 would generate images at 100, 200, 400 and 800px wide.
+    """
+    outputPixelDensities: [Float] = [0.25, 0.5, 1, 2]
+
+    """
+    Format of generated placeholder image, displayed while the main image loads.
+    BLURRED: a blurred, low resolution image, encoded as a base64 data URI (default)
+    DOMINANT_COLOR: a solid color, calculated from the dominant color of the image.
+    TRACED_SVG: a low-resolution traced SVG of the image.
+    NONE: no placeholder. Set the argument "backgroundColor" to use a fixed background color.
+    """
+    placeholder: RemoteFilePlaceholder = DOMINANT_COLOR
+    quality: Int = 75
+
+    """
+    The "sizes" property, passed to the img tag. This describes the display size of the image.
+    This does not affect the generated images, but is used by the browser to decide which images to download. You can leave this blank for fixed images, or if the responsive image
+    container will be the full width of the screen. In these cases we will generate an appropriate value.
+    """
+    sizes: String
+
+    """
+    The display width of the generated image for layout = FIXED, and the display width of the largest image for layout = CONSTRAINED.
+    The actual largest image resolution will be this value multiplied by the largest value in outputPixelDensities
+    Ignored if layout = FLUID.
+    """
+    width: Int
+  ): JSON
+  height: Int
+  id: ID!
+  mimeType: String!
+  publicUrl: String!
+  resize(
+    cropFocus: [RemoteFileCropFocus]
+    fit: RemoteFileFit = COVER
+
+    """
+    The image formats to generate. Valid values are AUTO (meaning the same format as the source image), JPG, PNG, WEBP and AVIF.
+    The default value is [AUTO, WEBP, AVIF], and you should rarely need to change this. Take care if you specify JPG or PNG when you do
+    not know the formats of the source images, as this could lead to unwanted results such as converting JPEGs to PNGs. Specifying
+    both PNG and JPG is not supported and will be ignored.
+    """
+    format: RemoteFileFormat = AUTO
+    height: Int
+    quality: Int = 75
+    width: Int
+  ): RemoteFileResize
+  width: Int
+}
+
+enum RemoteFileCropFocus {
+  BOTTOM
+  CENTER
+  EDGES
+  ENTROPY
+  FACES
+  LEFT
+  RIGHT
+  TOP
+}
+
+enum RemoteFileFit {
+  CONTAIN
+  COVER
+  FILL
+  OUTSIDE
+}
+
+enum RemoteFileFormat {
+  AUTO
+  AVIF
+  JPG
+  PNG
+  WEBP
+}
+
+enum RemoteFileLayout {
+  CONSTRAINED
+  FIXED
+  FULL_WIDTH
+}
+
+enum RemoteFilePlaceholder {
+  BLURRED
+  DOMINANT_COLOR
+  NONE
+}
+
+type RemoteFileResize {
+  height: Int
+  src: String
+  width: Int
+}
+
+input RemoteFileResizeFilterInput {
+  height: IntQueryOperatorInput
+  src: StringQueryOperatorInput
+  width: IntQueryOperatorInput
+}
+
+type Site implements Node {
+  buildTime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  children: [Node!]!
+  host: String
+  id: ID!
+  internal: Internal!
+  jsxRuntime: String
+  parent: Node
+  pathPrefix: String
+  polyfill: Boolean
+  port: Int
+  siteMetadata: SiteSiteMetadata
+  trailingSlash: String
+}
+
+type SiteBuildMetadata implements Node {
+  buildTime(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  children: [Node!]!
+  id: ID!
+  internal: Internal!
+  parent: Node
+}
+
+type SiteBuildMetadataConnection {
+  distinct(field: SiteBuildMetadataFieldsEnum!): [String!]!
+  edges: [SiteBuildMetadataEdge!]!
+  group(field: SiteBuildMetadataFieldsEnum!, limit: Int, skip: Int): [SiteBuildMetadataGroupConnection!]!
+  max(field: SiteBuildMetadataFieldsEnum!): Float
+  min(field: SiteBuildMetadataFieldsEnum!): Float
+  nodes: [SiteBuildMetadata!]!
+  pageInfo: PageInfo!
+  sum(field: SiteBuildMetadataFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type SiteBuildMetadataEdge {
+  next: SiteBuildMetadata
+  node: SiteBuildMetadata!
+  previous: SiteBuildMetadata
+}
+
+enum SiteBuildMetadataFieldsEnum {
+  buildTime
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+}
+
+input SiteBuildMetadataFilterInput {
+  buildTime: DateQueryOperatorInput
+  children: NodeFilterListInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  parent: NodeFilterInput
+}
+
+type SiteBuildMetadataGroupConnection {
+  distinct(field: SiteBuildMetadataFieldsEnum!): [String!]!
+  edges: [SiteBuildMetadataEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: SiteBuildMetadataFieldsEnum!, limit: Int, skip: Int): [SiteBuildMetadataGroupConnection!]!
+  max(field: SiteBuildMetadataFieldsEnum!): Float
+  min(field: SiteBuildMetadataFieldsEnum!): Float
+  nodes: [SiteBuildMetadata!]!
+  pageInfo: PageInfo!
+  sum(field: SiteBuildMetadataFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input SiteBuildMetadataSortInput {
+  fields: [SiteBuildMetadataFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+type SiteConnection {
+  distinct(field: SiteFieldsEnum!): [String!]!
+  edges: [SiteEdge!]!
+  group(field: SiteFieldsEnum!, limit: Int, skip: Int): [SiteGroupConnection!]!
+  max(field: SiteFieldsEnum!): Float
+  min(field: SiteFieldsEnum!): Float
+  nodes: [Site!]!
+  pageInfo: PageInfo!
+  sum(field: SiteFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type SiteEdge {
+  next: Site
+  node: Site!
+  previous: Site
+}
+
+enum SiteFieldsEnum {
+  buildTime
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  host
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  jsxRuntime
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  pathPrefix
+  polyfill
+  port
+  siteMetadata___description
+  siteMetadata___title
+  trailingSlash
+}
+
+input SiteFilterInput {
+  buildTime: DateQueryOperatorInput
+  children: NodeFilterListInput
+  host: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  jsxRuntime: StringQueryOperatorInput
+  parent: NodeFilterInput
+  pathPrefix: StringQueryOperatorInput
+  polyfill: BooleanQueryOperatorInput
+  port: IntQueryOperatorInput
+  siteMetadata: SiteSiteMetadataFilterInput
+  trailingSlash: StringQueryOperatorInput
+}
+
+type SiteFunction implements Node {
+  absoluteCompiledFilePath: String!
+  children: [Node!]!
+  functionRoute: String!
+  id: ID!
+  internal: Internal!
+  matchPath: String
+  originalAbsoluteFilePath: String!
+  originalRelativeFilePath: String!
+  parent: Node
+  pluginName: String!
+  relativeCompiledFilePath: String!
+}
+
+type SiteFunctionConnection {
+  distinct(field: SiteFunctionFieldsEnum!): [String!]!
+  edges: [SiteFunctionEdge!]!
+  group(field: SiteFunctionFieldsEnum!, limit: Int, skip: Int): [SiteFunctionGroupConnection!]!
+  max(field: SiteFunctionFieldsEnum!): Float
+  min(field: SiteFunctionFieldsEnum!): Float
+  nodes: [SiteFunction!]!
+  pageInfo: PageInfo!
+  sum(field: SiteFunctionFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type SiteFunctionEdge {
+  next: SiteFunction
+  node: SiteFunction!
+  previous: SiteFunction
+}
+
+enum SiteFunctionFieldsEnum {
+  absoluteCompiledFilePath
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  functionRoute
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  matchPath
+  originalAbsoluteFilePath
+  originalRelativeFilePath
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  pluginName
+  relativeCompiledFilePath
+}
+
+input SiteFunctionFilterInput {
+  absoluteCompiledFilePath: StringQueryOperatorInput
+  children: NodeFilterListInput
+  functionRoute: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  matchPath: StringQueryOperatorInput
+  originalAbsoluteFilePath: StringQueryOperatorInput
+  originalRelativeFilePath: StringQueryOperatorInput
+  parent: NodeFilterInput
+  pluginName: StringQueryOperatorInput
+  relativeCompiledFilePath: StringQueryOperatorInput
+}
+
+type SiteFunctionGroupConnection {
+  distinct(field: SiteFunctionFieldsEnum!): [String!]!
+  edges: [SiteFunctionEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: SiteFunctionFieldsEnum!, limit: Int, skip: Int): [SiteFunctionGroupConnection!]!
+  max(field: SiteFunctionFieldsEnum!): Float
+  min(field: SiteFunctionFieldsEnum!): Float
+  nodes: [SiteFunction!]!
+  pageInfo: PageInfo!
+  sum(field: SiteFunctionFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input SiteFunctionSortInput {
+  fields: [SiteFunctionFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+type SiteGroupConnection {
+  distinct(field: SiteFieldsEnum!): [String!]!
+  edges: [SiteEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: SiteFieldsEnum!, limit: Int, skip: Int): [SiteGroupConnection!]!
+  max(field: SiteFieldsEnum!): Float
+  min(field: SiteFieldsEnum!): Float
+  nodes: [Site!]!
+  pageInfo: PageInfo!
+  sum(field: SiteFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type SitePage implements Node {
+  children: [Node!]!
+  component: String!
+  componentChunkName: String!
+  id: ID!
+  internal: Internal!
+  internalComponentName: String!
+  matchPath: String
+  pageContext: JSON
+  parent: Node
+  path: String!
+  pluginCreator: SitePlugin
+}
+
+type SitePageConnection {
+  distinct(field: SitePageFieldsEnum!): [String!]!
+  edges: [SitePageEdge!]!
+  group(field: SitePageFieldsEnum!, limit: Int, skip: Int): [SitePageGroupConnection!]!
+  max(field: SitePageFieldsEnum!): Float
+  min(field: SitePageFieldsEnum!): Float
+  nodes: [SitePage!]!
+  pageInfo: PageInfo!
+  sum(field: SitePageFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type SitePageEdge {
+  next: SitePage
+  node: SitePage!
+  previous: SitePage
+}
+
+enum SitePageFieldsEnum {
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  component
+  componentChunkName
+  id
+  internalComponentName
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  matchPath
+  pageContext
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  path
+  pluginCreator___browserAPIs
+  pluginCreator___children
+  pluginCreator___children___children
+  pluginCreator___children___children___children
+  pluginCreator___children___children___id
+  pluginCreator___children___id
+  pluginCreator___children___internal___content
+  pluginCreator___children___internal___contentDigest
+  pluginCreator___children___internal___description
+  pluginCreator___children___internal___fieldOwners
+  pluginCreator___children___internal___ignoreType
+  pluginCreator___children___internal___mediaType
+  pluginCreator___children___internal___owner
+  pluginCreator___children___internal___type
+  pluginCreator___children___parent___children
+  pluginCreator___children___parent___id
+  pluginCreator___id
+  pluginCreator___internal___content
+  pluginCreator___internal___contentDigest
+  pluginCreator___internal___description
+  pluginCreator___internal___fieldOwners
+  pluginCreator___internal___ignoreType
+  pluginCreator___internal___mediaType
+  pluginCreator___internal___owner
+  pluginCreator___internal___type
+  pluginCreator___name
+  pluginCreator___nodeAPIs
+  pluginCreator___packageJson
+  pluginCreator___parent___children
+  pluginCreator___parent___children___children
+  pluginCreator___parent___children___id
+  pluginCreator___parent___id
+  pluginCreator___parent___internal___content
+  pluginCreator___parent___internal___contentDigest
+  pluginCreator___parent___internal___description
+  pluginCreator___parent___internal___fieldOwners
+  pluginCreator___parent___internal___ignoreType
+  pluginCreator___parent___internal___mediaType
+  pluginCreator___parent___internal___owner
+  pluginCreator___parent___internal___type
+  pluginCreator___parent___parent___children
+  pluginCreator___parent___parent___id
+  pluginCreator___pluginFilepath
+  pluginCreator___pluginOptions
+  pluginCreator___resolve
+  pluginCreator___ssrAPIs
+  pluginCreator___version
+}
+
+input SitePageFilterInput {
+  children: NodeFilterListInput
+  component: StringQueryOperatorInput
+  componentChunkName: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  internalComponentName: StringQueryOperatorInput
+  matchPath: StringQueryOperatorInput
+  pageContext: JSONQueryOperatorInput
+  parent: NodeFilterInput
+  path: StringQueryOperatorInput
+  pluginCreator: SitePluginFilterInput
+}
+
+type SitePageGroupConnection {
+  distinct(field: SitePageFieldsEnum!): [String!]!
+  edges: [SitePageEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: SitePageFieldsEnum!, limit: Int, skip: Int): [SitePageGroupConnection!]!
+  max(field: SitePageFieldsEnum!): Float
+  min(field: SitePageFieldsEnum!): Float
+  nodes: [SitePage!]!
+  pageInfo: PageInfo!
+  sum(field: SitePageFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input SitePageSortInput {
+  fields: [SitePageFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+type SitePlugin implements Node {
+  browserAPIs: [String]
+  children: [Node!]!
+  id: ID!
+  internal: Internal!
+  name: String
+  nodeAPIs: [String]
+  packageJson: JSON
+  parent: Node
+  pluginFilepath: String
+  pluginOptions: JSON
+  resolve: String
+  ssrAPIs: [String]
+  version: String
+}
+
+type SitePluginConnection {
+  distinct(field: SitePluginFieldsEnum!): [String!]!
+  edges: [SitePluginEdge!]!
+  group(field: SitePluginFieldsEnum!, limit: Int, skip: Int): [SitePluginGroupConnection!]!
+  max(field: SitePluginFieldsEnum!): Float
+  min(field: SitePluginFieldsEnum!): Float
+  nodes: [SitePlugin!]!
+  pageInfo: PageInfo!
+  sum(field: SitePluginFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type SitePluginEdge {
+  next: SitePlugin
+  node: SitePlugin!
+  previous: SitePlugin
+}
+
+enum SitePluginFieldsEnum {
+  browserAPIs
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  name
+  nodeAPIs
+  packageJson
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  pluginFilepath
+  pluginOptions
+  resolve
+  ssrAPIs
+  version
+}
+
+input SitePluginFilterInput {
+  browserAPIs: StringQueryOperatorInput
+  children: NodeFilterListInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  name: StringQueryOperatorInput
+  nodeAPIs: StringQueryOperatorInput
+  packageJson: JSONQueryOperatorInput
+  parent: NodeFilterInput
+  pluginFilepath: StringQueryOperatorInput
+  pluginOptions: JSONQueryOperatorInput
+  resolve: StringQueryOperatorInput
+  ssrAPIs: StringQueryOperatorInput
+  version: StringQueryOperatorInput
+}
+
+type SitePluginGroupConnection {
+  distinct(field: SitePluginFieldsEnum!): [String!]!
+  edges: [SitePluginEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: SitePluginFieldsEnum!, limit: Int, skip: Int): [SitePluginGroupConnection!]!
+  max(field: SitePluginFieldsEnum!): Float
+  min(field: SitePluginFieldsEnum!): Float
+  nodes: [SitePlugin!]!
+  pageInfo: PageInfo!
+  sum(field: SitePluginFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input SitePluginSortInput {
+  fields: [SitePluginFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+type SiteSiteMetadata {
+  description: String
+  title: String
+}
+
+input SiteSiteMetadataFilterInput {
+  description: StringQueryOperatorInput
+  title: StringQueryOperatorInput
+}
+
+input SiteSortInput {
+  fields: [SiteFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+enum SortOrderEnum {
+  ASC
+  DESC
+}
+
+input StringQueryOperatorInput {
+  eq: String
+  glob: String
+  in: [String]
+  ne: String
+  nin: [String]
+  regex: String
+}
+
+input TransformOptions {
+  cropFocus: ImageCropFocus = ATTENTION
+  duotone: DuotoneGradient
+  fit: ImageFit = COVER
+  grayscale: Boolean = false
+  rotate: Int = 0
+  trim: Float = 0
+}
+
+input WebPOptions {
+  quality: Int
+}
+
+"""
+Non-node WPGraphQL root fields.
+"""
+type Wp implements Node {
+  """
+  Entry point to get all settings for the site
+  """
+  allSettings: WpSettings
+  children: [Node!]!
+
+  """
+  Fields of the &#039;DiscussionSettings&#039; settings group
+  """
+  discussionSettings: WpDiscussionSettings
+
+  """
+  Fields of the &#039;GeneralSettings&#039; settings group
+  """
+  generalSettings: WpGeneralSettings
+  id: ID!
+  internal: Internal!
+  nodeType: String
+  parent: Node
+
+  """
+  Fields of the &#039;ReadingSettings&#039; settings group
+  """
+  readingSettings: WpReadingSettings
+
+  """
+  Information needed by gatsby-source-wordpress.
+  """
+  wpGatsby: WpWPGatsby
+
+  """
+  Fields of the &#039;WritingSettings&#039; settings group
+  """
+  writingSettings: WpWritingSettings
+}
+
+"""
+Avatars are profile images for users. WordPress by default uses the Gravatar service to host and fetch avatars from.
+"""
+type WpAvatar {
+  """
+  URL for the default image or a default type. Accepts &#039;404&#039; (return a 404 instead of a default image), &#039;retro&#039; (8bit), &#039;monsterid&#039; (monster), &#039;wavatar&#039; (cartoon face), &#039;indenticon&#039; (the &#039;quilt&#039;), &#039;mystery&#039;, &#039;mm&#039;, or &#039;mysteryman&#039; (The Oyster Man), &#039;blank&#039; (transparent GIF), or &#039;gravatar_default&#039; (the Gravatar logo).
+  """
+  default: String
+
+  """
+  HTML attributes to insert in the IMG element. Is not sanitized.
+  """
+  extraAttr: String
+
+  """
+  Whether to always show the default image, never the Gravatar.
+  """
+  forceDefault: Boolean
+
+  """
+  Whether the avatar was successfully found.
+  """
+  foundAvatar: Boolean
+
+  """
+  Height of the avatar image.
+  """
+  height: Int
+
+  """
+  What rating to display avatars up to. Accepts &#039;G&#039;, &#039;PG&#039;, &#039;R&#039;, &#039;X&#039;, and are judged in that order.
+  """
+  rating: String
+
+  """
+  Type of url scheme to use. Typically HTTP vs. HTTPS.
+  """
+  scheme: String
+
+  """
+  The size of the avatar in pixels. A value of 96 will match a 96px x 96px gravatar image.
+  """
+  size: Int
+
+  """
+  URL for the gravatar image source.
+  """
+  url: String
+
+  """
+  Width of the avatar image.
+  """
+  width: Int
+}
+
+input WpAvatarFilterInput {
+  default: StringQueryOperatorInput
+  extraAttr: StringQueryOperatorInput
+  forceDefault: BooleanQueryOperatorInput
+  foundAvatar: BooleanQueryOperatorInput
+  height: IntQueryOperatorInput
+  rating: StringQueryOperatorInput
+  scheme: StringQueryOperatorInput
+  size: IntQueryOperatorInput
+  url: StringQueryOperatorInput
+  width: IntQueryOperatorInput
+}
+
+interface WpBlock {
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpBlockAttributesObject {
+  foobar: String
+}
+
+interface WpBlockEditorContentNode implements Node {
+  """
+  Gutenberg blocks
+  """
+  blocks: [WpBlock!]
+
+  """
+  Gutenberg blocks as json string
+  """
+  blocksJSON: String
+  children: [Node!]!
+  id: ID!
+  internal: Internal!
+  nodeType: String
+  parent: Node
+
+  """
+  Previewed gutenberg blocks
+  """
+  previewBlocks: [WpBlock!]
+
+  """
+  Previewed Gutenberg blocks as json string
+  """
+  previewBlocksJSON: String
+}
+
+type WpBlockEditorContentNodeConnection {
+  distinct(field: WpBlockEditorContentNodeFieldsEnum!): [String!]!
+  edges: [WpBlockEditorContentNodeEdge!]!
+  group(field: WpBlockEditorContentNodeFieldsEnum!, limit: Int, skip: Int): [WpBlockEditorContentNodeGroupConnection!]!
+  max(field: WpBlockEditorContentNodeFieldsEnum!): Float
+  min(field: WpBlockEditorContentNodeFieldsEnum!): Float
+  nodes: [WpBlockEditorContentNode!]!
+  pageInfo: PageInfo!
+  sum(field: WpBlockEditorContentNodeFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpBlockEditorContentNodeEdge {
+  next: WpBlockEditorContentNode
+  node: WpBlockEditorContentNode!
+  previous: WpBlockEditorContentNode
+}
+
+enum WpBlockEditorContentNodeFieldsEnum {
+  blocks
+  blocksJSON
+  blocks___attributesJSON
+  blocks___dynamicContent
+  blocks___innerBlocks
+  blocks___innerBlocks___attributesJSON
+  blocks___innerBlocks___dynamicContent
+  blocks___innerBlocks___innerBlocks
+  blocks___innerBlocks___innerBlocks___attributesJSON
+  blocks___innerBlocks___innerBlocks___dynamicContent
+  blocks___innerBlocks___innerBlocks___innerBlocks
+  blocks___innerBlocks___innerBlocks___isDynamic
+  blocks___innerBlocks___innerBlocks___name
+  blocks___innerBlocks___innerBlocks___order
+  blocks___innerBlocks___innerBlocks___originalContent
+  blocks___innerBlocks___innerBlocks___parentNodeDatabaseId
+  blocks___innerBlocks___innerBlocks___saveContent
+  blocks___innerBlocks___isDynamic
+  blocks___innerBlocks___name
+  blocks___innerBlocks___order
+  blocks___innerBlocks___originalContent
+  blocks___innerBlocks___parentNodeDatabaseId
+  blocks___innerBlocks___parentNode___id
+  blocks___innerBlocks___saveContent
+  blocks___isDynamic
+  blocks___name
+  blocks___order
+  blocks___originalContent
+  blocks___parentNodeDatabaseId
+  blocks___parentNode___id
+  blocks___saveContent
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  previewBlocks
+  previewBlocksJSON
+  previewBlocks___attributesJSON
+  previewBlocks___dynamicContent
+  previewBlocks___innerBlocks
+  previewBlocks___innerBlocks___attributesJSON
+  previewBlocks___innerBlocks___dynamicContent
+  previewBlocks___innerBlocks___innerBlocks
+  previewBlocks___innerBlocks___innerBlocks___attributesJSON
+  previewBlocks___innerBlocks___innerBlocks___dynamicContent
+  previewBlocks___innerBlocks___innerBlocks___innerBlocks
+  previewBlocks___innerBlocks___innerBlocks___isDynamic
+  previewBlocks___innerBlocks___innerBlocks___name
+  previewBlocks___innerBlocks___innerBlocks___order
+  previewBlocks___innerBlocks___innerBlocks___originalContent
+  previewBlocks___innerBlocks___innerBlocks___parentNodeDatabaseId
+  previewBlocks___innerBlocks___innerBlocks___saveContent
+  previewBlocks___innerBlocks___isDynamic
+  previewBlocks___innerBlocks___name
+  previewBlocks___innerBlocks___order
+  previewBlocks___innerBlocks___originalContent
+  previewBlocks___innerBlocks___parentNodeDatabaseId
+  previewBlocks___innerBlocks___parentNode___id
+  previewBlocks___innerBlocks___saveContent
+  previewBlocks___isDynamic
+  previewBlocks___name
+  previewBlocks___order
+  previewBlocks___originalContent
+  previewBlocks___parentNodeDatabaseId
+  previewBlocks___parentNode___id
+  previewBlocks___saveContent
+}
+
+input WpBlockEditorContentNodeFilterInput {
+  blocks: WpBlockFilterListInput
+  blocksJSON: StringQueryOperatorInput
+  children: NodeFilterListInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  previewBlocks: WpBlockFilterListInput
+  previewBlocksJSON: StringQueryOperatorInput
+}
+
+type WpBlockEditorContentNodeGroupConnection {
+  distinct(field: WpBlockEditorContentNodeFieldsEnum!): [String!]!
+  edges: [WpBlockEditorContentNodeEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpBlockEditorContentNodeFieldsEnum!, limit: Int, skip: Int): [WpBlockEditorContentNodeGroupConnection!]!
+  max(field: WpBlockEditorContentNodeFieldsEnum!): Float
+  min(field: WpBlockEditorContentNodeFieldsEnum!): Float
+  nodes: [WpBlockEditorContentNode!]!
+  pageInfo: PageInfo!
+  sum(field: WpBlockEditorContentNodeFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpBlockEditorContentNodeSortInput {
+  fields: [WpBlockEditorContentNodeFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+The BlockEditorPreview type
+"""
+type WpBlockEditorPreview implements Node & WpContentNode & WpDatabaseIdentifier & WpNode & WpNodeWithAuthor & WpNodeWithContentEditor & WpNodeWithTemplate & WpNodeWithTitle & WpUniformResourceIdentifiable {
+  """
+  Connection between the NodeWithAuthor type and the User type
+  """
+  author: WpNodeWithAuthorToUserConnectionEdge
+
+  """
+  The database identifier of the author of the node
+  """
+  authorDatabaseId: Int
+
+  """
+  The globally unique identifier of the author of the node
+  """
+  authorId: ID
+  blocks: [WpBlock!]
+  blocksJSON: String
+  children: [Node!]!
+
+  """
+  The content of the post.
+  """
+  content: String
+
+  """
+  Connection between the ContentNode type and the ContentType type
+  """
+  contentType: WpContentNodeToContentTypeConnectionEdge
+
+  """
+  The name of the Content Type the node belongs to
+  """
+  contentTypeName: String!
+
+  """
+  The unique identifier stored in the database
+  """
+  databaseId: Int!
+
+  """
+  Post publishing date.
+  """
+  date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The publishing date set in GMT.
+  """
+  dateGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The desired slug of the post
+  """
+  desiredSlug: String
+
+  """
+  The RSS enclosure for the object
+  """
+  enclosure: String
+
+  """
+  The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table.
+  """
+  guid: String
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The user that most recently edited the node
+  """
+  lastEditedBy: WpContentNodeToEditLastConnectionEdge
+  lastUpdateTime: String
+
+  """
+  The permalink of the post
+  """
+  link: String
+
+  """
+  The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.
+  """
+  modified(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.
+  """
+  modifiedGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  nodeType: String
+  parent: Node
+  previewed: WpBlockEditorContentNode
+  previewedDatabaseId: Int
+  previewedParentDatabaseId: Int
+
+  """
+  The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table.
+  """
+  slug: String
+
+  """
+  The current status of the object
+  """
+  status: String
+
+  """
+  The template assigned to the node
+  """
+  template: WpContentTemplate
+
+  """
+  The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
+  """
+  title: String
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+}
+
+type WpBlockEditorPreviewConnection {
+  distinct(field: WpBlockEditorPreviewFieldsEnum!): [String!]!
+  edges: [WpBlockEditorPreviewEdge!]!
+  group(field: WpBlockEditorPreviewFieldsEnum!, limit: Int, skip: Int): [WpBlockEditorPreviewGroupConnection!]!
+  max(field: WpBlockEditorPreviewFieldsEnum!): Float
+  min(field: WpBlockEditorPreviewFieldsEnum!): Float
+  nodes: [WpBlockEditorPreview!]!
+  pageInfo: PageInfo!
+  sum(field: WpBlockEditorPreviewFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpBlockEditorPreviewEdge {
+  next: WpBlockEditorPreview
+  node: WpBlockEditorPreview!
+  previous: WpBlockEditorPreview
+}
+
+enum WpBlockEditorPreviewFieldsEnum {
+  authorDatabaseId
+  authorId
+  author___node___avatar___default
+  author___node___avatar___extraAttr
+  author___node___avatar___forceDefault
+  author___node___avatar___foundAvatar
+  author___node___avatar___height
+  author___node___avatar___rating
+  author___node___avatar___scheme
+  author___node___avatar___size
+  author___node___avatar___url
+  author___node___avatar___width
+  author___node___blockEditorPreviews___nodes
+  author___node___capKey
+  author___node___capabilities
+  author___node___children
+  author___node___children___children
+  author___node___children___id
+  author___node___comments___nodes
+  author___node___databaseId
+  author___node___description
+  author___node___email
+  author___node___extraCapabilities
+  author___node___firstName
+  author___node___id
+  author___node___internal___content
+  author___node___internal___contentDigest
+  author___node___internal___description
+  author___node___internal___fieldOwners
+  author___node___internal___ignoreType
+  author___node___internal___mediaType
+  author___node___internal___owner
+  author___node___internal___type
+  author___node___isContentNode
+  author___node___isTermNode
+  author___node___lastName
+  author___node___locale
+  author___node___name
+  author___node___nicename
+  author___node___nickname
+  author___node___nodeType
+  author___node___pages___nodes
+  author___node___parent___children
+  author___node___parent___id
+  author___node___posts___nodes
+  author___node___registeredDate
+  author___node___roles___nodes
+  author___node___slug
+  author___node___uri
+  author___node___url
+  author___node___username
+  blocks
+  blocksJSON
+  blocks___attributesJSON
+  blocks___dynamicContent
+  blocks___innerBlocks
+  blocks___innerBlocks___attributesJSON
+  blocks___innerBlocks___dynamicContent
+  blocks___innerBlocks___innerBlocks
+  blocks___innerBlocks___innerBlocks___attributesJSON
+  blocks___innerBlocks___innerBlocks___dynamicContent
+  blocks___innerBlocks___innerBlocks___innerBlocks
+  blocks___innerBlocks___innerBlocks___isDynamic
+  blocks___innerBlocks___innerBlocks___name
+  blocks___innerBlocks___innerBlocks___order
+  blocks___innerBlocks___innerBlocks___originalContent
+  blocks___innerBlocks___innerBlocks___parentNodeDatabaseId
+  blocks___innerBlocks___innerBlocks___saveContent
+  blocks___innerBlocks___isDynamic
+  blocks___innerBlocks___name
+  blocks___innerBlocks___order
+  blocks___innerBlocks___originalContent
+  blocks___innerBlocks___parentNodeDatabaseId
+  blocks___innerBlocks___parentNode___id
+  blocks___innerBlocks___saveContent
+  blocks___isDynamic
+  blocks___name
+  blocks___order
+  blocks___originalContent
+  blocks___parentNodeDatabaseId
+  blocks___parentNode___id
+  blocks___saveContent
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  content
+  contentTypeName
+  contentType___node___archivePath
+  contentType___node___canExport
+  contentType___node___children
+  contentType___node___children___children
+  contentType___node___children___id
+  contentType___node___connectedTaxonomies___nodes
+  contentType___node___contentNodes___nodes
+  contentType___node___deleteWithUser
+  contentType___node___description
+  contentType___node___excludeFromSearch
+  contentType___node___graphqlPluralName
+  contentType___node___graphqlSingleName
+  contentType___node___hasArchive
+  contentType___node___hierarchical
+  contentType___node___id
+  contentType___node___internal___content
+  contentType___node___internal___contentDigest
+  contentType___node___internal___description
+  contentType___node___internal___fieldOwners
+  contentType___node___internal___ignoreType
+  contentType___node___internal___mediaType
+  contentType___node___internal___owner
+  contentType___node___internal___type
+  contentType___node___isContentNode
+  contentType___node___isFrontPage
+  contentType___node___isPostsPage
+  contentType___node___isTermNode
+  contentType___node___label
+  contentType___node___labels___addNew
+  contentType___node___labels___addNewItem
+  contentType___node___labels___allItems
+  contentType___node___labels___archives
+  contentType___node___labels___attributes
+  contentType___node___labels___editItem
+  contentType___node___labels___featuredImage
+  contentType___node___labels___filterItemsList
+  contentType___node___labels___insertIntoItem
+  contentType___node___labels___itemsList
+  contentType___node___labels___itemsListNavigation
+  contentType___node___labels___menuName
+  contentType___node___labels___name
+  contentType___node___labels___newItem
+  contentType___node___labels___notFound
+  contentType___node___labels___notFoundInTrash
+  contentType___node___labels___parentItemColon
+  contentType___node___labels___removeFeaturedImage
+  contentType___node___labels___searchItems
+  contentType___node___labels___setFeaturedImage
+  contentType___node___labels___singularName
+  contentType___node___labels___uploadedToThisItem
+  contentType___node___labels___useFeaturedImage
+  contentType___node___labels___viewItem
+  contentType___node___labels___viewItems
+  contentType___node___menuIcon
+  contentType___node___menuPosition
+  contentType___node___name
+  contentType___node___nodeType
+  contentType___node___parent___children
+  contentType___node___parent___id
+  contentType___node___public
+  contentType___node___publiclyQueryable
+  contentType___node___restBase
+  contentType___node___restControllerClass
+  contentType___node___showInAdminBar
+  contentType___node___showInGraphql
+  contentType___node___showInMenu
+  contentType___node___showInNavMenus
+  contentType___node___showInRest
+  contentType___node___showUi
+  contentType___node___uri
+  databaseId
+  date
+  dateGmt
+  desiredSlug
+  enclosure
+  guid
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isTermNode
+  lastEditedBy___node___avatar___default
+  lastEditedBy___node___avatar___extraAttr
+  lastEditedBy___node___avatar___forceDefault
+  lastEditedBy___node___avatar___foundAvatar
+  lastEditedBy___node___avatar___height
+  lastEditedBy___node___avatar___rating
+  lastEditedBy___node___avatar___scheme
+  lastEditedBy___node___avatar___size
+  lastEditedBy___node___avatar___url
+  lastEditedBy___node___avatar___width
+  lastEditedBy___node___blockEditorPreviews___nodes
+  lastEditedBy___node___capKey
+  lastEditedBy___node___capabilities
+  lastEditedBy___node___children
+  lastEditedBy___node___children___children
+  lastEditedBy___node___children___id
+  lastEditedBy___node___comments___nodes
+  lastEditedBy___node___databaseId
+  lastEditedBy___node___description
+  lastEditedBy___node___email
+  lastEditedBy___node___extraCapabilities
+  lastEditedBy___node___firstName
+  lastEditedBy___node___id
+  lastEditedBy___node___internal___content
+  lastEditedBy___node___internal___contentDigest
+  lastEditedBy___node___internal___description
+  lastEditedBy___node___internal___fieldOwners
+  lastEditedBy___node___internal___ignoreType
+  lastEditedBy___node___internal___mediaType
+  lastEditedBy___node___internal___owner
+  lastEditedBy___node___internal___type
+  lastEditedBy___node___isContentNode
+  lastEditedBy___node___isTermNode
+  lastEditedBy___node___lastName
+  lastEditedBy___node___locale
+  lastEditedBy___node___name
+  lastEditedBy___node___nicename
+  lastEditedBy___node___nickname
+  lastEditedBy___node___nodeType
+  lastEditedBy___node___pages___nodes
+  lastEditedBy___node___parent___children
+  lastEditedBy___node___parent___id
+  lastEditedBy___node___posts___nodes
+  lastEditedBy___node___registeredDate
+  lastEditedBy___node___roles___nodes
+  lastEditedBy___node___slug
+  lastEditedBy___node___uri
+  lastEditedBy___node___url
+  lastEditedBy___node___username
+  lastUpdateTime
+  link
+  modified
+  modifiedGmt
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  previewedDatabaseId
+  previewedParentDatabaseId
+  previewed___blocks
+  previewed___blocksJSON
+  previewed___blocks___attributesJSON
+  previewed___blocks___dynamicContent
+  previewed___blocks___innerBlocks
+  previewed___blocks___innerBlocks___attributesJSON
+  previewed___blocks___innerBlocks___dynamicContent
+  previewed___blocks___innerBlocks___innerBlocks
+  previewed___blocks___innerBlocks___isDynamic
+  previewed___blocks___innerBlocks___name
+  previewed___blocks___innerBlocks___order
+  previewed___blocks___innerBlocks___originalContent
+  previewed___blocks___innerBlocks___parentNodeDatabaseId
+  previewed___blocks___innerBlocks___saveContent
+  previewed___blocks___isDynamic
+  previewed___blocks___name
+  previewed___blocks___order
+  previewed___blocks___originalContent
+  previewed___blocks___parentNodeDatabaseId
+  previewed___blocks___parentNode___id
+  previewed___blocks___saveContent
+  previewed___children
+  previewed___children___children
+  previewed___children___children___children
+  previewed___children___children___id
+  previewed___children___id
+  previewed___children___internal___content
+  previewed___children___internal___contentDigest
+  previewed___children___internal___description
+  previewed___children___internal___fieldOwners
+  previewed___children___internal___ignoreType
+  previewed___children___internal___mediaType
+  previewed___children___internal___owner
+  previewed___children___internal___type
+  previewed___children___parent___children
+  previewed___children___parent___id
+  previewed___id
+  previewed___internal___content
+  previewed___internal___contentDigest
+  previewed___internal___description
+  previewed___internal___fieldOwners
+  previewed___internal___ignoreType
+  previewed___internal___mediaType
+  previewed___internal___owner
+  previewed___internal___type
+  previewed___nodeType
+  previewed___parent___children
+  previewed___parent___children___children
+  previewed___parent___children___id
+  previewed___parent___id
+  previewed___parent___internal___content
+  previewed___parent___internal___contentDigest
+  previewed___parent___internal___description
+  previewed___parent___internal___fieldOwners
+  previewed___parent___internal___ignoreType
+  previewed___parent___internal___mediaType
+  previewed___parent___internal___owner
+  previewed___parent___internal___type
+  previewed___parent___parent___children
+  previewed___parent___parent___id
+  previewed___previewBlocks
+  previewed___previewBlocksJSON
+  previewed___previewBlocks___attributesJSON
+  previewed___previewBlocks___dynamicContent
+  previewed___previewBlocks___innerBlocks
+  previewed___previewBlocks___innerBlocks___attributesJSON
+  previewed___previewBlocks___innerBlocks___dynamicContent
+  previewed___previewBlocks___innerBlocks___innerBlocks
+  previewed___previewBlocks___innerBlocks___isDynamic
+  previewed___previewBlocks___innerBlocks___name
+  previewed___previewBlocks___innerBlocks___order
+  previewed___previewBlocks___innerBlocks___originalContent
+  previewed___previewBlocks___innerBlocks___parentNodeDatabaseId
+  previewed___previewBlocks___innerBlocks___saveContent
+  previewed___previewBlocks___isDynamic
+  previewed___previewBlocks___name
+  previewed___previewBlocks___order
+  previewed___previewBlocks___originalContent
+  previewed___previewBlocks___parentNodeDatabaseId
+  previewed___previewBlocks___parentNode___id
+  previewed___previewBlocks___saveContent
+  slug
+  status
+  template___templateName
+  title
+  uri
+}
+
+input WpBlockEditorPreviewFilterInput {
+  author: WpNodeWithAuthorToUserConnectionEdgeFilterInput
+  authorDatabaseId: IntQueryOperatorInput
+  authorId: IDQueryOperatorInput
+  blocks: WpBlockFilterListInput
+  blocksJSON: StringQueryOperatorInput
+  children: NodeFilterListInput
+  content: StringQueryOperatorInput
+  contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+  contentTypeName: StringQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  date: DateQueryOperatorInput
+  dateGmt: DateQueryOperatorInput
+  desiredSlug: StringQueryOperatorInput
+  enclosure: StringQueryOperatorInput
+  guid: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+  lastUpdateTime: StringQueryOperatorInput
+  link: StringQueryOperatorInput
+  modified: DateQueryOperatorInput
+  modifiedGmt: DateQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  previewed: WpBlockEditorContentNodeFilterInput
+  previewedDatabaseId: IntQueryOperatorInput
+  previewedParentDatabaseId: IntQueryOperatorInput
+  slug: StringQueryOperatorInput
+  status: StringQueryOperatorInput
+  template: WpContentTemplateFilterInput
+  title: StringQueryOperatorInput
+  uri: StringQueryOperatorInput
+}
+
+input WpBlockEditorPreviewFilterListInput {
+  elemMatch: WpBlockEditorPreviewFilterInput
+}
+
+type WpBlockEditorPreviewGroupConnection {
+  distinct(field: WpBlockEditorPreviewFieldsEnum!): [String!]!
+  edges: [WpBlockEditorPreviewEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpBlockEditorPreviewFieldsEnum!, limit: Int, skip: Int): [WpBlockEditorPreviewGroupConnection!]!
+  max(field: WpBlockEditorPreviewFieldsEnum!): Float
+  min(field: WpBlockEditorPreviewFieldsEnum!): Float
+  nodes: [WpBlockEditorPreview!]!
+  pageInfo: PageInfo!
+  sum(field: WpBlockEditorPreviewFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpBlockEditorPreviewSortInput {
+  fields: [WpBlockEditorPreviewFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+input WpBlockFilterInput {
+  attributesJSON: StringQueryOperatorInput
+  dynamicContent: StringQueryOperatorInput
+  innerBlocks: WpBlockFilterListInput
+  isDynamic: BooleanQueryOperatorInput
+  name: StringQueryOperatorInput
+  order: IntQueryOperatorInput
+  originalContent: StringQueryOperatorInput
+  parentNode: WpNodeFilterInput
+  parentNodeDatabaseId: IntQueryOperatorInput
+  saveContent: StringQueryOperatorInput
+}
+
+input WpBlockFilterListInput {
+  elemMatch: WpBlockFilterInput
+}
+
+"""
+The category type
+"""
+type WpCategory implements Node & WpDatabaseIdentifier & WpHierarchicalTermNode & WpMenuItemLinkable & WpNode & WpTermNode & WpUniformResourceIdentifiable {
+  """
+  The ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).
+  """
+  ancestors: WpCategoryToAncestorsCategoryConnection
+  children: [Node!]!
+
+  """
+  Connection between the category type and the ContentNode type
+  """
+  contentNodes: WpCategoryToContentNodeConnection
+
+  """
+  The number of objects connected to the object
+  """
+  count: Int
+
+  """
+  The unique resource identifier path
+  """
+  databaseId: Int!
+
+  """
+  The description of the object
+  """
+  description: String
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The link to the term
+  """
+  link: String
+
+  """
+  The human friendly name of the object.
+  """
+  name: String
+  nodeType: String
+  parent: Node
+
+  """
+  Database id of the parent node
+  """
+  parentDatabaseId: Int
+
+  """
+  The globally unique identifier of the parent node.
+  """
+  parentId: ID
+
+  """
+  Connection between the category type and the post type
+  """
+  posts: WpCategoryToPostConnection
+
+  """
+  An alphanumeric identifier for the object unique to its type.
+  """
+  slug: String
+
+  """
+  Connection between the category type and the Taxonomy type
+  """
+  taxonomy: WpCategoryToTaxonomyConnectionEdge
+
+  """
+  The name of the taxonomy that the object is associated with
+  """
+  taxonomyName: String
+
+  """
+  The ID of the term group that this term object belongs to
+  """
+  termGroupId: Int
+
+  """
+  The taxonomy ID that the object is associated with
+  """
+  termTaxonomyId: Int
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+
+  """
+  Connection between the category type and the category type
+  """
+  wpChildren: WpCategoryToCategoryConnection
+
+  """
+  Connection between the category type and the category type
+  """
+  wpParent: WpCategoryToParentCategoryConnectionEdge
+}
+
+type WpCategoryConnection {
+  distinct(field: WpCategoryFieldsEnum!): [String!]!
+  edges: [WpCategoryEdge!]!
+  group(field: WpCategoryFieldsEnum!, limit: Int, skip: Int): [WpCategoryGroupConnection!]!
+  max(field: WpCategoryFieldsEnum!): Float
+  min(field: WpCategoryFieldsEnum!): Float
+  nodes: [WpCategory!]!
+  pageInfo: PageInfo!
+  sum(field: WpCategoryFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpCategoryEdge {
+  next: WpCategory
+  node: WpCategory!
+  previous: WpCategory
+}
+
+enum WpCategoryFieldsEnum {
+  ancestors___nodes
+  ancestors___nodes___ancestors___nodes
+  ancestors___nodes___children
+  ancestors___nodes___children___children
+  ancestors___nodes___children___id
+  ancestors___nodes___contentNodes___nodes
+  ancestors___nodes___count
+  ancestors___nodes___databaseId
+  ancestors___nodes___description
+  ancestors___nodes___id
+  ancestors___nodes___internal___content
+  ancestors___nodes___internal___contentDigest
+  ancestors___nodes___internal___description
+  ancestors___nodes___internal___fieldOwners
+  ancestors___nodes___internal___ignoreType
+  ancestors___nodes___internal___mediaType
+  ancestors___nodes___internal___owner
+  ancestors___nodes___internal___type
+  ancestors___nodes___isContentNode
+  ancestors___nodes___isTermNode
+  ancestors___nodes___link
+  ancestors___nodes___name
+  ancestors___nodes___nodeType
+  ancestors___nodes___parentDatabaseId
+  ancestors___nodes___parentId
+  ancestors___nodes___parent___children
+  ancestors___nodes___parent___id
+  ancestors___nodes___posts___nodes
+  ancestors___nodes___slug
+  ancestors___nodes___taxonomyName
+  ancestors___nodes___termGroupId
+  ancestors___nodes___termTaxonomyId
+  ancestors___nodes___uri
+  ancestors___nodes___wpChildren___nodes
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  contentNodes___nodes
+  contentNodes___nodes___children
+  contentNodes___nodes___children___children
+  contentNodes___nodes___children___id
+  contentNodes___nodes___contentTypeName
+  contentNodes___nodes___databaseId
+  contentNodes___nodes___date
+  contentNodes___nodes___dateGmt
+  contentNodes___nodes___desiredSlug
+  contentNodes___nodes___enclosure
+  contentNodes___nodes___guid
+  contentNodes___nodes___id
+  contentNodes___nodes___internal___content
+  contentNodes___nodes___internal___contentDigest
+  contentNodes___nodes___internal___description
+  contentNodes___nodes___internal___fieldOwners
+  contentNodes___nodes___internal___ignoreType
+  contentNodes___nodes___internal___mediaType
+  contentNodes___nodes___internal___owner
+  contentNodes___nodes___internal___type
+  contentNodes___nodes___isContentNode
+  contentNodes___nodes___isTermNode
+  contentNodes___nodes___link
+  contentNodes___nodes___modified
+  contentNodes___nodes___modifiedGmt
+  contentNodes___nodes___nodeType
+  contentNodes___nodes___parent___children
+  contentNodes___nodes___parent___id
+  contentNodes___nodes___slug
+  contentNodes___nodes___status
+  contentNodes___nodes___template___templateName
+  contentNodes___nodes___uri
+  count
+  databaseId
+  description
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isTermNode
+  link
+  name
+  nodeType
+  parentDatabaseId
+  parentId
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  posts___nodes
+  posts___nodes___authorDatabaseId
+  posts___nodes___authorId
+  posts___nodes___blocks
+  posts___nodes___blocksJSON
+  posts___nodes___blocks___attributesJSON
+  posts___nodes___blocks___dynamicContent
+  posts___nodes___blocks___innerBlocks
+  posts___nodes___blocks___isDynamic
+  posts___nodes___blocks___name
+  posts___nodes___blocks___order
+  posts___nodes___blocks___originalContent
+  posts___nodes___blocks___parentNodeDatabaseId
+  posts___nodes___blocks___saveContent
+  posts___nodes___categories___nodes
+  posts___nodes___children
+  posts___nodes___children___children
+  posts___nodes___children___id
+  posts___nodes___commentCount
+  posts___nodes___commentStatus
+  posts___nodes___comments___nodes
+  posts___nodes___content
+  posts___nodes___contentTypeName
+  posts___nodes___databaseId
+  posts___nodes___date
+  posts___nodes___dateGmt
+  posts___nodes___desiredSlug
+  posts___nodes___enclosure
+  posts___nodes___excerpt
+  posts___nodes___featuredImageDatabaseId
+  posts___nodes___featuredImageId
+  posts___nodes___guid
+  posts___nodes___id
+  posts___nodes___internal___content
+  posts___nodes___internal___contentDigest
+  posts___nodes___internal___description
+  posts___nodes___internal___fieldOwners
+  posts___nodes___internal___ignoreType
+  posts___nodes___internal___mediaType
+  posts___nodes___internal___owner
+  posts___nodes___internal___type
+  posts___nodes___isContentNode
+  posts___nodes___isRevision
+  posts___nodes___isSticky
+  posts___nodes___isTermNode
+  posts___nodes___link
+  posts___nodes___modified
+  posts___nodes___modifiedGmt
+  posts___nodes___nodeType
+  posts___nodes___parent___children
+  posts___nodes___parent___id
+  posts___nodes___pingStatus
+  posts___nodes___pinged
+  posts___nodes___postFormats___nodes
+  posts___nodes___previewBlocks
+  posts___nodes___previewBlocksJSON
+  posts___nodes___previewBlocks___attributesJSON
+  posts___nodes___previewBlocks___dynamicContent
+  posts___nodes___previewBlocks___innerBlocks
+  posts___nodes___previewBlocks___isDynamic
+  posts___nodes___previewBlocks___name
+  posts___nodes___previewBlocks___order
+  posts___nodes___previewBlocks___originalContent
+  posts___nodes___previewBlocks___parentNodeDatabaseId
+  posts___nodes___previewBlocks___saveContent
+  posts___nodes___slug
+  posts___nodes___status
+  posts___nodes___tags___nodes
+  posts___nodes___template___templateName
+  posts___nodes___terms___nodes
+  posts___nodes___title
+  posts___nodes___toPing
+  posts___nodes___uri
+  slug
+  taxonomyName
+  taxonomy___node___archivePath
+  taxonomy___node___children
+  taxonomy___node___children___children
+  taxonomy___node___children___id
+  taxonomy___node___connectedContentTypes___nodes
+  taxonomy___node___description
+  taxonomy___node___graphqlPluralName
+  taxonomy___node___graphqlSingleName
+  taxonomy___node___hierarchical
+  taxonomy___node___id
+  taxonomy___node___internal___content
+  taxonomy___node___internal___contentDigest
+  taxonomy___node___internal___description
+  taxonomy___node___internal___fieldOwners
+  taxonomy___node___internal___ignoreType
+  taxonomy___node___internal___mediaType
+  taxonomy___node___internal___owner
+  taxonomy___node___internal___type
+  taxonomy___node___label
+  taxonomy___node___name
+  taxonomy___node___nodeType
+  taxonomy___node___parent___children
+  taxonomy___node___parent___id
+  taxonomy___node___public
+  taxonomy___node___restBase
+  taxonomy___node___restControllerClass
+  taxonomy___node___showCloud
+  taxonomy___node___showInAdminColumn
+  taxonomy___node___showInGraphql
+  taxonomy___node___showInMenu
+  taxonomy___node___showInNavMenus
+  taxonomy___node___showInQuickEdit
+  taxonomy___node___showInRest
+  taxonomy___node___showUi
+  termGroupId
+  termTaxonomyId
+  uri
+  wpChildren___nodes
+  wpChildren___nodes___ancestors___nodes
+  wpChildren___nodes___children
+  wpChildren___nodes___children___children
+  wpChildren___nodes___children___id
+  wpChildren___nodes___contentNodes___nodes
+  wpChildren___nodes___count
+  wpChildren___nodes___databaseId
+  wpChildren___nodes___description
+  wpChildren___nodes___id
+  wpChildren___nodes___internal___content
+  wpChildren___nodes___internal___contentDigest
+  wpChildren___nodes___internal___description
+  wpChildren___nodes___internal___fieldOwners
+  wpChildren___nodes___internal___ignoreType
+  wpChildren___nodes___internal___mediaType
+  wpChildren___nodes___internal___owner
+  wpChildren___nodes___internal___type
+  wpChildren___nodes___isContentNode
+  wpChildren___nodes___isTermNode
+  wpChildren___nodes___link
+  wpChildren___nodes___name
+  wpChildren___nodes___nodeType
+  wpChildren___nodes___parentDatabaseId
+  wpChildren___nodes___parentId
+  wpChildren___nodes___parent___children
+  wpChildren___nodes___parent___id
+  wpChildren___nodes___posts___nodes
+  wpChildren___nodes___slug
+  wpChildren___nodes___taxonomyName
+  wpChildren___nodes___termGroupId
+  wpChildren___nodes___termTaxonomyId
+  wpChildren___nodes___uri
+  wpChildren___nodes___wpChildren___nodes
+  wpParent___node___ancestors___nodes
+  wpParent___node___children
+  wpParent___node___children___children
+  wpParent___node___children___id
+  wpParent___node___contentNodes___nodes
+  wpParent___node___count
+  wpParent___node___databaseId
+  wpParent___node___description
+  wpParent___node___id
+  wpParent___node___internal___content
+  wpParent___node___internal___contentDigest
+  wpParent___node___internal___description
+  wpParent___node___internal___fieldOwners
+  wpParent___node___internal___ignoreType
+  wpParent___node___internal___mediaType
+  wpParent___node___internal___owner
+  wpParent___node___internal___type
+  wpParent___node___isContentNode
+  wpParent___node___isTermNode
+  wpParent___node___link
+  wpParent___node___name
+  wpParent___node___nodeType
+  wpParent___node___parentDatabaseId
+  wpParent___node___parentId
+  wpParent___node___parent___children
+  wpParent___node___parent___id
+  wpParent___node___posts___nodes
+  wpParent___node___slug
+  wpParent___node___taxonomyName
+  wpParent___node___termGroupId
+  wpParent___node___termTaxonomyId
+  wpParent___node___uri
+  wpParent___node___wpChildren___nodes
+}
+
+input WpCategoryFilterInput {
+  ancestors: WpCategoryToAncestorsCategoryConnectionFilterInput
+  children: NodeFilterListInput
+  contentNodes: WpCategoryToContentNodeConnectionFilterInput
+  count: IntQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  description: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  link: StringQueryOperatorInput
+  name: StringQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  parentDatabaseId: IntQueryOperatorInput
+  parentId: IDQueryOperatorInput
+  posts: WpCategoryToPostConnectionFilterInput
+  slug: StringQueryOperatorInput
+  taxonomy: WpCategoryToTaxonomyConnectionEdgeFilterInput
+  taxonomyName: StringQueryOperatorInput
+  termGroupId: IntQueryOperatorInput
+  termTaxonomyId: IntQueryOperatorInput
+  uri: StringQueryOperatorInput
+  wpChildren: WpCategoryToCategoryConnectionFilterInput
+  wpParent: WpCategoryToParentCategoryConnectionEdgeFilterInput
+}
+
+input WpCategoryFilterListInput {
+  elemMatch: WpCategoryFilterInput
+}
+
+type WpCategoryGroupConnection {
+  distinct(field: WpCategoryFieldsEnum!): [String!]!
+  edges: [WpCategoryEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpCategoryFieldsEnum!, limit: Int, skip: Int): [WpCategoryGroupConnection!]!
+  max(field: WpCategoryFieldsEnum!): Float
+  min(field: WpCategoryFieldsEnum!): Float
+  nodes: [WpCategory!]!
+  pageInfo: PageInfo!
+  sum(field: WpCategoryFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpCategorySortInput {
+  fields: [WpCategoryFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the category type and the category type
+"""
+type WpCategoryToAncestorsCategoryConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpCategory]
+}
+
+input WpCategoryToAncestorsCategoryConnectionFilterInput {
+  nodes: WpCategoryFilterListInput
+}
+
+"""
+Connection between the category type and the category type
+"""
+type WpCategoryToCategoryConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpCategory]
+}
+
+input WpCategoryToCategoryConnectionFilterInput {
+  nodes: WpCategoryFilterListInput
+}
+
+"""
+Connection between the category type and the ContentNode type
+"""
+type WpCategoryToContentNodeConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpContentNode]
+}
+
+input WpCategoryToContentNodeConnectionFilterInput {
+  nodes: WpContentNodeFilterListInput
+}
+
+"""
+Connection between the category type and the category type
+"""
+type WpCategoryToParentCategoryConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpCategory
+}
+
+input WpCategoryToParentCategoryConnectionEdgeFilterInput {
+  node: WpCategoryFilterInput
+}
+
+"""
+Connection between the category type and the post type
+"""
+type WpCategoryToPostConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpPost]
+}
+
+input WpCategoryToPostConnectionFilterInput {
+  nodes: WpPostFilterListInput
+}
+
+"""
+Connection between the category type and the Taxonomy type
+"""
+type WpCategoryToTaxonomyConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpTaxonomy
+}
+
+input WpCategoryToTaxonomyConnectionEdgeFilterInput {
+  node: WpTaxonomyFilterInput
+}
+
+"""
+A Comment object
+"""
+type WpComment implements Node & WpDatabaseIdentifier & WpNode {
+  """
+  User agent used to post the comment. This field is equivalent to WP_Comment-&gt;comment_agent and the value matching the &quot;comment_agent&quot; column in SQL.
+  """
+  agent: String
+
+  """
+  The approval status of the comment. This field is equivalent to WP_Comment-&gt;comment_approved and the value matching the &quot;comment_approved&quot; column in SQL.
+  """
+  approved: Boolean
+
+  """
+  The author of the comment
+  """
+  author: WpCommentToCommenterConnectionEdge
+
+  """
+  IP address for the author. This field is equivalent to WP_Comment-&gt;comment_author_IP and the value matching the &quot;comment_author_IP&quot; column in SQL.
+  """
+  authorIp: String
+  children: [Node!]!
+
+  """
+  Connection between the Comment type and the ContentNode type
+  """
+  commentedOn: WpCommentToContentNodeConnectionEdge
+
+  """
+  Content of the comment. This field is equivalent to WP_Comment-&gt;comment_content and the value matching the &quot;comment_content&quot; column in SQL.
+  """
+  content: String
+
+  """
+  The unique identifier stored in the database
+  """
+  databaseId: Int!
+
+  """
+  Date the comment was posted in local time. This field is equivalent to WP_Comment-&gt;date and the value matching the &quot;date&quot; column in SQL.
+  """
+  date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  Date the comment was posted in GMT. This field is equivalent to WP_Comment-&gt;date_gmt and the value matching the &quot;date_gmt&quot; column in SQL.
+  """
+  dateGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  id: ID!
+  internal: Internal!
+
+  """
+  Karma value for the comment. This field is equivalent to WP_Comment-&gt;comment_karma and the value matching the &quot;comment_karma&quot; column in SQL.
+  """
+  karma: Int
+  nodeType: String
+  parent: Node
+
+  """
+  The database id of the parent comment node or null if it is the root comment
+  """
+  parentDatabaseId: Int
+
+  """
+  The globally unique identifier of the parent comment node.
+  """
+  parentId: ID
+
+  """
+  Connection between the Comment type and the Comment type
+  """
+  replies: WpCommentToCommentConnection
+
+  """
+  Type of comment. This field is equivalent to WP_Comment-&gt;comment_type and the value matching the &quot;comment_type&quot; column in SQL.
+  """
+  type: String
+
+  """
+  Connection between the Comment type and the Comment type
+  """
+  wpParent: WpCommentToParentCommentConnectionEdge
+}
+
+"""
+A Comment Author object
+"""
+type WpCommentAuthor implements Node & WpCommenter & WpNode {
+  """
+  Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument.
+  """
+  avatar: WpAvatar
+  children: [Node!]!
+
+  """
+  Identifies the primary key from the database.
+  """
+  databaseId: Int!
+
+  """
+  The email for the comment author
+  """
+  email: String
+  id: ID!
+  internal: Internal!
+
+  """
+  The name for the comment author.
+  """
+  name: String
+  nodeType: String
+  parent: Node
+
+  """
+  The url the comment author.
+  """
+  url: String
+}
+
+type WpCommentAuthorConnection {
+  distinct(field: WpCommentAuthorFieldsEnum!): [String!]!
+  edges: [WpCommentAuthorEdge!]!
+  group(field: WpCommentAuthorFieldsEnum!, limit: Int, skip: Int): [WpCommentAuthorGroupConnection!]!
+  max(field: WpCommentAuthorFieldsEnum!): Float
+  min(field: WpCommentAuthorFieldsEnum!): Float
+  nodes: [WpCommentAuthor!]!
+  pageInfo: PageInfo!
+  sum(field: WpCommentAuthorFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpCommentAuthorEdge {
+  next: WpCommentAuthor
+  node: WpCommentAuthor!
+  previous: WpCommentAuthor
+}
+
+enum WpCommentAuthorFieldsEnum {
+  avatar___default
+  avatar___extraAttr
+  avatar___forceDefault
+  avatar___foundAvatar
+  avatar___height
+  avatar___rating
+  avatar___scheme
+  avatar___size
+  avatar___url
+  avatar___width
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  databaseId
+  email
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  name
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  url
+}
+
+input WpCommentAuthorFilterInput {
+  avatar: WpAvatarFilterInput
+  children: NodeFilterListInput
+  databaseId: IntQueryOperatorInput
+  email: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  name: StringQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  url: StringQueryOperatorInput
+}
+
+type WpCommentAuthorGroupConnection {
+  distinct(field: WpCommentAuthorFieldsEnum!): [String!]!
+  edges: [WpCommentAuthorEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpCommentAuthorFieldsEnum!, limit: Int, skip: Int): [WpCommentAuthorGroupConnection!]!
+  max(field: WpCommentAuthorFieldsEnum!): Float
+  min(field: WpCommentAuthorFieldsEnum!): Float
+  nodes: [WpCommentAuthor!]!
+  pageInfo: PageInfo!
+  sum(field: WpCommentAuthorFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpCommentAuthorSortInput {
+  fields: [WpCommentAuthorFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+type WpCommentConnection {
+  distinct(field: WpCommentFieldsEnum!): [String!]!
+  edges: [WpCommentEdge!]!
+  group(field: WpCommentFieldsEnum!, limit: Int, skip: Int): [WpCommentGroupConnection!]!
+  max(field: WpCommentFieldsEnum!): Float
+  min(field: WpCommentFieldsEnum!): Float
+  nodes: [WpComment!]!
+  pageInfo: PageInfo!
+  sum(field: WpCommentFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpCommentEdge {
+  next: WpComment
+  node: WpComment!
+  previous: WpComment
+}
+
+enum WpCommentFieldsEnum {
+  agent
+  approved
+  authorIp
+  author___node___avatar___default
+  author___node___avatar___extraAttr
+  author___node___avatar___forceDefault
+  author___node___avatar___foundAvatar
+  author___node___avatar___height
+  author___node___avatar___rating
+  author___node___avatar___scheme
+  author___node___avatar___size
+  author___node___avatar___url
+  author___node___avatar___width
+  author___node___databaseId
+  author___node___email
+  author___node___id
+  author___node___name
+  author___node___url
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  commentedOn___node___children
+  commentedOn___node___children___children
+  commentedOn___node___children___id
+  commentedOn___node___contentTypeName
+  commentedOn___node___databaseId
+  commentedOn___node___date
+  commentedOn___node___dateGmt
+  commentedOn___node___desiredSlug
+  commentedOn___node___enclosure
+  commentedOn___node___guid
+  commentedOn___node___id
+  commentedOn___node___internal___content
+  commentedOn___node___internal___contentDigest
+  commentedOn___node___internal___description
+  commentedOn___node___internal___fieldOwners
+  commentedOn___node___internal___ignoreType
+  commentedOn___node___internal___mediaType
+  commentedOn___node___internal___owner
+  commentedOn___node___internal___type
+  commentedOn___node___isContentNode
+  commentedOn___node___isTermNode
+  commentedOn___node___link
+  commentedOn___node___modified
+  commentedOn___node___modifiedGmt
+  commentedOn___node___nodeType
+  commentedOn___node___parent___children
+  commentedOn___node___parent___id
+  commentedOn___node___slug
+  commentedOn___node___status
+  commentedOn___node___template___templateName
+  commentedOn___node___uri
+  content
+  databaseId
+  date
+  dateGmt
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  karma
+  nodeType
+  parentDatabaseId
+  parentId
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  replies___nodes
+  replies___nodes___agent
+  replies___nodes___approved
+  replies___nodes___authorIp
+  replies___nodes___children
+  replies___nodes___children___children
+  replies___nodes___children___id
+  replies___nodes___content
+  replies___nodes___databaseId
+  replies___nodes___date
+  replies___nodes___dateGmt
+  replies___nodes___id
+  replies___nodes___internal___content
+  replies___nodes___internal___contentDigest
+  replies___nodes___internal___description
+  replies___nodes___internal___fieldOwners
+  replies___nodes___internal___ignoreType
+  replies___nodes___internal___mediaType
+  replies___nodes___internal___owner
+  replies___nodes___internal___type
+  replies___nodes___karma
+  replies___nodes___nodeType
+  replies___nodes___parentDatabaseId
+  replies___nodes___parentId
+  replies___nodes___parent___children
+  replies___nodes___parent___id
+  replies___nodes___replies___nodes
+  replies___nodes___type
+  type
+  wpParent___node___agent
+  wpParent___node___approved
+  wpParent___node___authorIp
+  wpParent___node___children
+  wpParent___node___children___children
+  wpParent___node___children___id
+  wpParent___node___content
+  wpParent___node___databaseId
+  wpParent___node___date
+  wpParent___node___dateGmt
+  wpParent___node___id
+  wpParent___node___internal___content
+  wpParent___node___internal___contentDigest
+  wpParent___node___internal___description
+  wpParent___node___internal___fieldOwners
+  wpParent___node___internal___ignoreType
+  wpParent___node___internal___mediaType
+  wpParent___node___internal___owner
+  wpParent___node___internal___type
+  wpParent___node___karma
+  wpParent___node___nodeType
+  wpParent___node___parentDatabaseId
+  wpParent___node___parentId
+  wpParent___node___parent___children
+  wpParent___node___parent___id
+  wpParent___node___replies___nodes
+  wpParent___node___type
+}
+
+input WpCommentFilterInput {
+  agent: StringQueryOperatorInput
+  approved: BooleanQueryOperatorInput
+  author: WpCommentToCommenterConnectionEdgeFilterInput
+  authorIp: StringQueryOperatorInput
+  children: NodeFilterListInput
+  commentedOn: WpCommentToContentNodeConnectionEdgeFilterInput
+  content: StringQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  date: DateQueryOperatorInput
+  dateGmt: DateQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  karma: IntQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  parentDatabaseId: IntQueryOperatorInput
+  parentId: IDQueryOperatorInput
+  replies: WpCommentToCommentConnectionFilterInput
+  type: StringQueryOperatorInput
+  wpParent: WpCommentToParentCommentConnectionEdgeFilterInput
+}
+
+input WpCommentFilterListInput {
+  elemMatch: WpCommentFilterInput
+}
+
+type WpCommentGroupConnection {
+  distinct(field: WpCommentFieldsEnum!): [String!]!
+  edges: [WpCommentEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpCommentFieldsEnum!, limit: Int, skip: Int): [WpCommentGroupConnection!]!
+  max(field: WpCommentFieldsEnum!): Float
+  min(field: WpCommentFieldsEnum!): Float
+  nodes: [WpComment!]!
+  pageInfo: PageInfo!
+  sum(field: WpCommentFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpCommentSortInput {
+  fields: [WpCommentFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the Comment type and the Comment type
+"""
+type WpCommentToCommentConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpComment]
+}
+
+input WpCommentToCommentConnectionFilterInput {
+  nodes: WpCommentFilterListInput
+}
+
+"""
+Connection between the Comment type and the Commenter type
+"""
+type WpCommentToCommenterConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpCommenter
+}
+
+input WpCommentToCommenterConnectionEdgeFilterInput {
+  node: WpCommenterFilterInput
+}
+
+"""
+Connection between the Comment type and the ContentNode type
+"""
+type WpCommentToContentNodeConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpContentNode
+}
+
+input WpCommentToContentNodeConnectionEdgeFilterInput {
+  node: WpContentNodeFilterInput
+}
+
+"""
+Connection between the Comment type and the Comment type
+"""
+type WpCommentToParentCommentConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpComment
+}
+
+input WpCommentToParentCommentConnectionEdgeFilterInput {
+  node: WpCommentFilterInput
+}
+
+interface WpCommenter {
+  """
+  Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument.
+  """
+  avatar: WpAvatar
+
+  """
+  Identifies the primary key from the database.
+  """
+  databaseId: Int!
+
+  """
+  The email address of the author of a comment.
+  """
+  email: String
+
+  """
+  The globally unique identifier for the comment author.
+  """
+  id: ID!
+
+  """
+  The name of the author of a comment.
+  """
+  name: String
+
+  """
+  The url of the author of a comment.
+  """
+  url: String
+}
+
+input WpCommenterFilterInput {
+  avatar: WpAvatarFilterInput
+  databaseId: IntQueryOperatorInput
+  email: StringQueryOperatorInput
+  id: IDQueryOperatorInput
+  name: StringQueryOperatorInput
+  url: StringQueryOperatorInput
+}
+
+type WpConnection {
+  distinct(field: WpFieldsEnum!): [String!]!
+  edges: [WpEdge!]!
+  group(field: WpFieldsEnum!, limit: Int, skip: Int): [WpGroupConnection!]!
+  max(field: WpFieldsEnum!): Float
+  min(field: WpFieldsEnum!): Float
+  nodes: [Wp!]!
+  pageInfo: PageInfo!
+  sum(field: WpFieldsEnum!): Float
+  totalCount: Int!
+}
+
+interface WpContentNode implements Node {
+  children: [Node!]!
+
+  """
+  Connection between the ContentNode type and the ContentType type
+  """
+  contentType: WpContentNodeToContentTypeConnectionEdge
+
+  """
+  The name of the Content Type the node belongs to
+  """
+  contentTypeName: String!
+
+  """
+  The ID of the node in the database.
+  """
+  databaseId: Int!
+
+  """
+  Post publishing date.
+  """
+  date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The publishing date set in GMT.
+  """
+  dateGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The desired slug of the post
+  """
+  desiredSlug: String
+
+  """
+  The RSS enclosure for the object
+  """
+  enclosure: String
+
+  """
+  The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table.
+  """
+  guid: String
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The user that most recently edited the node
+  """
+  lastEditedBy: WpContentNodeToEditLastConnectionEdge
+
+  """
+  The permalink of the post
+  """
+  link: String
+
+  """
+  The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.
+  """
+  modified(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.
+  """
+  modifiedGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  nodeType: String
+  parent: Node
+
+  """
+  The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table.
+  """
+  slug: String
+
+  """
+  The current status of the object
+  """
+  status: String
+
+  """
+  The template assigned to a node of content
+  """
+  template: WpContentTemplate
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+}
+
+type WpContentNodeConnection {
+  distinct(field: WpContentNodeFieldsEnum!): [String!]!
+  edges: [WpContentNodeEdge!]!
+  group(field: WpContentNodeFieldsEnum!, limit: Int, skip: Int): [WpContentNodeGroupConnection!]!
+  max(field: WpContentNodeFieldsEnum!): Float
+  min(field: WpContentNodeFieldsEnum!): Float
+  nodes: [WpContentNode!]!
+  pageInfo: PageInfo!
+  sum(field: WpContentNodeFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpContentNodeEdge {
+  next: WpContentNode
+  node: WpContentNode!
+  previous: WpContentNode
+}
+
+enum WpContentNodeFieldsEnum {
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  contentTypeName
+  contentType___node___archivePath
+  contentType___node___canExport
+  contentType___node___children
+  contentType___node___children___children
+  contentType___node___children___id
+  contentType___node___connectedTaxonomies___nodes
+  contentType___node___contentNodes___nodes
+  contentType___node___deleteWithUser
+  contentType___node___description
+  contentType___node___excludeFromSearch
+  contentType___node___graphqlPluralName
+  contentType___node___graphqlSingleName
+  contentType___node___hasArchive
+  contentType___node___hierarchical
+  contentType___node___id
+  contentType___node___internal___content
+  contentType___node___internal___contentDigest
+  contentType___node___internal___description
+  contentType___node___internal___fieldOwners
+  contentType___node___internal___ignoreType
+  contentType___node___internal___mediaType
+  contentType___node___internal___owner
+  contentType___node___internal___type
+  contentType___node___isContentNode
+  contentType___node___isFrontPage
+  contentType___node___isPostsPage
+  contentType___node___isTermNode
+  contentType___node___label
+  contentType___node___labels___addNew
+  contentType___node___labels___addNewItem
+  contentType___node___labels___allItems
+  contentType___node___labels___archives
+  contentType___node___labels___attributes
+  contentType___node___labels___editItem
+  contentType___node___labels___featuredImage
+  contentType___node___labels___filterItemsList
+  contentType___node___labels___insertIntoItem
+  contentType___node___labels___itemsList
+  contentType___node___labels___itemsListNavigation
+  contentType___node___labels___menuName
+  contentType___node___labels___name
+  contentType___node___labels___newItem
+  contentType___node___labels___notFound
+  contentType___node___labels___notFoundInTrash
+  contentType___node___labels___parentItemColon
+  contentType___node___labels___removeFeaturedImage
+  contentType___node___labels___searchItems
+  contentType___node___labels___setFeaturedImage
+  contentType___node___labels___singularName
+  contentType___node___labels___uploadedToThisItem
+  contentType___node___labels___useFeaturedImage
+  contentType___node___labels___viewItem
+  contentType___node___labels___viewItems
+  contentType___node___menuIcon
+  contentType___node___menuPosition
+  contentType___node___name
+  contentType___node___nodeType
+  contentType___node___parent___children
+  contentType___node___parent___id
+  contentType___node___public
+  contentType___node___publiclyQueryable
+  contentType___node___restBase
+  contentType___node___restControllerClass
+  contentType___node___showInAdminBar
+  contentType___node___showInGraphql
+  contentType___node___showInMenu
+  contentType___node___showInNavMenus
+  contentType___node___showInRest
+  contentType___node___showUi
+  contentType___node___uri
+  databaseId
+  date
+  dateGmt
+  desiredSlug
+  enclosure
+  guid
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isTermNode
+  lastEditedBy___node___avatar___default
+  lastEditedBy___node___avatar___extraAttr
+  lastEditedBy___node___avatar___forceDefault
+  lastEditedBy___node___avatar___foundAvatar
+  lastEditedBy___node___avatar___height
+  lastEditedBy___node___avatar___rating
+  lastEditedBy___node___avatar___scheme
+  lastEditedBy___node___avatar___size
+  lastEditedBy___node___avatar___url
+  lastEditedBy___node___avatar___width
+  lastEditedBy___node___blockEditorPreviews___nodes
+  lastEditedBy___node___capKey
+  lastEditedBy___node___capabilities
+  lastEditedBy___node___children
+  lastEditedBy___node___children___children
+  lastEditedBy___node___children___id
+  lastEditedBy___node___comments___nodes
+  lastEditedBy___node___databaseId
+  lastEditedBy___node___description
+  lastEditedBy___node___email
+  lastEditedBy___node___extraCapabilities
+  lastEditedBy___node___firstName
+  lastEditedBy___node___id
+  lastEditedBy___node___internal___content
+  lastEditedBy___node___internal___contentDigest
+  lastEditedBy___node___internal___description
+  lastEditedBy___node___internal___fieldOwners
+  lastEditedBy___node___internal___ignoreType
+  lastEditedBy___node___internal___mediaType
+  lastEditedBy___node___internal___owner
+  lastEditedBy___node___internal___type
+  lastEditedBy___node___isContentNode
+  lastEditedBy___node___isTermNode
+  lastEditedBy___node___lastName
+  lastEditedBy___node___locale
+  lastEditedBy___node___name
+  lastEditedBy___node___nicename
+  lastEditedBy___node___nickname
+  lastEditedBy___node___nodeType
+  lastEditedBy___node___pages___nodes
+  lastEditedBy___node___parent___children
+  lastEditedBy___node___parent___id
+  lastEditedBy___node___posts___nodes
+  lastEditedBy___node___registeredDate
+  lastEditedBy___node___roles___nodes
+  lastEditedBy___node___slug
+  lastEditedBy___node___uri
+  lastEditedBy___node___url
+  lastEditedBy___node___username
+  link
+  modified
+  modifiedGmt
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  slug
+  status
+  template___templateName
+  uri
+}
+
+input WpContentNodeFilterInput {
+  children: NodeFilterListInput
+  contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+  contentTypeName: StringQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  date: DateQueryOperatorInput
+  dateGmt: DateQueryOperatorInput
+  desiredSlug: StringQueryOperatorInput
+  enclosure: StringQueryOperatorInput
+  guid: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+  link: StringQueryOperatorInput
+  modified: DateQueryOperatorInput
+  modifiedGmt: DateQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  slug: StringQueryOperatorInput
+  status: StringQueryOperatorInput
+  template: WpContentTemplateFilterInput
+  uri: StringQueryOperatorInput
+}
+
+input WpContentNodeFilterListInput {
+  elemMatch: WpContentNodeFilterInput
+}
+
+type WpContentNodeGroupConnection {
+  distinct(field: WpContentNodeFieldsEnum!): [String!]!
+  edges: [WpContentNodeEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpContentNodeFieldsEnum!, limit: Int, skip: Int): [WpContentNodeGroupConnection!]!
+  max(field: WpContentNodeFieldsEnum!): Float
+  min(field: WpContentNodeFieldsEnum!): Float
+  nodes: [WpContentNode!]!
+  pageInfo: PageInfo!
+  sum(field: WpContentNodeFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpContentNodeSortInput {
+  fields: [WpContentNodeFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the ContentNode type and the ContentType type
+"""
+type WpContentNodeToContentTypeConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpContentType
+}
+
+input WpContentNodeToContentTypeConnectionEdgeFilterInput {
+  node: WpContentTypeFilterInput
+}
+
+"""
+Connection between the ContentNode type and the User type
+"""
+type WpContentNodeToEditLastConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpUser
+}
+
+input WpContentNodeToEditLastConnectionEdgeFilterInput {
+  node: WpUserFilterInput
+}
+
+"""
+Connection between the ContentNode type and the User type
+"""
+type WpContentNodeToEditLockConnectionEdge {
+  """
+  The timestamp for when the node was last edited
+  """
+  lockTimestamp: String
+
+  """
+  The node of the connection, without the edges
+  """
+  node: WpUser
+}
+
+interface WpContentTemplate {
+  """
+  The name of the template
+  """
+  templateName: String
+}
+
+input WpContentTemplateFilterInput {
+  templateName: StringQueryOperatorInput
+}
+
+"""
+An Post Type object
+"""
+type WpContentType implements Node & WpNode & WpUniformResourceIdentifiable {
+  """
+  The url path of the first page of the archive page for this content type.
+  """
+  archivePath: String
+
+  """
+  Whether this content type should can be exported.
+  """
+  canExport: Boolean
+  children: [Node!]!
+
+  """
+  Connection between the ContentType type and the Taxonomy type
+  """
+  connectedTaxonomies: WpContentTypeToTaxonomyConnection
+
+  """
+  Connection between the ContentType type and the ContentNode type
+  """
+  contentNodes: WpContentTypeToContentNodeConnection
+
+  """
+  Whether content of this type should be deleted when the author of it is deleted from the system.
+  """
+  deleteWithUser: Boolean
+
+  """
+  Description of the content type.
+  """
+  description: String
+
+  """
+  Whether to exclude nodes of this content type from front end search results.
+  """
+  excludeFromSearch: Boolean
+
+  """
+  The plural name of the content type within the GraphQL Schema.
+  """
+  graphqlPluralName: String
+
+  """
+  The singular name of the content type within the GraphQL Schema.
+  """
+  graphqlSingleName: String
+
+  """
+  Whether this content type should have archives. Content archives are generated by type and by date.
+  """
+  hasArchive: Boolean
+
+  """
+  Whether the content type is hierarchical, for example pages.
+  """
+  hierarchical: Boolean
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether this page is set to the static front page.
+  """
+  isFrontPage: Boolean!
+
+  """
+  Whether this page is set to the blog posts page.
+  """
+  isPostsPage: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  Display name of the content type.
+  """
+  label: String
+
+  """
+  Details about the content type labels.
+  """
+  labels: WpPostTypeLabelDetails
+
+  """
+  The name of the icon file to display as a menu icon.
+  """
+  menuIcon: String
+
+  """
+  The position of this post type in the menu. Only applies if show_in_menu is true.
+  """
+  menuPosition: Int
+
+  """
+  The internal name of the post type. This should not be used for display purposes.
+  """
+  name: String
+  nodeType: String
+  parent: Node
+
+  """
+  Whether a content type is intended for use publicly either via the admin interface or by front-end users. While the default settings of exclude_from_search, publicly_queryable, show_ui, and show_in_nav_menus are inherited from public, each does not rely on this relationship and controls a very specific intention.
+  """
+  public: Boolean
+
+  """
+  Whether queries can be performed on the front end for the content type as part of parse_request().
+  """
+  publiclyQueryable: Boolean
+
+  """
+  Name of content type to display in REST API &quot;wp/v2&quot; namespace.
+  """
+  restBase: String
+
+  """
+  The REST Controller class assigned to handling this content type.
+  """
+  restControllerClass: String
+
+  """
+  Makes this content type available via the admin bar.
+  """
+  showInAdminBar: Boolean
+
+  """
+  Whether to add the content type to the GraphQL Schema.
+  """
+  showInGraphql: Boolean
+
+  """
+  Where to show the content type in the admin menu. To work, $show_ui must be true. If true, the post type is shown in its own top level menu. If false, no menu is shown. If a string of an existing top level menu (eg. &quot;tools.php&quot; or &quot;edit.php?post_type=page&quot;), the post type will be placed as a sub-menu of that.
+  """
+  showInMenu: Boolean
+
+  """
+  Makes this content type available for selection in navigation menus.
+  """
+  showInNavMenus: Boolean
+
+  """
+  Whether the content type is associated with a route under the the REST API &quot;wp/v2&quot; namespace.
+  """
+  showInRest: Boolean
+
+  """
+  Whether to generate and allow a UI for managing this content type in the admin.
+  """
+  showUi: Boolean
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+}
+
+type WpContentTypeConnection {
+  distinct(field: WpContentTypeFieldsEnum!): [String!]!
+  edges: [WpContentTypeEdge!]!
+  group(field: WpContentTypeFieldsEnum!, limit: Int, skip: Int): [WpContentTypeGroupConnection!]!
+  max(field: WpContentTypeFieldsEnum!): Float
+  min(field: WpContentTypeFieldsEnum!): Float
+  nodes: [WpContentType!]!
+  pageInfo: PageInfo!
+  sum(field: WpContentTypeFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpContentTypeEdge {
+  next: WpContentType
+  node: WpContentType!
+  previous: WpContentType
+}
+
+enum WpContentTypeFieldsEnum {
+  archivePath
+  canExport
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  connectedTaxonomies___nodes
+  connectedTaxonomies___nodes___archivePath
+  connectedTaxonomies___nodes___children
+  connectedTaxonomies___nodes___children___children
+  connectedTaxonomies___nodes___children___id
+  connectedTaxonomies___nodes___connectedContentTypes___nodes
+  connectedTaxonomies___nodes___description
+  connectedTaxonomies___nodes___graphqlPluralName
+  connectedTaxonomies___nodes___graphqlSingleName
+  connectedTaxonomies___nodes___hierarchical
+  connectedTaxonomies___nodes___id
+  connectedTaxonomies___nodes___internal___content
+  connectedTaxonomies___nodes___internal___contentDigest
+  connectedTaxonomies___nodes___internal___description
+  connectedTaxonomies___nodes___internal___fieldOwners
+  connectedTaxonomies___nodes___internal___ignoreType
+  connectedTaxonomies___nodes___internal___mediaType
+  connectedTaxonomies___nodes___internal___owner
+  connectedTaxonomies___nodes___internal___type
+  connectedTaxonomies___nodes___label
+  connectedTaxonomies___nodes___name
+  connectedTaxonomies___nodes___nodeType
+  connectedTaxonomies___nodes___parent___children
+  connectedTaxonomies___nodes___parent___id
+  connectedTaxonomies___nodes___public
+  connectedTaxonomies___nodes___restBase
+  connectedTaxonomies___nodes___restControllerClass
+  connectedTaxonomies___nodes___showCloud
+  connectedTaxonomies___nodes___showInAdminColumn
+  connectedTaxonomies___nodes___showInGraphql
+  connectedTaxonomies___nodes___showInMenu
+  connectedTaxonomies___nodes___showInNavMenus
+  connectedTaxonomies___nodes___showInQuickEdit
+  connectedTaxonomies___nodes___showInRest
+  connectedTaxonomies___nodes___showUi
+  contentNodes___nodes
+  contentNodes___nodes___children
+  contentNodes___nodes___children___children
+  contentNodes___nodes___children___id
+  contentNodes___nodes___contentTypeName
+  contentNodes___nodes___databaseId
+  contentNodes___nodes___date
+  contentNodes___nodes___dateGmt
+  contentNodes___nodes___desiredSlug
+  contentNodes___nodes___enclosure
+  contentNodes___nodes___guid
+  contentNodes___nodes___id
+  contentNodes___nodes___internal___content
+  contentNodes___nodes___internal___contentDigest
+  contentNodes___nodes___internal___description
+  contentNodes___nodes___internal___fieldOwners
+  contentNodes___nodes___internal___ignoreType
+  contentNodes___nodes___internal___mediaType
+  contentNodes___nodes___internal___owner
+  contentNodes___nodes___internal___type
+  contentNodes___nodes___isContentNode
+  contentNodes___nodes___isTermNode
+  contentNodes___nodes___link
+  contentNodes___nodes___modified
+  contentNodes___nodes___modifiedGmt
+  contentNodes___nodes___nodeType
+  contentNodes___nodes___parent___children
+  contentNodes___nodes___parent___id
+  contentNodes___nodes___slug
+  contentNodes___nodes___status
+  contentNodes___nodes___template___templateName
+  contentNodes___nodes___uri
+  deleteWithUser
+  description
+  excludeFromSearch
+  graphqlPluralName
+  graphqlSingleName
+  hasArchive
+  hierarchical
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isFrontPage
+  isPostsPage
+  isTermNode
+  label
+  labels___addNew
+  labels___addNewItem
+  labels___allItems
+  labels___archives
+  labels___attributes
+  labels___editItem
+  labels___featuredImage
+  labels___filterItemsList
+  labels___insertIntoItem
+  labels___itemsList
+  labels___itemsListNavigation
+  labels___menuName
+  labels___name
+  labels___newItem
+  labels___notFound
+  labels___notFoundInTrash
+  labels___parentItemColon
+  labels___removeFeaturedImage
+  labels___searchItems
+  labels___setFeaturedImage
+  labels___singularName
+  labels___uploadedToThisItem
+  labels___useFeaturedImage
+  labels___viewItem
+  labels___viewItems
+  menuIcon
+  menuPosition
+  name
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  public
+  publiclyQueryable
+  restBase
+  restControllerClass
+  showInAdminBar
+  showInGraphql
+  showInMenu
+  showInNavMenus
+  showInRest
+  showUi
+  uri
+}
+
+input WpContentTypeFilterInput {
+  archivePath: StringQueryOperatorInput
+  canExport: BooleanQueryOperatorInput
+  children: NodeFilterListInput
+  connectedTaxonomies: WpContentTypeToTaxonomyConnectionFilterInput
+  contentNodes: WpContentTypeToContentNodeConnectionFilterInput
+  deleteWithUser: BooleanQueryOperatorInput
+  description: StringQueryOperatorInput
+  excludeFromSearch: BooleanQueryOperatorInput
+  graphqlPluralName: StringQueryOperatorInput
+  graphqlSingleName: StringQueryOperatorInput
+  hasArchive: BooleanQueryOperatorInput
+  hierarchical: BooleanQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isFrontPage: BooleanQueryOperatorInput
+  isPostsPage: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  label: StringQueryOperatorInput
+  labels: WpPostTypeLabelDetailsFilterInput
+  menuIcon: StringQueryOperatorInput
+  menuPosition: IntQueryOperatorInput
+  name: StringQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  public: BooleanQueryOperatorInput
+  publiclyQueryable: BooleanQueryOperatorInput
+  restBase: StringQueryOperatorInput
+  restControllerClass: StringQueryOperatorInput
+  showInAdminBar: BooleanQueryOperatorInput
+  showInGraphql: BooleanQueryOperatorInput
+  showInMenu: BooleanQueryOperatorInput
+  showInNavMenus: BooleanQueryOperatorInput
+  showInRest: BooleanQueryOperatorInput
+  showUi: BooleanQueryOperatorInput
+  uri: StringQueryOperatorInput
+}
+
+input WpContentTypeFilterListInput {
+  elemMatch: WpContentTypeFilterInput
+}
+
+type WpContentTypeGroupConnection {
+  distinct(field: WpContentTypeFieldsEnum!): [String!]!
+  edges: [WpContentTypeEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpContentTypeFieldsEnum!, limit: Int, skip: Int): [WpContentTypeGroupConnection!]!
+  max(field: WpContentTypeFieldsEnum!): Float
+  min(field: WpContentTypeFieldsEnum!): Float
+  nodes: [WpContentType!]!
+  pageInfo: PageInfo!
+  sum(field: WpContentTypeFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpContentTypeSortInput {
+  fields: [WpContentTypeFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the ContentType type and the ContentNode type
+"""
+type WpContentTypeToContentNodeConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpContentNode]
+}
+
+input WpContentTypeToContentNodeConnectionFilterInput {
+  nodes: WpContentNodeFilterListInput
+}
+
+"""
+Connection between the ContentType type and the Taxonomy type
+"""
+type WpContentTypeToTaxonomyConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpTaxonomy]
+}
+
+input WpContentTypeToTaxonomyConnectionFilterInput {
+  nodes: WpTaxonomyFilterListInput
+}
+
+"""
+core/archives block
+"""
+type WpCoreArchivesBlock implements WpBlock {
+  attributes: WpCoreArchivesBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreArchivesBlockAttributes {
+  align: String
+  className: String
+  displayAsDropdown: Boolean!
+  lock: JSON
+  showPostCounts: Boolean!
+}
+
+"""
+core/audio block
+"""
+type WpCoreAudioBlock implements WpBlock {
+  attributes: WpCoreAudioBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreAudioBlockAttributes {
+  align: String
+  anchor: String
+  autoplay: Boolean
+  caption: String
+  className: String
+  id: Float
+  lock: JSON
+  loop: Boolean
+  preload: String
+  src: String
+}
+
+union WpCoreAudioBlockAttributesUnion = WpCoreAudioBlockAttributes | WpCoreAudioBlockDeprecatedV1Attributes
+
+type WpCoreAudioBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  autoplay: Boolean
+  caption: String
+  className: String
+  id: Float
+  lock: JSON
+  loop: Boolean
+  preload: String
+  src: String
+}
+
+"""
+core/block block
+"""
+type WpCoreBlock implements WpBlock {
+  attributes: WpCoreBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+  reusableBlock: WpNode!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreBlockAttributes {
+  lock: JSON
+  ref: Float
+}
+
+"""
+core/button block
+"""
+type WpCoreButtonBlock implements WpBlock {
+  attributes: WpCoreButtonBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreButtonBlockAttributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  linkTarget: String
+  lock: JSON
+  placeholder: String
+  rel: String
+  style: JSON
+  text: String
+  textColor: String
+  title: String
+  url: String
+  width: Float
+}
+
+union WpCoreButtonBlockAttributesUnion =
+    WpCoreButtonBlockAttributes
+  | WpCoreButtonBlockDeprecatedV1Attributes
+  | WpCoreButtonBlockDeprecatedV2Attributes
+  | WpCoreButtonBlockDeprecatedV3Attributes
+  | WpCoreButtonBlockDeprecatedV4Attributes
+  | WpCoreButtonBlockDeprecatedV5Attributes
+  | WpCoreButtonBlockDeprecatedV6Attributes
+  | WpCoreButtonBlockDeprecatedV7Attributes
+  | WpCoreButtonBlockDeprecatedV8Attributes
+  | WpCoreButtonBlockDeprecatedV9Attributes
+  | WpCoreButtonBlockDeprecatedV10Attributes
+
+type WpCoreButtonBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  linkTarget: String
+  lock: JSON
+  placeholder: String
+  rel: String
+  style: JSON
+  text: String
+  textColor: String
+  title: String
+  url: String
+  width: Float
+}
+
+type WpCoreButtonBlockDeprecatedV2Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  linkTarget: String
+  lock: JSON
+  placeholder: String
+  rel: String
+  style: JSON
+  text: String
+  textColor: String
+  title: String
+  url: String
+  width: Float
+}
+
+type WpCoreButtonBlockDeprecatedV3Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  linkTarget: String
+  lock: JSON
+  placeholder: String
+  rel: String
+  style: JSON
+  text: String
+  textColor: String
+  title: String
+  url: String
+  width: Float
+}
+
+type WpCoreButtonBlockDeprecatedV4Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  linkTarget: String
+  lock: JSON
+  placeholder: String
+  rel: String
+  style: JSON
+  text: String
+  textColor: String
+  title: String
+  url: String
+  width: Float
+}
+
+type WpCoreButtonBlockDeprecatedV5Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  linkTarget: String
+  lock: JSON
+  placeholder: String
+  rel: String
+  style: JSON
+  text: String
+  textColor: String
+  title: String
+  url: String
+  width: Float
+}
+
+type WpCoreButtonBlockDeprecatedV6Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  linkTarget: String
+  lock: JSON
+  placeholder: String
+  rel: String
+  style: JSON
+  text: String
+  textColor: String
+  title: String
+  url: String
+  width: Float
+}
+
+type WpCoreButtonBlockDeprecatedV7Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  linkTarget: String
+  lock: JSON
+  placeholder: String
+  rel: String
+  style: JSON
+  text: String
+  textColor: String
+  title: String
+  url: String
+  width: Float
+}
+
+type WpCoreButtonBlockDeprecatedV8Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  linkTarget: String
+  lock: JSON
+  placeholder: String
+  rel: String
+  style: JSON
+  text: String
+  textColor: String
+  title: String
+  url: String
+  width: Float
+}
+
+type WpCoreButtonBlockDeprecatedV9Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  linkTarget: String
+  lock: JSON
+  placeholder: String
+  rel: String
+  style: JSON
+  text: String
+  textColor: String
+  title: String
+  url: String
+  width: Float
+}
+
+type WpCoreButtonBlockDeprecatedV10Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  linkTarget: String
+  lock: JSON
+  placeholder: String
+  rel: String
+  style: JSON
+  text: String
+  textColor: String
+  title: String
+  url: String
+  width: Float
+}
+
+"""
+core/buttons block
+"""
+type WpCoreButtonsBlock implements WpBlock {
+  attributes: WpCoreButtonsBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreButtonsBlockAttributes {
+  align: String
+  anchor: String
+  className: String
+  layout: JSON
+  lock: JSON
+  style: JSON
+}
+
+union WpCoreButtonsBlockAttributesUnion =
+    WpCoreButtonsBlockAttributes
+  | WpCoreButtonsBlockDeprecatedV1Attributes
+  | WpCoreButtonsBlockDeprecatedV2Attributes
+
+type WpCoreButtonsBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  className: String
+  layout: JSON
+  lock: JSON
+  style: JSON
+}
+
+type WpCoreButtonsBlockDeprecatedV2Attributes {
+  align: String
+  anchor: String
+  className: String
+  layout: JSON
+  lock: JSON
+  style: JSON
+}
+
+"""
+core/calendar block
+"""
+type WpCoreCalendarBlock implements WpBlock {
+  attributes: WpCoreCalendarBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreCalendarBlockAttributes {
+  align: String
+  className: String
+  lock: JSON
+  month: Int
+  year: Int
+}
+
+"""
+core/categories block
+"""
+type WpCoreCategoriesBlock implements WpBlock {
+  attributes: WpCoreCategoriesBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreCategoriesBlockAttributes {
+  align: String
+  className: String
+  displayAsDropdown: Boolean!
+  lock: JSON
+  showHierarchy: Boolean!
+  showOnlyTopLevel: Boolean!
+  showPostCounts: Boolean!
+}
+
+"""
+core/code block
+"""
+type WpCoreCodeBlock implements WpBlock {
+  attributes: WpCoreCodeBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreCodeBlockAttributes {
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  className: String
+  content: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textColor: String
+}
+
+"""
+core/column block
+"""
+type WpCoreColumnBlock implements WpBlock {
+  attributes: WpCoreColumnBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreColumnBlockAttributes {
+  allowedBlocks: JSON
+  anchor: String
+  backgroundColor: String
+  className: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textColor: String
+  verticalAlignment: String
+  width: String
+}
+
+union WpCoreColumnBlockAttributesUnion = WpCoreColumnBlockAttributes | WpCoreColumnBlockDeprecatedV1Attributes
+
+type WpCoreColumnBlockDeprecatedV1Attributes {
+  allowedBlocks: JSON
+  anchor: String
+  backgroundColor: String
+  className: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textColor: String
+  verticalAlignment: String
+  width: String
+}
+
+"""
+core/columns block
+"""
+type WpCoreColumnsBlock implements WpBlock {
+  attributes: WpCoreColumnsBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreColumnsBlockAttributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  gradient: String
+  isStackedOnMobile: Boolean!
+  lock: JSON
+  style: JSON
+  textColor: String
+  verticalAlignment: String
+}
+
+union WpCoreColumnsBlockAttributesUnion =
+    WpCoreColumnsBlockAttributes
+  | WpCoreColumnsBlockDeprecatedV1Attributes
+  | WpCoreColumnsBlockDeprecatedV2Attributes
+  | WpCoreColumnsBlockDeprecatedV3Attributes
+
+type WpCoreColumnsBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  gradient: String
+  isStackedOnMobile: Boolean!
+  lock: JSON
+  style: JSON
+  textColor: String
+  verticalAlignment: String
+}
+
+type WpCoreColumnsBlockDeprecatedV2Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  gradient: String
+  isStackedOnMobile: Boolean!
+  lock: JSON
+  style: JSON
+  textColor: String
+  verticalAlignment: String
+}
+
+type WpCoreColumnsBlockDeprecatedV3Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  gradient: String
+  isStackedOnMobile: Boolean!
+  lock: JSON
+  style: JSON
+  textColor: String
+  verticalAlignment: String
+}
+
+"""
+core/cover block
+"""
+type WpCoreCoverBlock implements WpBlock {
+  attributes: WpCoreCoverBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreCoverBlockAttributes {
+  align: String
+  allowedBlocks: JSON
+  alt: String!
+  anchor: String
+  backgroundType: String!
+  className: String
+  contentPosition: String
+  customGradient: String
+  customOverlayColor: String
+  dimRatio: Float!
+  focalPoint: JSON
+  gradient: String
+  hasParallax: Boolean!
+  id: Float
+  isDark: Boolean!
+  isRepeated: Boolean!
+  lock: JSON
+  minHeight: Float
+  minHeightUnit: String
+  overlayColor: String
+  style: JSON
+  url: String
+}
+
+union WpCoreCoverBlockAttributesUnion =
+    WpCoreCoverBlockAttributes
+  | WpCoreCoverBlockDeprecatedV1Attributes
+  | WpCoreCoverBlockDeprecatedV2Attributes
+  | WpCoreCoverBlockDeprecatedV3Attributes
+  | WpCoreCoverBlockDeprecatedV4Attributes
+  | WpCoreCoverBlockDeprecatedV5Attributes
+  | WpCoreCoverBlockDeprecatedV6Attributes
+  | WpCoreCoverBlockDeprecatedV7Attributes
+
+type WpCoreCoverBlockDeprecatedV1Attributes {
+  align: String
+  allowedBlocks: JSON
+  alt: String!
+  anchor: String
+  backgroundType: String!
+  className: String
+  contentPosition: String
+  customGradient: String
+  customOverlayColor: String
+  dimRatio: Float!
+  focalPoint: JSON
+  gradient: String
+  hasParallax: Boolean!
+  id: Float
+  isDark: Boolean!
+  isRepeated: Boolean!
+  lock: JSON
+  minHeight: Float
+  minHeightUnit: String
+  overlayColor: String
+  style: JSON
+  url: String
+}
+
+type WpCoreCoverBlockDeprecatedV2Attributes {
+  align: String
+  allowedBlocks: JSON
+  alt: String!
+  anchor: String
+  backgroundType: String!
+  className: String
+  contentPosition: String
+  customGradient: String
+  customOverlayColor: String
+  dimRatio: Float!
+  focalPoint: JSON
+  gradient: String
+  hasParallax: Boolean!
+  id: Float
+  isDark: Boolean!
+  isRepeated: Boolean!
+  lock: JSON
+  minHeight: Float
+  minHeightUnit: String
+  overlayColor: String
+  style: JSON
+  url: String
+}
+
+type WpCoreCoverBlockDeprecatedV3Attributes {
+  align: String
+  allowedBlocks: JSON
+  alt: String!
+  anchor: String
+  backgroundType: String!
+  className: String
+  contentPosition: String
+  customGradient: String
+  customOverlayColor: String
+  dimRatio: Float!
+  focalPoint: JSON
+  gradient: String
+  hasParallax: Boolean!
+  id: Float
+  isDark: Boolean!
+  isRepeated: Boolean!
+  lock: JSON
+  minHeight: Float
+  minHeightUnit: String
+  overlayColor: String
+  style: JSON
+  url: String
+}
+
+type WpCoreCoverBlockDeprecatedV4Attributes {
+  align: String
+  allowedBlocks: JSON
+  alt: String!
+  anchor: String
+  backgroundType: String!
+  className: String
+  contentPosition: String
+  customGradient: String
+  customOverlayColor: String
+  dimRatio: Float!
+  focalPoint: JSON
+  gradient: String
+  hasParallax: Boolean!
+  id: Float
+  isDark: Boolean!
+  isRepeated: Boolean!
+  lock: JSON
+  minHeight: Float
+  minHeightUnit: String
+  overlayColor: String
+  style: JSON
+  url: String
+}
+
+type WpCoreCoverBlockDeprecatedV5Attributes {
+  align: String
+  allowedBlocks: JSON
+  alt: String!
+  anchor: String
+  backgroundType: String!
+  className: String
+  contentPosition: String
+  customGradient: String
+  customOverlayColor: String
+  dimRatio: Float!
+  focalPoint: JSON
+  gradient: String
+  hasParallax: Boolean!
+  id: Float
+  isDark: Boolean!
+  isRepeated: Boolean!
+  lock: JSON
+  minHeight: Float
+  minHeightUnit: String
+  overlayColor: String
+  style: JSON
+  url: String
+}
+
+type WpCoreCoverBlockDeprecatedV6Attributes {
+  align: String
+  allowedBlocks: JSON
+  alt: String!
+  anchor: String
+  backgroundType: String!
+  className: String
+  contentPosition: String
+  customGradient: String
+  customOverlayColor: String
+  dimRatio: Float!
+  focalPoint: JSON
+  gradient: String
+  hasParallax: Boolean!
+  id: Float
+  isDark: Boolean!
+  isRepeated: Boolean!
+  lock: JSON
+  minHeight: Float
+  minHeightUnit: String
+  overlayColor: String
+  style: JSON
+  url: String
+}
+
+type WpCoreCoverBlockDeprecatedV7Attributes {
+  align: String
+  allowedBlocks: JSON
+  alt: String!
+  anchor: String
+  backgroundType: String!
+  className: String
+  contentPosition: String
+  customGradient: String
+  customOverlayColor: String
+  dimRatio: Float!
+  focalPoint: JSON
+  gradient: String
+  hasParallax: Boolean!
+  id: Float
+  isDark: Boolean!
+  isRepeated: Boolean!
+  lock: JSON
+  minHeight: Float
+  minHeightUnit: String
+  overlayColor: String
+  style: JSON
+  url: String
+}
+
+"""
+core/embed block
+"""
+type WpCoreEmbedBlock implements WpBlock {
+  attributes: WpCoreEmbedBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreEmbedBlockAttributes {
+  align: String
+  allowResponsive: Boolean!
+  caption: String
+  className: String
+  lock: JSON
+  previewable: Boolean!
+  providerNameSlug: String
+  responsive: Boolean!
+  type: String
+  url: String
+}
+
+union WpCoreEmbedBlockAttributesUnion = WpCoreEmbedBlockAttributes | WpCoreEmbedBlockDeprecatedV1Attributes
+
+type WpCoreEmbedBlockDeprecatedV1Attributes {
+  align: String
+  allowResponsive: Boolean!
+  caption: String
+  className: String
+  lock: JSON
+  previewable: Boolean!
+  providerNameSlug: String
+  responsive: Boolean!
+  type: String
+  url: String
+}
+
+"""
+core/file block
+"""
+type WpCoreFileBlock implements WpBlock {
+  attributes: WpCoreFileBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreFileBlockAttributes {
+  align: String
+  anchor: String
+  className: String
+  displayPreview: Boolean
+  downloadButtonText: String
+  fileId: String
+  fileName: String
+  href: String
+  id: Float
+  lock: JSON
+  previewHeight: Float!
+  showDownloadButton: Boolean!
+  textLinkHref: String
+  textLinkTarget: String
+}
+
+union WpCoreFileBlockAttributesUnion = WpCoreFileBlockAttributes | WpCoreFileBlockDeprecatedV1Attributes
+
+type WpCoreFileBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  className: String
+  displayPreview: Boolean
+  downloadButtonText: String
+  fileId: String
+  fileName: String
+  href: String
+  id: Float
+  lock: JSON
+  previewHeight: Float!
+  showDownloadButton: Boolean!
+  textLinkHref: String
+  textLinkTarget: String
+}
+
+"""
+core/freeform block
+"""
+type WpCoreFreeformBlock implements WpBlock {
+  attributes: WpCoreFreeformBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreFreeformBlockAttributes {
+  content: String
+  lock: JSON
+}
+
+"""
+core/gallery block
+"""
+type WpCoreGalleryBlock implements WpBlock {
+  attributes: WpCoreGalleryBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreGalleryBlockAttributes {
+  align: String
+  allowResize: Boolean!
+  anchor: String
+  caption: String
+  className: String
+  columns: Float
+  fixedHeight: Boolean!
+  ids: [Float]!
+  imageCrop: Boolean!
+  images: [WpCoreGalleryBlockAttributesImages]!
+  linkTarget: String
+  linkTo: String
+  lock: JSON
+  shortCodeTransforms: [WpBlockAttributesObject]!
+  sizeSlug: String!
+}
+
+type WpCoreGalleryBlockAttributesImages {
+  alt: String!
+  caption: String
+  fullUrl: String
+  id: String
+  link: String
+  url: String
+}
+
+union WpCoreGalleryBlockAttributesUnion =
+    WpCoreGalleryBlockAttributes
+  | WpCoreGalleryBlockDeprecatedV1Attributes
+  | WpCoreGalleryBlockDeprecatedV2Attributes
+  | WpCoreGalleryBlockDeprecatedV3Attributes
+  | WpCoreGalleryBlockDeprecatedV4Attributes
+  | WpCoreGalleryBlockDeprecatedV5Attributes
+  | WpCoreGalleryBlockDeprecatedV6Attributes
+
+type WpCoreGalleryBlockDeprecatedV1Attributes {
+  align: String
+  allowResize: Boolean!
+  anchor: String
+  caption: String
+  className: String
+  columns: Float
+  fixedHeight: Boolean!
+  ids: [Float]!
+  imageCrop: Boolean!
+  images: [WpCoreGalleryBlockDeprecatedV1AttributesImages]!
+  linkTarget: String
+  linkTo: String
+  lock: JSON
+  shortCodeTransforms: [WpBlockAttributesObject]!
+  sizeSlug: String!
+}
+
+type WpCoreGalleryBlockDeprecatedV1AttributesImages {
+  alt: String!
+  caption: String
+  fullUrl: String
+  id: String
+  link: String
+  url: String
+}
+
+type WpCoreGalleryBlockDeprecatedV2Attributes {
+  align: String
+  allowResize: Boolean!
+  anchor: String
+  caption: String
+  className: String
+  columns: Float
+  fixedHeight: Boolean!
+  ids: [Float]!
+  imageCrop: Boolean!
+  images: [WpCoreGalleryBlockDeprecatedV2AttributesImages]!
+  linkTarget: String
+  linkTo: String
+  lock: JSON
+  shortCodeTransforms: [WpBlockAttributesObject]!
+  sizeSlug: String!
+}
+
+type WpCoreGalleryBlockDeprecatedV2AttributesImages {
+  alt: String!
+  caption: String
+  fullUrl: String
+  id: String
+  link: String
+  url: String
+}
+
+type WpCoreGalleryBlockDeprecatedV3Attributes {
+  align: String
+  allowResize: Boolean!
+  anchor: String
+  caption: String
+  className: String
+  columns: Float
+  fixedHeight: Boolean!
+  ids: [Float]!
+  imageCrop: Boolean!
+  images: [WpCoreGalleryBlockDeprecatedV3AttributesImages]!
+  linkTarget: String
+  linkTo: String
+  lock: JSON
+  shortCodeTransforms: [WpBlockAttributesObject]!
+  sizeSlug: String!
+}
+
+type WpCoreGalleryBlockDeprecatedV3AttributesImages {
+  alt: String!
+  caption: String
+  fullUrl: String
+  id: String
+  link: String
+  url: String
+}
+
+type WpCoreGalleryBlockDeprecatedV4Attributes {
+  align: String
+  allowResize: Boolean!
+  anchor: String
+  caption: String
+  className: String
+  columns: Float
+  fixedHeight: Boolean!
+  ids: [Float]!
+  imageCrop: Boolean!
+  images: [WpCoreGalleryBlockDeprecatedV4AttributesImages]!
+  linkTarget: String
+  linkTo: String
+  lock: JSON
+  shortCodeTransforms: [WpBlockAttributesObject]!
+  sizeSlug: String!
+}
+
+type WpCoreGalleryBlockDeprecatedV4AttributesImages {
+  alt: String!
+  caption: String
+  fullUrl: String
+  id: String
+  link: String
+  url: String
+}
+
+type WpCoreGalleryBlockDeprecatedV5Attributes {
+  align: String
+  allowResize: Boolean!
+  anchor: String
+  caption: String
+  className: String
+  columns: Float
+  fixedHeight: Boolean!
+  ids: [Float]!
+  imageCrop: Boolean!
+  images: [WpCoreGalleryBlockDeprecatedV5AttributesImages]!
+  linkTarget: String
+  linkTo: String
+  lock: JSON
+  shortCodeTransforms: [WpBlockAttributesObject]!
+  sizeSlug: String!
+}
+
+type WpCoreGalleryBlockDeprecatedV5AttributesImages {
+  alt: String!
+  caption: String
+  fullUrl: String
+  id: String
+  link: String
+  url: String
+}
+
+type WpCoreGalleryBlockDeprecatedV6Attributes {
+  align: String
+  allowResize: Boolean!
+  anchor: String
+  caption: String
+  className: String
+  columns: Float
+  fixedHeight: Boolean!
+  ids: [Float]!
+  imageCrop: Boolean!
+  images: [WpCoreGalleryBlockDeprecatedV6AttributesImages]!
+  linkTarget: String
+  linkTo: String
+  lock: JSON
+  shortCodeTransforms: [WpBlockAttributesObject]!
+  sizeSlug: String!
+}
+
+type WpCoreGalleryBlockDeprecatedV6AttributesImages {
+  alt: String!
+  caption: String
+  fullUrl: String
+  id: String
+  link: String
+  url: String
+}
+
+"""
+core/group block
+"""
+type WpCoreGroupBlock implements WpBlock {
+  attributes: WpCoreGroupBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreGroupBlockAttributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  className: String
+  gradient: String
+  layout: JSON
+  lock: JSON
+  style: JSON
+  tagName: String!
+  textColor: String
+}
+
+union WpCoreGroupBlockAttributesUnion =
+    WpCoreGroupBlockAttributes
+  | WpCoreGroupBlockDeprecatedV1Attributes
+  | WpCoreGroupBlockDeprecatedV2Attributes
+  | WpCoreGroupBlockDeprecatedV3Attributes
+  | WpCoreGroupBlockDeprecatedV4Attributes
+
+type WpCoreGroupBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  className: String
+  gradient: String
+  layout: JSON
+  lock: JSON
+  style: JSON
+  tagName: String!
+  textColor: String
+}
+
+type WpCoreGroupBlockDeprecatedV2Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  className: String
+  gradient: String
+  layout: JSON
+  lock: JSON
+  style: JSON
+  tagName: String!
+  textColor: String
+}
+
+type WpCoreGroupBlockDeprecatedV3Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  className: String
+  gradient: String
+  layout: JSON
+  lock: JSON
+  style: JSON
+  tagName: String!
+  textColor: String
+}
+
+type WpCoreGroupBlockDeprecatedV4Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  className: String
+  gradient: String
+  layout: JSON
+  lock: JSON
+  style: JSON
+  tagName: String!
+  textColor: String
+}
+
+"""
+core/heading block
+"""
+type WpCoreHeadingBlock implements WpBlock {
+  attributes: WpCoreHeadingBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreHeadingBlockAttributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  fontSize: String
+  level: Float!
+  lock: JSON
+  placeholder: String
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+union WpCoreHeadingBlockAttributesUnion =
+    WpCoreHeadingBlockAttributes
+  | WpCoreHeadingBlockDeprecatedV1Attributes
+  | WpCoreHeadingBlockDeprecatedV2Attributes
+  | WpCoreHeadingBlockDeprecatedV3Attributes
+  | WpCoreHeadingBlockDeprecatedV4Attributes
+
+type WpCoreHeadingBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  fontSize: String
+  level: Float!
+  lock: JSON
+  placeholder: String
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+type WpCoreHeadingBlockDeprecatedV2Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  fontSize: String
+  level: Float!
+  lock: JSON
+  placeholder: String
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+type WpCoreHeadingBlockDeprecatedV3Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  fontSize: String
+  level: Float!
+  lock: JSON
+  placeholder: String
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+type WpCoreHeadingBlockDeprecatedV4Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  fontSize: String
+  level: Float!
+  lock: JSON
+  placeholder: String
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+"""
+core/html block
+"""
+type WpCoreHtmlBlock implements WpBlock {
+  attributes: WpCoreHtmlBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreHtmlBlockAttributes {
+  content: String
+  lock: JSON
+}
+
+"""
+core/image block
+"""
+type WpCoreImageBlock implements WpBlock {
+  attributes: WpCoreImageBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreImageBlockAttributes {
+  align: String
+  alt: String!
+  anchor: String
+  caption: String
+  className: String
+  height: Float
+  href: String
+  id: Float
+  imageFluid: File
+  linkClass: String
+  linkDestination: String
+  linkTarget: String
+  lock: JSON
+  rel: String
+  sizeSlug: String
+  style: JSON
+  title: String
+  url: String
+  width: Float
+}
+
+union WpCoreImageBlockAttributesUnion =
+    WpCoreImageBlockAttributes
+  | WpCoreImageBlockDeprecatedV1Attributes
+  | WpCoreImageBlockDeprecatedV2Attributes
+  | WpCoreImageBlockDeprecatedV3Attributes
+
+type WpCoreImageBlockDeprecatedV1Attributes {
+  align: String
+  alt: String!
+  anchor: String
+  caption: String
+  className: String
+  height: Float
+  href: String
+  id: Float
+  linkClass: String
+  linkDestination: String
+  linkTarget: String
+  lock: JSON
+  rel: String
+  sizeSlug: String
+  style: JSON
+  title: String
+  url: String
+  width: Float
+}
+
+type WpCoreImageBlockDeprecatedV2Attributes {
+  align: String
+  alt: String!
+  anchor: String
+  caption: String
+  className: String
+  height: Float
+  href: String
+  id: Float
+  linkClass: String
+  linkDestination: String
+  linkTarget: String
+  lock: JSON
+  rel: String
+  sizeSlug: String
+  style: JSON
+  title: String
+  url: String
+  width: Float
+}
+
+type WpCoreImageBlockDeprecatedV3Attributes {
+  align: String
+  alt: String!
+  anchor: String
+  caption: String
+  className: String
+  height: Float
+  href: String
+  id: Float
+  linkClass: String
+  linkDestination: String
+  linkTarget: String
+  lock: JSON
+  rel: String
+  sizeSlug: String
+  style: JSON
+  title: String
+  url: String
+  width: Float
+}
+
+"""
+core/latest-comments block
+"""
+type WpCoreLatestCommentsBlock implements WpBlock {
+  attributes: WpCoreLatestCommentsBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreLatestCommentsBlockAttributes {
+  align: String
+  className: String
+  commentsToShow: Float!
+  displayAvatar: Boolean!
+  displayDate: Boolean!
+  displayExcerpt: Boolean!
+  lock: JSON
+}
+
+"""
+core/latest-posts block
+"""
+type WpCoreLatestPostsBlock implements WpBlock {
+  attributes: WpCoreLatestPostsBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreLatestPostsBlockAttributes {
+  addLinkToFeaturedImage: Boolean!
+  align: String
+  categories: [JSON]
+  className: String
+  columns: Float!
+  displayAuthor: Boolean!
+  displayFeaturedImage: Boolean!
+  displayPostContent: Boolean!
+  displayPostContentRadio: String!
+  displayPostDate: Boolean!
+  excerptLength: Float!
+  featuredImageAlign: String
+  featuredImageSizeHeight: Float
+  featuredImageSizeSlug: String!
+  featuredImageSizeWidth: Float
+  lock: JSON
+  order: String!
+  orderBy: String!
+  postLayout: String!
+  postsToShow: Float!
+  selectedAuthor: Float
+}
+
+union WpCoreLatestPostsBlockAttributesUnion =
+    WpCoreLatestPostsBlockAttributes
+  | WpCoreLatestPostsBlockDeprecatedV1Attributes
+
+type WpCoreLatestPostsBlockDeprecatedV1Attributes {
+  addLinkToFeaturedImage: Boolean!
+  align: String
+  categories: [JSON]
+  className: String
+  columns: Float!
+  displayAuthor: Boolean!
+  displayFeaturedImage: Boolean!
+  displayPostContent: Boolean!
+  displayPostContentRadio: String!
+  displayPostDate: Boolean!
+  excerptLength: Float!
+  featuredImageAlign: String
+  featuredImageSizeHeight: Float
+  featuredImageSizeSlug: String!
+  featuredImageSizeWidth: Float
+  lock: JSON
+  order: String!
+  orderBy: String!
+  postLayout: String!
+  postsToShow: Float!
+  selectedAuthor: Float
+}
+
+"""
+core/legacy-widget block
+"""
+type WpCoreLegacyWidgetBlock implements WpBlock {
+  attributes: WpCoreLegacyWidgetBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreLegacyWidgetBlockAttributes {
+  id: String
+  idBase: String
+  instance: JSON
+  lock: JSON
+}
+
+"""
+core/list block
+"""
+type WpCoreListBlock implements WpBlock {
+  attributes: WpCoreListBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreListBlockAttributes {
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  ordered: Boolean!
+  placeholder: String
+  reversed: Boolean
+  start: Float
+  style: JSON
+  textColor: String
+  type: String
+  values: String!
+}
+
+union WpCoreListBlockAttributesUnion = WpCoreListBlockAttributes | WpCoreListBlockDeprecatedV1Attributes
+
+type WpCoreListBlockDeprecatedV1Attributes {
+  anchor: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  ordered: Boolean!
+  placeholder: String
+  reversed: Boolean
+  start: Float
+  style: JSON
+  textColor: String
+  type: String
+  values: String!
+}
+
+"""
+core/loginout block
+"""
+type WpCoreLoginoutBlock implements WpBlock {
+  attributes: WpCoreLoginoutBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreLoginoutBlockAttributes {
+  className: String
+  displayLoginAsForm: Boolean!
+  lock: JSON
+  redirectToCurrent: Boolean!
+}
+
+"""
+core/media-text block
+"""
+type WpCoreMediaTextBlock implements WpBlock {
+  attributes: WpCoreMediaTextBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreMediaTextBlockAttributes {
+  align: String!
+  anchor: String
+  backgroundColor: String
+  className: String
+  focalPoint: JSON
+  gradient: String
+  href: String
+  imageFill: Boolean
+  isStackedOnMobile: Boolean!
+  linkClass: String
+  linkDestination: String
+  linkTarget: String
+  lock: JSON
+  mediaAlt: String!
+  mediaId: Float
+  mediaLink: String
+  mediaPosition: String!
+  mediaSizeSlug: String
+  mediaType: String
+  mediaUrl: String
+  mediaWidth: Float!
+  rel: String
+  style: JSON
+  textColor: String
+  verticalAlignment: String
+}
+
+union WpCoreMediaTextBlockAttributesUnion =
+    WpCoreMediaTextBlockAttributes
+  | WpCoreMediaTextBlockDeprecatedV1Attributes
+  | WpCoreMediaTextBlockDeprecatedV2Attributes
+  | WpCoreMediaTextBlockDeprecatedV3Attributes
+
+type WpCoreMediaTextBlockDeprecatedV1Attributes {
+  align: String!
+  anchor: String
+  backgroundColor: String
+  className: String
+  focalPoint: JSON
+  gradient: String
+  href: String
+  imageFill: Boolean
+  isStackedOnMobile: Boolean!
+  linkClass: String
+  linkDestination: String
+  linkTarget: String
+  lock: JSON
+  mediaAlt: String!
+  mediaId: Float
+  mediaLink: String
+  mediaPosition: String!
+  mediaSizeSlug: String
+  mediaType: String
+  mediaUrl: String
+  mediaWidth: Float!
+  rel: String
+  style: JSON
+  textColor: String
+  verticalAlignment: String
+}
+
+type WpCoreMediaTextBlockDeprecatedV2Attributes {
+  align: String!
+  anchor: String
+  backgroundColor: String
+  className: String
+  focalPoint: JSON
+  gradient: String
+  href: String
+  imageFill: Boolean
+  isStackedOnMobile: Boolean!
+  linkClass: String
+  linkDestination: String
+  linkTarget: String
+  lock: JSON
+  mediaAlt: String!
+  mediaId: Float
+  mediaLink: String
+  mediaPosition: String!
+  mediaSizeSlug: String
+  mediaType: String
+  mediaUrl: String
+  mediaWidth: Float!
+  rel: String
+  style: JSON
+  textColor: String
+  verticalAlignment: String
+}
+
+type WpCoreMediaTextBlockDeprecatedV3Attributes {
+  align: String!
+  anchor: String
+  backgroundColor: String
+  className: String
+  focalPoint: JSON
+  gradient: String
+  href: String
+  imageFill: Boolean
+  isStackedOnMobile: Boolean!
+  linkClass: String
+  linkDestination: String
+  linkTarget: String
+  lock: JSON
+  mediaAlt: String!
+  mediaId: Float
+  mediaLink: String
+  mediaPosition: String!
+  mediaSizeSlug: String
+  mediaType: String
+  mediaUrl: String
+  mediaWidth: Float!
+  rel: String
+  style: JSON
+  textColor: String
+  verticalAlignment: String
+}
+
+"""
+core/missing block
+"""
+type WpCoreMissingBlock implements WpBlock {
+  attributes: WpCoreMissingBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreMissingBlockAttributes {
+  lock: JSON
+  originalContent: String
+  originalName: String
+  originalUndelimitedContent: String
+}
+
+"""
+core/more block
+"""
+type WpCoreMoreBlock implements WpBlock {
+  attributes: WpCoreMoreBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreMoreBlockAttributes {
+  customText: String
+  lock: JSON
+  noTeaser: Boolean!
+}
+
+"""
+core/navigation block
+"""
+type WpCoreNavigationBlock implements WpBlock {
+  attributes: WpCoreNavigationBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreNavigationBlockAttributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  customBackgroundColor: String
+  customOverlayBackgroundColor: String
+  customOverlayTextColor: String
+  customTextColor: String
+  fontFamily: String
+  fontSize: String
+  layout: JSON
+  lock: JSON
+  openSubmenusOnClick: Boolean!
+  overlayBackgroundColor: String
+  overlayMenu: String!
+  overlayTextColor: String
+  ref: Float
+  rgbBackgroundColor: String
+  rgbTextColor: String
+  showSubmenuIcon: Boolean!
+  style: JSON
+  textColor: String
+  unstableLocation: String
+}
+
+union WpCoreNavigationBlockAttributesUnion =
+    WpCoreNavigationBlockAttributes
+  | WpCoreNavigationBlockDeprecatedV1Attributes
+  | WpCoreNavigationBlockDeprecatedV2Attributes
+  | WpCoreNavigationBlockDeprecatedV3Attributes
+  | WpCoreNavigationBlockDeprecatedV4Attributes
+  | WpCoreNavigationBlockDeprecatedV5Attributes
+  | WpCoreNavigationBlockDeprecatedV6Attributes
+
+type WpCoreNavigationBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  customBackgroundColor: String
+  customOverlayBackgroundColor: String
+  customOverlayTextColor: String
+  customTextColor: String
+  fontFamily: String
+  fontSize: String
+  layout: JSON
+  lock: JSON
+  openSubmenusOnClick: Boolean!
+  overlayBackgroundColor: String
+  overlayMenu: String!
+  overlayTextColor: String
+  ref: Float
+  rgbBackgroundColor: String
+  rgbTextColor: String
+  showSubmenuIcon: Boolean!
+  style: JSON
+  textColor: String
+  unstableLocation: String
+}
+
+type WpCoreNavigationBlockDeprecatedV2Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  customBackgroundColor: String
+  customOverlayBackgroundColor: String
+  customOverlayTextColor: String
+  customTextColor: String
+  fontFamily: String
+  fontSize: String
+  layout: JSON
+  lock: JSON
+  openSubmenusOnClick: Boolean!
+  overlayBackgroundColor: String
+  overlayMenu: String!
+  overlayTextColor: String
+  ref: Float
+  rgbBackgroundColor: String
+  rgbTextColor: String
+  showSubmenuIcon: Boolean!
+  style: JSON
+  textColor: String
+  unstableLocation: String
+}
+
+type WpCoreNavigationBlockDeprecatedV3Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  customBackgroundColor: String
+  customOverlayBackgroundColor: String
+  customOverlayTextColor: String
+  customTextColor: String
+  fontFamily: String
+  fontSize: String
+  layout: JSON
+  lock: JSON
+  openSubmenusOnClick: Boolean!
+  overlayBackgroundColor: String
+  overlayMenu: String!
+  overlayTextColor: String
+  ref: Float
+  rgbBackgroundColor: String
+  rgbTextColor: String
+  showSubmenuIcon: Boolean!
+  style: JSON
+  textColor: String
+  unstableLocation: String
+}
+
+type WpCoreNavigationBlockDeprecatedV4Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  customBackgroundColor: String
+  customOverlayBackgroundColor: String
+  customOverlayTextColor: String
+  customTextColor: String
+  fontFamily: String
+  fontSize: String
+  layout: JSON
+  lock: JSON
+  openSubmenusOnClick: Boolean!
+  overlayBackgroundColor: String
+  overlayMenu: String!
+  overlayTextColor: String
+  ref: Float
+  rgbBackgroundColor: String
+  rgbTextColor: String
+  showSubmenuIcon: Boolean!
+  style: JSON
+  textColor: String
+  unstableLocation: String
+}
+
+type WpCoreNavigationBlockDeprecatedV5Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  customBackgroundColor: String
+  customOverlayBackgroundColor: String
+  customOverlayTextColor: String
+  customTextColor: String
+  fontFamily: String
+  fontSize: String
+  layout: JSON
+  lock: JSON
+  openSubmenusOnClick: Boolean!
+  overlayBackgroundColor: String
+  overlayMenu: String!
+  overlayTextColor: String
+  ref: Float
+  rgbBackgroundColor: String
+  rgbTextColor: String
+  showSubmenuIcon: Boolean!
+  style: JSON
+  textColor: String
+  unstableLocation: String
+}
+
+type WpCoreNavigationBlockDeprecatedV6Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  customBackgroundColor: String
+  customOverlayBackgroundColor: String
+  customOverlayTextColor: String
+  customTextColor: String
+  fontFamily: String
+  fontSize: String
+  layout: JSON
+  lock: JSON
+  openSubmenusOnClick: Boolean!
+  overlayBackgroundColor: String
+  overlayMenu: String!
+  overlayTextColor: String
+  ref: Float
+  rgbBackgroundColor: String
+  rgbTextColor: String
+  showSubmenuIcon: Boolean!
+  style: JSON
+  textColor: String
+  unstableLocation: String
+}
+
+"""
+core/navigation-link block
+"""
+type WpCoreNavigationLinkBlock implements WpBlock {
+  attributes: WpCoreNavigationLinkBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreNavigationLinkBlockAttributes {
+  className: String
+  description: String
+  id: Float
+  isTopLevelLink: Boolean
+  kind: String
+  label: String
+  lock: JSON
+  opensInNewTab: Boolean!
+  rel: String
+  title: String
+  type: String
+  url: String
+}
+
+union WpCoreNavigationLinkBlockAttributesUnion =
+    WpCoreNavigationLinkBlockAttributes
+  | WpCoreNavigationLinkBlockDeprecatedV1Attributes
+
+type WpCoreNavigationLinkBlockDeprecatedV1Attributes {
+  className: String
+  description: String
+  id: Float
+  isTopLevelLink: Boolean
+  kind: String
+  label: String
+  lock: JSON
+  opensInNewTab: Boolean!
+  rel: String
+  title: String
+  type: String
+  url: String
+}
+
+"""
+core/navigation-submenu block
+"""
+type WpCoreNavigationSubmenuBlock implements WpBlock {
+  attributes: WpCoreNavigationSubmenuBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreNavigationSubmenuBlockAttributes {
+  className: String
+  description: String
+  id: Float
+  isTopLevelItem: Boolean
+  kind: String
+  label: String
+  lock: JSON
+  opensInNewTab: Boolean!
+  rel: String
+  title: String
+  type: String
+  url: String
+}
+
+"""
+core/nextpage block
+"""
+type WpCoreNextpageBlock implements WpBlock {
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreNextpageBlockAttributes {
+  lock: JSON
+}
+
+"""
+core/page-list block
+"""
+type WpCorePageListBlock implements WpBlock {
+  attributes: WpCorePageListBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePageListBlockAttributes {
+  className: String
+  lock: JSON
+}
+
+"""
+core/paragraph block
+"""
+type WpCoreParagraphBlock implements WpBlock {
+  attributes: WpCoreParagraphBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreParagraphBlockAttributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  direction: String
+  dropCap: Boolean!
+  fontSize: String
+  lock: JSON
+  placeholder: String
+  style: JSON
+  textColor: String
+}
+
+union WpCoreParagraphBlockAttributesUnion =
+    WpCoreParagraphBlockAttributes
+  | WpCoreParagraphBlockDeprecatedV1Attributes
+  | WpCoreParagraphBlockDeprecatedV2Attributes
+  | WpCoreParagraphBlockDeprecatedV3Attributes
+  | WpCoreParagraphBlockDeprecatedV4Attributes
+  | WpCoreParagraphBlockDeprecatedV5Attributes
+
+type WpCoreParagraphBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  direction: String
+  dropCap: Boolean!
+  fontSize: String
+  lock: JSON
+  placeholder: String
+  style: JSON
+  textColor: String
+}
+
+type WpCoreParagraphBlockDeprecatedV2Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  direction: String
+  dropCap: Boolean!
+  fontSize: String
+  lock: JSON
+  placeholder: String
+  style: JSON
+  textColor: String
+}
+
+type WpCoreParagraphBlockDeprecatedV3Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  direction: String
+  dropCap: Boolean!
+  fontSize: String
+  lock: JSON
+  placeholder: String
+  style: JSON
+  textColor: String
+}
+
+type WpCoreParagraphBlockDeprecatedV4Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  direction: String
+  dropCap: Boolean!
+  fontSize: String
+  lock: JSON
+  placeholder: String
+  style: JSON
+  textColor: String
+}
+
+type WpCoreParagraphBlockDeprecatedV5Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  direction: String
+  dropCap: Boolean!
+  fontSize: String
+  lock: JSON
+  placeholder: String
+  style: JSON
+  textColor: String
+}
+
+"""
+core/pattern block
+"""
+type WpCorePatternBlock implements WpBlock {
+  attributes: WpCorePatternBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePatternBlockAttributes {
+  className: String
+  lock: JSON
+  slug: String
+}
+
+"""
+core/post-author block
+"""
+type WpCorePostAuthorBlock implements WpBlock {
+  attributes: WpCorePostAuthorBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePostAuthorBlockAttributes {
+  avatarSize: Float!
+  backgroundColor: String
+  byline: String
+  className: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  showAvatar: Boolean!
+  showBio: Boolean
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+"""
+core/post-comments block
+"""
+type WpCorePostCommentsBlock implements WpBlock {
+  attributes: WpCorePostCommentsBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePostCommentsBlockAttributes {
+  align: String
+  backgroundColor: String
+  className: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+"""
+core/post-content block
+"""
+type WpCorePostContentBlock implements WpBlock {
+  attributes: WpCorePostContentBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePostContentBlockAttributes {
+  align: String
+  className: String
+  layout: JSON
+  lock: JSON
+}
+
+"""
+core/post-date block
+"""
+type WpCorePostDateBlock implements WpBlock {
+  attributes: WpCorePostDateBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePostDateBlockAttributes {
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  format: String
+  gradient: String
+  isLink: Boolean!
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+union WpCorePostDateBlockAttributesUnion = WpCorePostDateBlockAttributes | WpCorePostDateBlockDeprecatedV1Attributes
+
+type WpCorePostDateBlockDeprecatedV1Attributes {
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  format: String
+  gradient: String
+  isLink: Boolean!
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+"""
+core/post-excerpt block
+"""
+type WpCorePostExcerptBlock implements WpBlock {
+  attributes: WpCorePostExcerptBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePostExcerptBlockAttributes {
+  backgroundColor: String
+  className: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  moreText: String
+  showMoreOnNewLine: Boolean!
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+"""
+core/post-featured-image block
+"""
+type WpCorePostFeaturedImageBlock implements WpBlock {
+  attributes: WpCorePostFeaturedImageBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePostFeaturedImageBlockAttributes {
+  align: String
+  className: String
+  height: String
+  isLink: Boolean!
+  lock: JSON
+  scale: String!
+  style: JSON
+  width: String
+}
+
+"""
+core/post-navigation-link block
+"""
+type WpCorePostNavigationLinkBlock implements WpBlock {
+  attributes: WpCorePostNavigationLinkBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePostNavigationLinkBlockAttributes {
+  className: String
+  fontSize: String
+  label: String
+  linkLabel: Boolean!
+  lock: JSON
+  showTitle: Boolean!
+  style: JSON
+  textAlign: String
+  type: String!
+}
+
+"""
+core/post-template block
+"""
+type WpCorePostTemplateBlock implements WpBlock {
+  attributes: WpCorePostTemplateBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePostTemplateBlockAttributes {
+  align: String
+  className: String
+  layout: JSON
+  lock: JSON
+}
+
+"""
+core/post-terms block
+"""
+type WpCorePostTermsBlock implements WpBlock {
+  attributes: WpCorePostTermsBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePostTermsBlockAttributes {
+  backgroundColor: String
+  className: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  separator: String!
+  style: JSON
+  term: String
+  textAlign: String
+  textColor: String
+}
+
+"""
+core/post-title block
+"""
+type WpCorePostTitleBlock implements WpBlock {
+  attributes: WpCorePostTitleBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePostTitleBlockAttributes {
+  align: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  isLink: Boolean!
+  level: Float!
+  linkTarget: String!
+  lock: JSON
+  rel: String!
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+union WpCorePostTitleBlockAttributesUnion = WpCorePostTitleBlockAttributes | WpCorePostTitleBlockDeprecatedV1Attributes
+
+type WpCorePostTitleBlockDeprecatedV1Attributes {
+  align: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  isLink: Boolean!
+  level: Float!
+  linkTarget: String!
+  lock: JSON
+  rel: String!
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+"""
+core/preformatted block
+"""
+type WpCorePreformattedBlock implements WpBlock {
+  attributes: WpCorePreformattedBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePreformattedBlockAttributes {
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textColor: String
+}
+
+"""
+core/pullquote block
+"""
+type WpCorePullquoteBlock implements WpBlock {
+  attributes: WpCorePullquoteBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCorePullquoteBlockAttributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  citation: String!
+  className: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+  value: String
+}
+
+union WpCorePullquoteBlockAttributesUnion =
+    WpCorePullquoteBlockAttributes
+  | WpCorePullquoteBlockDeprecatedV1Attributes
+  | WpCorePullquoteBlockDeprecatedV2Attributes
+  | WpCorePullquoteBlockDeprecatedV3Attributes
+  | WpCorePullquoteBlockDeprecatedV4Attributes
+  | WpCorePullquoteBlockDeprecatedV5Attributes
+
+type WpCorePullquoteBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  citation: String!
+  className: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+  value: String
+}
+
+type WpCorePullquoteBlockDeprecatedV2Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  citation: String!
+  className: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+  value: String
+}
+
+type WpCorePullquoteBlockDeprecatedV3Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  citation: String!
+  className: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+  value: String
+}
+
+type WpCorePullquoteBlockDeprecatedV4Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  citation: String!
+  className: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+  value: String
+}
+
+type WpCorePullquoteBlockDeprecatedV5Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  borderColor: String
+  citation: String!
+  className: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+  value: String
+}
+
+"""
+core/query block
+"""
+type WpCoreQueryBlock implements WpBlock {
+  attributes: WpCoreQueryBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreQueryBlockAttributes {
+  align: String
+  backgroundColor: String
+  className: String
+  displayLayout: JSON!
+  gradient: String
+  layout: JSON
+  lock: JSON
+  query: JSON!
+  queryId: Float
+  style: JSON
+  tagName: String!
+  textColor: String
+}
+
+union WpCoreQueryBlockAttributesUnion = WpCoreQueryBlockAttributes | WpCoreQueryBlockDeprecatedV1Attributes
+
+type WpCoreQueryBlockDeprecatedV1Attributes {
+  align: String
+  backgroundColor: String
+  className: String
+  displayLayout: JSON!
+  gradient: String
+  layout: JSON
+  lock: JSON
+  query: JSON!
+  queryId: Float
+  style: JSON
+  tagName: String!
+  textColor: String
+}
+
+"""
+core/query-pagination block
+"""
+type WpCoreQueryPaginationBlock implements WpBlock {
+  attributes: WpCoreQueryPaginationBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreQueryPaginationBlockAttributes {
+  align: String
+  backgroundColor: String
+  className: String
+  gradient: String
+  layout: JSON
+  lock: JSON
+  paginationArrow: String!
+  style: JSON
+  textColor: String
+}
+
+union WpCoreQueryPaginationBlockAttributesUnion =
+    WpCoreQueryPaginationBlockAttributes
+  | WpCoreQueryPaginationBlockDeprecatedV1Attributes
+
+type WpCoreQueryPaginationBlockDeprecatedV1Attributes {
+  align: String
+  backgroundColor: String
+  className: String
+  gradient: String
+  layout: JSON
+  lock: JSON
+  paginationArrow: String!
+  style: JSON
+  textColor: String
+}
+
+"""
+core/query-pagination-next block
+"""
+type WpCoreQueryPaginationNextBlock implements WpBlock {
+  attributes: WpCoreQueryPaginationNextBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreQueryPaginationNextBlockAttributes {
+  backgroundColor: String
+  className: String
+  fontSize: String
+  gradient: String
+  label: String
+  lock: JSON
+  style: JSON
+  textColor: String
+}
+
+"""
+core/query-pagination-numbers block
+"""
+type WpCoreQueryPaginationNumbersBlock implements WpBlock {
+  attributes: WpCoreQueryPaginationNumbersBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreQueryPaginationNumbersBlockAttributes {
+  className: String
+  lock: JSON
+}
+
+"""
+core/query-pagination-previous block
+"""
+type WpCoreQueryPaginationPreviousBlock implements WpBlock {
+  attributes: WpCoreQueryPaginationPreviousBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreQueryPaginationPreviousBlockAttributes {
+  backgroundColor: String
+  className: String
+  fontSize: String
+  gradient: String
+  label: String
+  lock: JSON
+  style: JSON
+  textColor: String
+}
+
+"""
+core/query-title block
+"""
+type WpCoreQueryTitleBlock implements WpBlock {
+  attributes: WpCoreQueryTitleBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreQueryTitleBlockAttributes {
+  align: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  level: Float!
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+  type: String
+}
+
+union WpCoreQueryTitleBlockAttributesUnion =
+    WpCoreQueryTitleBlockAttributes
+  | WpCoreQueryTitleBlockDeprecatedV1Attributes
+
+type WpCoreQueryTitleBlockDeprecatedV1Attributes {
+  align: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  level: Float!
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+  type: String
+}
+
+"""
+core/quote block
+"""
+type WpCoreQuoteBlock implements WpBlock {
+  attributes: WpCoreQuoteBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreQuoteBlockAttributes {
+  align: String
+  anchor: String
+  citation: String!
+  className: String
+  fontSize: String
+  lock: JSON
+  style: JSON
+  value: String!
+}
+
+union WpCoreQuoteBlockAttributesUnion =
+    WpCoreQuoteBlockAttributes
+  | WpCoreQuoteBlockDeprecatedV1Attributes
+  | WpCoreQuoteBlockDeprecatedV2Attributes
+  | WpCoreQuoteBlockDeprecatedV3Attributes
+
+type WpCoreQuoteBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  citation: String!
+  className: String
+  fontSize: String
+  lock: JSON
+  style: JSON
+  value: String!
+}
+
+type WpCoreQuoteBlockDeprecatedV2Attributes {
+  align: String
+  anchor: String
+  citation: String!
+  className: String
+  fontSize: String
+  lock: JSON
+  style: JSON
+  value: String!
+}
+
+type WpCoreQuoteBlockDeprecatedV3Attributes {
+  align: String
+  anchor: String
+  citation: String!
+  className: String
+  fontSize: String
+  lock: JSON
+  style: JSON
+  value: String!
+}
+
+"""
+core/rss block
+"""
+type WpCoreRssBlock implements WpBlock {
+  attributes: WpCoreRssBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreRssBlockAttributes {
+  align: String
+  blockLayout: String!
+  className: String
+  columns: Float!
+  displayAuthor: Boolean!
+  displayDate: Boolean!
+  displayExcerpt: Boolean!
+  excerptLength: Float!
+  feedURL: String!
+  itemsToShow: Float!
+  lock: JSON
+}
+
+"""
+core/search block
+"""
+type WpCoreSearchBlock implements WpBlock {
+  attributes: WpCoreSearchBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreSearchBlockAttributes {
+  align: String
+  backgroundColor: String
+  borderColor: String
+  buttonPosition: String!
+  buttonText: String
+  buttonUseIcon: Boolean!
+  className: String
+  gradient: String
+  label: String
+  lock: JSON
+  placeholder: String!
+  showLabel: Boolean!
+  style: JSON
+  textColor: String
+  width: Float
+  widthUnit: String
+}
+
+"""
+core/separator block
+"""
+type WpCoreSeparatorBlock implements WpBlock {
+  attributes: WpCoreSeparatorBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreSeparatorBlockAttributes {
+  align: String
+  anchor: String
+  className: String
+  color: String
+  customColor: String
+  lock: JSON
+}
+
+"""
+core/shortcode block
+"""
+type WpCoreShortcodeBlock implements WpBlock {
+  attributes: WpCoreShortcodeBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreShortcodeBlockAttributes {
+  lock: JSON
+  text: String
+}
+
+"""
+core/site-logo block
+"""
+type WpCoreSiteLogoBlock implements WpBlock {
+  attributes: WpCoreSiteLogoBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreSiteLogoBlockAttributes {
+  align: String
+  className: String
+  isLink: Boolean!
+  linkTarget: String!
+  lock: JSON
+  shouldSyncIcon: Boolean
+  style: JSON
+  width: Float
+}
+
+"""
+core/site-tagline block
+"""
+type WpCoreSiteTaglineBlock implements WpBlock {
+  attributes: WpCoreSiteTaglineBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreSiteTaglineBlockAttributes {
+  align: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+union WpCoreSiteTaglineBlockAttributesUnion =
+    WpCoreSiteTaglineBlockAttributes
+  | WpCoreSiteTaglineBlockDeprecatedV1Attributes
+
+type WpCoreSiteTaglineBlockDeprecatedV1Attributes {
+  align: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+"""
+core/site-title block
+"""
+type WpCoreSiteTitleBlock implements WpBlock {
+  attributes: WpCoreSiteTitleBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreSiteTitleBlockAttributes {
+  align: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  isLink: Boolean!
+  level: Float!
+  linkTarget: String!
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+union WpCoreSiteTitleBlockAttributesUnion = WpCoreSiteTitleBlockAttributes | WpCoreSiteTitleBlockDeprecatedV1Attributes
+
+type WpCoreSiteTitleBlockDeprecatedV1Attributes {
+  align: String
+  backgroundColor: String
+  className: String
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  isLink: Boolean!
+  level: Float!
+  linkTarget: String!
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+"""
+core/social-link block
+"""
+type WpCoreSocialLinkBlock implements WpBlock {
+  attributes: WpCoreSocialLinkBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreSocialLinkBlockAttributes {
+  className: String
+  label: String
+  lock: JSON
+  service: String
+  url: String
+}
+
+"""
+core/social-links block
+"""
+type WpCoreSocialLinksBlock implements WpBlock {
+  attributes: WpCoreSocialLinksBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreSocialLinksBlockAttributes {
+  align: String
+  anchor: String
+  className: String
+  customIconBackgroundColor: String
+  customIconColor: String
+  iconBackgroundColor: String
+  iconBackgroundColorValue: String
+  iconColor: String
+  iconColorValue: String
+  layout: JSON
+  lock: JSON
+  openInNewTab: Boolean!
+  size: String
+  style: JSON
+}
+
+union WpCoreSocialLinksBlockAttributesUnion =
+    WpCoreSocialLinksBlockAttributes
+  | WpCoreSocialLinksBlockDeprecatedV1Attributes
+
+type WpCoreSocialLinksBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  className: String
+  customIconBackgroundColor: String
+  customIconColor: String
+  iconBackgroundColor: String
+  iconBackgroundColorValue: String
+  iconColor: String
+  iconColorValue: String
+  layout: JSON
+  lock: JSON
+  openInNewTab: Boolean!
+  size: String
+  style: JSON
+}
+
+"""
+core/spacer block
+"""
+type WpCoreSpacerBlock implements WpBlock {
+  attributes: WpCoreSpacerBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreSpacerBlockAttributes {
+  anchor: String
+  className: String
+  height: String!
+  lock: JSON
+  width: String
+}
+
+union WpCoreSpacerBlockAttributesUnion = WpCoreSpacerBlockAttributes | WpCoreSpacerBlockDeprecatedV1Attributes
+
+type WpCoreSpacerBlockDeprecatedV1Attributes {
+  anchor: String
+  className: String
+  height: String!
+  lock: JSON
+  width: String
+}
+
+"""
+core/table block
+"""
+type WpCoreTableBlock implements WpBlock {
+  attributes: WpCoreTableBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreTableBlockAttributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  body: [WpCoreTableBlockAttributesBody]!
+  borderColor: String
+  caption: String!
+  className: String
+  fontSize: String
+  foot: [WpCoreTableBlockAttributesFoot]!
+  gradient: String
+  hasFixedLayout: Boolean!
+  head: [WpCoreTableBlockAttributesHead]!
+  lock: JSON
+  style: JSON
+  textColor: String
+}
+
+type WpCoreTableBlockAttributesBody {
+  cells: [WpCoreTableBlockAttributesBodyCells]!
+}
+
+type WpCoreTableBlockAttributesBodyCells {
+  align: String
+  content: String
+  scope: String
+  tag: String!
+}
+
+type WpCoreTableBlockAttributesFoot {
+  cells: [WpCoreTableBlockAttributesFootCells]!
+}
+
+type WpCoreTableBlockAttributesFootCells {
+  align: String
+  content: String
+  scope: String
+  tag: String!
+}
+
+type WpCoreTableBlockAttributesHead {
+  cells: [WpCoreTableBlockAttributesHeadCells]!
+}
+
+type WpCoreTableBlockAttributesHeadCells {
+  align: String
+  content: String
+  scope: String
+  tag: String!
+}
+
+union WpCoreTableBlockAttributesUnion =
+    WpCoreTableBlockAttributes
+  | WpCoreTableBlockDeprecatedV1Attributes
+  | WpCoreTableBlockDeprecatedV2Attributes
+
+type WpCoreTableBlockDeprecatedV1Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  body: [WpCoreTableBlockDeprecatedV1AttributesBody]!
+  borderColor: String
+  caption: String!
+  className: String
+  fontSize: String
+  foot: [WpCoreTableBlockDeprecatedV1AttributesFoot]!
+  gradient: String
+  hasFixedLayout: Boolean!
+  head: [WpCoreTableBlockDeprecatedV1AttributesHead]!
+  lock: JSON
+  style: JSON
+  textColor: String
+}
+
+type WpCoreTableBlockDeprecatedV1AttributesBody {
+  cells: [WpCoreTableBlockDeprecatedV1AttributesBodyCells]!
+}
+
+type WpCoreTableBlockDeprecatedV1AttributesBodyCells {
+  align: String
+  content: String
+  scope: String
+  tag: String!
+}
+
+type WpCoreTableBlockDeprecatedV1AttributesFoot {
+  cells: [WpCoreTableBlockDeprecatedV1AttributesFootCells]!
+}
+
+type WpCoreTableBlockDeprecatedV1AttributesFootCells {
+  align: String
+  content: String
+  scope: String
+  tag: String!
+}
+
+type WpCoreTableBlockDeprecatedV1AttributesHead {
+  cells: [WpCoreTableBlockDeprecatedV1AttributesHeadCells]!
+}
+
+type WpCoreTableBlockDeprecatedV1AttributesHeadCells {
+  align: String
+  content: String
+  scope: String
+  tag: String!
+}
+
+type WpCoreTableBlockDeprecatedV2Attributes {
+  align: String
+  anchor: String
+  backgroundColor: String
+  body: [WpCoreTableBlockDeprecatedV2AttributesBody]!
+  borderColor: String
+  caption: String!
+  className: String
+  fontSize: String
+  foot: [WpCoreTableBlockDeprecatedV2AttributesFoot]!
+  gradient: String
+  hasFixedLayout: Boolean!
+  head: [WpCoreTableBlockDeprecatedV2AttributesHead]!
+  lock: JSON
+  style: JSON
+  textColor: String
+}
+
+type WpCoreTableBlockDeprecatedV2AttributesBody {
+  cells: [WpCoreTableBlockDeprecatedV2AttributesBodyCells]!
+}
+
+type WpCoreTableBlockDeprecatedV2AttributesBodyCells {
+  align: String
+  content: String
+  scope: String
+  tag: String!
+}
+
+type WpCoreTableBlockDeprecatedV2AttributesFoot {
+  cells: [WpCoreTableBlockDeprecatedV2AttributesFootCells]!
+}
+
+type WpCoreTableBlockDeprecatedV2AttributesFootCells {
+  align: String
+  content: String
+  scope: String
+  tag: String!
+}
+
+type WpCoreTableBlockDeprecatedV2AttributesHead {
+  cells: [WpCoreTableBlockDeprecatedV2AttributesHeadCells]!
+}
+
+type WpCoreTableBlockDeprecatedV2AttributesHeadCells {
+  align: String
+  content: String
+  scope: String
+  tag: String!
+}
+
+"""
+core/tag-cloud block
+"""
+type WpCoreTagCloudBlock implements WpBlock {
+  attributes: WpCoreTagCloudBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreTagCloudBlockAttributes {
+  align: String
+  className: String
+  lock: JSON
+  numberOfTags: Float!
+  showTagCounts: Boolean!
+  taxonomy: String!
+}
+
+"""
+core/template-part block
+"""
+type WpCoreTemplatePartBlock implements WpBlock {
+  attributes: WpCoreTemplatePartBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreTemplatePartBlockAttributes {
+  align: String
+  area: String
+  className: String
+  lock: JSON
+  slug: String
+  tagName: String
+  theme: String
+}
+
+"""
+core/term-description block
+"""
+type WpCoreTermDescriptionBlock implements WpBlock {
+  attributes: WpCoreTermDescriptionBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreTermDescriptionBlockAttributes {
+  align: String
+  backgroundColor: String
+  className: String
+  fontSize: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+"""
+core/text-columns block
+"""
+type WpCoreTextColumnsBlock implements WpBlock {
+  attributes: WpCoreTextColumnsBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreTextColumnsBlockAttributes {
+  className: String
+  columns: Float!
+  content: [WpCoreTextColumnsBlockAttributesContent]!
+  lock: JSON
+  width: String
+}
+
+type WpCoreTextColumnsBlockAttributesContent {
+  wpChildren: String
+}
+
+"""
+core/verse block
+"""
+type WpCoreVerseBlock implements WpBlock {
+  attributes: WpCoreVerseBlockAttributesUnion
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreVerseBlockAttributes {
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+union WpCoreVerseBlockAttributesUnion =
+    WpCoreVerseBlockAttributes
+  | WpCoreVerseBlockDeprecatedV1Attributes
+  | WpCoreVerseBlockDeprecatedV2Attributes
+
+type WpCoreVerseBlockDeprecatedV1Attributes {
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+type WpCoreVerseBlockDeprecatedV2Attributes {
+  anchor: String
+  backgroundColor: String
+  className: String
+  content: String!
+  fontFamily: String
+  fontSize: String
+  gradient: String
+  lock: JSON
+  style: JSON
+  textAlign: String
+  textColor: String
+}
+
+"""
+core/video block
+"""
+type WpCoreVideoBlock implements WpBlock {
+  attributes: WpCoreVideoBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpCoreVideoBlockAttributes {
+  align: String
+  anchor: String
+  autoplay: Boolean
+  caption: String
+  className: String
+  controls: Boolean!
+  id: Float
+  lock: JSON
+  loop: Boolean
+  muted: Boolean
+  playsInline: Boolean
+  poster: String
+  preload: String!
+  src: String
+  tracks: [WpBlockAttributesObject]!
+}
+
+interface WpDatabaseIdentifier {
+  """
+  The unique identifier stored in the database
+  """
+  databaseId: Int!
+}
+
+"""
+The template assigned to the node
+"""
+type WpDefaultTemplate implements WpContentTemplate {
+  """
+  The name of the template
+  """
+  templateName: String
+}
+
+"""
+The discussion setting type
+"""
+type WpDiscussionSettings {
+  """
+  Erlaube Besuchern, neue Beiträge zu kommentieren.
+  """
+  defaultCommentStatus: String
+
+  """
+  Link-Benachrichtigungen von anderen Blogs (Pingbacks und Trackbacks) zu neuen Beiträgen erlauben.
+  """
+  defaultPingStatus: String
+}
+
+input WpDiscussionSettingsFilterInput {
+  defaultCommentStatus: StringQueryOperatorInput
+  defaultPingStatus: StringQueryOperatorInput
+}
+
+type WpEdge {
+  next: Wp
+  node: Wp!
+  previous: Wp
+}
+
+enum WpFieldsEnum {
+  allSettings___discussionSettingsDefaultCommentStatus
+  allSettings___discussionSettingsDefaultPingStatus
+  allSettings___generalSettingsDateFormat
+  allSettings___generalSettingsDescription
+  allSettings___generalSettingsEmail
+  allSettings___generalSettingsLanguage
+  allSettings___generalSettingsStartOfWeek
+  allSettings___generalSettingsTimeFormat
+  allSettings___generalSettingsTimezone
+  allSettings___generalSettingsTitle
+  allSettings___generalSettingsUrl
+  allSettings___readingSettingsPostsPerPage
+  allSettings___writingSettingsDefaultCategory
+  allSettings___writingSettingsDefaultPostFormat
+  allSettings___writingSettingsUseSmilies
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  discussionSettings___defaultCommentStatus
+  discussionSettings___defaultPingStatus
+  generalSettings___dateFormat
+  generalSettings___description
+  generalSettings___email
+  generalSettings___language
+  generalSettings___startOfWeek
+  generalSettings___timeFormat
+  generalSettings___timezone
+  generalSettings___title
+  generalSettings___url
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  readingSettings___postsPerPage
+  wpGatsby___arePrettyPermalinksEnabled
+  wpGatsby___isPreviewFrontendOnline
+  writingSettings___defaultCategory
+  writingSettings___defaultPostFormat
+  writingSettings___useSmilies
+}
+
+input WpFilterInput {
+  allSettings: WpSettingsFilterInput
+  children: NodeFilterListInput
+  discussionSettings: WpDiscussionSettingsFilterInput
+  generalSettings: WpGeneralSettingsFilterInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  readingSettings: WpReadingSettingsFilterInput
+  wpGatsby: WpWPGatsbyFilterInput
+  writingSettings: WpWritingSettingsFilterInput
+}
+
+"""
+The general setting type
+"""
+type WpGeneralSettings {
+  """
+  Ein Zeitformat für alle datumsbasierten Zeichenfolgen.
+  """
+  dateFormat: String
+
+  """
+  Website-Untertitel.
+  """
+  description: String
+
+  """
+  Diese Adresse wird für administrative Zwecke verwendet, wie Benachrichtigungen über neue Benutzer.
+  """
+  email: String
+
+  """
+  WordPress-Ländercode.
+  """
+  language: String
+
+  """
+  Die Zahl eines Wochentages, mit dem die Woche beginnen sollte.
+  """
+  startOfWeek: Int
+
+  """
+  Ein Zeitformat für alle zeitbasierten Zeichenfolgen.
+  """
+  timeFormat: String
+
+  """
+  Eine Stadt in deiner Zeitzone.
+  """
+  timezone: String
+
+  """
+  Website-Titel.
+  """
+  title: String
+
+  """
+  Website-URL.
+  """
+  url: String
+}
+
+input WpGeneralSettingsFilterInput {
+  dateFormat: StringQueryOperatorInput
+  description: StringQueryOperatorInput
+  email: StringQueryOperatorInput
+  language: StringQueryOperatorInput
+  startOfWeek: IntQueryOperatorInput
+  timeFormat: StringQueryOperatorInput
+  timezone: StringQueryOperatorInput
+  title: StringQueryOperatorInput
+  url: StringQueryOperatorInput
+}
+
+type WpGroupConnection {
+  distinct(field: WpFieldsEnum!): [String!]!
+  edges: [WpEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpFieldsEnum!, limit: Int, skip: Int): [WpGroupConnection!]!
+  max(field: WpFieldsEnum!): Float
+  min(field: WpFieldsEnum!): Float
+  nodes: [Wp!]!
+  pageInfo: PageInfo!
+  sum(field: WpFieldsEnum!): Float
+  totalCount: Int!
+}
+
+interface WpHierarchicalContentNode {
+  """
+  Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).
+  """
+  ancestors: WpHierarchicalContentNodeToContentNodeAncestorsConnection
+
+  """
+  Database id of the parent node
+  """
+  parentDatabaseId: Int
+
+  """
+  The globally unique identifier of the parent node.
+  """
+  parentId: ID
+
+  """
+  Connection between the HierarchicalContentNode type and the ContentNode type
+  """
+  wpChildren: WpHierarchicalContentNodeToContentNodeChildrenConnection
+
+  """
+  The parent of the node. The parent object can be of various types
+  """
+  wpParent: WpHierarchicalContentNodeToParentContentNodeConnectionEdge
+}
+
+"""
+Connection between the HierarchicalContentNode type and the ContentNode type
+"""
+type WpHierarchicalContentNodeToContentNodeAncestorsConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpContentNode]
+}
+
+input WpHierarchicalContentNodeToContentNodeAncestorsConnectionFilterInput {
+  nodes: WpContentNodeFilterListInput
+}
+
+"""
+Connection between the HierarchicalContentNode type and the ContentNode type
+"""
+type WpHierarchicalContentNodeToContentNodeChildrenConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpContentNode]
+}
+
+input WpHierarchicalContentNodeToContentNodeChildrenConnectionFilterInput {
+  nodes: WpContentNodeFilterListInput
+}
+
+"""
+Connection between the HierarchicalContentNode type and the ContentNode type
+"""
+type WpHierarchicalContentNodeToParentContentNodeConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpContentNode
+}
+
+input WpHierarchicalContentNodeToParentContentNodeConnectionEdgeFilterInput {
+  node: WpContentNodeFilterInput
+}
+
+interface WpHierarchicalTermNode {
+  """
+  Database id of the parent node
+  """
+  parentDatabaseId: Int
+
+  """
+  The globally unique identifier of the parent node.
+  """
+  parentId: ID
+}
+
+"""
+lazyblock-core/free block
+"""
+type WpLazyblockCoreFreeBlock implements WpBlock {
+  attributes: WpLazyblockCoreFreeBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpLazyblockCoreFreeBlockAttributes {
+  className: String
+  lock: JSON
+}
+
+"""
+lazyblock/image-repeater block
+"""
+type WpLazyblockImageRepeaterBlock implements WpBlock {
+  attributes: WpLazyblockImageRepeaterBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpLazyblockImageRepeaterBlockAttributes {
+  align: String!
+  anchor: String!
+  blockId: String!
+  blockUniqueClass: String!
+  className: String
+  ghostkitSR: String!
+  ghostkitSpacings: JSON!
+  images: String!
+  innerBlock: String!
+  lazyblock: JSON!
+  lock: JSON
+}
+
+"""
+lazyblock/lightbox-image block
+"""
+type WpLazyblockLightboxImageBlock implements WpBlock {
+  attributes: WpLazyblockLightboxImageBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpLazyblockLightboxImageBlockAttributes {
+  align: String!
+  anchor: String!
+  blockId: String!
+  blockUniqueClass: String!
+  className: String
+  ghostkitSR: String!
+  ghostkitSpacings: JSON!
+  image: String!
+  lazyblock: JSON!
+  lock: JSON
+}
+
+"""
+lazyblock/project-highlight block
+"""
+type WpLazyblockProjectHighlightBlock implements WpBlock {
+  attributes: WpLazyblockProjectHighlightBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpLazyblockProjectHighlightBlockAttributes {
+  align: String!
+  anchor: String!
+  blockId: String!
+  blockUniqueClass: String!
+  className: String
+  ghostkitSR: String!
+  ghostkitSpacings: JSON!
+  highlights: String!
+  images: String!
+  lazyblock: JSON!
+  lock: JSON
+  title: String!
+}
+
+"""
+lazyblock/projectecho block
+"""
+type WpLazyblockProjectechoBlock implements WpBlock {
+  attributes: WpLazyblockProjectechoBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpLazyblockProjectechoBlockAttributes {
+  align: String!
+  anchor: String!
+  blockId: String!
+  blockUniqueClass: String!
+  className: String
+  gallery: String!
+  ghostkitSR: String!
+  ghostkitSpacings: JSON!
+  lazyblock: JSON!
+  lock: JSON
+}
+
+"""
+File details for a Media Item
+"""
+type WpMediaDetails {
+  """
+  The filename of the mediaItem
+  """
+  file: String
+
+  """
+  The height of the mediaItem
+  """
+  height: Int
+
+  """
+  Meta information associated with the mediaItem
+  """
+  meta: WpMediaItemMeta
+
+  """
+  The available sizes of the mediaItem
+  """
+  sizes: [WpMediaSize]
+
+  """
+  The width of the mediaItem
+  """
+  width: Int
+}
+
+input WpMediaDetailsFilterInput {
+  file: StringQueryOperatorInput
+  height: IntQueryOperatorInput
+  meta: WpMediaItemMetaFilterInput
+  sizes: WpMediaSizeFilterListInput
+  width: IntQueryOperatorInput
+}
+
+"""
+The mediaItem type
+"""
+type WpMediaItem implements Node & RemoteFile & WpContentNode & WpDatabaseIdentifier & WpHierarchicalContentNode & WpNode & WpNodeWithAuthor & WpNodeWithComments & WpNodeWithTemplate & WpNodeWithTitle & WpUniformResourceIdentifiable {
+  """
+  Alternative text to display when resource is not displayed
+  """
+  altText: String
+
+  """
+  Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).
+  """
+  ancestors: WpHierarchicalContentNodeToContentNodeAncestorsConnection
+
+  """
+  Connection between the NodeWithAuthor type and the User type
+  """
+  author: WpNodeWithAuthorToUserConnectionEdge
+
+  """
+  The database identifier of the author of the node
+  """
+  authorDatabaseId: Int
+
+  """
+  The globally unique identifier of the author of the node
+  """
+  authorId: ID
+
+  """
+  The caption for the resource
+  """
+  caption: String
+  children: [Node!]!
+
+  """
+  The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatibility.
+  """
+  commentCount: Int
+
+  """
+  Whether the comments are open or closed for this particular post.
+  """
+  commentStatus: String
+
+  """
+  Connection between the mediaItem type and the Comment type
+  """
+  comments: WpMediaItemToCommentConnection
+
+  """
+  Connection between the ContentNode type and the ContentType type
+  """
+  contentType: WpContentNodeToContentTypeConnectionEdge
+
+  """
+  The name of the Content Type the node belongs to
+  """
+  contentTypeName: String!
+
+  """
+  The unique identifier stored in the database
+  """
+  databaseId: Int!
+
+  """
+  Post publishing date.
+  """
+  date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The publishing date set in GMT.
+  """
+  dateGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  Description of the image (stored as post_content)
+  """
+  description: String
+
+  """
+  The desired slug of the post
+  """
+  desiredSlug: String
+
+  """
+  The RSS enclosure for the object
+  """
+  enclosure: String
+
+  """
+  The filesize in bytes of the resource
+  """
+  fileSize: Int
+  filename: String!
+  filesize: Int
+
+  """
+  Data used in the <GatsbyImage /> component. See https://gatsby.dev/img for more info.
+  """
+  gatsbyImage(
+    """
+    If set along with width or height, this will set the value of the other dimension to match the provided aspect ratio, cropping the image if needed.
+    If neither width or height is provided, height will be set based on the intrinsic width of the source image.
+    """
+    aspectRatio: Float
+
+    """
+    Background color applied to the wrapper, or when "letterboxing" an image to another aspect ratio.
+    """
+    backgroundColor: String
+
+    """
+    Specifies the image widths to generate. You should rarely need to change this. For FIXED and CONSTRAINED images it is better to allow these to be determined automatically,
+    based on the image size. For FULL_WIDTH images this can be used to override the default, which is [750, 1080, 1366, 1920].
+    It will never generate any images larger than the source.
+    """
+    breakpoints: [Int] = [750, 1080, 1366, 1920]
+    cropFocus: [RemoteFileCropFocus]
+    fit: RemoteFileFit = COVER
+
+    """
+    The image formats to generate. Valid values are AUTO (meaning the same format as the source image), JPG, PNG, WEBP and AVIF.
+    The default value is [AUTO, WEBP, AVIF], and you should rarely need to change this. Take care if you specify JPG or PNG when you do
+    not know the formats of the source images, as this could lead to unwanted results such as converting JPEGs to PNGs. Specifying
+    both PNG and JPG is not supported and will be ignored.
+    """
+    formats: [RemoteFileFormat!] = [AUTO, WEBP, AVIF]
+
+    """
+    If set, the height of the generated image. If omitted, it is calculated from the supplied width, matching the aspect ratio of the source image.
+    """
+    height: Int
+
+    """
+    The layout for the image.
+    FIXED: A static image sized, that does not resize according to the screen width
+    FULL_WIDTH: The image resizes to fit its container. Pass a "sizes" option if it isn't going to be the full width of the screen.
+    CONSTRAINED: Resizes to fit its container, up to a maximum width, at which point it will remain fixed in size.
+    """
+    layout: RemoteFileLayout = CONSTRAINED
+
+    """
+    A list of image pixel densities to generate for FIXED and CONSTRAINED images. You should rarely need to change this. It will never generate images larger than the source, and will always include a 1x image.
+    Default is [ 1, 2 ] for fixed images, meaning 1x, 2x, and [0.25, 0.5, 1, 2] for fluid. In this case, an image with a fluid layout and width = 400 would generate images at 100, 200, 400 and 800px wide.
+    """
+    outputPixelDensities: [Float] = [0.25, 0.5, 1, 2]
+
+    """
+    Format of generated placeholder image, displayed while the main image loads.
+    BLURRED: a blurred, low resolution image, encoded as a base64 data URI (default)
+    DOMINANT_COLOR: a solid color, calculated from the dominant color of the image.
+    TRACED_SVG: a low-resolution traced SVG of the image.
+    NONE: no placeholder. Set the argument "backgroundColor" to use a fixed background color.
+    """
+    placeholder: RemoteFilePlaceholder = DOMINANT_COLOR
+    quality: Int = 75
+
+    """
+    The "sizes" property, passed to the img tag. This describes the display size of the image.
+    This does not affect the generated images, but is used by the browser to decide which images to download. You can leave this blank for fixed images, or if the responsive image
+    container will be the full width of the screen. In these cases we will generate an appropriate value.
+    """
+    sizes: String
+
+    """
+    The display width of the generated image for layout = FIXED, and the display width of the largest image for layout = CONSTRAINED.
+    The actual largest image resolution will be this value multiplied by the largest value in outputPixelDensities
+    Ignored if layout = FLUID.
+    """
+    width: Int
+  ): JSON
+
+  """
+  The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table.
+  """
+  guid: String
+  height: Int
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The user that most recently edited the node
+  """
+  lastEditedBy: WpContentNodeToEditLastConnectionEdge
+
+  """
+  The permalink of the post
+  """
+  link: String
+  localFile: File
+
+  """
+  Details about the mediaItem
+  """
+  mediaDetails: WpMediaDetails
+
+  """
+  Url of the mediaItem
+  """
+  mediaItemUrl: String
+
+  """
+  Type of resource
+  """
+  mediaType: String
+  mimeType: String!
+
+  """
+  The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.
+  """
+  modified(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.
+  """
+  modifiedGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  nodeType: String
+  parent: Node
+
+  """
+  Database id of the parent node
+  """
+  parentDatabaseId: Int
+
+  """
+  The globally unique identifier of the parent node.
+  """
+  parentId: ID
+  publicUrl: String!
+  remoteFile: File @deprecated(reason: "MediaItem.remoteFile was renamed to localFile")
+  resize(
+    cropFocus: [RemoteFileCropFocus]
+    fit: RemoteFileFit = COVER
+
+    """
+    The image formats to generate. Valid values are AUTO (meaning the same format as the source image), JPG, PNG, WEBP and AVIF.
+    The default value is [AUTO, WEBP, AVIF], and you should rarely need to change this. Take care if you specify JPG or PNG when you do
+    not know the formats of the source images, as this could lead to unwanted results such as converting JPEGs to PNGs. Specifying
+    both PNG and JPG is not supported and will be ignored.
+    """
+    format: RemoteFileFormat = AUTO
+    height: Int
+    quality: Int = 75
+    width: Int
+  ): RemoteFileResize
+
+  """
+  The sizes attribute value for an image.
+  """
+  sizes: String
+
+  """
+  The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table.
+  """
+  slug: String
+
+  """
+  Url of the mediaItem
+  """
+  sourceUrl: String
+
+  """
+  The srcset attribute specifies the URL of the image to use in different situations. It is a comma separated string of urls and their widths.
+  """
+  srcSet: String
+
+  """
+  The current status of the object
+  """
+  status: String
+
+  """
+  The template assigned to the node
+  """
+  template: WpContentTemplate
+
+  """
+  The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
+  """
+  title: String
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+  width: Int
+
+  """
+  Connection between the HierarchicalContentNode type and the ContentNode type
+  """
+  wpChildren: WpHierarchicalContentNodeToContentNodeChildrenConnection
+
+  """
+  The parent of the node. The parent object can be of various types
+  """
+  wpParent: WpHierarchicalContentNodeToParentContentNodeConnectionEdge
+}
+
+type WpMediaItemConnection {
+  distinct(field: WpMediaItemFieldsEnum!): [String!]!
+  edges: [WpMediaItemEdge!]!
+  group(field: WpMediaItemFieldsEnum!, limit: Int, skip: Int): [WpMediaItemGroupConnection!]!
+  max(field: WpMediaItemFieldsEnum!): Float
+  min(field: WpMediaItemFieldsEnum!): Float
+  nodes: [WpMediaItem!]!
+  pageInfo: PageInfo!
+  sum(field: WpMediaItemFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpMediaItemEdge {
+  next: WpMediaItem
+  node: WpMediaItem!
+  previous: WpMediaItem
+}
+
+enum WpMediaItemFieldsEnum {
+  altText
+  ancestors___nodes
+  ancestors___nodes___children
+  ancestors___nodes___children___children
+  ancestors___nodes___children___id
+  ancestors___nodes___contentTypeName
+  ancestors___nodes___databaseId
+  ancestors___nodes___date
+  ancestors___nodes___dateGmt
+  ancestors___nodes___desiredSlug
+  ancestors___nodes___enclosure
+  ancestors___nodes___guid
+  ancestors___nodes___id
+  ancestors___nodes___internal___content
+  ancestors___nodes___internal___contentDigest
+  ancestors___nodes___internal___description
+  ancestors___nodes___internal___fieldOwners
+  ancestors___nodes___internal___ignoreType
+  ancestors___nodes___internal___mediaType
+  ancestors___nodes___internal___owner
+  ancestors___nodes___internal___type
+  ancestors___nodes___isContentNode
+  ancestors___nodes___isTermNode
+  ancestors___nodes___link
+  ancestors___nodes___modified
+  ancestors___nodes___modifiedGmt
+  ancestors___nodes___nodeType
+  ancestors___nodes___parent___children
+  ancestors___nodes___parent___id
+  ancestors___nodes___slug
+  ancestors___nodes___status
+  ancestors___nodes___template___templateName
+  ancestors___nodes___uri
+  authorDatabaseId
+  authorId
+  author___node___avatar___default
+  author___node___avatar___extraAttr
+  author___node___avatar___forceDefault
+  author___node___avatar___foundAvatar
+  author___node___avatar___height
+  author___node___avatar___rating
+  author___node___avatar___scheme
+  author___node___avatar___size
+  author___node___avatar___url
+  author___node___avatar___width
+  author___node___blockEditorPreviews___nodes
+  author___node___capKey
+  author___node___capabilities
+  author___node___children
+  author___node___children___children
+  author___node___children___id
+  author___node___comments___nodes
+  author___node___databaseId
+  author___node___description
+  author___node___email
+  author___node___extraCapabilities
+  author___node___firstName
+  author___node___id
+  author___node___internal___content
+  author___node___internal___contentDigest
+  author___node___internal___description
+  author___node___internal___fieldOwners
+  author___node___internal___ignoreType
+  author___node___internal___mediaType
+  author___node___internal___owner
+  author___node___internal___type
+  author___node___isContentNode
+  author___node___isTermNode
+  author___node___lastName
+  author___node___locale
+  author___node___name
+  author___node___nicename
+  author___node___nickname
+  author___node___nodeType
+  author___node___pages___nodes
+  author___node___parent___children
+  author___node___parent___id
+  author___node___posts___nodes
+  author___node___registeredDate
+  author___node___roles___nodes
+  author___node___slug
+  author___node___uri
+  author___node___url
+  author___node___username
+  caption
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  commentCount
+  commentStatus
+  comments___nodes
+  comments___nodes___agent
+  comments___nodes___approved
+  comments___nodes___authorIp
+  comments___nodes___children
+  comments___nodes___children___children
+  comments___nodes___children___id
+  comments___nodes___content
+  comments___nodes___databaseId
+  comments___nodes___date
+  comments___nodes___dateGmt
+  comments___nodes___id
+  comments___nodes___internal___content
+  comments___nodes___internal___contentDigest
+  comments___nodes___internal___description
+  comments___nodes___internal___fieldOwners
+  comments___nodes___internal___ignoreType
+  comments___nodes___internal___mediaType
+  comments___nodes___internal___owner
+  comments___nodes___internal___type
+  comments___nodes___karma
+  comments___nodes___nodeType
+  comments___nodes___parentDatabaseId
+  comments___nodes___parentId
+  comments___nodes___parent___children
+  comments___nodes___parent___id
+  comments___nodes___replies___nodes
+  comments___nodes___type
+  contentTypeName
+  contentType___node___archivePath
+  contentType___node___canExport
+  contentType___node___children
+  contentType___node___children___children
+  contentType___node___children___id
+  contentType___node___connectedTaxonomies___nodes
+  contentType___node___contentNodes___nodes
+  contentType___node___deleteWithUser
+  contentType___node___description
+  contentType___node___excludeFromSearch
+  contentType___node___graphqlPluralName
+  contentType___node___graphqlSingleName
+  contentType___node___hasArchive
+  contentType___node___hierarchical
+  contentType___node___id
+  contentType___node___internal___content
+  contentType___node___internal___contentDigest
+  contentType___node___internal___description
+  contentType___node___internal___fieldOwners
+  contentType___node___internal___ignoreType
+  contentType___node___internal___mediaType
+  contentType___node___internal___owner
+  contentType___node___internal___type
+  contentType___node___isContentNode
+  contentType___node___isFrontPage
+  contentType___node___isPostsPage
+  contentType___node___isTermNode
+  contentType___node___label
+  contentType___node___labels___addNew
+  contentType___node___labels___addNewItem
+  contentType___node___labels___allItems
+  contentType___node___labels___archives
+  contentType___node___labels___attributes
+  contentType___node___labels___editItem
+  contentType___node___labels___featuredImage
+  contentType___node___labels___filterItemsList
+  contentType___node___labels___insertIntoItem
+  contentType___node___labels___itemsList
+  contentType___node___labels___itemsListNavigation
+  contentType___node___labels___menuName
+  contentType___node___labels___name
+  contentType___node___labels___newItem
+  contentType___node___labels___notFound
+  contentType___node___labels___notFoundInTrash
+  contentType___node___labels___parentItemColon
+  contentType___node___labels___removeFeaturedImage
+  contentType___node___labels___searchItems
+  contentType___node___labels___setFeaturedImage
+  contentType___node___labels___singularName
+  contentType___node___labels___uploadedToThisItem
+  contentType___node___labels___useFeaturedImage
+  contentType___node___labels___viewItem
+  contentType___node___labels___viewItems
+  contentType___node___menuIcon
+  contentType___node___menuPosition
+  contentType___node___name
+  contentType___node___nodeType
+  contentType___node___parent___children
+  contentType___node___parent___id
+  contentType___node___public
+  contentType___node___publiclyQueryable
+  contentType___node___restBase
+  contentType___node___restControllerClass
+  contentType___node___showInAdminBar
+  contentType___node___showInGraphql
+  contentType___node___showInMenu
+  contentType___node___showInNavMenus
+  contentType___node___showInRest
+  contentType___node___showUi
+  contentType___node___uri
+  databaseId
+  date
+  dateGmt
+  description
+  desiredSlug
+  enclosure
+  fileSize
+  filename
+  filesize
+  gatsbyImage
+  guid
+  height
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isTermNode
+  lastEditedBy___node___avatar___default
+  lastEditedBy___node___avatar___extraAttr
+  lastEditedBy___node___avatar___forceDefault
+  lastEditedBy___node___avatar___foundAvatar
+  lastEditedBy___node___avatar___height
+  lastEditedBy___node___avatar___rating
+  lastEditedBy___node___avatar___scheme
+  lastEditedBy___node___avatar___size
+  lastEditedBy___node___avatar___url
+  lastEditedBy___node___avatar___width
+  lastEditedBy___node___blockEditorPreviews___nodes
+  lastEditedBy___node___capKey
+  lastEditedBy___node___capabilities
+  lastEditedBy___node___children
+  lastEditedBy___node___children___children
+  lastEditedBy___node___children___id
+  lastEditedBy___node___comments___nodes
+  lastEditedBy___node___databaseId
+  lastEditedBy___node___description
+  lastEditedBy___node___email
+  lastEditedBy___node___extraCapabilities
+  lastEditedBy___node___firstName
+  lastEditedBy___node___id
+  lastEditedBy___node___internal___content
+  lastEditedBy___node___internal___contentDigest
+  lastEditedBy___node___internal___description
+  lastEditedBy___node___internal___fieldOwners
+  lastEditedBy___node___internal___ignoreType
+  lastEditedBy___node___internal___mediaType
+  lastEditedBy___node___internal___owner
+  lastEditedBy___node___internal___type
+  lastEditedBy___node___isContentNode
+  lastEditedBy___node___isTermNode
+  lastEditedBy___node___lastName
+  lastEditedBy___node___locale
+  lastEditedBy___node___name
+  lastEditedBy___node___nicename
+  lastEditedBy___node___nickname
+  lastEditedBy___node___nodeType
+  lastEditedBy___node___pages___nodes
+  lastEditedBy___node___parent___children
+  lastEditedBy___node___parent___id
+  lastEditedBy___node___posts___nodes
+  lastEditedBy___node___registeredDate
+  lastEditedBy___node___roles___nodes
+  lastEditedBy___node___slug
+  lastEditedBy___node___uri
+  lastEditedBy___node___url
+  lastEditedBy___node___username
+  link
+  localFile___absolutePath
+  localFile___accessTime
+  localFile___atime
+  localFile___atimeMs
+  localFile___base
+  localFile___birthTime
+  localFile___birthtime
+  localFile___birthtimeMs
+  localFile___blksize
+  localFile___blocks
+  localFile___changeTime
+  localFile___childImageSharp___children
+  localFile___childImageSharp___children___children
+  localFile___childImageSharp___children___id
+  localFile___childImageSharp___fixed___aspectRatio
+  localFile___childImageSharp___fixed___base64
+  localFile___childImageSharp___fixed___height
+  localFile___childImageSharp___fixed___originalName
+  localFile___childImageSharp___fixed___src
+  localFile___childImageSharp___fixed___srcSet
+  localFile___childImageSharp___fixed___srcSetWebp
+  localFile___childImageSharp___fixed___srcWebp
+  localFile___childImageSharp___fixed___tracedSVG
+  localFile___childImageSharp___fixed___width
+  localFile___childImageSharp___fluid___aspectRatio
+  localFile___childImageSharp___fluid___base64
+  localFile___childImageSharp___fluid___originalImg
+  localFile___childImageSharp___fluid___originalName
+  localFile___childImageSharp___fluid___presentationHeight
+  localFile___childImageSharp___fluid___presentationWidth
+  localFile___childImageSharp___fluid___sizes
+  localFile___childImageSharp___fluid___src
+  localFile___childImageSharp___fluid___srcSet
+  localFile___childImageSharp___fluid___srcSetWebp
+  localFile___childImageSharp___fluid___srcWebp
+  localFile___childImageSharp___fluid___tracedSVG
+  localFile___childImageSharp___gatsbyImageData
+  localFile___childImageSharp___id
+  localFile___childImageSharp___internal___content
+  localFile___childImageSharp___internal___contentDigest
+  localFile___childImageSharp___internal___description
+  localFile___childImageSharp___internal___fieldOwners
+  localFile___childImageSharp___internal___ignoreType
+  localFile___childImageSharp___internal___mediaType
+  localFile___childImageSharp___internal___owner
+  localFile___childImageSharp___internal___type
+  localFile___childImageSharp___original___height
+  localFile___childImageSharp___original___src
+  localFile___childImageSharp___original___width
+  localFile___childImageSharp___parent___children
+  localFile___childImageSharp___parent___id
+  localFile___childImageSharp___resize___aspectRatio
+  localFile___childImageSharp___resize___height
+  localFile___childImageSharp___resize___originalName
+  localFile___childImageSharp___resize___src
+  localFile___childImageSharp___resize___tracedSVG
+  localFile___childImageSharp___resize___width
+  localFile___children
+  localFile___childrenImageSharp
+  localFile___childrenImageSharp___children
+  localFile___childrenImageSharp___children___children
+  localFile___childrenImageSharp___children___id
+  localFile___childrenImageSharp___fixed___aspectRatio
+  localFile___childrenImageSharp___fixed___base64
+  localFile___childrenImageSharp___fixed___height
+  localFile___childrenImageSharp___fixed___originalName
+  localFile___childrenImageSharp___fixed___src
+  localFile___childrenImageSharp___fixed___srcSet
+  localFile___childrenImageSharp___fixed___srcSetWebp
+  localFile___childrenImageSharp___fixed___srcWebp
+  localFile___childrenImageSharp___fixed___tracedSVG
+  localFile___childrenImageSharp___fixed___width
+  localFile___childrenImageSharp___fluid___aspectRatio
+  localFile___childrenImageSharp___fluid___base64
+  localFile___childrenImageSharp___fluid___originalImg
+  localFile___childrenImageSharp___fluid___originalName
+  localFile___childrenImageSharp___fluid___presentationHeight
+  localFile___childrenImageSharp___fluid___presentationWidth
+  localFile___childrenImageSharp___fluid___sizes
+  localFile___childrenImageSharp___fluid___src
+  localFile___childrenImageSharp___fluid___srcSet
+  localFile___childrenImageSharp___fluid___srcSetWebp
+  localFile___childrenImageSharp___fluid___srcWebp
+  localFile___childrenImageSharp___fluid___tracedSVG
+  localFile___childrenImageSharp___gatsbyImageData
+  localFile___childrenImageSharp___id
+  localFile___childrenImageSharp___internal___content
+  localFile___childrenImageSharp___internal___contentDigest
+  localFile___childrenImageSharp___internal___description
+  localFile___childrenImageSharp___internal___fieldOwners
+  localFile___childrenImageSharp___internal___ignoreType
+  localFile___childrenImageSharp___internal___mediaType
+  localFile___childrenImageSharp___internal___owner
+  localFile___childrenImageSharp___internal___type
+  localFile___childrenImageSharp___original___height
+  localFile___childrenImageSharp___original___src
+  localFile___childrenImageSharp___original___width
+  localFile___childrenImageSharp___parent___children
+  localFile___childrenImageSharp___parent___id
+  localFile___childrenImageSharp___resize___aspectRatio
+  localFile___childrenImageSharp___resize___height
+  localFile___childrenImageSharp___resize___originalName
+  localFile___childrenImageSharp___resize___src
+  localFile___childrenImageSharp___resize___tracedSVG
+  localFile___childrenImageSharp___resize___width
+  localFile___children___children
+  localFile___children___children___children
+  localFile___children___children___id
+  localFile___children___id
+  localFile___children___internal___content
+  localFile___children___internal___contentDigest
+  localFile___children___internal___description
+  localFile___children___internal___fieldOwners
+  localFile___children___internal___ignoreType
+  localFile___children___internal___mediaType
+  localFile___children___internal___owner
+  localFile___children___internal___type
+  localFile___children___parent___children
+  localFile___children___parent___id
+  localFile___ctime
+  localFile___ctimeMs
+  localFile___dev
+  localFile___dir
+  localFile___ext
+  localFile___extension
+  localFile___gid
+  localFile___hash
+  localFile___id
+  localFile___ino
+  localFile___internal___content
+  localFile___internal___contentDigest
+  localFile___internal___description
+  localFile___internal___fieldOwners
+  localFile___internal___ignoreType
+  localFile___internal___mediaType
+  localFile___internal___owner
+  localFile___internal___type
+  localFile___mode
+  localFile___modifiedTime
+  localFile___mtime
+  localFile___mtimeMs
+  localFile___name
+  localFile___nlink
+  localFile___parent___children
+  localFile___parent___children___children
+  localFile___parent___children___id
+  localFile___parent___id
+  localFile___parent___internal___content
+  localFile___parent___internal___contentDigest
+  localFile___parent___internal___description
+  localFile___parent___internal___fieldOwners
+  localFile___parent___internal___ignoreType
+  localFile___parent___internal___mediaType
+  localFile___parent___internal___owner
+  localFile___parent___internal___type
+  localFile___parent___parent___children
+  localFile___parent___parent___id
+  localFile___prettySize
+  localFile___publicURL
+  localFile___rdev
+  localFile___relativeDirectory
+  localFile___relativePath
+  localFile___root
+  localFile___size
+  localFile___sourceInstanceName
+  localFile___uid
+  mediaDetails___file
+  mediaDetails___height
+  mediaDetails___meta___aperture
+  mediaDetails___meta___camera
+  mediaDetails___meta___caption
+  mediaDetails___meta___copyright
+  mediaDetails___meta___createdTimestamp
+  mediaDetails___meta___credit
+  mediaDetails___meta___focalLength
+  mediaDetails___meta___iso
+  mediaDetails___meta___keywords
+  mediaDetails___meta___orientation
+  mediaDetails___meta___shutterSpeed
+  mediaDetails___meta___title
+  mediaDetails___sizes
+  mediaDetails___sizes___file
+  mediaDetails___sizes___fileSize
+  mediaDetails___sizes___height
+  mediaDetails___sizes___mimeType
+  mediaDetails___sizes___name
+  mediaDetails___sizes___sourceUrl
+  mediaDetails___sizes___width
+  mediaDetails___width
+  mediaItemUrl
+  mediaType
+  mimeType
+  modified
+  modifiedGmt
+  nodeType
+  parentDatabaseId
+  parentId
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  publicUrl
+  remoteFile___absolutePath
+  remoteFile___accessTime
+  remoteFile___atime
+  remoteFile___atimeMs
+  remoteFile___base
+  remoteFile___birthTime
+  remoteFile___birthtime
+  remoteFile___birthtimeMs
+  remoteFile___blksize
+  remoteFile___blocks
+  remoteFile___changeTime
+  remoteFile___childImageSharp___children
+  remoteFile___childImageSharp___children___children
+  remoteFile___childImageSharp___children___id
+  remoteFile___childImageSharp___fixed___aspectRatio
+  remoteFile___childImageSharp___fixed___base64
+  remoteFile___childImageSharp___fixed___height
+  remoteFile___childImageSharp___fixed___originalName
+  remoteFile___childImageSharp___fixed___src
+  remoteFile___childImageSharp___fixed___srcSet
+  remoteFile___childImageSharp___fixed___srcSetWebp
+  remoteFile___childImageSharp___fixed___srcWebp
+  remoteFile___childImageSharp___fixed___tracedSVG
+  remoteFile___childImageSharp___fixed___width
+  remoteFile___childImageSharp___fluid___aspectRatio
+  remoteFile___childImageSharp___fluid___base64
+  remoteFile___childImageSharp___fluid___originalImg
+  remoteFile___childImageSharp___fluid___originalName
+  remoteFile___childImageSharp___fluid___presentationHeight
+  remoteFile___childImageSharp___fluid___presentationWidth
+  remoteFile___childImageSharp___fluid___sizes
+  remoteFile___childImageSharp___fluid___src
+  remoteFile___childImageSharp___fluid___srcSet
+  remoteFile___childImageSharp___fluid___srcSetWebp
+  remoteFile___childImageSharp___fluid___srcWebp
+  remoteFile___childImageSharp___fluid___tracedSVG
+  remoteFile___childImageSharp___gatsbyImageData
+  remoteFile___childImageSharp___id
+  remoteFile___childImageSharp___internal___content
+  remoteFile___childImageSharp___internal___contentDigest
+  remoteFile___childImageSharp___internal___description
+  remoteFile___childImageSharp___internal___fieldOwners
+  remoteFile___childImageSharp___internal___ignoreType
+  remoteFile___childImageSharp___internal___mediaType
+  remoteFile___childImageSharp___internal___owner
+  remoteFile___childImageSharp___internal___type
+  remoteFile___childImageSharp___original___height
+  remoteFile___childImageSharp___original___src
+  remoteFile___childImageSharp___original___width
+  remoteFile___childImageSharp___parent___children
+  remoteFile___childImageSharp___parent___id
+  remoteFile___childImageSharp___resize___aspectRatio
+  remoteFile___childImageSharp___resize___height
+  remoteFile___childImageSharp___resize___originalName
+  remoteFile___childImageSharp___resize___src
+  remoteFile___childImageSharp___resize___tracedSVG
+  remoteFile___childImageSharp___resize___width
+  remoteFile___children
+  remoteFile___childrenImageSharp
+  remoteFile___childrenImageSharp___children
+  remoteFile___childrenImageSharp___children___children
+  remoteFile___childrenImageSharp___children___id
+  remoteFile___childrenImageSharp___fixed___aspectRatio
+  remoteFile___childrenImageSharp___fixed___base64
+  remoteFile___childrenImageSharp___fixed___height
+  remoteFile___childrenImageSharp___fixed___originalName
+  remoteFile___childrenImageSharp___fixed___src
+  remoteFile___childrenImageSharp___fixed___srcSet
+  remoteFile___childrenImageSharp___fixed___srcSetWebp
+  remoteFile___childrenImageSharp___fixed___srcWebp
+  remoteFile___childrenImageSharp___fixed___tracedSVG
+  remoteFile___childrenImageSharp___fixed___width
+  remoteFile___childrenImageSharp___fluid___aspectRatio
+  remoteFile___childrenImageSharp___fluid___base64
+  remoteFile___childrenImageSharp___fluid___originalImg
+  remoteFile___childrenImageSharp___fluid___originalName
+  remoteFile___childrenImageSharp___fluid___presentationHeight
+  remoteFile___childrenImageSharp___fluid___presentationWidth
+  remoteFile___childrenImageSharp___fluid___sizes
+  remoteFile___childrenImageSharp___fluid___src
+  remoteFile___childrenImageSharp___fluid___srcSet
+  remoteFile___childrenImageSharp___fluid___srcSetWebp
+  remoteFile___childrenImageSharp___fluid___srcWebp
+  remoteFile___childrenImageSharp___fluid___tracedSVG
+  remoteFile___childrenImageSharp___gatsbyImageData
+  remoteFile___childrenImageSharp___id
+  remoteFile___childrenImageSharp___internal___content
+  remoteFile___childrenImageSharp___internal___contentDigest
+  remoteFile___childrenImageSharp___internal___description
+  remoteFile___childrenImageSharp___internal___fieldOwners
+  remoteFile___childrenImageSharp___internal___ignoreType
+  remoteFile___childrenImageSharp___internal___mediaType
+  remoteFile___childrenImageSharp___internal___owner
+  remoteFile___childrenImageSharp___internal___type
+  remoteFile___childrenImageSharp___original___height
+  remoteFile___childrenImageSharp___original___src
+  remoteFile___childrenImageSharp___original___width
+  remoteFile___childrenImageSharp___parent___children
+  remoteFile___childrenImageSharp___parent___id
+  remoteFile___childrenImageSharp___resize___aspectRatio
+  remoteFile___childrenImageSharp___resize___height
+  remoteFile___childrenImageSharp___resize___originalName
+  remoteFile___childrenImageSharp___resize___src
+  remoteFile___childrenImageSharp___resize___tracedSVG
+  remoteFile___childrenImageSharp___resize___width
+  remoteFile___children___children
+  remoteFile___children___children___children
+  remoteFile___children___children___id
+  remoteFile___children___id
+  remoteFile___children___internal___content
+  remoteFile___children___internal___contentDigest
+  remoteFile___children___internal___description
+  remoteFile___children___internal___fieldOwners
+  remoteFile___children___internal___ignoreType
+  remoteFile___children___internal___mediaType
+  remoteFile___children___internal___owner
+  remoteFile___children___internal___type
+  remoteFile___children___parent___children
+  remoteFile___children___parent___id
+  remoteFile___ctime
+  remoteFile___ctimeMs
+  remoteFile___dev
+  remoteFile___dir
+  remoteFile___ext
+  remoteFile___extension
+  remoteFile___gid
+  remoteFile___hash
+  remoteFile___id
+  remoteFile___ino
+  remoteFile___internal___content
+  remoteFile___internal___contentDigest
+  remoteFile___internal___description
+  remoteFile___internal___fieldOwners
+  remoteFile___internal___ignoreType
+  remoteFile___internal___mediaType
+  remoteFile___internal___owner
+  remoteFile___internal___type
+  remoteFile___mode
+  remoteFile___modifiedTime
+  remoteFile___mtime
+  remoteFile___mtimeMs
+  remoteFile___name
+  remoteFile___nlink
+  remoteFile___parent___children
+  remoteFile___parent___children___children
+  remoteFile___parent___children___id
+  remoteFile___parent___id
+  remoteFile___parent___internal___content
+  remoteFile___parent___internal___contentDigest
+  remoteFile___parent___internal___description
+  remoteFile___parent___internal___fieldOwners
+  remoteFile___parent___internal___ignoreType
+  remoteFile___parent___internal___mediaType
+  remoteFile___parent___internal___owner
+  remoteFile___parent___internal___type
+  remoteFile___parent___parent___children
+  remoteFile___parent___parent___id
+  remoteFile___prettySize
+  remoteFile___publicURL
+  remoteFile___rdev
+  remoteFile___relativeDirectory
+  remoteFile___relativePath
+  remoteFile___root
+  remoteFile___size
+  remoteFile___sourceInstanceName
+  remoteFile___uid
+  resize___height
+  resize___src
+  resize___width
+  sizes
+  slug
+  sourceUrl
+  srcSet
+  status
+  template___templateName
+  title
+  uri
+  width
+  wpChildren___nodes
+  wpChildren___nodes___children
+  wpChildren___nodes___children___children
+  wpChildren___nodes___children___id
+  wpChildren___nodes___contentTypeName
+  wpChildren___nodes___databaseId
+  wpChildren___nodes___date
+  wpChildren___nodes___dateGmt
+  wpChildren___nodes___desiredSlug
+  wpChildren___nodes___enclosure
+  wpChildren___nodes___guid
+  wpChildren___nodes___id
+  wpChildren___nodes___internal___content
+  wpChildren___nodes___internal___contentDigest
+  wpChildren___nodes___internal___description
+  wpChildren___nodes___internal___fieldOwners
+  wpChildren___nodes___internal___ignoreType
+  wpChildren___nodes___internal___mediaType
+  wpChildren___nodes___internal___owner
+  wpChildren___nodes___internal___type
+  wpChildren___nodes___isContentNode
+  wpChildren___nodes___isTermNode
+  wpChildren___nodes___link
+  wpChildren___nodes___modified
+  wpChildren___nodes___modifiedGmt
+  wpChildren___nodes___nodeType
+  wpChildren___nodes___parent___children
+  wpChildren___nodes___parent___id
+  wpChildren___nodes___slug
+  wpChildren___nodes___status
+  wpChildren___nodes___template___templateName
+  wpChildren___nodes___uri
+  wpParent___node___children
+  wpParent___node___children___children
+  wpParent___node___children___id
+  wpParent___node___contentTypeName
+  wpParent___node___databaseId
+  wpParent___node___date
+  wpParent___node___dateGmt
+  wpParent___node___desiredSlug
+  wpParent___node___enclosure
+  wpParent___node___guid
+  wpParent___node___id
+  wpParent___node___internal___content
+  wpParent___node___internal___contentDigest
+  wpParent___node___internal___description
+  wpParent___node___internal___fieldOwners
+  wpParent___node___internal___ignoreType
+  wpParent___node___internal___mediaType
+  wpParent___node___internal___owner
+  wpParent___node___internal___type
+  wpParent___node___isContentNode
+  wpParent___node___isTermNode
+  wpParent___node___link
+  wpParent___node___modified
+  wpParent___node___modifiedGmt
+  wpParent___node___nodeType
+  wpParent___node___parent___children
+  wpParent___node___parent___id
+  wpParent___node___slug
+  wpParent___node___status
+  wpParent___node___template___templateName
+  wpParent___node___uri
+}
+
+input WpMediaItemFilterInput {
+  altText: StringQueryOperatorInput
+  ancestors: WpHierarchicalContentNodeToContentNodeAncestorsConnectionFilterInput
+  author: WpNodeWithAuthorToUserConnectionEdgeFilterInput
+  authorDatabaseId: IntQueryOperatorInput
+  authorId: IDQueryOperatorInput
+  caption: StringQueryOperatorInput
+  children: NodeFilterListInput
+  commentCount: IntQueryOperatorInput
+  commentStatus: StringQueryOperatorInput
+  comments: WpMediaItemToCommentConnectionFilterInput
+  contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+  contentTypeName: StringQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  date: DateQueryOperatorInput
+  dateGmt: DateQueryOperatorInput
+  description: StringQueryOperatorInput
+  desiredSlug: StringQueryOperatorInput
+  enclosure: StringQueryOperatorInput
+  fileSize: IntQueryOperatorInput
+  filename: StringQueryOperatorInput
+  filesize: IntQueryOperatorInput
+  gatsbyImage: JSONQueryOperatorInput
+  guid: StringQueryOperatorInput
+  height: IntQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+  link: StringQueryOperatorInput
+  localFile: FileFilterInput
+  mediaDetails: WpMediaDetailsFilterInput
+  mediaItemUrl: StringQueryOperatorInput
+  mediaType: StringQueryOperatorInput
+  mimeType: StringQueryOperatorInput
+  modified: DateQueryOperatorInput
+  modifiedGmt: DateQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  parentDatabaseId: IntQueryOperatorInput
+  parentId: IDQueryOperatorInput
+  publicUrl: StringQueryOperatorInput
+  remoteFile: FileFilterInput
+  resize: RemoteFileResizeFilterInput
+  sizes: StringQueryOperatorInput
+  slug: StringQueryOperatorInput
+  sourceUrl: StringQueryOperatorInput
+  srcSet: StringQueryOperatorInput
+  status: StringQueryOperatorInput
+  template: WpContentTemplateFilterInput
+  title: StringQueryOperatorInput
+  uri: StringQueryOperatorInput
+  width: IntQueryOperatorInput
+  wpChildren: WpHierarchicalContentNodeToContentNodeChildrenConnectionFilterInput
+  wpParent: WpHierarchicalContentNodeToParentContentNodeConnectionEdgeFilterInput
+}
+
+type WpMediaItemGroupConnection {
+  distinct(field: WpMediaItemFieldsEnum!): [String!]!
+  edges: [WpMediaItemEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpMediaItemFieldsEnum!, limit: Int, skip: Int): [WpMediaItemGroupConnection!]!
+  max(field: WpMediaItemFieldsEnum!): Float
+  min(field: WpMediaItemFieldsEnum!): Float
+  nodes: [WpMediaItem!]!
+  pageInfo: PageInfo!
+  sum(field: WpMediaItemFieldsEnum!): Float
+  totalCount: Int!
+}
+
+"""
+Meta connected to a MediaItem
+"""
+type WpMediaItemMeta {
+  """
+  Aperture measurement of the media item.
+  """
+  aperture: Float
+
+  """
+  Information about the camera used to create the media item.
+  """
+  camera: String
+
+  """
+  The text string description associated with the media item.
+  """
+  caption: String
+
+  """
+  Copyright information associated with the media item.
+  """
+  copyright: String
+
+  """
+  The date/time when the media was created.
+  """
+  createdTimestamp: Int
+
+  """
+  The original creator of the media item.
+  """
+  credit: String
+
+  """
+  The focal length value of the media item.
+  """
+  focalLength: Float
+
+  """
+  The ISO (International Organization for Standardization) value of the media item.
+  """
+  iso: Int
+
+  """
+  List of keywords used to describe or identfy the media item.
+  """
+  keywords: [String]
+
+  """
+  The vertical or horizontal aspect of the media item.
+  """
+  orientation: String
+
+  """
+  The shutter speed information of the media item.
+  """
+  shutterSpeed: Float
+
+  """
+  A useful title for the media item.
+  """
+  title: String
+}
+
+input WpMediaItemMetaFilterInput {
+  aperture: FloatQueryOperatorInput
+  camera: StringQueryOperatorInput
+  caption: StringQueryOperatorInput
+  copyright: StringQueryOperatorInput
+  createdTimestamp: IntQueryOperatorInput
+  credit: StringQueryOperatorInput
+  focalLength: FloatQueryOperatorInput
+  iso: IntQueryOperatorInput
+  keywords: StringQueryOperatorInput
+  orientation: StringQueryOperatorInput
+  shutterSpeed: FloatQueryOperatorInput
+  title: StringQueryOperatorInput
+}
+
+input WpMediaItemSortInput {
+  fields: [WpMediaItemFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the mediaItem type and the Comment type
+"""
+type WpMediaItemToCommentConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpComment]
+}
+
+input WpMediaItemToCommentConnectionFilterInput {
+  nodes: WpCommentFilterListInput
+}
+
+"""
+Details of an available size for a media item
+"""
+type WpMediaSize {
+  """
+  The filename of the referenced size
+  """
+  file: String
+
+  """
+  The filesize of the resource
+  """
+  fileSize: Int
+
+  """
+  The height of the referenced size
+  """
+  height: String
+
+  """
+  The mime type of the referenced size
+  """
+  mimeType: String
+
+  """
+  The referenced size name
+  """
+  name: String
+
+  """
+  The url of the referenced size
+  """
+  sourceUrl: String
+
+  """
+  The width of the referenced size
+  """
+  width: String
+}
+
+input WpMediaSizeFilterInput {
+  file: StringQueryOperatorInput
+  fileSize: IntQueryOperatorInput
+  height: StringQueryOperatorInput
+  mimeType: StringQueryOperatorInput
+  name: StringQueryOperatorInput
+  sourceUrl: StringQueryOperatorInput
+  width: StringQueryOperatorInput
+}
+
+input WpMediaSizeFilterListInput {
+  elemMatch: WpMediaSizeFilterInput
+}
+
+"""
+Menus are the containers for navigation items. Menus can be assigned to menu locations, which are typically registered by the active theme.
+"""
+type WpMenu implements Node & WpDatabaseIdentifier & WpNode {
+  children: [Node!]!
+
+  """
+  The number of items in the menu
+  """
+  count: Int
+
+  """
+  The unique identifier stored in the database
+  """
+  databaseId: Int!
+  id: ID!
+  internal: Internal!
+
+  """
+  The locations a menu is assigned to
+  """
+  locations: [WpMenuLocationEnum]
+
+  """
+  Connection between the Menu type and the MenuItem type
+  """
+  menuItems: WpMenuToMenuItemConnection
+
+  """
+  Display name of the menu. Equivalent to WP_Term-&gt;name.
+  """
+  name: String
+  nodeType: String
+  parent: Node
+
+  """
+  The url friendly name of the menu. Equivalent to WP_Term-&gt;slug
+  """
+  slug: String
+}
+
+type WpMenuConnection {
+  distinct(field: WpMenuFieldsEnum!): [String!]!
+  edges: [WpMenuEdge!]!
+  group(field: WpMenuFieldsEnum!, limit: Int, skip: Int): [WpMenuGroupConnection!]!
+  max(field: WpMenuFieldsEnum!): Float
+  min(field: WpMenuFieldsEnum!): Float
+  nodes: [WpMenu!]!
+  pageInfo: PageInfo!
+  sum(field: WpMenuFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpMenuEdge {
+  next: WpMenu
+  node: WpMenu!
+  previous: WpMenu
+}
+
+enum WpMenuFieldsEnum {
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  count
+  databaseId
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  locations
+  menuItems___nodes
+  menuItems___nodes___childItems___nodes
+  menuItems___nodes___children
+  menuItems___nodes___children___children
+  menuItems___nodes___children___id
+  menuItems___nodes___cssClasses
+  menuItems___nodes___databaseId
+  menuItems___nodes___description
+  menuItems___nodes___id
+  menuItems___nodes___internal___content
+  menuItems___nodes___internal___contentDigest
+  menuItems___nodes___internal___description
+  menuItems___nodes___internal___fieldOwners
+  menuItems___nodes___internal___ignoreType
+  menuItems___nodes___internal___mediaType
+  menuItems___nodes___internal___owner
+  menuItems___nodes___internal___type
+  menuItems___nodes___label
+  menuItems___nodes___linkRelationship
+  menuItems___nodes___locations
+  menuItems___nodes___nodeType
+  menuItems___nodes___order
+  menuItems___nodes___parentDatabaseId
+  menuItems___nodes___parentId
+  menuItems___nodes___parent___children
+  menuItems___nodes___parent___id
+  menuItems___nodes___path
+  menuItems___nodes___target
+  menuItems___nodes___title
+  menuItems___nodes___url
+  name
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  slug
+}
+
+input WpMenuFilterInput {
+  children: NodeFilterListInput
+  count: IntQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  locations: WpMenuLocationEnumQueryOperatorInput
+  menuItems: WpMenuToMenuItemConnectionFilterInput
+  name: StringQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  slug: StringQueryOperatorInput
+}
+
+type WpMenuGroupConnection {
+  distinct(field: WpMenuFieldsEnum!): [String!]!
+  edges: [WpMenuEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpMenuFieldsEnum!, limit: Int, skip: Int): [WpMenuGroupConnection!]!
+  max(field: WpMenuFieldsEnum!): Float
+  min(field: WpMenuFieldsEnum!): Float
+  nodes: [WpMenu!]!
+  pageInfo: PageInfo!
+  sum(field: WpMenuFieldsEnum!): Float
+  totalCount: Int!
+}
+
+"""
+Navigation menu items are the individual items assigned to a menu. These are rendered as the links in a navigation menu.
+"""
+type WpMenuItem implements Node & WpDatabaseIdentifier & WpNode {
+  """
+  Connection between the MenuItem type and the MenuItem type
+  """
+  childItems: WpMenuItemToMenuItemConnection
+  children: [Node!]!
+
+  """
+  Connection from MenuItem to it&#039;s connected node
+  """
+  connectedNode: WpMenuItemToMenuItemLinkableConnectionEdge
+
+  """
+  Class attribute for the menu item link
+  """
+  cssClasses: [String]
+
+  """
+  The unique identifier stored in the database
+  """
+  databaseId: Int!
+
+  """
+  Description of the menu item.
+  """
+  description: String
+  id: ID!
+  internal: Internal!
+
+  """
+  Label or title of the menu item.
+  """
+  label: String
+
+  """
+  Link relationship (XFN) of the menu item.
+  """
+  linkRelationship: String
+
+  """
+  The locations the menu item&#039;s Menu is assigned to
+  """
+  locations: [WpMenuLocationEnum]
+
+  """
+  The Menu a MenuItem is part of
+  """
+  menu: WpMenuItemToMenuConnectionEdge
+  nodeType: String
+
+  """
+  Menu item order
+  """
+  order: Int
+  parent: Node
+
+  """
+  The database id of the parent menu item or null if it is the root
+  """
+  parentDatabaseId: Int
+
+  """
+  The globally unique identifier of the parent nav menu item object.
+  """
+  parentId: ID
+
+  """
+  Path for the resource. Relative path for internal resources. Absolute path for external resources.
+  """
+  path: String
+
+  """
+  Target attribute for the menu item link.
+  """
+  target: String
+
+  """
+  Title attribute for the menu item link
+  """
+  title: String
+
+  """
+  URL or destination of the menu item.
+  """
+  url: String
+}
+
+type WpMenuItemConnection {
+  distinct(field: WpMenuItemFieldsEnum!): [String!]!
+  edges: [WpMenuItemEdge!]!
+  group(field: WpMenuItemFieldsEnum!, limit: Int, skip: Int): [WpMenuItemGroupConnection!]!
+  max(field: WpMenuItemFieldsEnum!): Float
+  min(field: WpMenuItemFieldsEnum!): Float
+  nodes: [WpMenuItem!]!
+  pageInfo: PageInfo!
+  sum(field: WpMenuItemFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpMenuItemEdge {
+  next: WpMenuItem
+  node: WpMenuItem!
+  previous: WpMenuItem
+}
+
+enum WpMenuItemFieldsEnum {
+  childItems___nodes
+  childItems___nodes___childItems___nodes
+  childItems___nodes___children
+  childItems___nodes___children___children
+  childItems___nodes___children___id
+  childItems___nodes___cssClasses
+  childItems___nodes___databaseId
+  childItems___nodes___description
+  childItems___nodes___id
+  childItems___nodes___internal___content
+  childItems___nodes___internal___contentDigest
+  childItems___nodes___internal___description
+  childItems___nodes___internal___fieldOwners
+  childItems___nodes___internal___ignoreType
+  childItems___nodes___internal___mediaType
+  childItems___nodes___internal___owner
+  childItems___nodes___internal___type
+  childItems___nodes___label
+  childItems___nodes___linkRelationship
+  childItems___nodes___locations
+  childItems___nodes___nodeType
+  childItems___nodes___order
+  childItems___nodes___parentDatabaseId
+  childItems___nodes___parentId
+  childItems___nodes___parent___children
+  childItems___nodes___parent___id
+  childItems___nodes___path
+  childItems___nodes___target
+  childItems___nodes___title
+  childItems___nodes___url
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  connectedNode___node___databaseId
+  connectedNode___node___id
+  connectedNode___node___uri
+  cssClasses
+  databaseId
+  description
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  label
+  linkRelationship
+  locations
+  menu___node___children
+  menu___node___children___children
+  menu___node___children___id
+  menu___node___count
+  menu___node___databaseId
+  menu___node___id
+  menu___node___internal___content
+  menu___node___internal___contentDigest
+  menu___node___internal___description
+  menu___node___internal___fieldOwners
+  menu___node___internal___ignoreType
+  menu___node___internal___mediaType
+  menu___node___internal___owner
+  menu___node___internal___type
+  menu___node___locations
+  menu___node___menuItems___nodes
+  menu___node___name
+  menu___node___nodeType
+  menu___node___parent___children
+  menu___node___parent___id
+  menu___node___slug
+  nodeType
+  order
+  parentDatabaseId
+  parentId
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  path
+  target
+  title
+  url
+}
+
+input WpMenuItemFilterInput {
+  childItems: WpMenuItemToMenuItemConnectionFilterInput
+  children: NodeFilterListInput
+  connectedNode: WpMenuItemToMenuItemLinkableConnectionEdgeFilterInput
+  cssClasses: StringQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  description: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  label: StringQueryOperatorInput
+  linkRelationship: StringQueryOperatorInput
+  locations: WpMenuLocationEnumQueryOperatorInput
+  menu: WpMenuItemToMenuConnectionEdgeFilterInput
+  nodeType: StringQueryOperatorInput
+  order: IntQueryOperatorInput
+  parent: NodeFilterInput
+  parentDatabaseId: IntQueryOperatorInput
+  parentId: IDQueryOperatorInput
+  path: StringQueryOperatorInput
+  target: StringQueryOperatorInput
+  title: StringQueryOperatorInput
+  url: StringQueryOperatorInput
+}
+
+input WpMenuItemFilterListInput {
+  elemMatch: WpMenuItemFilterInput
+}
+
+type WpMenuItemGroupConnection {
+  distinct(field: WpMenuItemFieldsEnum!): [String!]!
+  edges: [WpMenuItemEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpMenuItemFieldsEnum!, limit: Int, skip: Int): [WpMenuItemGroupConnection!]!
+  max(field: WpMenuItemFieldsEnum!): Float
+  min(field: WpMenuItemFieldsEnum!): Float
+  nodes: [WpMenuItem!]!
+  pageInfo: PageInfo!
+  sum(field: WpMenuItemFieldsEnum!): Float
+  totalCount: Int!
+}
+
+interface WpMenuItemLinkable {
+  """
+  The unique resource identifier path
+  """
+  databaseId: Int!
+
+  """
+  The unique resource identifier path
+  """
+  id: ID!
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+}
+
+input WpMenuItemLinkableFilterInput {
+  databaseId: IntQueryOperatorInput
+  id: IDQueryOperatorInput
+  uri: StringQueryOperatorInput
+}
+
+input WpMenuItemSortInput {
+  fields: [WpMenuItemFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the MenuItem type and the Menu type
+"""
+type WpMenuItemToMenuConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpMenu
+}
+
+input WpMenuItemToMenuConnectionEdgeFilterInput {
+  node: WpMenuFilterInput
+}
+
+"""
+Connection between the MenuItem type and the MenuItem type
+"""
+type WpMenuItemToMenuItemConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpMenuItem]
+}
+
+input WpMenuItemToMenuItemConnectionFilterInput {
+  nodes: WpMenuItemFilterListInput
+}
+
+"""
+Connection between the MenuItem type and the MenuItemLinkable type
+"""
+type WpMenuItemToMenuItemLinkableConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpMenuItemLinkable
+}
+
+input WpMenuItemToMenuItemLinkableConnectionEdgeFilterInput {
+  node: WpMenuItemLinkableFilterInput
+}
+
+"""
+Registered menu locations
+"""
+enum WpMenuLocationEnum {
+  EMPTY
+}
+
+input WpMenuLocationEnumQueryOperatorInput {
+  eq: WpMenuLocationEnum
+  in: [WpMenuLocationEnum]
+  ne: WpMenuLocationEnum
+  nin: [WpMenuLocationEnum]
+}
+
+input WpMenuSortInput {
+  fields: [WpMenuFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the Menu type and the MenuItem type
+"""
+type WpMenuToMenuItemConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpMenuItem]
+}
+
+input WpMenuToMenuItemConnectionFilterInput {
+  nodes: WpMenuItemFilterListInput
+}
+
+interface WpNode {
+  """
+  The globally unique ID for the object
+  """
+  id: ID!
+}
+
+input WpNodeFilterInput {
+  id: IDQueryOperatorInput
+}
+
+interface WpNodeWithAuthor {
+  """
+  Connection between the NodeWithAuthor type and the User type
+  """
+  author: WpNodeWithAuthorToUserConnectionEdge
+
+  """
+  The database identifier of the author of the node
+  """
+  authorDatabaseId: Int
+
+  """
+  The globally unique identifier of the author of the node
+  """
+  authorId: ID
+}
+
+"""
+Connection between the NodeWithAuthor type and the User type
+"""
+type WpNodeWithAuthorToUserConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpUser
+}
+
+input WpNodeWithAuthorToUserConnectionEdgeFilterInput {
+  node: WpUserFilterInput
+}
+
+interface WpNodeWithComments {
+  """
+  The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatibility.
+  """
+  commentCount: Int
+
+  """
+  Whether the comments are open or closed for this particular post.
+  """
+  commentStatus: String
+}
+
+interface WpNodeWithContentEditor {
+  """
+  The content of the post.
+  """
+  content: String
+}
+
+interface WpNodeWithExcerpt {
+  """
+  The excerpt of the post.
+  """
+  excerpt: String
+}
+
+interface WpNodeWithFeaturedImage {
+  """
+  Connection between the ContentNode type and the ContentType type
+  """
+  contentType: WpContentNodeToContentTypeConnectionEdge
+
+  """
+  The name of the Content Type the node belongs to
+  """
+  contentTypeName: String!
+
+  """
+  The unique identifier stored in the database
+  """
+  databaseId: Int!
+
+  """
+  Post publishing date.
+  """
+  date: Date
+
+  """
+  The publishing date set in GMT.
+  """
+  dateGmt: Date
+
+  """
+  The desired slug of the post
+  """
+  desiredSlug: String
+
+  """
+  The RSS enclosure for the object
+  """
+  enclosure: String
+
+  """
+  Connection between the NodeWithFeaturedImage type and the MediaItem type
+  """
+  featuredImage: WpNodeWithFeaturedImageToMediaItemConnectionEdge
+
+  """
+  The database identifier for the featured image node assigned to the content node
+  """
+  featuredImageDatabaseId: Int
+
+  """
+  Globally unique ID of the featured image assigned to the node
+  """
+  featuredImageId: ID
+
+  """
+  The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table.
+  """
+  guid: String
+
+  """
+  The unique resource identifier path
+  """
+  id: ID!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The user that most recently edited the node
+  """
+  lastEditedBy: WpContentNodeToEditLastConnectionEdge
+
+  """
+  The permalink of the post
+  """
+  link: String
+
+  """
+  The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.
+  """
+  modified: Date
+
+  """
+  The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.
+  """
+  modifiedGmt: Date
+
+  """
+  The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table.
+  """
+  slug: String
+
+  """
+  The current status of the object
+  """
+  status: String
+
+  """
+  The template assigned to a node of content
+  """
+  template: WpContentTemplate
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+}
+
+"""
+Connection between the NodeWithFeaturedImage type and the MediaItem type
+"""
+type WpNodeWithFeaturedImageToMediaItemConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpMediaItem
+}
+
+input WpNodeWithFeaturedImageToMediaItemConnectionEdgeFilterInput {
+  node: WpMediaItemFilterInput
+}
+
+interface WpNodeWithPageAttributes {
+  """
+  A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.
+  """
+  menuOrder: Int
+}
+
+interface WpNodeWithRevisions {
+  """
+  True if the node is a revision of another node
+  """
+  isRevision: Boolean
+}
+
+"""
+Connection between the NodeWithRevisions type and the ContentNode type
+"""
+type WpNodeWithRevisionsToContentNodeConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpContentNode
+}
+
+interface WpNodeWithTemplate {
+  """
+  The template assigned to the node
+  """
+  template: WpContentTemplate
+}
+
+interface WpNodeWithTitle {
+  """
+  The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
+  """
+  title: String
+}
+
+interface WpNodeWithTrackbacks {
+  """
+  Whether the pings are open or closed for this particular post.
+  """
+  pingStatus: String
+
+  """
+  URLs that have been pinged.
+  """
+  pinged: [String]
+
+  """
+  URLs queued to be pinged.
+  """
+  toPing: [String]
+}
+
+"""
+The page type
+"""
+type WpPage implements Node & WpBlockEditorContentNode & WpContentNode & WpDatabaseIdentifier & WpHierarchicalContentNode & WpMenuItemLinkable & WpNode & WpNodeWithAuthor & WpNodeWithComments & WpNodeWithContentEditor & WpNodeWithFeaturedImage & WpNodeWithPageAttributes & WpNodeWithRevisions & WpNodeWithTemplate & WpNodeWithTitle & WpUniformResourceIdentifiable {
+  """
+  Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root).
+  """
+  ancestors: WpHierarchicalContentNodeToContentNodeAncestorsConnection
+
+  """
+  Connection between the NodeWithAuthor type and the User type
+  """
+  author: WpNodeWithAuthorToUserConnectionEdge
+
+  """
+  The database identifier of the author of the node
+  """
+  authorDatabaseId: Int
+
+  """
+  The globally unique identifier of the author of the node
+  """
+  authorId: ID
+
+  """
+  Gutenberg blocks
+  """
+  blocks: [WpBlock!]
+
+  """
+  Gutenberg blocks as json string
+  """
+  blocksJSON: String
+  children: [Node!]!
+
+  """
+  The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatibility.
+  """
+  commentCount: Int
+
+  """
+  Whether the comments are open or closed for this particular post.
+  """
+  commentStatus: String
+
+  """
+  Connection between the page type and the Comment type
+  """
+  comments: WpPageToCommentConnection
+
+  """
+  The content of the post.
+  """
+  content: String
+
+  """
+  Connection between the ContentNode type and the ContentType type
+  """
+  contentType: WpContentNodeToContentTypeConnectionEdge
+
+  """
+  The name of the Content Type the node belongs to
+  """
+  contentTypeName: String!
+
+  """
+  The unique resource identifier path
+  """
+  databaseId: Int!
+
+  """
+  Post publishing date.
+  """
+  date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The publishing date set in GMT.
+  """
+  dateGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The desired slug of the post
+  """
+  desiredSlug: String
+
+  """
+  The RSS enclosure for the object
+  """
+  enclosure: String
+
+  """
+  Connection between the NodeWithFeaturedImage type and the MediaItem type
+  """
+  featuredImage: WpNodeWithFeaturedImageToMediaItemConnectionEdge
+
+  """
+  The database identifier for the featured image node assigned to the content node
+  """
+  featuredImageDatabaseId: Int
+
+  """
+  Globally unique ID of the featured image assigned to the node
+  """
+  featuredImageId: ID
+
+  """
+  The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table.
+  """
+  guid: String
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether this page is set to the static front page.
+  """
+  isFrontPage: Boolean!
+
+  """
+  Whether this page is set to the blog posts page.
+  """
+  isPostsPage: Boolean!
+
+  """
+  Whether this page is set to the privacy page.
+  """
+  isPrivacyPage: Boolean!
+
+  """
+  True if the node is a revision of another node
+  """
+  isRevision: Boolean
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The user that most recently edited the node
+  """
+  lastEditedBy: WpContentNodeToEditLastConnectionEdge
+
+  """
+  The permalink of the post
+  """
+  link: String
+
+  """
+  A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.
+  """
+  menuOrder: Int
+
+  """
+  The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.
+  """
+  modified(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.
+  """
+  modifiedGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  nodeType: String
+  parent: Node
+
+  """
+  Database id of the parent node
+  """
+  parentDatabaseId: Int
+
+  """
+  The globally unique identifier of the parent node.
+  """
+  parentId: ID
+
+  """
+  Previewed gutenberg blocks
+  """
+  previewBlocks: [WpBlock!]
+
+  """
+  Previewed Gutenberg blocks as json string
+  """
+  previewBlocksJSON: String
+
+  """
+  The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table.
+  """
+  slug: String
+
+  """
+  The current status of the object
+  """
+  status: String
+
+  """
+  The template assigned to a node of content
+  """
+  template: WpContentTemplate
+
+  """
+  The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
+  """
+  title: String
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+
+  """
+  Connection between the HierarchicalContentNode type and the ContentNode type
+  """
+  wpChildren: WpHierarchicalContentNodeToContentNodeChildrenConnection
+
+  """
+  The parent of the node. The parent object can be of various types
+  """
+  wpParent: WpHierarchicalContentNodeToParentContentNodeConnectionEdge
+}
+
+type WpPageConnection {
+  distinct(field: WpPageFieldsEnum!): [String!]!
+  edges: [WpPageEdge!]!
+  group(field: WpPageFieldsEnum!, limit: Int, skip: Int): [WpPageGroupConnection!]!
+  max(field: WpPageFieldsEnum!): Float
+  min(field: WpPageFieldsEnum!): Float
+  nodes: [WpPage!]!
+  pageInfo: PageInfo!
+  sum(field: WpPageFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpPageEdge {
+  next: WpPage
+  node: WpPage!
+  previous: WpPage
+}
+
+enum WpPageFieldsEnum {
+  ancestors___nodes
+  ancestors___nodes___children
+  ancestors___nodes___children___children
+  ancestors___nodes___children___id
+  ancestors___nodes___contentTypeName
+  ancestors___nodes___databaseId
+  ancestors___nodes___date
+  ancestors___nodes___dateGmt
+  ancestors___nodes___desiredSlug
+  ancestors___nodes___enclosure
+  ancestors___nodes___guid
+  ancestors___nodes___id
+  ancestors___nodes___internal___content
+  ancestors___nodes___internal___contentDigest
+  ancestors___nodes___internal___description
+  ancestors___nodes___internal___fieldOwners
+  ancestors___nodes___internal___ignoreType
+  ancestors___nodes___internal___mediaType
+  ancestors___nodes___internal___owner
+  ancestors___nodes___internal___type
+  ancestors___nodes___isContentNode
+  ancestors___nodes___isTermNode
+  ancestors___nodes___link
+  ancestors___nodes___modified
+  ancestors___nodes___modifiedGmt
+  ancestors___nodes___nodeType
+  ancestors___nodes___parent___children
+  ancestors___nodes___parent___id
+  ancestors___nodes___slug
+  ancestors___nodes___status
+  ancestors___nodes___template___templateName
+  ancestors___nodes___uri
+  authorDatabaseId
+  authorId
+  author___node___avatar___default
+  author___node___avatar___extraAttr
+  author___node___avatar___forceDefault
+  author___node___avatar___foundAvatar
+  author___node___avatar___height
+  author___node___avatar___rating
+  author___node___avatar___scheme
+  author___node___avatar___size
+  author___node___avatar___url
+  author___node___avatar___width
+  author___node___blockEditorPreviews___nodes
+  author___node___capKey
+  author___node___capabilities
+  author___node___children
+  author___node___children___children
+  author___node___children___id
+  author___node___comments___nodes
+  author___node___databaseId
+  author___node___description
+  author___node___email
+  author___node___extraCapabilities
+  author___node___firstName
+  author___node___id
+  author___node___internal___content
+  author___node___internal___contentDigest
+  author___node___internal___description
+  author___node___internal___fieldOwners
+  author___node___internal___ignoreType
+  author___node___internal___mediaType
+  author___node___internal___owner
+  author___node___internal___type
+  author___node___isContentNode
+  author___node___isTermNode
+  author___node___lastName
+  author___node___locale
+  author___node___name
+  author___node___nicename
+  author___node___nickname
+  author___node___nodeType
+  author___node___pages___nodes
+  author___node___parent___children
+  author___node___parent___id
+  author___node___posts___nodes
+  author___node___registeredDate
+  author___node___roles___nodes
+  author___node___slug
+  author___node___uri
+  author___node___url
+  author___node___username
+  blocks
+  blocksJSON
+  blocks___attributesJSON
+  blocks___dynamicContent
+  blocks___innerBlocks
+  blocks___innerBlocks___attributesJSON
+  blocks___innerBlocks___dynamicContent
+  blocks___innerBlocks___innerBlocks
+  blocks___innerBlocks___innerBlocks___attributesJSON
+  blocks___innerBlocks___innerBlocks___dynamicContent
+  blocks___innerBlocks___innerBlocks___innerBlocks
+  blocks___innerBlocks___innerBlocks___isDynamic
+  blocks___innerBlocks___innerBlocks___name
+  blocks___innerBlocks___innerBlocks___order
+  blocks___innerBlocks___innerBlocks___originalContent
+  blocks___innerBlocks___innerBlocks___parentNodeDatabaseId
+  blocks___innerBlocks___innerBlocks___saveContent
+  blocks___innerBlocks___isDynamic
+  blocks___innerBlocks___name
+  blocks___innerBlocks___order
+  blocks___innerBlocks___originalContent
+  blocks___innerBlocks___parentNodeDatabaseId
+  blocks___innerBlocks___parentNode___id
+  blocks___innerBlocks___saveContent
+  blocks___isDynamic
+  blocks___name
+  blocks___order
+  blocks___originalContent
+  blocks___parentNodeDatabaseId
+  blocks___parentNode___id
+  blocks___saveContent
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  commentCount
+  commentStatus
+  comments___nodes
+  comments___nodes___agent
+  comments___nodes___approved
+  comments___nodes___authorIp
+  comments___nodes___children
+  comments___nodes___children___children
+  comments___nodes___children___id
+  comments___nodes___content
+  comments___nodes___databaseId
+  comments___nodes___date
+  comments___nodes___dateGmt
+  comments___nodes___id
+  comments___nodes___internal___content
+  comments___nodes___internal___contentDigest
+  comments___nodes___internal___description
+  comments___nodes___internal___fieldOwners
+  comments___nodes___internal___ignoreType
+  comments___nodes___internal___mediaType
+  comments___nodes___internal___owner
+  comments___nodes___internal___type
+  comments___nodes___karma
+  comments___nodes___nodeType
+  comments___nodes___parentDatabaseId
+  comments___nodes___parentId
+  comments___nodes___parent___children
+  comments___nodes___parent___id
+  comments___nodes___replies___nodes
+  comments___nodes___type
+  content
+  contentTypeName
+  contentType___node___archivePath
+  contentType___node___canExport
+  contentType___node___children
+  contentType___node___children___children
+  contentType___node___children___id
+  contentType___node___connectedTaxonomies___nodes
+  contentType___node___contentNodes___nodes
+  contentType___node___deleteWithUser
+  contentType___node___description
+  contentType___node___excludeFromSearch
+  contentType___node___graphqlPluralName
+  contentType___node___graphqlSingleName
+  contentType___node___hasArchive
+  contentType___node___hierarchical
+  contentType___node___id
+  contentType___node___internal___content
+  contentType___node___internal___contentDigest
+  contentType___node___internal___description
+  contentType___node___internal___fieldOwners
+  contentType___node___internal___ignoreType
+  contentType___node___internal___mediaType
+  contentType___node___internal___owner
+  contentType___node___internal___type
+  contentType___node___isContentNode
+  contentType___node___isFrontPage
+  contentType___node___isPostsPage
+  contentType___node___isTermNode
+  contentType___node___label
+  contentType___node___labels___addNew
+  contentType___node___labels___addNewItem
+  contentType___node___labels___allItems
+  contentType___node___labels___archives
+  contentType___node___labels___attributes
+  contentType___node___labels___editItem
+  contentType___node___labels___featuredImage
+  contentType___node___labels___filterItemsList
+  contentType___node___labels___insertIntoItem
+  contentType___node___labels___itemsList
+  contentType___node___labels___itemsListNavigation
+  contentType___node___labels___menuName
+  contentType___node___labels___name
+  contentType___node___labels___newItem
+  contentType___node___labels___notFound
+  contentType___node___labels___notFoundInTrash
+  contentType___node___labels___parentItemColon
+  contentType___node___labels___removeFeaturedImage
+  contentType___node___labels___searchItems
+  contentType___node___labels___setFeaturedImage
+  contentType___node___labels___singularName
+  contentType___node___labels___uploadedToThisItem
+  contentType___node___labels___useFeaturedImage
+  contentType___node___labels___viewItem
+  contentType___node___labels___viewItems
+  contentType___node___menuIcon
+  contentType___node___menuPosition
+  contentType___node___name
+  contentType___node___nodeType
+  contentType___node___parent___children
+  contentType___node___parent___id
+  contentType___node___public
+  contentType___node___publiclyQueryable
+  contentType___node___restBase
+  contentType___node___restControllerClass
+  contentType___node___showInAdminBar
+  contentType___node___showInGraphql
+  contentType___node___showInMenu
+  contentType___node___showInNavMenus
+  contentType___node___showInRest
+  contentType___node___showUi
+  contentType___node___uri
+  databaseId
+  date
+  dateGmt
+  desiredSlug
+  enclosure
+  featuredImageDatabaseId
+  featuredImageId
+  featuredImage___node___altText
+  featuredImage___node___ancestors___nodes
+  featuredImage___node___authorDatabaseId
+  featuredImage___node___authorId
+  featuredImage___node___caption
+  featuredImage___node___children
+  featuredImage___node___children___children
+  featuredImage___node___children___id
+  featuredImage___node___commentCount
+  featuredImage___node___commentStatus
+  featuredImage___node___comments___nodes
+  featuredImage___node___contentTypeName
+  featuredImage___node___databaseId
+  featuredImage___node___date
+  featuredImage___node___dateGmt
+  featuredImage___node___description
+  featuredImage___node___desiredSlug
+  featuredImage___node___enclosure
+  featuredImage___node___fileSize
+  featuredImage___node___filename
+  featuredImage___node___filesize
+  featuredImage___node___gatsbyImage
+  featuredImage___node___guid
+  featuredImage___node___height
+  featuredImage___node___id
+  featuredImage___node___internal___content
+  featuredImage___node___internal___contentDigest
+  featuredImage___node___internal___description
+  featuredImage___node___internal___fieldOwners
+  featuredImage___node___internal___ignoreType
+  featuredImage___node___internal___mediaType
+  featuredImage___node___internal___owner
+  featuredImage___node___internal___type
+  featuredImage___node___isContentNode
+  featuredImage___node___isTermNode
+  featuredImage___node___link
+  featuredImage___node___localFile___absolutePath
+  featuredImage___node___localFile___accessTime
+  featuredImage___node___localFile___atime
+  featuredImage___node___localFile___atimeMs
+  featuredImage___node___localFile___base
+  featuredImage___node___localFile___birthTime
+  featuredImage___node___localFile___birthtime
+  featuredImage___node___localFile___birthtimeMs
+  featuredImage___node___localFile___blksize
+  featuredImage___node___localFile___blocks
+  featuredImage___node___localFile___changeTime
+  featuredImage___node___localFile___children
+  featuredImage___node___localFile___childrenImageSharp
+  featuredImage___node___localFile___ctime
+  featuredImage___node___localFile___ctimeMs
+  featuredImage___node___localFile___dev
+  featuredImage___node___localFile___dir
+  featuredImage___node___localFile___ext
+  featuredImage___node___localFile___extension
+  featuredImage___node___localFile___gid
+  featuredImage___node___localFile___hash
+  featuredImage___node___localFile___id
+  featuredImage___node___localFile___ino
+  featuredImage___node___localFile___mode
+  featuredImage___node___localFile___modifiedTime
+  featuredImage___node___localFile___mtime
+  featuredImage___node___localFile___mtimeMs
+  featuredImage___node___localFile___name
+  featuredImage___node___localFile___nlink
+  featuredImage___node___localFile___prettySize
+  featuredImage___node___localFile___publicURL
+  featuredImage___node___localFile___rdev
+  featuredImage___node___localFile___relativeDirectory
+  featuredImage___node___localFile___relativePath
+  featuredImage___node___localFile___root
+  featuredImage___node___localFile___size
+  featuredImage___node___localFile___sourceInstanceName
+  featuredImage___node___localFile___uid
+  featuredImage___node___mediaDetails___file
+  featuredImage___node___mediaDetails___height
+  featuredImage___node___mediaDetails___sizes
+  featuredImage___node___mediaDetails___width
+  featuredImage___node___mediaItemUrl
+  featuredImage___node___mediaType
+  featuredImage___node___mimeType
+  featuredImage___node___modified
+  featuredImage___node___modifiedGmt
+  featuredImage___node___nodeType
+  featuredImage___node___parentDatabaseId
+  featuredImage___node___parentId
+  featuredImage___node___parent___children
+  featuredImage___node___parent___id
+  featuredImage___node___publicUrl
+  featuredImage___node___remoteFile___absolutePath
+  featuredImage___node___remoteFile___accessTime
+  featuredImage___node___remoteFile___atime
+  featuredImage___node___remoteFile___atimeMs
+  featuredImage___node___remoteFile___base
+  featuredImage___node___remoteFile___birthTime
+  featuredImage___node___remoteFile___birthtime
+  featuredImage___node___remoteFile___birthtimeMs
+  featuredImage___node___remoteFile___blksize
+  featuredImage___node___remoteFile___blocks
+  featuredImage___node___remoteFile___changeTime
+  featuredImage___node___remoteFile___children
+  featuredImage___node___remoteFile___childrenImageSharp
+  featuredImage___node___remoteFile___ctime
+  featuredImage___node___remoteFile___ctimeMs
+  featuredImage___node___remoteFile___dev
+  featuredImage___node___remoteFile___dir
+  featuredImage___node___remoteFile___ext
+  featuredImage___node___remoteFile___extension
+  featuredImage___node___remoteFile___gid
+  featuredImage___node___remoteFile___hash
+  featuredImage___node___remoteFile___id
+  featuredImage___node___remoteFile___ino
+  featuredImage___node___remoteFile___mode
+  featuredImage___node___remoteFile___modifiedTime
+  featuredImage___node___remoteFile___mtime
+  featuredImage___node___remoteFile___mtimeMs
+  featuredImage___node___remoteFile___name
+  featuredImage___node___remoteFile___nlink
+  featuredImage___node___remoteFile___prettySize
+  featuredImage___node___remoteFile___publicURL
+  featuredImage___node___remoteFile___rdev
+  featuredImage___node___remoteFile___relativeDirectory
+  featuredImage___node___remoteFile___relativePath
+  featuredImage___node___remoteFile___root
+  featuredImage___node___remoteFile___size
+  featuredImage___node___remoteFile___sourceInstanceName
+  featuredImage___node___remoteFile___uid
+  featuredImage___node___resize___height
+  featuredImage___node___resize___src
+  featuredImage___node___resize___width
+  featuredImage___node___sizes
+  featuredImage___node___slug
+  featuredImage___node___sourceUrl
+  featuredImage___node___srcSet
+  featuredImage___node___status
+  featuredImage___node___template___templateName
+  featuredImage___node___title
+  featuredImage___node___uri
+  featuredImage___node___width
+  featuredImage___node___wpChildren___nodes
+  guid
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isFrontPage
+  isPostsPage
+  isPrivacyPage
+  isRevision
+  isTermNode
+  lastEditedBy___node___avatar___default
+  lastEditedBy___node___avatar___extraAttr
+  lastEditedBy___node___avatar___forceDefault
+  lastEditedBy___node___avatar___foundAvatar
+  lastEditedBy___node___avatar___height
+  lastEditedBy___node___avatar___rating
+  lastEditedBy___node___avatar___scheme
+  lastEditedBy___node___avatar___size
+  lastEditedBy___node___avatar___url
+  lastEditedBy___node___avatar___width
+  lastEditedBy___node___blockEditorPreviews___nodes
+  lastEditedBy___node___capKey
+  lastEditedBy___node___capabilities
+  lastEditedBy___node___children
+  lastEditedBy___node___children___children
+  lastEditedBy___node___children___id
+  lastEditedBy___node___comments___nodes
+  lastEditedBy___node___databaseId
+  lastEditedBy___node___description
+  lastEditedBy___node___email
+  lastEditedBy___node___extraCapabilities
+  lastEditedBy___node___firstName
+  lastEditedBy___node___id
+  lastEditedBy___node___internal___content
+  lastEditedBy___node___internal___contentDigest
+  lastEditedBy___node___internal___description
+  lastEditedBy___node___internal___fieldOwners
+  lastEditedBy___node___internal___ignoreType
+  lastEditedBy___node___internal___mediaType
+  lastEditedBy___node___internal___owner
+  lastEditedBy___node___internal___type
+  lastEditedBy___node___isContentNode
+  lastEditedBy___node___isTermNode
+  lastEditedBy___node___lastName
+  lastEditedBy___node___locale
+  lastEditedBy___node___name
+  lastEditedBy___node___nicename
+  lastEditedBy___node___nickname
+  lastEditedBy___node___nodeType
+  lastEditedBy___node___pages___nodes
+  lastEditedBy___node___parent___children
+  lastEditedBy___node___parent___id
+  lastEditedBy___node___posts___nodes
+  lastEditedBy___node___registeredDate
+  lastEditedBy___node___roles___nodes
+  lastEditedBy___node___slug
+  lastEditedBy___node___uri
+  lastEditedBy___node___url
+  lastEditedBy___node___username
+  link
+  menuOrder
+  modified
+  modifiedGmt
+  nodeType
+  parentDatabaseId
+  parentId
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  previewBlocks
+  previewBlocksJSON
+  previewBlocks___attributesJSON
+  previewBlocks___dynamicContent
+  previewBlocks___innerBlocks
+  previewBlocks___innerBlocks___attributesJSON
+  previewBlocks___innerBlocks___dynamicContent
+  previewBlocks___innerBlocks___innerBlocks
+  previewBlocks___innerBlocks___innerBlocks___attributesJSON
+  previewBlocks___innerBlocks___innerBlocks___dynamicContent
+  previewBlocks___innerBlocks___innerBlocks___innerBlocks
+  previewBlocks___innerBlocks___innerBlocks___isDynamic
+  previewBlocks___innerBlocks___innerBlocks___name
+  previewBlocks___innerBlocks___innerBlocks___order
+  previewBlocks___innerBlocks___innerBlocks___originalContent
+  previewBlocks___innerBlocks___innerBlocks___parentNodeDatabaseId
+  previewBlocks___innerBlocks___innerBlocks___saveContent
+  previewBlocks___innerBlocks___isDynamic
+  previewBlocks___innerBlocks___name
+  previewBlocks___innerBlocks___order
+  previewBlocks___innerBlocks___originalContent
+  previewBlocks___innerBlocks___parentNodeDatabaseId
+  previewBlocks___innerBlocks___parentNode___id
+  previewBlocks___innerBlocks___saveContent
+  previewBlocks___isDynamic
+  previewBlocks___name
+  previewBlocks___order
+  previewBlocks___originalContent
+  previewBlocks___parentNodeDatabaseId
+  previewBlocks___parentNode___id
+  previewBlocks___saveContent
+  slug
+  status
+  template___templateName
+  title
+  uri
+  wpChildren___nodes
+  wpChildren___nodes___children
+  wpChildren___nodes___children___children
+  wpChildren___nodes___children___id
+  wpChildren___nodes___contentTypeName
+  wpChildren___nodes___databaseId
+  wpChildren___nodes___date
+  wpChildren___nodes___dateGmt
+  wpChildren___nodes___desiredSlug
+  wpChildren___nodes___enclosure
+  wpChildren___nodes___guid
+  wpChildren___nodes___id
+  wpChildren___nodes___internal___content
+  wpChildren___nodes___internal___contentDigest
+  wpChildren___nodes___internal___description
+  wpChildren___nodes___internal___fieldOwners
+  wpChildren___nodes___internal___ignoreType
+  wpChildren___nodes___internal___mediaType
+  wpChildren___nodes___internal___owner
+  wpChildren___nodes___internal___type
+  wpChildren___nodes___isContentNode
+  wpChildren___nodes___isTermNode
+  wpChildren___nodes___link
+  wpChildren___nodes___modified
+  wpChildren___nodes___modifiedGmt
+  wpChildren___nodes___nodeType
+  wpChildren___nodes___parent___children
+  wpChildren___nodes___parent___id
+  wpChildren___nodes___slug
+  wpChildren___nodes___status
+  wpChildren___nodes___template___templateName
+  wpChildren___nodes___uri
+  wpParent___node___children
+  wpParent___node___children___children
+  wpParent___node___children___id
+  wpParent___node___contentTypeName
+  wpParent___node___databaseId
+  wpParent___node___date
+  wpParent___node___dateGmt
+  wpParent___node___desiredSlug
+  wpParent___node___enclosure
+  wpParent___node___guid
+  wpParent___node___id
+  wpParent___node___internal___content
+  wpParent___node___internal___contentDigest
+  wpParent___node___internal___description
+  wpParent___node___internal___fieldOwners
+  wpParent___node___internal___ignoreType
+  wpParent___node___internal___mediaType
+  wpParent___node___internal___owner
+  wpParent___node___internal___type
+  wpParent___node___isContentNode
+  wpParent___node___isTermNode
+  wpParent___node___link
+  wpParent___node___modified
+  wpParent___node___modifiedGmt
+  wpParent___node___nodeType
+  wpParent___node___parent___children
+  wpParent___node___parent___id
+  wpParent___node___slug
+  wpParent___node___status
+  wpParent___node___template___templateName
+  wpParent___node___uri
+}
+
+input WpPageFilterInput {
+  ancestors: WpHierarchicalContentNodeToContentNodeAncestorsConnectionFilterInput
+  author: WpNodeWithAuthorToUserConnectionEdgeFilterInput
+  authorDatabaseId: IntQueryOperatorInput
+  authorId: IDQueryOperatorInput
+  blocks: WpBlockFilterListInput
+  blocksJSON: StringQueryOperatorInput
+  children: NodeFilterListInput
+  commentCount: IntQueryOperatorInput
+  commentStatus: StringQueryOperatorInput
+  comments: WpPageToCommentConnectionFilterInput
+  content: StringQueryOperatorInput
+  contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+  contentTypeName: StringQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  date: DateQueryOperatorInput
+  dateGmt: DateQueryOperatorInput
+  desiredSlug: StringQueryOperatorInput
+  enclosure: StringQueryOperatorInput
+  featuredImage: WpNodeWithFeaturedImageToMediaItemConnectionEdgeFilterInput
+  featuredImageDatabaseId: IntQueryOperatorInput
+  featuredImageId: IDQueryOperatorInput
+  guid: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isFrontPage: BooleanQueryOperatorInput
+  isPostsPage: BooleanQueryOperatorInput
+  isPrivacyPage: BooleanQueryOperatorInput
+  isRevision: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+  link: StringQueryOperatorInput
+  menuOrder: IntQueryOperatorInput
+  modified: DateQueryOperatorInput
+  modifiedGmt: DateQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  parentDatabaseId: IntQueryOperatorInput
+  parentId: IDQueryOperatorInput
+  previewBlocks: WpBlockFilterListInput
+  previewBlocksJSON: StringQueryOperatorInput
+  slug: StringQueryOperatorInput
+  status: StringQueryOperatorInput
+  template: WpContentTemplateFilterInput
+  title: StringQueryOperatorInput
+  uri: StringQueryOperatorInput
+  wpChildren: WpHierarchicalContentNodeToContentNodeChildrenConnectionFilterInput
+  wpParent: WpHierarchicalContentNodeToParentContentNodeConnectionEdgeFilterInput
+}
+
+input WpPageFilterListInput {
+  elemMatch: WpPageFilterInput
+}
+
+type WpPageGroupConnection {
+  distinct(field: WpPageFieldsEnum!): [String!]!
+  edges: [WpPageEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpPageFieldsEnum!, limit: Int, skip: Int): [WpPageGroupConnection!]!
+  max(field: WpPageFieldsEnum!): Float
+  min(field: WpPageFieldsEnum!): Float
+  nodes: [WpPage!]!
+  pageInfo: PageInfo!
+  sum(field: WpPageFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpPageSortInput {
+  fields: [WpPageFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the page type and the Comment type
+"""
+type WpPageToCommentConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpComment]
+}
+
+input WpPageToCommentConnectionFilterInput {
+  nodes: WpCommentFilterListInput
+}
+
+"""
+The post type
+"""
+type WpPost implements Node & WpBlockEditorContentNode & WpContentNode & WpDatabaseIdentifier & WpMenuItemLinkable & WpNode & WpNodeWithAuthor & WpNodeWithComments & WpNodeWithContentEditor & WpNodeWithExcerpt & WpNodeWithFeaturedImage & WpNodeWithRevisions & WpNodeWithTemplate & WpNodeWithTitle & WpNodeWithTrackbacks & WpUniformResourceIdentifiable {
+  """
+  Connection between the NodeWithAuthor type and the User type
+  """
+  author: WpNodeWithAuthorToUserConnectionEdge
+
+  """
+  The database identifier of the author of the node
+  """
+  authorDatabaseId: Int
+
+  """
+  The globally unique identifier of the author of the node
+  """
+  authorId: ID
+
+  """
+  Gutenberg blocks
+  """
+  blocks: [WpBlock!]
+
+  """
+  Gutenberg blocks as json string
+  """
+  blocksJSON: String
+
+  """
+  Connection between the post type and the category type
+  """
+  categories: WpPostToCategoryConnection
+  children: [Node!]!
+
+  """
+  The number of comments. Even though WPGraphQL denotes this field as an integer, in WordPress this field should be saved as a numeric string for compatibility.
+  """
+  commentCount: Int
+
+  """
+  Whether the comments are open or closed for this particular post.
+  """
+  commentStatus: String
+
+  """
+  Connection between the post type and the Comment type
+  """
+  comments: WpPostToCommentConnection
+
+  """
+  The content of the post.
+  """
+  content: String
+
+  """
+  Connection between the ContentNode type and the ContentType type
+  """
+  contentType: WpContentNodeToContentTypeConnectionEdge
+
+  """
+  The name of the Content Type the node belongs to
+  """
+  contentTypeName: String!
+
+  """
+  The unique resource identifier path
+  """
+  databaseId: Int!
+
+  """
+  Post publishing date.
+  """
+  date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The publishing date set in GMT.
+  """
+  dateGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The desired slug of the post
+  """
+  desiredSlug: String
+
+  """
+  The RSS enclosure for the object
+  """
+  enclosure: String
+
+  """
+  The excerpt of the post.
+  """
+  excerpt: String
+
+  """
+  Connection between the NodeWithFeaturedImage type and the MediaItem type
+  """
+  featuredImage: WpNodeWithFeaturedImageToMediaItemConnectionEdge
+
+  """
+  The database identifier for the featured image node assigned to the content node
+  """
+  featuredImageDatabaseId: Int
+
+  """
+  Globally unique ID of the featured image assigned to the node
+  """
+  featuredImageId: ID
+
+  """
+  The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table.
+  """
+  guid: String
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  True if the node is a revision of another node
+  """
+  isRevision: Boolean
+
+  """
+  Whether this page is sticky
+  """
+  isSticky: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The user that most recently edited the node
+  """
+  lastEditedBy: WpContentNodeToEditLastConnectionEdge
+
+  """
+  The permalink of the post
+  """
+  link: String
+
+  """
+  The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.
+  """
+  modified(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.
+  """
+  modifiedGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  nodeType: String
+  parent: Node
+
+  """
+  Whether the pings are open or closed for this particular post.
+  """
+  pingStatus: String
+
+  """
+  URLs that have been pinged.
+  """
+  pinged: [String]
+
+  """
+  Connection between the post type and the postFormat type
+  """
+  postFormats: WpPostToPostFormatConnection
+
+  """
+  Previewed gutenberg blocks
+  """
+  previewBlocks: [WpBlock!]
+
+  """
+  Previewed Gutenberg blocks as json string
+  """
+  previewBlocksJSON: String
+
+  """
+  The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table.
+  """
+  slug: String
+
+  """
+  The current status of the object
+  """
+  status: String
+
+  """
+  Connection between the post type and the tag type
+  """
+  tags: WpPostToTagConnection
+
+  """
+  The template assigned to a node of content
+  """
+  template: WpContentTemplate
+
+  """
+  Connection between the post type and the TermNode type
+  """
+  terms: WpPostToTermNodeConnection
+
+  """
+  The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
+  """
+  title: String
+
+  """
+  URLs queued to be pinged.
+  """
+  toPing: [String]
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+}
+
+type WpPostConnection {
+  distinct(field: WpPostFieldsEnum!): [String!]!
+  edges: [WpPostEdge!]!
+  group(field: WpPostFieldsEnum!, limit: Int, skip: Int): [WpPostGroupConnection!]!
+  max(field: WpPostFieldsEnum!): Float
+  min(field: WpPostFieldsEnum!): Float
+  nodes: [WpPost!]!
+  pageInfo: PageInfo!
+  sum(field: WpPostFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpPostEdge {
+  next: WpPost
+  node: WpPost!
+  previous: WpPost
+}
+
+enum WpPostFieldsEnum {
+  authorDatabaseId
+  authorId
+  author___node___avatar___default
+  author___node___avatar___extraAttr
+  author___node___avatar___forceDefault
+  author___node___avatar___foundAvatar
+  author___node___avatar___height
+  author___node___avatar___rating
+  author___node___avatar___scheme
+  author___node___avatar___size
+  author___node___avatar___url
+  author___node___avatar___width
+  author___node___blockEditorPreviews___nodes
+  author___node___capKey
+  author___node___capabilities
+  author___node___children
+  author___node___children___children
+  author___node___children___id
+  author___node___comments___nodes
+  author___node___databaseId
+  author___node___description
+  author___node___email
+  author___node___extraCapabilities
+  author___node___firstName
+  author___node___id
+  author___node___internal___content
+  author___node___internal___contentDigest
+  author___node___internal___description
+  author___node___internal___fieldOwners
+  author___node___internal___ignoreType
+  author___node___internal___mediaType
+  author___node___internal___owner
+  author___node___internal___type
+  author___node___isContentNode
+  author___node___isTermNode
+  author___node___lastName
+  author___node___locale
+  author___node___name
+  author___node___nicename
+  author___node___nickname
+  author___node___nodeType
+  author___node___pages___nodes
+  author___node___parent___children
+  author___node___parent___id
+  author___node___posts___nodes
+  author___node___registeredDate
+  author___node___roles___nodes
+  author___node___slug
+  author___node___uri
+  author___node___url
+  author___node___username
+  blocks
+  blocksJSON
+  blocks___attributesJSON
+  blocks___dynamicContent
+  blocks___innerBlocks
+  blocks___innerBlocks___attributesJSON
+  blocks___innerBlocks___dynamicContent
+  blocks___innerBlocks___innerBlocks
+  blocks___innerBlocks___innerBlocks___attributesJSON
+  blocks___innerBlocks___innerBlocks___dynamicContent
+  blocks___innerBlocks___innerBlocks___innerBlocks
+  blocks___innerBlocks___innerBlocks___isDynamic
+  blocks___innerBlocks___innerBlocks___name
+  blocks___innerBlocks___innerBlocks___order
+  blocks___innerBlocks___innerBlocks___originalContent
+  blocks___innerBlocks___innerBlocks___parentNodeDatabaseId
+  blocks___innerBlocks___innerBlocks___saveContent
+  blocks___innerBlocks___isDynamic
+  blocks___innerBlocks___name
+  blocks___innerBlocks___order
+  blocks___innerBlocks___originalContent
+  blocks___innerBlocks___parentNodeDatabaseId
+  blocks___innerBlocks___parentNode___id
+  blocks___innerBlocks___saveContent
+  blocks___isDynamic
+  blocks___name
+  blocks___order
+  blocks___originalContent
+  blocks___parentNodeDatabaseId
+  blocks___parentNode___id
+  blocks___saveContent
+  categories___nodes
+  categories___nodes___ancestors___nodes
+  categories___nodes___children
+  categories___nodes___children___children
+  categories___nodes___children___id
+  categories___nodes___contentNodes___nodes
+  categories___nodes___count
+  categories___nodes___databaseId
+  categories___nodes___description
+  categories___nodes___id
+  categories___nodes___internal___content
+  categories___nodes___internal___contentDigest
+  categories___nodes___internal___description
+  categories___nodes___internal___fieldOwners
+  categories___nodes___internal___ignoreType
+  categories___nodes___internal___mediaType
+  categories___nodes___internal___owner
+  categories___nodes___internal___type
+  categories___nodes___isContentNode
+  categories___nodes___isTermNode
+  categories___nodes___link
+  categories___nodes___name
+  categories___nodes___nodeType
+  categories___nodes___parentDatabaseId
+  categories___nodes___parentId
+  categories___nodes___parent___children
+  categories___nodes___parent___id
+  categories___nodes___posts___nodes
+  categories___nodes___slug
+  categories___nodes___taxonomyName
+  categories___nodes___termGroupId
+  categories___nodes___termTaxonomyId
+  categories___nodes___uri
+  categories___nodes___wpChildren___nodes
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  commentCount
+  commentStatus
+  comments___nodes
+  comments___nodes___agent
+  comments___nodes___approved
+  comments___nodes___authorIp
+  comments___nodes___children
+  comments___nodes___children___children
+  comments___nodes___children___id
+  comments___nodes___content
+  comments___nodes___databaseId
+  comments___nodes___date
+  comments___nodes___dateGmt
+  comments___nodes___id
+  comments___nodes___internal___content
+  comments___nodes___internal___contentDigest
+  comments___nodes___internal___description
+  comments___nodes___internal___fieldOwners
+  comments___nodes___internal___ignoreType
+  comments___nodes___internal___mediaType
+  comments___nodes___internal___owner
+  comments___nodes___internal___type
+  comments___nodes___karma
+  comments___nodes___nodeType
+  comments___nodes___parentDatabaseId
+  comments___nodes___parentId
+  comments___nodes___parent___children
+  comments___nodes___parent___id
+  comments___nodes___replies___nodes
+  comments___nodes___type
+  content
+  contentTypeName
+  contentType___node___archivePath
+  contentType___node___canExport
+  contentType___node___children
+  contentType___node___children___children
+  contentType___node___children___id
+  contentType___node___connectedTaxonomies___nodes
+  contentType___node___contentNodes___nodes
+  contentType___node___deleteWithUser
+  contentType___node___description
+  contentType___node___excludeFromSearch
+  contentType___node___graphqlPluralName
+  contentType___node___graphqlSingleName
+  contentType___node___hasArchive
+  contentType___node___hierarchical
+  contentType___node___id
+  contentType___node___internal___content
+  contentType___node___internal___contentDigest
+  contentType___node___internal___description
+  contentType___node___internal___fieldOwners
+  contentType___node___internal___ignoreType
+  contentType___node___internal___mediaType
+  contentType___node___internal___owner
+  contentType___node___internal___type
+  contentType___node___isContentNode
+  contentType___node___isFrontPage
+  contentType___node___isPostsPage
+  contentType___node___isTermNode
+  contentType___node___label
+  contentType___node___labels___addNew
+  contentType___node___labels___addNewItem
+  contentType___node___labels___allItems
+  contentType___node___labels___archives
+  contentType___node___labels___attributes
+  contentType___node___labels___editItem
+  contentType___node___labels___featuredImage
+  contentType___node___labels___filterItemsList
+  contentType___node___labels___insertIntoItem
+  contentType___node___labels___itemsList
+  contentType___node___labels___itemsListNavigation
+  contentType___node___labels___menuName
+  contentType___node___labels___name
+  contentType___node___labels___newItem
+  contentType___node___labels___notFound
+  contentType___node___labels___notFoundInTrash
+  contentType___node___labels___parentItemColon
+  contentType___node___labels___removeFeaturedImage
+  contentType___node___labels___searchItems
+  contentType___node___labels___setFeaturedImage
+  contentType___node___labels___singularName
+  contentType___node___labels___uploadedToThisItem
+  contentType___node___labels___useFeaturedImage
+  contentType___node___labels___viewItem
+  contentType___node___labels___viewItems
+  contentType___node___menuIcon
+  contentType___node___menuPosition
+  contentType___node___name
+  contentType___node___nodeType
+  contentType___node___parent___children
+  contentType___node___parent___id
+  contentType___node___public
+  contentType___node___publiclyQueryable
+  contentType___node___restBase
+  contentType___node___restControllerClass
+  contentType___node___showInAdminBar
+  contentType___node___showInGraphql
+  contentType___node___showInMenu
+  contentType___node___showInNavMenus
+  contentType___node___showInRest
+  contentType___node___showUi
+  contentType___node___uri
+  databaseId
+  date
+  dateGmt
+  desiredSlug
+  enclosure
+  excerpt
+  featuredImageDatabaseId
+  featuredImageId
+  featuredImage___node___altText
+  featuredImage___node___ancestors___nodes
+  featuredImage___node___authorDatabaseId
+  featuredImage___node___authorId
+  featuredImage___node___caption
+  featuredImage___node___children
+  featuredImage___node___children___children
+  featuredImage___node___children___id
+  featuredImage___node___commentCount
+  featuredImage___node___commentStatus
+  featuredImage___node___comments___nodes
+  featuredImage___node___contentTypeName
+  featuredImage___node___databaseId
+  featuredImage___node___date
+  featuredImage___node___dateGmt
+  featuredImage___node___description
+  featuredImage___node___desiredSlug
+  featuredImage___node___enclosure
+  featuredImage___node___fileSize
+  featuredImage___node___filename
+  featuredImage___node___filesize
+  featuredImage___node___gatsbyImage
+  featuredImage___node___guid
+  featuredImage___node___height
+  featuredImage___node___id
+  featuredImage___node___internal___content
+  featuredImage___node___internal___contentDigest
+  featuredImage___node___internal___description
+  featuredImage___node___internal___fieldOwners
+  featuredImage___node___internal___ignoreType
+  featuredImage___node___internal___mediaType
+  featuredImage___node___internal___owner
+  featuredImage___node___internal___type
+  featuredImage___node___isContentNode
+  featuredImage___node___isTermNode
+  featuredImage___node___link
+  featuredImage___node___localFile___absolutePath
+  featuredImage___node___localFile___accessTime
+  featuredImage___node___localFile___atime
+  featuredImage___node___localFile___atimeMs
+  featuredImage___node___localFile___base
+  featuredImage___node___localFile___birthTime
+  featuredImage___node___localFile___birthtime
+  featuredImage___node___localFile___birthtimeMs
+  featuredImage___node___localFile___blksize
+  featuredImage___node___localFile___blocks
+  featuredImage___node___localFile___changeTime
+  featuredImage___node___localFile___children
+  featuredImage___node___localFile___childrenImageSharp
+  featuredImage___node___localFile___ctime
+  featuredImage___node___localFile___ctimeMs
+  featuredImage___node___localFile___dev
+  featuredImage___node___localFile___dir
+  featuredImage___node___localFile___ext
+  featuredImage___node___localFile___extension
+  featuredImage___node___localFile___gid
+  featuredImage___node___localFile___hash
+  featuredImage___node___localFile___id
+  featuredImage___node___localFile___ino
+  featuredImage___node___localFile___mode
+  featuredImage___node___localFile___modifiedTime
+  featuredImage___node___localFile___mtime
+  featuredImage___node___localFile___mtimeMs
+  featuredImage___node___localFile___name
+  featuredImage___node___localFile___nlink
+  featuredImage___node___localFile___prettySize
+  featuredImage___node___localFile___publicURL
+  featuredImage___node___localFile___rdev
+  featuredImage___node___localFile___relativeDirectory
+  featuredImage___node___localFile___relativePath
+  featuredImage___node___localFile___root
+  featuredImage___node___localFile___size
+  featuredImage___node___localFile___sourceInstanceName
+  featuredImage___node___localFile___uid
+  featuredImage___node___mediaDetails___file
+  featuredImage___node___mediaDetails___height
+  featuredImage___node___mediaDetails___sizes
+  featuredImage___node___mediaDetails___width
+  featuredImage___node___mediaItemUrl
+  featuredImage___node___mediaType
+  featuredImage___node___mimeType
+  featuredImage___node___modified
+  featuredImage___node___modifiedGmt
+  featuredImage___node___nodeType
+  featuredImage___node___parentDatabaseId
+  featuredImage___node___parentId
+  featuredImage___node___parent___children
+  featuredImage___node___parent___id
+  featuredImage___node___publicUrl
+  featuredImage___node___remoteFile___absolutePath
+  featuredImage___node___remoteFile___accessTime
+  featuredImage___node___remoteFile___atime
+  featuredImage___node___remoteFile___atimeMs
+  featuredImage___node___remoteFile___base
+  featuredImage___node___remoteFile___birthTime
+  featuredImage___node___remoteFile___birthtime
+  featuredImage___node___remoteFile___birthtimeMs
+  featuredImage___node___remoteFile___blksize
+  featuredImage___node___remoteFile___blocks
+  featuredImage___node___remoteFile___changeTime
+  featuredImage___node___remoteFile___children
+  featuredImage___node___remoteFile___childrenImageSharp
+  featuredImage___node___remoteFile___ctime
+  featuredImage___node___remoteFile___ctimeMs
+  featuredImage___node___remoteFile___dev
+  featuredImage___node___remoteFile___dir
+  featuredImage___node___remoteFile___ext
+  featuredImage___node___remoteFile___extension
+  featuredImage___node___remoteFile___gid
+  featuredImage___node___remoteFile___hash
+  featuredImage___node___remoteFile___id
+  featuredImage___node___remoteFile___ino
+  featuredImage___node___remoteFile___mode
+  featuredImage___node___remoteFile___modifiedTime
+  featuredImage___node___remoteFile___mtime
+  featuredImage___node___remoteFile___mtimeMs
+  featuredImage___node___remoteFile___name
+  featuredImage___node___remoteFile___nlink
+  featuredImage___node___remoteFile___prettySize
+  featuredImage___node___remoteFile___publicURL
+  featuredImage___node___remoteFile___rdev
+  featuredImage___node___remoteFile___relativeDirectory
+  featuredImage___node___remoteFile___relativePath
+  featuredImage___node___remoteFile___root
+  featuredImage___node___remoteFile___size
+  featuredImage___node___remoteFile___sourceInstanceName
+  featuredImage___node___remoteFile___uid
+  featuredImage___node___resize___height
+  featuredImage___node___resize___src
+  featuredImage___node___resize___width
+  featuredImage___node___sizes
+  featuredImage___node___slug
+  featuredImage___node___sourceUrl
+  featuredImage___node___srcSet
+  featuredImage___node___status
+  featuredImage___node___template___templateName
+  featuredImage___node___title
+  featuredImage___node___uri
+  featuredImage___node___width
+  featuredImage___node___wpChildren___nodes
+  guid
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isRevision
+  isSticky
+  isTermNode
+  lastEditedBy___node___avatar___default
+  lastEditedBy___node___avatar___extraAttr
+  lastEditedBy___node___avatar___forceDefault
+  lastEditedBy___node___avatar___foundAvatar
+  lastEditedBy___node___avatar___height
+  lastEditedBy___node___avatar___rating
+  lastEditedBy___node___avatar___scheme
+  lastEditedBy___node___avatar___size
+  lastEditedBy___node___avatar___url
+  lastEditedBy___node___avatar___width
+  lastEditedBy___node___blockEditorPreviews___nodes
+  lastEditedBy___node___capKey
+  lastEditedBy___node___capabilities
+  lastEditedBy___node___children
+  lastEditedBy___node___children___children
+  lastEditedBy___node___children___id
+  lastEditedBy___node___comments___nodes
+  lastEditedBy___node___databaseId
+  lastEditedBy___node___description
+  lastEditedBy___node___email
+  lastEditedBy___node___extraCapabilities
+  lastEditedBy___node___firstName
+  lastEditedBy___node___id
+  lastEditedBy___node___internal___content
+  lastEditedBy___node___internal___contentDigest
+  lastEditedBy___node___internal___description
+  lastEditedBy___node___internal___fieldOwners
+  lastEditedBy___node___internal___ignoreType
+  lastEditedBy___node___internal___mediaType
+  lastEditedBy___node___internal___owner
+  lastEditedBy___node___internal___type
+  lastEditedBy___node___isContentNode
+  lastEditedBy___node___isTermNode
+  lastEditedBy___node___lastName
+  lastEditedBy___node___locale
+  lastEditedBy___node___name
+  lastEditedBy___node___nicename
+  lastEditedBy___node___nickname
+  lastEditedBy___node___nodeType
+  lastEditedBy___node___pages___nodes
+  lastEditedBy___node___parent___children
+  lastEditedBy___node___parent___id
+  lastEditedBy___node___posts___nodes
+  lastEditedBy___node___registeredDate
+  lastEditedBy___node___roles___nodes
+  lastEditedBy___node___slug
+  lastEditedBy___node___uri
+  lastEditedBy___node___url
+  lastEditedBy___node___username
+  link
+  modified
+  modifiedGmt
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  pingStatus
+  pinged
+  postFormats___nodes
+  postFormats___nodes___children
+  postFormats___nodes___children___children
+  postFormats___nodes___children___id
+  postFormats___nodes___contentNodes___nodes
+  postFormats___nodes___count
+  postFormats___nodes___databaseId
+  postFormats___nodes___description
+  postFormats___nodes___id
+  postFormats___nodes___internal___content
+  postFormats___nodes___internal___contentDigest
+  postFormats___nodes___internal___description
+  postFormats___nodes___internal___fieldOwners
+  postFormats___nodes___internal___ignoreType
+  postFormats___nodes___internal___mediaType
+  postFormats___nodes___internal___owner
+  postFormats___nodes___internal___type
+  postFormats___nodes___isContentNode
+  postFormats___nodes___isTermNode
+  postFormats___nodes___link
+  postFormats___nodes___name
+  postFormats___nodes___nodeType
+  postFormats___nodes___parent___children
+  postFormats___nodes___parent___id
+  postFormats___nodes___posts___nodes
+  postFormats___nodes___slug
+  postFormats___nodes___taxonomyName
+  postFormats___nodes___termGroupId
+  postFormats___nodes___termTaxonomyId
+  postFormats___nodes___uri
+  previewBlocks
+  previewBlocksJSON
+  previewBlocks___attributesJSON
+  previewBlocks___dynamicContent
+  previewBlocks___innerBlocks
+  previewBlocks___innerBlocks___attributesJSON
+  previewBlocks___innerBlocks___dynamicContent
+  previewBlocks___innerBlocks___innerBlocks
+  previewBlocks___innerBlocks___innerBlocks___attributesJSON
+  previewBlocks___innerBlocks___innerBlocks___dynamicContent
+  previewBlocks___innerBlocks___innerBlocks___innerBlocks
+  previewBlocks___innerBlocks___innerBlocks___isDynamic
+  previewBlocks___innerBlocks___innerBlocks___name
+  previewBlocks___innerBlocks___innerBlocks___order
+  previewBlocks___innerBlocks___innerBlocks___originalContent
+  previewBlocks___innerBlocks___innerBlocks___parentNodeDatabaseId
+  previewBlocks___innerBlocks___innerBlocks___saveContent
+  previewBlocks___innerBlocks___isDynamic
+  previewBlocks___innerBlocks___name
+  previewBlocks___innerBlocks___order
+  previewBlocks___innerBlocks___originalContent
+  previewBlocks___innerBlocks___parentNodeDatabaseId
+  previewBlocks___innerBlocks___parentNode___id
+  previewBlocks___innerBlocks___saveContent
+  previewBlocks___isDynamic
+  previewBlocks___name
+  previewBlocks___order
+  previewBlocks___originalContent
+  previewBlocks___parentNodeDatabaseId
+  previewBlocks___parentNode___id
+  previewBlocks___saveContent
+  slug
+  status
+  tags___nodes
+  tags___nodes___children
+  tags___nodes___children___children
+  tags___nodes___children___id
+  tags___nodes___contentNodes___nodes
+  tags___nodes___count
+  tags___nodes___databaseId
+  tags___nodes___description
+  tags___nodes___id
+  tags___nodes___internal___content
+  tags___nodes___internal___contentDigest
+  tags___nodes___internal___description
+  tags___nodes___internal___fieldOwners
+  tags___nodes___internal___ignoreType
+  tags___nodes___internal___mediaType
+  tags___nodes___internal___owner
+  tags___nodes___internal___type
+  tags___nodes___isContentNode
+  tags___nodes___isTermNode
+  tags___nodes___link
+  tags___nodes___name
+  tags___nodes___nodeType
+  tags___nodes___parent___children
+  tags___nodes___parent___id
+  tags___nodes___posts___nodes
+  tags___nodes___slug
+  tags___nodes___taxonomyName
+  tags___nodes___termGroupId
+  tags___nodes___termTaxonomyId
+  tags___nodes___uri
+  template___templateName
+  terms___nodes
+  terms___nodes___children
+  terms___nodes___children___children
+  terms___nodes___children___id
+  terms___nodes___count
+  terms___nodes___databaseId
+  terms___nodes___description
+  terms___nodes___id
+  terms___nodes___internal___content
+  terms___nodes___internal___contentDigest
+  terms___nodes___internal___description
+  terms___nodes___internal___fieldOwners
+  terms___nodes___internal___ignoreType
+  terms___nodes___internal___mediaType
+  terms___nodes___internal___owner
+  terms___nodes___internal___type
+  terms___nodes___isContentNode
+  terms___nodes___isTermNode
+  terms___nodes___link
+  terms___nodes___name
+  terms___nodes___nodeType
+  terms___nodes___parent___children
+  terms___nodes___parent___id
+  terms___nodes___slug
+  terms___nodes___taxonomyName
+  terms___nodes___termGroupId
+  terms___nodes___termTaxonomyId
+  terms___nodes___uri
+  title
+  toPing
+  uri
+}
+
+input WpPostFilterInput {
+  author: WpNodeWithAuthorToUserConnectionEdgeFilterInput
+  authorDatabaseId: IntQueryOperatorInput
+  authorId: IDQueryOperatorInput
+  blocks: WpBlockFilterListInput
+  blocksJSON: StringQueryOperatorInput
+  categories: WpPostToCategoryConnectionFilterInput
+  children: NodeFilterListInput
+  commentCount: IntQueryOperatorInput
+  commentStatus: StringQueryOperatorInput
+  comments: WpPostToCommentConnectionFilterInput
+  content: StringQueryOperatorInput
+  contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+  contentTypeName: StringQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  date: DateQueryOperatorInput
+  dateGmt: DateQueryOperatorInput
+  desiredSlug: StringQueryOperatorInput
+  enclosure: StringQueryOperatorInput
+  excerpt: StringQueryOperatorInput
+  featuredImage: WpNodeWithFeaturedImageToMediaItemConnectionEdgeFilterInput
+  featuredImageDatabaseId: IntQueryOperatorInput
+  featuredImageId: IDQueryOperatorInput
+  guid: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isRevision: BooleanQueryOperatorInput
+  isSticky: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+  link: StringQueryOperatorInput
+  modified: DateQueryOperatorInput
+  modifiedGmt: DateQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  pingStatus: StringQueryOperatorInput
+  pinged: StringQueryOperatorInput
+  postFormats: WpPostToPostFormatConnectionFilterInput
+  previewBlocks: WpBlockFilterListInput
+  previewBlocksJSON: StringQueryOperatorInput
+  slug: StringQueryOperatorInput
+  status: StringQueryOperatorInput
+  tags: WpPostToTagConnectionFilterInput
+  template: WpContentTemplateFilterInput
+  terms: WpPostToTermNodeConnectionFilterInput
+  title: StringQueryOperatorInput
+  toPing: StringQueryOperatorInput
+  uri: StringQueryOperatorInput
+}
+
+input WpPostFilterListInput {
+  elemMatch: WpPostFilterInput
+}
+
+"""
+The postFormat type
+"""
+type WpPostFormat implements Node & WpDatabaseIdentifier & WpNode & WpTermNode & WpUniformResourceIdentifiable {
+  children: [Node!]!
+
+  """
+  Connection between the postFormat type and the ContentNode type
+  """
+  contentNodes: WpPostFormatToContentNodeConnection
+
+  """
+  The number of objects connected to the object
+  """
+  count: Int
+
+  """
+  The unique identifier stored in the database
+  """
+  databaseId: Int!
+
+  """
+  The description of the object
+  """
+  description: String
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The link to the term
+  """
+  link: String
+
+  """
+  The human friendly name of the object.
+  """
+  name: String
+  nodeType: String
+  parent: Node
+
+  """
+  Connection between the postFormat type and the post type
+  """
+  posts: WpPostFormatToPostConnection
+
+  """
+  An alphanumeric identifier for the object unique to its type.
+  """
+  slug: String
+
+  """
+  Connection between the postFormat type and the Taxonomy type
+  """
+  taxonomy: WpPostFormatToTaxonomyConnectionEdge
+
+  """
+  The name of the taxonomy that the object is associated with
+  """
+  taxonomyName: String
+
+  """
+  The ID of the term group that this term object belongs to
+  """
+  termGroupId: Int
+
+  """
+  The taxonomy ID that the object is associated with
+  """
+  termTaxonomyId: Int
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+}
+
+type WpPostFormatConnection {
+  distinct(field: WpPostFormatFieldsEnum!): [String!]!
+  edges: [WpPostFormatEdge!]!
+  group(field: WpPostFormatFieldsEnum!, limit: Int, skip: Int): [WpPostFormatGroupConnection!]!
+  max(field: WpPostFormatFieldsEnum!): Float
+  min(field: WpPostFormatFieldsEnum!): Float
+  nodes: [WpPostFormat!]!
+  pageInfo: PageInfo!
+  sum(field: WpPostFormatFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpPostFormatEdge {
+  next: WpPostFormat
+  node: WpPostFormat!
+  previous: WpPostFormat
+}
+
+enum WpPostFormatFieldsEnum {
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  contentNodes___nodes
+  contentNodes___nodes___children
+  contentNodes___nodes___children___children
+  contentNodes___nodes___children___id
+  contentNodes___nodes___contentTypeName
+  contentNodes___nodes___databaseId
+  contentNodes___nodes___date
+  contentNodes___nodes___dateGmt
+  contentNodes___nodes___desiredSlug
+  contentNodes___nodes___enclosure
+  contentNodes___nodes___guid
+  contentNodes___nodes___id
+  contentNodes___nodes___internal___content
+  contentNodes___nodes___internal___contentDigest
+  contentNodes___nodes___internal___description
+  contentNodes___nodes___internal___fieldOwners
+  contentNodes___nodes___internal___ignoreType
+  contentNodes___nodes___internal___mediaType
+  contentNodes___nodes___internal___owner
+  contentNodes___nodes___internal___type
+  contentNodes___nodes___isContentNode
+  contentNodes___nodes___isTermNode
+  contentNodes___nodes___link
+  contentNodes___nodes___modified
+  contentNodes___nodes___modifiedGmt
+  contentNodes___nodes___nodeType
+  contentNodes___nodes___parent___children
+  contentNodes___nodes___parent___id
+  contentNodes___nodes___slug
+  contentNodes___nodes___status
+  contentNodes___nodes___template___templateName
+  contentNodes___nodes___uri
+  count
+  databaseId
+  description
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isTermNode
+  link
+  name
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  posts___nodes
+  posts___nodes___authorDatabaseId
+  posts___nodes___authorId
+  posts___nodes___blocks
+  posts___nodes___blocksJSON
+  posts___nodes___blocks___attributesJSON
+  posts___nodes___blocks___dynamicContent
+  posts___nodes___blocks___innerBlocks
+  posts___nodes___blocks___isDynamic
+  posts___nodes___blocks___name
+  posts___nodes___blocks___order
+  posts___nodes___blocks___originalContent
+  posts___nodes___blocks___parentNodeDatabaseId
+  posts___nodes___blocks___saveContent
+  posts___nodes___categories___nodes
+  posts___nodes___children
+  posts___nodes___children___children
+  posts___nodes___children___id
+  posts___nodes___commentCount
+  posts___nodes___commentStatus
+  posts___nodes___comments___nodes
+  posts___nodes___content
+  posts___nodes___contentTypeName
+  posts___nodes___databaseId
+  posts___nodes___date
+  posts___nodes___dateGmt
+  posts___nodes___desiredSlug
+  posts___nodes___enclosure
+  posts___nodes___excerpt
+  posts___nodes___featuredImageDatabaseId
+  posts___nodes___featuredImageId
+  posts___nodes___guid
+  posts___nodes___id
+  posts___nodes___internal___content
+  posts___nodes___internal___contentDigest
+  posts___nodes___internal___description
+  posts___nodes___internal___fieldOwners
+  posts___nodes___internal___ignoreType
+  posts___nodes___internal___mediaType
+  posts___nodes___internal___owner
+  posts___nodes___internal___type
+  posts___nodes___isContentNode
+  posts___nodes___isRevision
+  posts___nodes___isSticky
+  posts___nodes___isTermNode
+  posts___nodes___link
+  posts___nodes___modified
+  posts___nodes___modifiedGmt
+  posts___nodes___nodeType
+  posts___nodes___parent___children
+  posts___nodes___parent___id
+  posts___nodes___pingStatus
+  posts___nodes___pinged
+  posts___nodes___postFormats___nodes
+  posts___nodes___previewBlocks
+  posts___nodes___previewBlocksJSON
+  posts___nodes___previewBlocks___attributesJSON
+  posts___nodes___previewBlocks___dynamicContent
+  posts___nodes___previewBlocks___innerBlocks
+  posts___nodes___previewBlocks___isDynamic
+  posts___nodes___previewBlocks___name
+  posts___nodes___previewBlocks___order
+  posts___nodes___previewBlocks___originalContent
+  posts___nodes___previewBlocks___parentNodeDatabaseId
+  posts___nodes___previewBlocks___saveContent
+  posts___nodes___slug
+  posts___nodes___status
+  posts___nodes___tags___nodes
+  posts___nodes___template___templateName
+  posts___nodes___terms___nodes
+  posts___nodes___title
+  posts___nodes___toPing
+  posts___nodes___uri
+  slug
+  taxonomyName
+  taxonomy___node___archivePath
+  taxonomy___node___children
+  taxonomy___node___children___children
+  taxonomy___node___children___id
+  taxonomy___node___connectedContentTypes___nodes
+  taxonomy___node___description
+  taxonomy___node___graphqlPluralName
+  taxonomy___node___graphqlSingleName
+  taxonomy___node___hierarchical
+  taxonomy___node___id
+  taxonomy___node___internal___content
+  taxonomy___node___internal___contentDigest
+  taxonomy___node___internal___description
+  taxonomy___node___internal___fieldOwners
+  taxonomy___node___internal___ignoreType
+  taxonomy___node___internal___mediaType
+  taxonomy___node___internal___owner
+  taxonomy___node___internal___type
+  taxonomy___node___label
+  taxonomy___node___name
+  taxonomy___node___nodeType
+  taxonomy___node___parent___children
+  taxonomy___node___parent___id
+  taxonomy___node___public
+  taxonomy___node___restBase
+  taxonomy___node___restControllerClass
+  taxonomy___node___showCloud
+  taxonomy___node___showInAdminColumn
+  taxonomy___node___showInGraphql
+  taxonomy___node___showInMenu
+  taxonomy___node___showInNavMenus
+  taxonomy___node___showInQuickEdit
+  taxonomy___node___showInRest
+  taxonomy___node___showUi
+  termGroupId
+  termTaxonomyId
+  uri
+}
+
+input WpPostFormatFilterInput {
+  children: NodeFilterListInput
+  contentNodes: WpPostFormatToContentNodeConnectionFilterInput
+  count: IntQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  description: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  link: StringQueryOperatorInput
+  name: StringQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  posts: WpPostFormatToPostConnectionFilterInput
+  slug: StringQueryOperatorInput
+  taxonomy: WpPostFormatToTaxonomyConnectionEdgeFilterInput
+  taxonomyName: StringQueryOperatorInput
+  termGroupId: IntQueryOperatorInput
+  termTaxonomyId: IntQueryOperatorInput
+  uri: StringQueryOperatorInput
+}
+
+input WpPostFormatFilterListInput {
+  elemMatch: WpPostFormatFilterInput
+}
+
+type WpPostFormatGroupConnection {
+  distinct(field: WpPostFormatFieldsEnum!): [String!]!
+  edges: [WpPostFormatEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpPostFormatFieldsEnum!, limit: Int, skip: Int): [WpPostFormatGroupConnection!]!
+  max(field: WpPostFormatFieldsEnum!): Float
+  min(field: WpPostFormatFieldsEnum!): Float
+  nodes: [WpPostFormat!]!
+  pageInfo: PageInfo!
+  sum(field: WpPostFormatFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpPostFormatSortInput {
+  fields: [WpPostFormatFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the postFormat type and the ContentNode type
+"""
+type WpPostFormatToContentNodeConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpContentNode]
+}
+
+input WpPostFormatToContentNodeConnectionFilterInput {
+  nodes: WpContentNodeFilterListInput
+}
+
+"""
+Connection between the postFormat type and the post type
+"""
+type WpPostFormatToPostConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpPost]
+}
+
+input WpPostFormatToPostConnectionFilterInput {
+  nodes: WpPostFilterListInput
+}
+
+"""
+Connection between the postFormat type and the Taxonomy type
+"""
+type WpPostFormatToTaxonomyConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpTaxonomy
+}
+
+input WpPostFormatToTaxonomyConnectionEdgeFilterInput {
+  node: WpTaxonomyFilterInput
+}
+
+type WpPostGroupConnection {
+  distinct(field: WpPostFieldsEnum!): [String!]!
+  edges: [WpPostEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpPostFieldsEnum!, limit: Int, skip: Int): [WpPostGroupConnection!]!
+  max(field: WpPostFieldsEnum!): Float
+  min(field: WpPostFieldsEnum!): Float
+  nodes: [WpPost!]!
+  pageInfo: PageInfo!
+  sum(field: WpPostFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpPostSortInput {
+  fields: [WpPostFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the post type and the category type
+"""
+type WpPostToCategoryConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpCategory]
+}
+
+input WpPostToCategoryConnectionFilterInput {
+  nodes: WpCategoryFilterListInput
+}
+
+"""
+Connection between the post type and the Comment type
+"""
+type WpPostToCommentConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpComment]
+}
+
+input WpPostToCommentConnectionFilterInput {
+  nodes: WpCommentFilterListInput
+}
+
+"""
+Connection between the post type and the postFormat type
+"""
+type WpPostToPostFormatConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpPostFormat]
+}
+
+input WpPostToPostFormatConnectionFilterInput {
+  nodes: WpPostFormatFilterListInput
+}
+
+"""
+Connection between the post type and the tag type
+"""
+type WpPostToTagConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpTag]
+}
+
+input WpPostToTagConnectionFilterInput {
+  nodes: WpTagFilterListInput
+}
+
+"""
+Connection between the post type and the TermNode type
+"""
+type WpPostToTermNodeConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpTermNode]
+}
+
+input WpPostToTermNodeConnectionFilterInput {
+  nodes: WpTermNodeFilterListInput
+}
+
+"""
+Details for labels of the PostType
+"""
+type WpPostTypeLabelDetails {
+  """
+  Default is ‘Add New’ for both hierarchical and non-hierarchical types.
+  """
+  addNew: String
+
+  """
+  Label for adding a new singular item.
+  """
+  addNewItem: String
+
+  """
+  Label to signify all items in a submenu link.
+  """
+  allItems: String
+
+  """
+  Label for archives in nav menus
+  """
+  archives: String
+
+  """
+  Label for the attributes meta box.
+  """
+  attributes: String
+
+  """
+  Label for editing a singular item.
+  """
+  editItem: String
+
+  """
+  Label for the Featured Image meta box title.
+  """
+  featuredImage: String
+
+  """
+  Label for the table views hidden heading.
+  """
+  filterItemsList: String
+
+  """
+  Label for the media frame button.
+  """
+  insertIntoItem: String
+
+  """
+  Label for the table hidden heading.
+  """
+  itemsList: String
+
+  """
+  Label for the table pagination hidden heading.
+  """
+  itemsListNavigation: String
+
+  """
+  Label for the menu name.
+  """
+  menuName: String
+
+  """
+  General name for the post type, usually plural.
+  """
+  name: String
+
+  """
+  Label for the new item page title.
+  """
+  newItem: String
+
+  """
+  Label used when no items are found.
+  """
+  notFound: String
+
+  """
+  Label used when no items are in the trash.
+  """
+  notFoundInTrash: String
+
+  """
+  Label used to prefix parents of hierarchical items.
+  """
+  parentItemColon: String
+
+  """
+  Label for removing the featured image.
+  """
+  removeFeaturedImage: String
+
+  """
+  Label for searching plural items.
+  """
+  searchItems: String
+
+  """
+  Label for setting the featured image.
+  """
+  setFeaturedImage: String
+
+  """
+  Name for one object of this post type.
+  """
+  singularName: String
+
+  """
+  Label for the media frame filter.
+  """
+  uploadedToThisItem: String
+
+  """
+  Label in the media frame for using a featured image.
+  """
+  useFeaturedImage: String
+
+  """
+  Label for viewing a singular item.
+  """
+  viewItem: String
+
+  """
+  Label for viewing post type archives.
+  """
+  viewItems: String
+}
+
+input WpPostTypeLabelDetailsFilterInput {
+  addNew: StringQueryOperatorInput
+  addNewItem: StringQueryOperatorInput
+  allItems: StringQueryOperatorInput
+  archives: StringQueryOperatorInput
+  attributes: StringQueryOperatorInput
+  editItem: StringQueryOperatorInput
+  featuredImage: StringQueryOperatorInput
+  filterItemsList: StringQueryOperatorInput
+  insertIntoItem: StringQueryOperatorInput
+  itemsList: StringQueryOperatorInput
+  itemsListNavigation: StringQueryOperatorInput
+  menuName: StringQueryOperatorInput
+  name: StringQueryOperatorInput
+  newItem: StringQueryOperatorInput
+  notFound: StringQueryOperatorInput
+  notFoundInTrash: StringQueryOperatorInput
+  parentItemColon: StringQueryOperatorInput
+  removeFeaturedImage: StringQueryOperatorInput
+  searchItems: StringQueryOperatorInput
+  setFeaturedImage: StringQueryOperatorInput
+  singularName: StringQueryOperatorInput
+  uploadedToThisItem: StringQueryOperatorInput
+  useFeaturedImage: StringQueryOperatorInput
+  viewItem: StringQueryOperatorInput
+  viewItems: StringQueryOperatorInput
+}
+
+"""
+The reading setting type
+"""
+type WpReadingSettings {
+  """
+  Maximal angezeigte Beiträge.
+  """
+  postsPerPage: Int
+}
+
+input WpReadingSettingsFilterInput {
+  postsPerPage: IntQueryOperatorInput
+}
+
+"""
+real-media-library/gallery block
+"""
+type WpRealMediaLibraryGalleryBlock implements WpBlock {
+  attributes: WpRealMediaLibraryGalleryBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpRealMediaLibraryGalleryBlockAttributes {
+  align: String
+  captions: Boolean!
+  className: String
+  columns: Float!
+  fid: Float!
+  imageCrop: Boolean!
+  lastEditReload: Float!
+  linkTo: String!
+  lock: JSON
+}
+
+"""
+The ReusableBlock type
+"""
+type WpReusableBlock implements Node & WpBlockEditorContentNode & WpContentNode & WpDatabaseIdentifier & WpNode & WpNodeWithContentEditor & WpNodeWithRevisions & WpNodeWithTemplate & WpNodeWithTitle & WpUniformResourceIdentifiable {
+  """
+  Gutenberg blocks
+  """
+  blocks: [WpBlock!]
+
+  """
+  Gutenberg blocks as json string
+  """
+  blocksJSON: String
+  children: [Node!]!
+
+  """
+  The content of the post.
+  """
+  content: String
+
+  """
+  Connection between the ContentNode type and the ContentType type
+  """
+  contentType: WpContentNodeToContentTypeConnectionEdge
+
+  """
+  The name of the Content Type the node belongs to
+  """
+  contentTypeName: String!
+
+  """
+  The unique identifier stored in the database
+  """
+  databaseId: Int!
+
+  """
+  Post publishing date.
+  """
+  date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The publishing date set in GMT.
+  """
+  dateGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The desired slug of the post
+  """
+  desiredSlug: String
+
+  """
+  The RSS enclosure for the object
+  """
+  enclosure: String
+
+  """
+  The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table.
+  """
+  guid: String
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  True if the node is a revision of another node
+  """
+  isRevision: Boolean
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The user that most recently edited the node
+  """
+  lastEditedBy: WpContentNodeToEditLastConnectionEdge
+
+  """
+  The permalink of the post
+  """
+  link: String
+
+  """
+  The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.
+  """
+  modified(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+
+  """
+  The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.
+  """
+  modifiedGmt(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  nodeType: String
+  parent: Node
+
+  """
+  Previewed gutenberg blocks
+  """
+  previewBlocks: [WpBlock!]
+
+  """
+  Previewed Gutenberg blocks as json string
+  """
+  previewBlocksJSON: String
+
+  """
+  The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table.
+  """
+  slug: String
+
+  """
+  The current status of the object
+  """
+  status: String
+
+  """
+  The template assigned to the node
+  """
+  template: WpContentTemplate
+
+  """
+  The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
+  """
+  title: String
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+}
+
+type WpReusableBlockConnection {
+  distinct(field: WpReusableBlockFieldsEnum!): [String!]!
+  edges: [WpReusableBlockEdge!]!
+  group(field: WpReusableBlockFieldsEnum!, limit: Int, skip: Int): [WpReusableBlockGroupConnection!]!
+  max(field: WpReusableBlockFieldsEnum!): Float
+  min(field: WpReusableBlockFieldsEnum!): Float
+  nodes: [WpReusableBlock!]!
+  pageInfo: PageInfo!
+  sum(field: WpReusableBlockFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpReusableBlockEdge {
+  next: WpReusableBlock
+  node: WpReusableBlock!
+  previous: WpReusableBlock
+}
+
+enum WpReusableBlockFieldsEnum {
+  blocks
+  blocksJSON
+  blocks___attributesJSON
+  blocks___dynamicContent
+  blocks___innerBlocks
+  blocks___innerBlocks___attributesJSON
+  blocks___innerBlocks___dynamicContent
+  blocks___innerBlocks___innerBlocks
+  blocks___innerBlocks___innerBlocks___attributesJSON
+  blocks___innerBlocks___innerBlocks___dynamicContent
+  blocks___innerBlocks___innerBlocks___innerBlocks
+  blocks___innerBlocks___innerBlocks___isDynamic
+  blocks___innerBlocks___innerBlocks___name
+  blocks___innerBlocks___innerBlocks___order
+  blocks___innerBlocks___innerBlocks___originalContent
+  blocks___innerBlocks___innerBlocks___parentNodeDatabaseId
+  blocks___innerBlocks___innerBlocks___saveContent
+  blocks___innerBlocks___isDynamic
+  blocks___innerBlocks___name
+  blocks___innerBlocks___order
+  blocks___innerBlocks___originalContent
+  blocks___innerBlocks___parentNodeDatabaseId
+  blocks___innerBlocks___parentNode___id
+  blocks___innerBlocks___saveContent
+  blocks___isDynamic
+  blocks___name
+  blocks___order
+  blocks___originalContent
+  blocks___parentNodeDatabaseId
+  blocks___parentNode___id
+  blocks___saveContent
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  content
+  contentTypeName
+  contentType___node___archivePath
+  contentType___node___canExport
+  contentType___node___children
+  contentType___node___children___children
+  contentType___node___children___id
+  contentType___node___connectedTaxonomies___nodes
+  contentType___node___contentNodes___nodes
+  contentType___node___deleteWithUser
+  contentType___node___description
+  contentType___node___excludeFromSearch
+  contentType___node___graphqlPluralName
+  contentType___node___graphqlSingleName
+  contentType___node___hasArchive
+  contentType___node___hierarchical
+  contentType___node___id
+  contentType___node___internal___content
+  contentType___node___internal___contentDigest
+  contentType___node___internal___description
+  contentType___node___internal___fieldOwners
+  contentType___node___internal___ignoreType
+  contentType___node___internal___mediaType
+  contentType___node___internal___owner
+  contentType___node___internal___type
+  contentType___node___isContentNode
+  contentType___node___isFrontPage
+  contentType___node___isPostsPage
+  contentType___node___isTermNode
+  contentType___node___label
+  contentType___node___labels___addNew
+  contentType___node___labels___addNewItem
+  contentType___node___labels___allItems
+  contentType___node___labels___archives
+  contentType___node___labels___attributes
+  contentType___node___labels___editItem
+  contentType___node___labels___featuredImage
+  contentType___node___labels___filterItemsList
+  contentType___node___labels___insertIntoItem
+  contentType___node___labels___itemsList
+  contentType___node___labels___itemsListNavigation
+  contentType___node___labels___menuName
+  contentType___node___labels___name
+  contentType___node___labels___newItem
+  contentType___node___labels___notFound
+  contentType___node___labels___notFoundInTrash
+  contentType___node___labels___parentItemColon
+  contentType___node___labels___removeFeaturedImage
+  contentType___node___labels___searchItems
+  contentType___node___labels___setFeaturedImage
+  contentType___node___labels___singularName
+  contentType___node___labels___uploadedToThisItem
+  contentType___node___labels___useFeaturedImage
+  contentType___node___labels___viewItem
+  contentType___node___labels___viewItems
+  contentType___node___menuIcon
+  contentType___node___menuPosition
+  contentType___node___name
+  contentType___node___nodeType
+  contentType___node___parent___children
+  contentType___node___parent___id
+  contentType___node___public
+  contentType___node___publiclyQueryable
+  contentType___node___restBase
+  contentType___node___restControllerClass
+  contentType___node___showInAdminBar
+  contentType___node___showInGraphql
+  contentType___node___showInMenu
+  contentType___node___showInNavMenus
+  contentType___node___showInRest
+  contentType___node___showUi
+  contentType___node___uri
+  databaseId
+  date
+  dateGmt
+  desiredSlug
+  enclosure
+  guid
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isRevision
+  isTermNode
+  lastEditedBy___node___avatar___default
+  lastEditedBy___node___avatar___extraAttr
+  lastEditedBy___node___avatar___forceDefault
+  lastEditedBy___node___avatar___foundAvatar
+  lastEditedBy___node___avatar___height
+  lastEditedBy___node___avatar___rating
+  lastEditedBy___node___avatar___scheme
+  lastEditedBy___node___avatar___size
+  lastEditedBy___node___avatar___url
+  lastEditedBy___node___avatar___width
+  lastEditedBy___node___blockEditorPreviews___nodes
+  lastEditedBy___node___capKey
+  lastEditedBy___node___capabilities
+  lastEditedBy___node___children
+  lastEditedBy___node___children___children
+  lastEditedBy___node___children___id
+  lastEditedBy___node___comments___nodes
+  lastEditedBy___node___databaseId
+  lastEditedBy___node___description
+  lastEditedBy___node___email
+  lastEditedBy___node___extraCapabilities
+  lastEditedBy___node___firstName
+  lastEditedBy___node___id
+  lastEditedBy___node___internal___content
+  lastEditedBy___node___internal___contentDigest
+  lastEditedBy___node___internal___description
+  lastEditedBy___node___internal___fieldOwners
+  lastEditedBy___node___internal___ignoreType
+  lastEditedBy___node___internal___mediaType
+  lastEditedBy___node___internal___owner
+  lastEditedBy___node___internal___type
+  lastEditedBy___node___isContentNode
+  lastEditedBy___node___isTermNode
+  lastEditedBy___node___lastName
+  lastEditedBy___node___locale
+  lastEditedBy___node___name
+  lastEditedBy___node___nicename
+  lastEditedBy___node___nickname
+  lastEditedBy___node___nodeType
+  lastEditedBy___node___pages___nodes
+  lastEditedBy___node___parent___children
+  lastEditedBy___node___parent___id
+  lastEditedBy___node___posts___nodes
+  lastEditedBy___node___registeredDate
+  lastEditedBy___node___roles___nodes
+  lastEditedBy___node___slug
+  lastEditedBy___node___uri
+  lastEditedBy___node___url
+  lastEditedBy___node___username
+  link
+  modified
+  modifiedGmt
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  previewBlocks
+  previewBlocksJSON
+  previewBlocks___attributesJSON
+  previewBlocks___dynamicContent
+  previewBlocks___innerBlocks
+  previewBlocks___innerBlocks___attributesJSON
+  previewBlocks___innerBlocks___dynamicContent
+  previewBlocks___innerBlocks___innerBlocks
+  previewBlocks___innerBlocks___innerBlocks___attributesJSON
+  previewBlocks___innerBlocks___innerBlocks___dynamicContent
+  previewBlocks___innerBlocks___innerBlocks___innerBlocks
+  previewBlocks___innerBlocks___innerBlocks___isDynamic
+  previewBlocks___innerBlocks___innerBlocks___name
+  previewBlocks___innerBlocks___innerBlocks___order
+  previewBlocks___innerBlocks___innerBlocks___originalContent
+  previewBlocks___innerBlocks___innerBlocks___parentNodeDatabaseId
+  previewBlocks___innerBlocks___innerBlocks___saveContent
+  previewBlocks___innerBlocks___isDynamic
+  previewBlocks___innerBlocks___name
+  previewBlocks___innerBlocks___order
+  previewBlocks___innerBlocks___originalContent
+  previewBlocks___innerBlocks___parentNodeDatabaseId
+  previewBlocks___innerBlocks___parentNode___id
+  previewBlocks___innerBlocks___saveContent
+  previewBlocks___isDynamic
+  previewBlocks___name
+  previewBlocks___order
+  previewBlocks___originalContent
+  previewBlocks___parentNodeDatabaseId
+  previewBlocks___parentNode___id
+  previewBlocks___saveContent
+  slug
+  status
+  template___templateName
+  title
+  uri
+}
+
+input WpReusableBlockFilterInput {
+  blocks: WpBlockFilterListInput
+  blocksJSON: StringQueryOperatorInput
+  children: NodeFilterListInput
+  content: StringQueryOperatorInput
+  contentType: WpContentNodeToContentTypeConnectionEdgeFilterInput
+  contentTypeName: StringQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  date: DateQueryOperatorInput
+  dateGmt: DateQueryOperatorInput
+  desiredSlug: StringQueryOperatorInput
+  enclosure: StringQueryOperatorInput
+  guid: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isRevision: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  lastEditedBy: WpContentNodeToEditLastConnectionEdgeFilterInput
+  link: StringQueryOperatorInput
+  modified: DateQueryOperatorInput
+  modifiedGmt: DateQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  previewBlocks: WpBlockFilterListInput
+  previewBlocksJSON: StringQueryOperatorInput
+  slug: StringQueryOperatorInput
+  status: StringQueryOperatorInput
+  template: WpContentTemplateFilterInput
+  title: StringQueryOperatorInput
+  uri: StringQueryOperatorInput
+}
+
+type WpReusableBlockGroupConnection {
+  distinct(field: WpReusableBlockFieldsEnum!): [String!]!
+  edges: [WpReusableBlockEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpReusableBlockFieldsEnum!, limit: Int, skip: Int): [WpReusableBlockGroupConnection!]!
+  max(field: WpReusableBlockFieldsEnum!): Float
+  min(field: WpReusableBlockFieldsEnum!): Float
+  nodes: [WpReusableBlock!]!
+  pageInfo: PageInfo!
+  sum(field: WpReusableBlockFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpReusableBlockSortInput {
+  fields: [WpReusableBlockFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+All of the registered settings
+"""
+type WpSettings {
+  """
+  Settings of the the string Settings Group
+  """
+  discussionSettingsDefaultCommentStatus: String
+
+  """
+  Settings of the the string Settings Group
+  """
+  discussionSettingsDefaultPingStatus: String
+
+  """
+  Settings of the the string Settings Group
+  """
+  generalSettingsDateFormat: String
+
+  """
+  Settings of the the string Settings Group
+  """
+  generalSettingsDescription: String
+
+  """
+  Settings of the the string Settings Group
+  """
+  generalSettingsEmail: String
+
+  """
+  Settings of the the string Settings Group
+  """
+  generalSettingsLanguage: String
+
+  """
+  Settings of the the integer Settings Group
+  """
+  generalSettingsStartOfWeek: Int
+
+  """
+  Settings of the the string Settings Group
+  """
+  generalSettingsTimeFormat: String
+
+  """
+  Settings of the the string Settings Group
+  """
+  generalSettingsTimezone: String
+
+  """
+  Settings of the the string Settings Group
+  """
+  generalSettingsTitle: String
+
+  """
+  Settings of the the string Settings Group
+  """
+  generalSettingsUrl: String
+
+  """
+  Settings of the the integer Settings Group
+  """
+  readingSettingsPostsPerPage: Int
+
+  """
+  Settings of the the integer Settings Group
+  """
+  writingSettingsDefaultCategory: Int
+
+  """
+  Settings of the the string Settings Group
+  """
+  writingSettingsDefaultPostFormat: String
+
+  """
+  Settings of the the boolean Settings Group
+  """
+  writingSettingsUseSmilies: Boolean
+}
+
+input WpSettingsFilterInput {
+  discussionSettingsDefaultCommentStatus: StringQueryOperatorInput
+  discussionSettingsDefaultPingStatus: StringQueryOperatorInput
+  generalSettingsDateFormat: StringQueryOperatorInput
+  generalSettingsDescription: StringQueryOperatorInput
+  generalSettingsEmail: StringQueryOperatorInput
+  generalSettingsLanguage: StringQueryOperatorInput
+  generalSettingsStartOfWeek: IntQueryOperatorInput
+  generalSettingsTimeFormat: StringQueryOperatorInput
+  generalSettingsTimezone: StringQueryOperatorInput
+  generalSettingsTitle: StringQueryOperatorInput
+  generalSettingsUrl: StringQueryOperatorInput
+  readingSettingsPostsPerPage: IntQueryOperatorInput
+  writingSettingsDefaultCategory: IntQueryOperatorInput
+  writingSettingsDefaultPostFormat: StringQueryOperatorInput
+  writingSettingsUseSmilies: BooleanQueryOperatorInput
+}
+
+input WpSortInput {
+  fields: [WpFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+tadv/classic-paragraph block
+"""
+type WpTadvClassicParagraphBlock implements WpBlock {
+  attributes: WpTadvClassicParagraphBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpTadvClassicParagraphBlockAttributes {
+  align: String
+  content: String
+  lock: JSON
+}
+
+"""
+The tag type
+"""
+type WpTag implements Node & WpDatabaseIdentifier & WpMenuItemLinkable & WpNode & WpTermNode & WpUniformResourceIdentifiable {
+  children: [Node!]!
+
+  """
+  Connection between the tag type and the ContentNode type
+  """
+  contentNodes: WpTagToContentNodeConnection
+
+  """
+  The number of objects connected to the object
+  """
+  count: Int
+
+  """
+  The unique resource identifier path
+  """
+  databaseId: Int!
+
+  """
+  The description of the object
+  """
+  description: String
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The link to the term
+  """
+  link: String
+
+  """
+  The human friendly name of the object.
+  """
+  name: String
+  nodeType: String
+  parent: Node
+
+  """
+  Connection between the tag type and the post type
+  """
+  posts: WpTagToPostConnection
+
+  """
+  An alphanumeric identifier for the object unique to its type.
+  """
+  slug: String
+
+  """
+  Connection between the tag type and the Taxonomy type
+  """
+  taxonomy: WpTagToTaxonomyConnectionEdge
+
+  """
+  The name of the taxonomy that the object is associated with
+  """
+  taxonomyName: String
+
+  """
+  The ID of the term group that this term object belongs to
+  """
+  termGroupId: Int
+
+  """
+  The taxonomy ID that the object is associated with
+  """
+  termTaxonomyId: Int
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+}
+
+type WpTagConnection {
+  distinct(field: WpTagFieldsEnum!): [String!]!
+  edges: [WpTagEdge!]!
+  group(field: WpTagFieldsEnum!, limit: Int, skip: Int): [WpTagGroupConnection!]!
+  max(field: WpTagFieldsEnum!): Float
+  min(field: WpTagFieldsEnum!): Float
+  nodes: [WpTag!]!
+  pageInfo: PageInfo!
+  sum(field: WpTagFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpTagEdge {
+  next: WpTag
+  node: WpTag!
+  previous: WpTag
+}
+
+enum WpTagFieldsEnum {
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  contentNodes___nodes
+  contentNodes___nodes___children
+  contentNodes___nodes___children___children
+  contentNodes___nodes___children___id
+  contentNodes___nodes___contentTypeName
+  contentNodes___nodes___databaseId
+  contentNodes___nodes___date
+  contentNodes___nodes___dateGmt
+  contentNodes___nodes___desiredSlug
+  contentNodes___nodes___enclosure
+  contentNodes___nodes___guid
+  contentNodes___nodes___id
+  contentNodes___nodes___internal___content
+  contentNodes___nodes___internal___contentDigest
+  contentNodes___nodes___internal___description
+  contentNodes___nodes___internal___fieldOwners
+  contentNodes___nodes___internal___ignoreType
+  contentNodes___nodes___internal___mediaType
+  contentNodes___nodes___internal___owner
+  contentNodes___nodes___internal___type
+  contentNodes___nodes___isContentNode
+  contentNodes___nodes___isTermNode
+  contentNodes___nodes___link
+  contentNodes___nodes___modified
+  contentNodes___nodes___modifiedGmt
+  contentNodes___nodes___nodeType
+  contentNodes___nodes___parent___children
+  contentNodes___nodes___parent___id
+  contentNodes___nodes___slug
+  contentNodes___nodes___status
+  contentNodes___nodes___template___templateName
+  contentNodes___nodes___uri
+  count
+  databaseId
+  description
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isTermNode
+  link
+  name
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  posts___nodes
+  posts___nodes___authorDatabaseId
+  posts___nodes___authorId
+  posts___nodes___blocks
+  posts___nodes___blocksJSON
+  posts___nodes___blocks___attributesJSON
+  posts___nodes___blocks___dynamicContent
+  posts___nodes___blocks___innerBlocks
+  posts___nodes___blocks___isDynamic
+  posts___nodes___blocks___name
+  posts___nodes___blocks___order
+  posts___nodes___blocks___originalContent
+  posts___nodes___blocks___parentNodeDatabaseId
+  posts___nodes___blocks___saveContent
+  posts___nodes___categories___nodes
+  posts___nodes___children
+  posts___nodes___children___children
+  posts___nodes___children___id
+  posts___nodes___commentCount
+  posts___nodes___commentStatus
+  posts___nodes___comments___nodes
+  posts___nodes___content
+  posts___nodes___contentTypeName
+  posts___nodes___databaseId
+  posts___nodes___date
+  posts___nodes___dateGmt
+  posts___nodes___desiredSlug
+  posts___nodes___enclosure
+  posts___nodes___excerpt
+  posts___nodes___featuredImageDatabaseId
+  posts___nodes___featuredImageId
+  posts___nodes___guid
+  posts___nodes___id
+  posts___nodes___internal___content
+  posts___nodes___internal___contentDigest
+  posts___nodes___internal___description
+  posts___nodes___internal___fieldOwners
+  posts___nodes___internal___ignoreType
+  posts___nodes___internal___mediaType
+  posts___nodes___internal___owner
+  posts___nodes___internal___type
+  posts___nodes___isContentNode
+  posts___nodes___isRevision
+  posts___nodes___isSticky
+  posts___nodes___isTermNode
+  posts___nodes___link
+  posts___nodes___modified
+  posts___nodes___modifiedGmt
+  posts___nodes___nodeType
+  posts___nodes___parent___children
+  posts___nodes___parent___id
+  posts___nodes___pingStatus
+  posts___nodes___pinged
+  posts___nodes___postFormats___nodes
+  posts___nodes___previewBlocks
+  posts___nodes___previewBlocksJSON
+  posts___nodes___previewBlocks___attributesJSON
+  posts___nodes___previewBlocks___dynamicContent
+  posts___nodes___previewBlocks___innerBlocks
+  posts___nodes___previewBlocks___isDynamic
+  posts___nodes___previewBlocks___name
+  posts___nodes___previewBlocks___order
+  posts___nodes___previewBlocks___originalContent
+  posts___nodes___previewBlocks___parentNodeDatabaseId
+  posts___nodes___previewBlocks___saveContent
+  posts___nodes___slug
+  posts___nodes___status
+  posts___nodes___tags___nodes
+  posts___nodes___template___templateName
+  posts___nodes___terms___nodes
+  posts___nodes___title
+  posts___nodes___toPing
+  posts___nodes___uri
+  slug
+  taxonomyName
+  taxonomy___node___archivePath
+  taxonomy___node___children
+  taxonomy___node___children___children
+  taxonomy___node___children___id
+  taxonomy___node___connectedContentTypes___nodes
+  taxonomy___node___description
+  taxonomy___node___graphqlPluralName
+  taxonomy___node___graphqlSingleName
+  taxonomy___node___hierarchical
+  taxonomy___node___id
+  taxonomy___node___internal___content
+  taxonomy___node___internal___contentDigest
+  taxonomy___node___internal___description
+  taxonomy___node___internal___fieldOwners
+  taxonomy___node___internal___ignoreType
+  taxonomy___node___internal___mediaType
+  taxonomy___node___internal___owner
+  taxonomy___node___internal___type
+  taxonomy___node___label
+  taxonomy___node___name
+  taxonomy___node___nodeType
+  taxonomy___node___parent___children
+  taxonomy___node___parent___id
+  taxonomy___node___public
+  taxonomy___node___restBase
+  taxonomy___node___restControllerClass
+  taxonomy___node___showCloud
+  taxonomy___node___showInAdminColumn
+  taxonomy___node___showInGraphql
+  taxonomy___node___showInMenu
+  taxonomy___node___showInNavMenus
+  taxonomy___node___showInQuickEdit
+  taxonomy___node___showInRest
+  taxonomy___node___showUi
+  termGroupId
+  termTaxonomyId
+  uri
+}
+
+input WpTagFilterInput {
+  children: NodeFilterListInput
+  contentNodes: WpTagToContentNodeConnectionFilterInput
+  count: IntQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  description: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  link: StringQueryOperatorInput
+  name: StringQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  posts: WpTagToPostConnectionFilterInput
+  slug: StringQueryOperatorInput
+  taxonomy: WpTagToTaxonomyConnectionEdgeFilterInput
+  taxonomyName: StringQueryOperatorInput
+  termGroupId: IntQueryOperatorInput
+  termTaxonomyId: IntQueryOperatorInput
+  uri: StringQueryOperatorInput
+}
+
+input WpTagFilterListInput {
+  elemMatch: WpTagFilterInput
+}
+
+type WpTagGroupConnection {
+  distinct(field: WpTagFieldsEnum!): [String!]!
+  edges: [WpTagEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpTagFieldsEnum!, limit: Int, skip: Int): [WpTagGroupConnection!]!
+  max(field: WpTagFieldsEnum!): Float
+  min(field: WpTagFieldsEnum!): Float
+  nodes: [WpTag!]!
+  pageInfo: PageInfo!
+  sum(field: WpTagFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpTagSortInput {
+  fields: [WpTagFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the tag type and the ContentNode type
+"""
+type WpTagToContentNodeConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpContentNode]
+}
+
+input WpTagToContentNodeConnectionFilterInput {
+  nodes: WpContentNodeFilterListInput
+}
+
+"""
+Connection between the tag type and the post type
+"""
+type WpTagToPostConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpPost]
+}
+
+input WpTagToPostConnectionFilterInput {
+  nodes: WpPostFilterListInput
+}
+
+"""
+Connection between the tag type and the Taxonomy type
+"""
+type WpTagToTaxonomyConnectionEdge {
+  """
+  The node of the connection, without the edges
+  """
+  node: WpTaxonomy
+}
+
+input WpTagToTaxonomyConnectionEdgeFilterInput {
+  node: WpTaxonomyFilterInput
+}
+
+"""
+A taxonomy object
+"""
+type WpTaxonomy implements Node & WpNode {
+  """
+  The url path of the first page of the archive page for this content type.
+  """
+  archivePath: String
+  children: [Node!]!
+
+  """
+  List of Content Types associated with the Taxonomy
+  """
+  connectedContentTypes: WpTaxonomyToContentTypeConnection
+
+  """
+  Description of the taxonomy. This field is equivalent to WP_Taxonomy-&gt;description
+  """
+  description: String
+
+  """
+  The plural name of the post type within the GraphQL Schema.
+  """
+  graphqlPluralName: String
+
+  """
+  The singular name of the post type within the GraphQL Schema.
+  """
+  graphqlSingleName: String
+
+  """
+  Whether the taxonomy is hierarchical
+  """
+  hierarchical: Boolean
+  id: ID!
+  internal: Internal!
+
+  """
+  Name of the taxonomy shown in the menu. Usually plural.
+  """
+  label: String
+
+  """
+  The display name of the taxonomy. This field is equivalent to WP_Taxonomy-&gt;label
+  """
+  name: String
+  nodeType: String
+  parent: Node
+
+  """
+  Whether the taxonomy is publicly queryable
+  """
+  public: Boolean
+
+  """
+  Name of content type to diplay in REST API &quot;wp/v2&quot; namespace.
+  """
+  restBase: String
+
+  """
+  The REST Controller class assigned to handling this content type.
+  """
+  restControllerClass: String
+
+  """
+  Whether to show the taxonomy as part of a tag cloud widget. This field is equivalent to WP_Taxonomy-&gt;show_tagcloud
+  """
+  showCloud: Boolean
+
+  """
+  Whether to display a column for the taxonomy on its post type listing screens.
+  """
+  showInAdminColumn: Boolean
+
+  """
+  Whether to add the post type to the GraphQL Schema.
+  """
+  showInGraphql: Boolean
+
+  """
+  Whether to show the taxonomy in the admin menu
+  """
+  showInMenu: Boolean
+
+  """
+  Whether the taxonomy is available for selection in navigation menus.
+  """
+  showInNavMenus: Boolean
+
+  """
+  Whether to show the taxonomy in the quick/bulk edit panel.
+  """
+  showInQuickEdit: Boolean
+
+  """
+  Whether to add the post type route in the REST API &quot;wp/v2&quot; namespace.
+  """
+  showInRest: Boolean
+
+  """
+  Whether to generate and allow a UI for managing terms in this taxonomy in the admin
+  """
+  showUi: Boolean
+}
+
+type WpTaxonomyConnection {
+  distinct(field: WpTaxonomyFieldsEnum!): [String!]!
+  edges: [WpTaxonomyEdge!]!
+  group(field: WpTaxonomyFieldsEnum!, limit: Int, skip: Int): [WpTaxonomyGroupConnection!]!
+  max(field: WpTaxonomyFieldsEnum!): Float
+  min(field: WpTaxonomyFieldsEnum!): Float
+  nodes: [WpTaxonomy!]!
+  pageInfo: PageInfo!
+  sum(field: WpTaxonomyFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpTaxonomyEdge {
+  next: WpTaxonomy
+  node: WpTaxonomy!
+  previous: WpTaxonomy
+}
+
+enum WpTaxonomyFieldsEnum {
+  archivePath
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  connectedContentTypes___nodes
+  connectedContentTypes___nodes___archivePath
+  connectedContentTypes___nodes___canExport
+  connectedContentTypes___nodes___children
+  connectedContentTypes___nodes___children___children
+  connectedContentTypes___nodes___children___id
+  connectedContentTypes___nodes___connectedTaxonomies___nodes
+  connectedContentTypes___nodes___contentNodes___nodes
+  connectedContentTypes___nodes___deleteWithUser
+  connectedContentTypes___nodes___description
+  connectedContentTypes___nodes___excludeFromSearch
+  connectedContentTypes___nodes___graphqlPluralName
+  connectedContentTypes___nodes___graphqlSingleName
+  connectedContentTypes___nodes___hasArchive
+  connectedContentTypes___nodes___hierarchical
+  connectedContentTypes___nodes___id
+  connectedContentTypes___nodes___internal___content
+  connectedContentTypes___nodes___internal___contentDigest
+  connectedContentTypes___nodes___internal___description
+  connectedContentTypes___nodes___internal___fieldOwners
+  connectedContentTypes___nodes___internal___ignoreType
+  connectedContentTypes___nodes___internal___mediaType
+  connectedContentTypes___nodes___internal___owner
+  connectedContentTypes___nodes___internal___type
+  connectedContentTypes___nodes___isContentNode
+  connectedContentTypes___nodes___isFrontPage
+  connectedContentTypes___nodes___isPostsPage
+  connectedContentTypes___nodes___isTermNode
+  connectedContentTypes___nodes___label
+  connectedContentTypes___nodes___labels___addNew
+  connectedContentTypes___nodes___labels___addNewItem
+  connectedContentTypes___nodes___labels___allItems
+  connectedContentTypes___nodes___labels___archives
+  connectedContentTypes___nodes___labels___attributes
+  connectedContentTypes___nodes___labels___editItem
+  connectedContentTypes___nodes___labels___featuredImage
+  connectedContentTypes___nodes___labels___filterItemsList
+  connectedContentTypes___nodes___labels___insertIntoItem
+  connectedContentTypes___nodes___labels___itemsList
+  connectedContentTypes___nodes___labels___itemsListNavigation
+  connectedContentTypes___nodes___labels___menuName
+  connectedContentTypes___nodes___labels___name
+  connectedContentTypes___nodes___labels___newItem
+  connectedContentTypes___nodes___labels___notFound
+  connectedContentTypes___nodes___labels___notFoundInTrash
+  connectedContentTypes___nodes___labels___parentItemColon
+  connectedContentTypes___nodes___labels___removeFeaturedImage
+  connectedContentTypes___nodes___labels___searchItems
+  connectedContentTypes___nodes___labels___setFeaturedImage
+  connectedContentTypes___nodes___labels___singularName
+  connectedContentTypes___nodes___labels___uploadedToThisItem
+  connectedContentTypes___nodes___labels___useFeaturedImage
+  connectedContentTypes___nodes___labels___viewItem
+  connectedContentTypes___nodes___labels___viewItems
+  connectedContentTypes___nodes___menuIcon
+  connectedContentTypes___nodes___menuPosition
+  connectedContentTypes___nodes___name
+  connectedContentTypes___nodes___nodeType
+  connectedContentTypes___nodes___parent___children
+  connectedContentTypes___nodes___parent___id
+  connectedContentTypes___nodes___public
+  connectedContentTypes___nodes___publiclyQueryable
+  connectedContentTypes___nodes___restBase
+  connectedContentTypes___nodes___restControllerClass
+  connectedContentTypes___nodes___showInAdminBar
+  connectedContentTypes___nodes___showInGraphql
+  connectedContentTypes___nodes___showInMenu
+  connectedContentTypes___nodes___showInNavMenus
+  connectedContentTypes___nodes___showInRest
+  connectedContentTypes___nodes___showUi
+  connectedContentTypes___nodes___uri
+  description
+  graphqlPluralName
+  graphqlSingleName
+  hierarchical
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  label
+  name
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  public
+  restBase
+  restControllerClass
+  showCloud
+  showInAdminColumn
+  showInGraphql
+  showInMenu
+  showInNavMenus
+  showInQuickEdit
+  showInRest
+  showUi
+}
+
+input WpTaxonomyFilterInput {
+  archivePath: StringQueryOperatorInput
+  children: NodeFilterListInput
+  connectedContentTypes: WpTaxonomyToContentTypeConnectionFilterInput
+  description: StringQueryOperatorInput
+  graphqlPluralName: StringQueryOperatorInput
+  graphqlSingleName: StringQueryOperatorInput
+  hierarchical: BooleanQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  label: StringQueryOperatorInput
+  name: StringQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  public: BooleanQueryOperatorInput
+  restBase: StringQueryOperatorInput
+  restControllerClass: StringQueryOperatorInput
+  showCloud: BooleanQueryOperatorInput
+  showInAdminColumn: BooleanQueryOperatorInput
+  showInGraphql: BooleanQueryOperatorInput
+  showInMenu: BooleanQueryOperatorInput
+  showInNavMenus: BooleanQueryOperatorInput
+  showInQuickEdit: BooleanQueryOperatorInput
+  showInRest: BooleanQueryOperatorInput
+  showUi: BooleanQueryOperatorInput
+}
+
+input WpTaxonomyFilterListInput {
+  elemMatch: WpTaxonomyFilterInput
+}
+
+type WpTaxonomyGroupConnection {
+  distinct(field: WpTaxonomyFieldsEnum!): [String!]!
+  edges: [WpTaxonomyEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpTaxonomyFieldsEnum!, limit: Int, skip: Int): [WpTaxonomyGroupConnection!]!
+  max(field: WpTaxonomyFieldsEnum!): Float
+  min(field: WpTaxonomyFieldsEnum!): Float
+  nodes: [WpTaxonomy!]!
+  pageInfo: PageInfo!
+  sum(field: WpTaxonomyFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpTaxonomySortInput {
+  fields: [WpTaxonomyFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the Taxonomy type and the ContentType type
+"""
+type WpTaxonomyToContentTypeConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpContentType]
+}
+
+input WpTaxonomyToContentTypeConnectionFilterInput {
+  nodes: WpContentTypeFilterListInput
+}
+
+interface WpTermNode implements Node {
+  children: [Node!]!
+
+  """
+  The number of objects connected to the object
+  """
+  count: Int
+
+  """
+  Identifies the primary key from the database.
+  """
+  databaseId: Int!
+
+  """
+  The description of the object
+  """
+  description: String
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The link to the term
+  """
+  link: String
+
+  """
+  The human friendly name of the object.
+  """
+  name: String
+  nodeType: String
+  parent: Node
+
+  """
+  An alphanumeric identifier for the object unique to its type.
+  """
+  slug: String
+
+  """
+  The name of the taxonomy that the object is associated with
+  """
+  taxonomyName: String
+
+  """
+  The ID of the term group that this term object belongs to
+  """
+  termGroupId: Int
+
+  """
+  The taxonomy ID that the object is associated with
+  """
+  termTaxonomyId: Int
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+}
+
+type WpTermNodeConnection {
+  distinct(field: WpTermNodeFieldsEnum!): [String!]!
+  edges: [WpTermNodeEdge!]!
+  group(field: WpTermNodeFieldsEnum!, limit: Int, skip: Int): [WpTermNodeGroupConnection!]!
+  max(field: WpTermNodeFieldsEnum!): Float
+  min(field: WpTermNodeFieldsEnum!): Float
+  nodes: [WpTermNode!]!
+  pageInfo: PageInfo!
+  sum(field: WpTermNodeFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpTermNodeEdge {
+  next: WpTermNode
+  node: WpTermNode!
+  previous: WpTermNode
+}
+
+enum WpTermNodeFieldsEnum {
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  count
+  databaseId
+  description
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isTermNode
+  link
+  name
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  slug
+  taxonomyName
+  termGroupId
+  termTaxonomyId
+  uri
+}
+
+input WpTermNodeFilterInput {
+  children: NodeFilterListInput
+  count: IntQueryOperatorInput
+  databaseId: IntQueryOperatorInput
+  description: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  link: StringQueryOperatorInput
+  name: StringQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+  slug: StringQueryOperatorInput
+  taxonomyName: StringQueryOperatorInput
+  termGroupId: IntQueryOperatorInput
+  termTaxonomyId: IntQueryOperatorInput
+  uri: StringQueryOperatorInput
+}
+
+input WpTermNodeFilterListInput {
+  elemMatch: WpTermNodeFilterInput
+}
+
+type WpTermNodeGroupConnection {
+  distinct(field: WpTermNodeFieldsEnum!): [String!]!
+  edges: [WpTermNodeEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpTermNodeFieldsEnum!, limit: Int, skip: Int): [WpTermNodeGroupConnection!]!
+  max(field: WpTermNodeFieldsEnum!): Float
+  min(field: WpTermNodeFieldsEnum!): Float
+  nodes: [WpTermNode!]!
+  pageInfo: PageInfo!
+  sum(field: WpTermNodeFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpTermNodeSortInput {
+  fields: [WpTermNodeFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+tribe/events-list block
+"""
+type WpTribeEventsListBlock implements WpBlock {
+  attributes: WpTribeEventsListBlockAttributes
+
+  """
+  Block attributes, JSON encoded
+  """
+  attributesJSON: String
+
+  """
+  Server side rendered content.
+  """
+  dynamicContent: String
+
+  """
+  Gutenberg blocks
+  """
+  innerBlocks: [WpBlock!]
+
+  """
+  Is block rendered server side.
+  """
+  isDynamic: Boolean!
+
+  """
+  Name of the block.
+  """
+  name: String!
+  order: Int!
+
+  """
+  Original HTML content.
+  """
+  originalContent: String
+
+  """
+  Parent post.
+  """
+  parentNode: WpNode!
+
+  """
+  Parent post id.
+  """
+  parentNodeDatabaseId: Int!
+
+  """
+  Original HTML content with inner blocks.
+  """
+  saveContent: String
+}
+
+type WpTribeEventsListBlockAttributes {
+  className: String
+  lock: JSON
+}
+
+interface WpUniformResourceIdentifiable {
+  """
+  The unique resource identifier path
+  """
+  id: ID!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+}
+
+"""
+A User object
+"""
+type WpUser implements Node & WpCommenter & WpDatabaseIdentifier & WpNode & WpUniformResourceIdentifiable {
+  """
+  Avatar object for user. The avatar object can be retrieved in different sizes by specifying the size argument.
+  """
+  avatar: WpAvatar
+
+  """
+  Connection between the User type and the BlockEditorPreview type
+  """
+  blockEditorPreviews: WpUserToBlockEditorPreviewConnection
+
+  """
+  User metadata option name. Usually it will be &quot;wp_capabilities&quot;.
+  """
+  capKey: String
+
+  """
+  A list of capabilities (permissions) granted to the user
+  """
+  capabilities: [String]
+  children: [Node!]!
+
+  """
+  Connection between the User type and the Comment type
+  """
+  comments: WpUserToCommentConnection
+
+  """
+  Identifies the primary key from the database.
+  """
+  databaseId: Int!
+
+  """
+  Description of the user.
+  """
+  description: String
+
+  """
+  Email address of the user. This is equivalent to the WP_User-&gt;user_email property.
+  """
+  email: String
+
+  """
+  A complete list of capabilities including capabilities inherited from a role. This is equivalent to the array keys of WP_User-&gt;allcaps.
+  """
+  extraCapabilities: [String]
+
+  """
+  First name of the user. This is equivalent to the WP_User-&gt;user_first_name property.
+  """
+  firstName: String
+  id: ID!
+  internal: Internal!
+
+  """
+  Whether the node is a Content Node
+  """
+  isContentNode: Boolean!
+
+  """
+  Whether the node is a Term
+  """
+  isTermNode: Boolean!
+
+  """
+  Last name of the user. This is equivalent to the WP_User-&gt;user_last_name property.
+  """
+  lastName: String
+
+  """
+  The preferred language locale set for the user. Value derived from get_user_locale().
+  """
+  locale: String
+
+  """
+  Display name of the user. This is equivalent to the WP_User-&gt;dispaly_name property.
+  """
+  name: String
+
+  """
+  The nicename for the user. This field is equivalent to WP_User-&gt;user_nicename
+  """
+  nicename: String
+
+  """
+  Nickname of the user.
+  """
+  nickname: String
+  nodeType: String
+
+  """
+  Connection between the User type and the page type
+  """
+  pages: WpUserToPageConnection
+  parent: Node
+
+  """
+  Connection between the User type and the post type
+  """
+  posts: WpUserToPostConnection
+
+  """
+  The date the user registered or was created. The field follows a full ISO8601 date string format.
+  """
+  registeredDate: String
+
+  """
+  Connection between the User type and the UserRole type
+  """
+  roles: WpUserToUserRoleConnection
+
+  """
+  The slug for the user. This field is equivalent to WP_User-&gt;user_nicename
+  """
+  slug: String
+
+  """
+  The unique resource identifier path
+  """
+  uri: String
+
+  """
+  A website url that is associated with the user.
+  """
+  url: String
+
+  """
+  Username for the user. This field is equivalent to WP_User-&gt;user_login.
+  """
+  username: String
+}
+
+type WpUserConnection {
+  distinct(field: WpUserFieldsEnum!): [String!]!
+  edges: [WpUserEdge!]!
+  group(field: WpUserFieldsEnum!, limit: Int, skip: Int): [WpUserGroupConnection!]!
+  max(field: WpUserFieldsEnum!): Float
+  min(field: WpUserFieldsEnum!): Float
+  nodes: [WpUser!]!
+  pageInfo: PageInfo!
+  sum(field: WpUserFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpUserEdge {
+  next: WpUser
+  node: WpUser!
+  previous: WpUser
+}
+
+enum WpUserFieldsEnum {
+  avatar___default
+  avatar___extraAttr
+  avatar___forceDefault
+  avatar___foundAvatar
+  avatar___height
+  avatar___rating
+  avatar___scheme
+  avatar___size
+  avatar___url
+  avatar___width
+  blockEditorPreviews___nodes
+  blockEditorPreviews___nodes___authorDatabaseId
+  blockEditorPreviews___nodes___authorId
+  blockEditorPreviews___nodes___blocks
+  blockEditorPreviews___nodes___blocksJSON
+  blockEditorPreviews___nodes___blocks___attributesJSON
+  blockEditorPreviews___nodes___blocks___dynamicContent
+  blockEditorPreviews___nodes___blocks___innerBlocks
+  blockEditorPreviews___nodes___blocks___isDynamic
+  blockEditorPreviews___nodes___blocks___name
+  blockEditorPreviews___nodes___blocks___order
+  blockEditorPreviews___nodes___blocks___originalContent
+  blockEditorPreviews___nodes___blocks___parentNodeDatabaseId
+  blockEditorPreviews___nodes___blocks___saveContent
+  blockEditorPreviews___nodes___children
+  blockEditorPreviews___nodes___children___children
+  blockEditorPreviews___nodes___children___id
+  blockEditorPreviews___nodes___content
+  blockEditorPreviews___nodes___contentTypeName
+  blockEditorPreviews___nodes___databaseId
+  blockEditorPreviews___nodes___date
+  blockEditorPreviews___nodes___dateGmt
+  blockEditorPreviews___nodes___desiredSlug
+  blockEditorPreviews___nodes___enclosure
+  blockEditorPreviews___nodes___guid
+  blockEditorPreviews___nodes___id
+  blockEditorPreviews___nodes___internal___content
+  blockEditorPreviews___nodes___internal___contentDigest
+  blockEditorPreviews___nodes___internal___description
+  blockEditorPreviews___nodes___internal___fieldOwners
+  blockEditorPreviews___nodes___internal___ignoreType
+  blockEditorPreviews___nodes___internal___mediaType
+  blockEditorPreviews___nodes___internal___owner
+  blockEditorPreviews___nodes___internal___type
+  blockEditorPreviews___nodes___isContentNode
+  blockEditorPreviews___nodes___isTermNode
+  blockEditorPreviews___nodes___lastUpdateTime
+  blockEditorPreviews___nodes___link
+  blockEditorPreviews___nodes___modified
+  blockEditorPreviews___nodes___modifiedGmt
+  blockEditorPreviews___nodes___nodeType
+  blockEditorPreviews___nodes___parent___children
+  blockEditorPreviews___nodes___parent___id
+  blockEditorPreviews___nodes___previewedDatabaseId
+  blockEditorPreviews___nodes___previewedParentDatabaseId
+  blockEditorPreviews___nodes___previewed___blocks
+  blockEditorPreviews___nodes___previewed___blocksJSON
+  blockEditorPreviews___nodes___previewed___children
+  blockEditorPreviews___nodes___previewed___id
+  blockEditorPreviews___nodes___previewed___nodeType
+  blockEditorPreviews___nodes___previewed___previewBlocks
+  blockEditorPreviews___nodes___previewed___previewBlocksJSON
+  blockEditorPreviews___nodes___slug
+  blockEditorPreviews___nodes___status
+  blockEditorPreviews___nodes___template___templateName
+  blockEditorPreviews___nodes___title
+  blockEditorPreviews___nodes___uri
+  capKey
+  capabilities
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  comments___nodes
+  comments___nodes___agent
+  comments___nodes___approved
+  comments___nodes___authorIp
+  comments___nodes___children
+  comments___nodes___children___children
+  comments___nodes___children___id
+  comments___nodes___content
+  comments___nodes___databaseId
+  comments___nodes___date
+  comments___nodes___dateGmt
+  comments___nodes___id
+  comments___nodes___internal___content
+  comments___nodes___internal___contentDigest
+  comments___nodes___internal___description
+  comments___nodes___internal___fieldOwners
+  comments___nodes___internal___ignoreType
+  comments___nodes___internal___mediaType
+  comments___nodes___internal___owner
+  comments___nodes___internal___type
+  comments___nodes___karma
+  comments___nodes___nodeType
+  comments___nodes___parentDatabaseId
+  comments___nodes___parentId
+  comments___nodes___parent___children
+  comments___nodes___parent___id
+  comments___nodes___replies___nodes
+  comments___nodes___type
+  databaseId
+  description
+  email
+  extraCapabilities
+  firstName
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  isContentNode
+  isTermNode
+  lastName
+  locale
+  name
+  nicename
+  nickname
+  nodeType
+  pages___nodes
+  pages___nodes___ancestors___nodes
+  pages___nodes___authorDatabaseId
+  pages___nodes___authorId
+  pages___nodes___blocks
+  pages___nodes___blocksJSON
+  pages___nodes___blocks___attributesJSON
+  pages___nodes___blocks___dynamicContent
+  pages___nodes___blocks___innerBlocks
+  pages___nodes___blocks___isDynamic
+  pages___nodes___blocks___name
+  pages___nodes___blocks___order
+  pages___nodes___blocks___originalContent
+  pages___nodes___blocks___parentNodeDatabaseId
+  pages___nodes___blocks___saveContent
+  pages___nodes___children
+  pages___nodes___children___children
+  pages___nodes___children___id
+  pages___nodes___commentCount
+  pages___nodes___commentStatus
+  pages___nodes___comments___nodes
+  pages___nodes___content
+  pages___nodes___contentTypeName
+  pages___nodes___databaseId
+  pages___nodes___date
+  pages___nodes___dateGmt
+  pages___nodes___desiredSlug
+  pages___nodes___enclosure
+  pages___nodes___featuredImageDatabaseId
+  pages___nodes___featuredImageId
+  pages___nodes___guid
+  pages___nodes___id
+  pages___nodes___internal___content
+  pages___nodes___internal___contentDigest
+  pages___nodes___internal___description
+  pages___nodes___internal___fieldOwners
+  pages___nodes___internal___ignoreType
+  pages___nodes___internal___mediaType
+  pages___nodes___internal___owner
+  pages___nodes___internal___type
+  pages___nodes___isContentNode
+  pages___nodes___isFrontPage
+  pages___nodes___isPostsPage
+  pages___nodes___isPrivacyPage
+  pages___nodes___isRevision
+  pages___nodes___isTermNode
+  pages___nodes___link
+  pages___nodes___menuOrder
+  pages___nodes___modified
+  pages___nodes___modifiedGmt
+  pages___nodes___nodeType
+  pages___nodes___parentDatabaseId
+  pages___nodes___parentId
+  pages___nodes___parent___children
+  pages___nodes___parent___id
+  pages___nodes___previewBlocks
+  pages___nodes___previewBlocksJSON
+  pages___nodes___previewBlocks___attributesJSON
+  pages___nodes___previewBlocks___dynamicContent
+  pages___nodes___previewBlocks___innerBlocks
+  pages___nodes___previewBlocks___isDynamic
+  pages___nodes___previewBlocks___name
+  pages___nodes___previewBlocks___order
+  pages___nodes___previewBlocks___originalContent
+  pages___nodes___previewBlocks___parentNodeDatabaseId
+  pages___nodes___previewBlocks___saveContent
+  pages___nodes___slug
+  pages___nodes___status
+  pages___nodes___template___templateName
+  pages___nodes___title
+  pages___nodes___uri
+  pages___nodes___wpChildren___nodes
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  posts___nodes
+  posts___nodes___authorDatabaseId
+  posts___nodes___authorId
+  posts___nodes___blocks
+  posts___nodes___blocksJSON
+  posts___nodes___blocks___attributesJSON
+  posts___nodes___blocks___dynamicContent
+  posts___nodes___blocks___innerBlocks
+  posts___nodes___blocks___isDynamic
+  posts___nodes___blocks___name
+  posts___nodes___blocks___order
+  posts___nodes___blocks___originalContent
+  posts___nodes___blocks___parentNodeDatabaseId
+  posts___nodes___blocks___saveContent
+  posts___nodes___categories___nodes
+  posts___nodes___children
+  posts___nodes___children___children
+  posts___nodes___children___id
+  posts___nodes___commentCount
+  posts___nodes___commentStatus
+  posts___nodes___comments___nodes
+  posts___nodes___content
+  posts___nodes___contentTypeName
+  posts___nodes___databaseId
+  posts___nodes___date
+  posts___nodes___dateGmt
+  posts___nodes___desiredSlug
+  posts___nodes___enclosure
+  posts___nodes___excerpt
+  posts___nodes___featuredImageDatabaseId
+  posts___nodes___featuredImageId
+  posts___nodes___guid
+  posts___nodes___id
+  posts___nodes___internal___content
+  posts___nodes___internal___contentDigest
+  posts___nodes___internal___description
+  posts___nodes___internal___fieldOwners
+  posts___nodes___internal___ignoreType
+  posts___nodes___internal___mediaType
+  posts___nodes___internal___owner
+  posts___nodes___internal___type
+  posts___nodes___isContentNode
+  posts___nodes___isRevision
+  posts___nodes___isSticky
+  posts___nodes___isTermNode
+  posts___nodes___link
+  posts___nodes___modified
+  posts___nodes___modifiedGmt
+  posts___nodes___nodeType
+  posts___nodes___parent___children
+  posts___nodes___parent___id
+  posts___nodes___pingStatus
+  posts___nodes___pinged
+  posts___nodes___postFormats___nodes
+  posts___nodes___previewBlocks
+  posts___nodes___previewBlocksJSON
+  posts___nodes___previewBlocks___attributesJSON
+  posts___nodes___previewBlocks___dynamicContent
+  posts___nodes___previewBlocks___innerBlocks
+  posts___nodes___previewBlocks___isDynamic
+  posts___nodes___previewBlocks___name
+  posts___nodes___previewBlocks___order
+  posts___nodes___previewBlocks___originalContent
+  posts___nodes___previewBlocks___parentNodeDatabaseId
+  posts___nodes___previewBlocks___saveContent
+  posts___nodes___slug
+  posts___nodes___status
+  posts___nodes___tags___nodes
+  posts___nodes___template___templateName
+  posts___nodes___terms___nodes
+  posts___nodes___title
+  posts___nodes___toPing
+  posts___nodes___uri
+  registeredDate
+  roles___nodes
+  roles___nodes___capabilities
+  roles___nodes___children
+  roles___nodes___children___children
+  roles___nodes___children___id
+  roles___nodes___displayName
+  roles___nodes___id
+  roles___nodes___internal___content
+  roles___nodes___internal___contentDigest
+  roles___nodes___internal___description
+  roles___nodes___internal___fieldOwners
+  roles___nodes___internal___ignoreType
+  roles___nodes___internal___mediaType
+  roles___nodes___internal___owner
+  roles___nodes___internal___type
+  roles___nodes___name
+  roles___nodes___nodeType
+  roles___nodes___parent___children
+  roles___nodes___parent___id
+  slug
+  uri
+  url
+  username
+}
+
+input WpUserFilterInput {
+  avatar: WpAvatarFilterInput
+  blockEditorPreviews: WpUserToBlockEditorPreviewConnectionFilterInput
+  capKey: StringQueryOperatorInput
+  capabilities: StringQueryOperatorInput
+  children: NodeFilterListInput
+  comments: WpUserToCommentConnectionFilterInput
+  databaseId: IntQueryOperatorInput
+  description: StringQueryOperatorInput
+  email: StringQueryOperatorInput
+  extraCapabilities: StringQueryOperatorInput
+  firstName: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  isContentNode: BooleanQueryOperatorInput
+  isTermNode: BooleanQueryOperatorInput
+  lastName: StringQueryOperatorInput
+  locale: StringQueryOperatorInput
+  name: StringQueryOperatorInput
+  nicename: StringQueryOperatorInput
+  nickname: StringQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  pages: WpUserToPageConnectionFilterInput
+  parent: NodeFilterInput
+  posts: WpUserToPostConnectionFilterInput
+  registeredDate: StringQueryOperatorInput
+  roles: WpUserToUserRoleConnectionFilterInput
+  slug: StringQueryOperatorInput
+  uri: StringQueryOperatorInput
+  url: StringQueryOperatorInput
+  username: StringQueryOperatorInput
+}
+
+type WpUserGroupConnection {
+  distinct(field: WpUserFieldsEnum!): [String!]!
+  edges: [WpUserEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpUserFieldsEnum!, limit: Int, skip: Int): [WpUserGroupConnection!]!
+  max(field: WpUserFieldsEnum!): Float
+  min(field: WpUserFieldsEnum!): Float
+  nodes: [WpUser!]!
+  pageInfo: PageInfo!
+  sum(field: WpUserFieldsEnum!): Float
+  totalCount: Int!
+}
+
+"""
+A user role object
+"""
+type WpUserRole implements Node & WpNode {
+  """
+  The capabilities that belong to this role
+  """
+  capabilities: [String]
+  children: [Node!]!
+
+  """
+  The display name of the role
+  """
+  displayName: String
+  id: ID!
+  internal: Internal!
+
+  """
+  The registered name of the role
+  """
+  name: String
+  nodeType: String
+  parent: Node
+}
+
+type WpUserRoleConnection {
+  distinct(field: WpUserRoleFieldsEnum!): [String!]!
+  edges: [WpUserRoleEdge!]!
+  group(field: WpUserRoleFieldsEnum!, limit: Int, skip: Int): [WpUserRoleGroupConnection!]!
+  max(field: WpUserRoleFieldsEnum!): Float
+  min(field: WpUserRoleFieldsEnum!): Float
+  nodes: [WpUserRole!]!
+  pageInfo: PageInfo!
+  sum(field: WpUserRoleFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type WpUserRoleEdge {
+  next: WpUserRole
+  node: WpUserRole!
+  previous: WpUserRole
+}
+
+enum WpUserRoleFieldsEnum {
+  capabilities
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  displayName
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  name
+  nodeType
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+}
+
+input WpUserRoleFilterInput {
+  capabilities: StringQueryOperatorInput
+  children: NodeFilterListInput
+  displayName: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  name: StringQueryOperatorInput
+  nodeType: StringQueryOperatorInput
+  parent: NodeFilterInput
+}
+
+input WpUserRoleFilterListInput {
+  elemMatch: WpUserRoleFilterInput
+}
+
+type WpUserRoleGroupConnection {
+  distinct(field: WpUserRoleFieldsEnum!): [String!]!
+  edges: [WpUserRoleEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: WpUserRoleFieldsEnum!, limit: Int, skip: Int): [WpUserRoleGroupConnection!]!
+  max(field: WpUserRoleFieldsEnum!): Float
+  min(field: WpUserRoleFieldsEnum!): Float
+  nodes: [WpUserRole!]!
+  pageInfo: PageInfo!
+  sum(field: WpUserRoleFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input WpUserRoleSortInput {
+  fields: [WpUserRoleFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+input WpUserSortInput {
+  fields: [WpUserFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+"""
+Connection between the User type and the BlockEditorPreview type
+"""
+type WpUserToBlockEditorPreviewConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpBlockEditorPreview]
+}
+
+input WpUserToBlockEditorPreviewConnectionFilterInput {
+  nodes: WpBlockEditorPreviewFilterListInput
+}
+
+"""
+Connection between the User type and the Comment type
+"""
+type WpUserToCommentConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpComment]
+}
+
+input WpUserToCommentConnectionFilterInput {
+  nodes: WpCommentFilterListInput
+}
+
+"""
+Connection between the User type and the page type
+"""
+type WpUserToPageConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpPage]
+}
+
+input WpUserToPageConnectionFilterInput {
+  nodes: WpPageFilterListInput
+}
+
+"""
+Connection between the User type and the post type
+"""
+type WpUserToPostConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpPost]
+}
+
+input WpUserToPostConnectionFilterInput {
+  nodes: WpPostFilterListInput
+}
+
+"""
+Connection between the User type and the UserRole type
+"""
+type WpUserToUserRoleConnection {
+  """
+  The nodes of the connection, without the edges
+  """
+  nodes: [WpUserRole]
+}
+
+input WpUserToUserRoleConnectionFilterInput {
+  nodes: WpUserRoleFilterListInput
+}
+
+"""
+Information needed by gatsby-source-wordpress.
+"""
+type WpWPGatsby {
+  """
+  Returns wether or not pretty permalinks are enabled.
+  """
+  arePrettyPermalinksEnabled: Boolean
+
+  """
+  Wether or not the Preview frontend URL is online.
+  """
+  isPreviewFrontendOnline: Boolean
+}
+
+input WpWPGatsbyFilterInput {
+  arePrettyPermalinksEnabled: BooleanQueryOperatorInput
+  isPreviewFrontendOnline: BooleanQueryOperatorInput
+}
+
+"""
+The writing setting type
+"""
+type WpWritingSettings {
+  """
+  Standard-Beitragskategorie.
+  """
+  defaultCategory: Int
+
+  """
+  Standard-Beitragsformat.
+  """
+  defaultPostFormat: String
+
+  """
+  Emoticons wie :-) und :-P als Grafiken anzeigen.
+  """
+  useSmilies: Boolean
+}
+
+input WpWritingSettingsFilterInput {
+  defaultCategory: IntQueryOperatorInput
+  defaultPostFormat: StringQueryOperatorInput
+  useSmilies: BooleanQueryOperatorInput
+}
+
+type internal__events implements Node {
+  children: [Node!]!
+  events: [internal__eventsEvents]
+  id: ID!
+  internal: Internal!
+  next_rest_url: String
+  parent: Node
+  previous_rest_url: String
+  rest_url: String
+  total: Int
+  total_pages: Int
+}
+
+type internal__eventsConnection {
+  distinct(field: internal__eventsFieldsEnum!): [String!]!
+  edges: [internal__eventsEdge!]!
+  group(field: internal__eventsFieldsEnum!, limit: Int, skip: Int): [internal__eventsGroupConnection!]!
+  max(field: internal__eventsFieldsEnum!): Float
+  min(field: internal__eventsFieldsEnum!): Float
+  nodes: [internal__events!]!
+  pageInfo: PageInfo!
+  sum(field: internal__eventsFieldsEnum!): Float
+  totalCount: Int!
+}
+
+type internal__eventsEdge {
+  next: internal__events
+  node: internal__events!
+  previous: internal__events
+}
+
+type internal__eventsEvents {
+  all_day: Boolean
+  alternative_id: Int
+  author: String
+  categories: [internal__eventsEventsCategories]
+  cost: String
+  cost_details: internal__eventsEventsCost_details
+  date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  date_utc(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  description: String
+  end_date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  end_date_details: internal__eventsEventsEnd_date_details
+  excerpt: String
+  featured: Boolean
+  global_id: String
+  global_id_lineage: [String]
+  hide_from_listings: Boolean
+  image: Boolean
+  modified(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  modified_utc(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  rest_url: String
+  show_map: Boolean
+  show_map_link: Boolean
+  slug: String
+  start_date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  start_date_details: internal__eventsEventsStart_date_details
+  status: String
+  sticky: Boolean
+  timezone: String
+  timezone_abbr: String
+  title: String
+  url: String
+  utc_end_date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  utc_end_date_details: internal__eventsEventsUtc_end_date_details
+  utc_start_date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  utc_start_date_details: internal__eventsEventsUtc_start_date_details
+  venue: internal__eventsEventsVenue
+  website: String
+}
+
+type internal__eventsEventsCategories {
+  alternative_id: Int
+  alternative_parent: Int
+  count: Int
+  description: String
+  filter: String
+  name: String
+  slug: String
+  taxonomy: String
+  term_group: Int
+  term_taxonomy_id: Int
+  urls: internal__eventsEventsCategoriesUrls
+}
+
+input internal__eventsEventsCategoriesFilterInput {
+  alternative_id: IntQueryOperatorInput
+  alternative_parent: IntQueryOperatorInput
+  count: IntQueryOperatorInput
+  description: StringQueryOperatorInput
+  filter: StringQueryOperatorInput
+  name: StringQueryOperatorInput
+  slug: StringQueryOperatorInput
+  taxonomy: StringQueryOperatorInput
+  term_group: IntQueryOperatorInput
+  term_taxonomy_id: IntQueryOperatorInput
+  urls: internal__eventsEventsCategoriesUrlsFilterInput
+}
+
+input internal__eventsEventsCategoriesFilterListInput {
+  elemMatch: internal__eventsEventsCategoriesFilterInput
+}
+
+type internal__eventsEventsCategoriesUrls {
+  collection: String
+  self: String
+  up: String
+}
+
+input internal__eventsEventsCategoriesUrlsFilterInput {
+  collection: StringQueryOperatorInput
+  self: StringQueryOperatorInput
+  up: StringQueryOperatorInput
+}
+
+type internal__eventsEventsCost_details {
+  currency_code: String
+  currency_position: String
+  currency_symbol: String
+}
+
+input internal__eventsEventsCost_detailsFilterInput {
+  currency_code: StringQueryOperatorInput
+  currency_position: StringQueryOperatorInput
+  currency_symbol: StringQueryOperatorInput
+}
+
+type internal__eventsEventsEnd_date_details {
+  day: String
+  hour: String
+  minutes: String
+  month: String
+  seconds: String
+  year(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+}
+
+input internal__eventsEventsEnd_date_detailsFilterInput {
+  day: StringQueryOperatorInput
+  hour: StringQueryOperatorInput
+  minutes: StringQueryOperatorInput
+  month: StringQueryOperatorInput
+  seconds: StringQueryOperatorInput
+  year: DateQueryOperatorInput
+}
+
+input internal__eventsEventsFilterInput {
+  all_day: BooleanQueryOperatorInput
+  alternative_id: IntQueryOperatorInput
+  author: StringQueryOperatorInput
+  categories: internal__eventsEventsCategoriesFilterListInput
+  cost: StringQueryOperatorInput
+  cost_details: internal__eventsEventsCost_detailsFilterInput
+  date: DateQueryOperatorInput
+  date_utc: DateQueryOperatorInput
+  description: StringQueryOperatorInput
+  end_date: DateQueryOperatorInput
+  end_date_details: internal__eventsEventsEnd_date_detailsFilterInput
+  excerpt: StringQueryOperatorInput
+  featured: BooleanQueryOperatorInput
+  global_id: StringQueryOperatorInput
+  global_id_lineage: StringQueryOperatorInput
+  hide_from_listings: BooleanQueryOperatorInput
+  image: BooleanQueryOperatorInput
+  modified: DateQueryOperatorInput
+  modified_utc: DateQueryOperatorInput
+  rest_url: StringQueryOperatorInput
+  show_map: BooleanQueryOperatorInput
+  show_map_link: BooleanQueryOperatorInput
+  slug: StringQueryOperatorInput
+  start_date: DateQueryOperatorInput
+  start_date_details: internal__eventsEventsStart_date_detailsFilterInput
+  status: StringQueryOperatorInput
+  sticky: BooleanQueryOperatorInput
+  timezone: StringQueryOperatorInput
+  timezone_abbr: StringQueryOperatorInput
+  title: StringQueryOperatorInput
+  url: StringQueryOperatorInput
+  utc_end_date: DateQueryOperatorInput
+  utc_end_date_details: internal__eventsEventsUtc_end_date_detailsFilterInput
+  utc_start_date: DateQueryOperatorInput
+  utc_start_date_details: internal__eventsEventsUtc_start_date_detailsFilterInput
+  venue: internal__eventsEventsVenueFilterInput
+  website: StringQueryOperatorInput
+}
+
+input internal__eventsEventsFilterListInput {
+  elemMatch: internal__eventsEventsFilterInput
+}
+
+type internal__eventsEventsStart_date_details {
+  day: String
+  hour: String
+  minutes: String
+  month: String
+  seconds: String
+  year(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+}
+
+input internal__eventsEventsStart_date_detailsFilterInput {
+  day: StringQueryOperatorInput
+  hour: StringQueryOperatorInput
+  minutes: StringQueryOperatorInput
+  month: StringQueryOperatorInput
+  seconds: StringQueryOperatorInput
+  year: DateQueryOperatorInput
+}
+
+type internal__eventsEventsUtc_end_date_details {
+  day: String
+  hour: String
+  minutes: String
+  month: String
+  seconds: String
+  year(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+}
+
+input internal__eventsEventsUtc_end_date_detailsFilterInput {
+  day: StringQueryOperatorInput
+  hour: StringQueryOperatorInput
+  minutes: StringQueryOperatorInput
+  month: StringQueryOperatorInput
+  seconds: StringQueryOperatorInput
+  year: DateQueryOperatorInput
+}
+
+type internal__eventsEventsUtc_start_date_details {
+  day: String
+  hour: String
+  minutes: String
+  month: String
+  seconds: String
+  year(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+}
+
+input internal__eventsEventsUtc_start_date_detailsFilterInput {
+  day: StringQueryOperatorInput
+  hour: StringQueryOperatorInput
+  minutes: StringQueryOperatorInput
+  month: StringQueryOperatorInput
+  seconds: StringQueryOperatorInput
+  year: DateQueryOperatorInput
+}
+
+type internal__eventsEventsVenue {
+  alternative_id: Int
+  author: String
+  country: String
+  date(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  date_utc(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  global_id: String
+  global_id_lineage: [String]
+  modified(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  modified_utc(
+    """
+    Returns the difference between this date and the current time. Defaults to "milliseconds" but you can also pass in as the measurement "years", "months", "weeks", "days", "hours", "minutes", and "seconds".
+    """
+    difference: String
+
+    """
+    Format the date using Moment.js' date tokens, e.g. `date(formatString: "YYYY MMMM DD")`. See https://momentjs.com/docs/#/displaying/format/ for documentation for different tokens.
+    """
+    formatString: String
+
+    """
+    Returns a string generated with Moment.js' `fromNow` function
+    """
+    fromNow: Boolean
+
+    """
+    Configures the locale Moment.js will use to format the date.
+    """
+    locale: String
+  ): Date
+  show_map: Boolean
+  show_map_link: Boolean
+  slug: String
+  status: String
+  url: String
+  venue: String
+}
+
+input internal__eventsEventsVenueFilterInput {
+  alternative_id: IntQueryOperatorInput
+  author: StringQueryOperatorInput
+  country: StringQueryOperatorInput
+  date: DateQueryOperatorInput
+  date_utc: DateQueryOperatorInput
+  global_id: StringQueryOperatorInput
+  global_id_lineage: StringQueryOperatorInput
+  modified: DateQueryOperatorInput
+  modified_utc: DateQueryOperatorInput
+  show_map: BooleanQueryOperatorInput
+  show_map_link: BooleanQueryOperatorInput
+  slug: StringQueryOperatorInput
+  status: StringQueryOperatorInput
+  url: StringQueryOperatorInput
+  venue: StringQueryOperatorInput
+}
+
+enum internal__eventsFieldsEnum {
+  children
+  children___children
+  children___children___children
+  children___children___children___children
+  children___children___children___id
+  children___children___id
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___children___parent___children
+  children___children___parent___id
+  children___id
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  children___parent___children
+  children___parent___children___children
+  children___parent___children___id
+  children___parent___id
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___parent___parent___children
+  children___parent___parent___id
+  events
+  events___all_day
+  events___alternative_id
+  events___author
+  events___categories
+  events___categories___alternative_id
+  events___categories___alternative_parent
+  events___categories___count
+  events___categories___description
+  events___categories___filter
+  events___categories___name
+  events___categories___slug
+  events___categories___taxonomy
+  events___categories___term_group
+  events___categories___term_taxonomy_id
+  events___categories___urls___collection
+  events___categories___urls___self
+  events___categories___urls___up
+  events___cost
+  events___cost_details___currency_code
+  events___cost_details___currency_position
+  events___cost_details___currency_symbol
+  events___date
+  events___date_utc
+  events___description
+  events___end_date
+  events___end_date_details___day
+  events___end_date_details___hour
+  events___end_date_details___minutes
+  events___end_date_details___month
+  events___end_date_details___seconds
+  events___end_date_details___year
+  events___excerpt
+  events___featured
+  events___global_id
+  events___global_id_lineage
+  events___hide_from_listings
+  events___image
+  events___modified
+  events___modified_utc
+  events___rest_url
+  events___show_map
+  events___show_map_link
+  events___slug
+  events___start_date
+  events___start_date_details___day
+  events___start_date_details___hour
+  events___start_date_details___minutes
+  events___start_date_details___month
+  events___start_date_details___seconds
+  events___start_date_details___year
+  events___status
+  events___sticky
+  events___timezone
+  events___timezone_abbr
+  events___title
+  events___url
+  events___utc_end_date
+  events___utc_end_date_details___day
+  events___utc_end_date_details___hour
+  events___utc_end_date_details___minutes
+  events___utc_end_date_details___month
+  events___utc_end_date_details___seconds
+  events___utc_end_date_details___year
+  events___utc_start_date
+  events___utc_start_date_details___day
+  events___utc_start_date_details___hour
+  events___utc_start_date_details___minutes
+  events___utc_start_date_details___month
+  events___utc_start_date_details___seconds
+  events___utc_start_date_details___year
+  events___venue___alternative_id
+  events___venue___author
+  events___venue___country
+  events___venue___date
+  events___venue___date_utc
+  events___venue___global_id
+  events___venue___global_id_lineage
+  events___venue___modified
+  events___venue___modified_utc
+  events___venue___show_map
+  events___venue___show_map_link
+  events___venue___slug
+  events___venue___status
+  events___venue___url
+  events___venue___venue
+  events___website
+  id
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+  next_rest_url
+  parent___children
+  parent___children___children
+  parent___children___children___children
+  parent___children___children___id
+  parent___children___id
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___children___parent___children
+  parent___children___parent___id
+  parent___id
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  parent___parent___children
+  parent___parent___children___children
+  parent___parent___children___id
+  parent___parent___id
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___parent___parent___children
+  parent___parent___parent___id
+  previous_rest_url
+  rest_url
+  total
+  total_pages
+}
+
+input internal__eventsFilterInput {
+  children: NodeFilterListInput
+  events: internal__eventsEventsFilterListInput
+  id: StringQueryOperatorInput
+  internal: InternalFilterInput
+  next_rest_url: StringQueryOperatorInput
+  parent: NodeFilterInput
+  previous_rest_url: StringQueryOperatorInput
+  rest_url: StringQueryOperatorInput
+  total: IntQueryOperatorInput
+  total_pages: IntQueryOperatorInput
+}
+
+type internal__eventsGroupConnection {
+  distinct(field: internal__eventsFieldsEnum!): [String!]!
+  edges: [internal__eventsEdge!]!
+  field: String!
+  fieldValue: String
+  group(field: internal__eventsFieldsEnum!, limit: Int, skip: Int): [internal__eventsGroupConnection!]!
+  max(field: internal__eventsFieldsEnum!): Float
+  min(field: internal__eventsFieldsEnum!): Float
+  nodes: [internal__events!]!
+  pageInfo: PageInfo!
+  sum(field: internal__eventsFieldsEnum!): Float
+  totalCount: Int!
+}
+
+input internal__eventsSortInput {
+  fields: [internal__eventsFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}

--- a/dev-test/githunt/types.flatten.preResolveTypes.ts
+++ b/dev-test/githunt/types.flatten.preResolveTypes.ts
@@ -248,7 +248,7 @@ export type FeedQuery = {
       owner?: { __typename?: 'User'; avatar_url: string } | null;
     };
     vote: { __typename?: 'Vote'; vote_value: number };
-    postedBy: { __typename?: 'User'; html_url: string; login: string };
+    postedBy: { __typename?: 'User'; login: string; html_url: string };
   } | null> | null;
 };
 

--- a/packages/graphql-codegen-cli/tests/codegen.spec.ts
+++ b/packages/graphql-codegen-cli/tests/codegen.spec.ts
@@ -1305,4 +1305,22 @@ describe('Codegen Executor', () => {
       expect(fileOutput.content).toContain('export type BarQuery');
     });
   });
+
+  it('should not run out of memory when generating very complex types (issue #7720)', async () => {
+    const result = await executeCodegen({
+      schema: ['../../dev-test/gatsby/schema.graphql'],
+      documents: ['../../dev-test/gatsby/fragments.ts'],
+      config: {
+        extractAllFieldsToTypes: true,
+        dedupeOperationSuffix: true,
+      },
+      generates: {
+        'out1.ts': {
+          plugins: ['typescript', 'typescript-operations'],
+        },
+      },
+    });
+    expect(result.length).toBe(1);
+    expect(result[0].content).toContain('export type WpCoreImageBlockForGalleryFragment = ');
+  });
 });

--- a/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
@@ -30,6 +30,7 @@ function getRootType(operation: OperationTypeNode, schema: GraphQLSchema) {
 export interface ParsedDocumentsConfig extends ParsedTypesConfig {
   addTypename: boolean;
   preResolveTypes: boolean;
+  extractAllFieldsToTypes: boolean;
   globalNamespace: boolean;
   operationResultSuffix: string;
   dedupeOperationSuffix: boolean;
@@ -275,6 +276,11 @@ export class BaseDocumentsVisitor<
     );
     const operationType: string = pascalCase(node.operation);
     const operationTypeSuffix = this.getOperationSuffix(name, operationType);
+    const selectionSetObjects = selectionSet.transformSelectionSet(
+      this.convertName(name, {
+        suffix: operationTypeSuffix,
+      })
+    );
 
     const operationResult = new DeclarationBlock(this._declarationBlockConfig)
       .export()
@@ -284,7 +290,7 @@ export class BaseDocumentsVisitor<
           suffix: operationTypeSuffix + this._parsedConfig.operationResultSuffix,
         })
       )
-      .withContent(selectionSet.transformSelectionSet()).string;
+      .withContent(selectionSetObjects.mergedTypeString).string;
 
     const operationVariables = new DeclarationBlock({
       ...this._declarationBlockConfig,
@@ -299,6 +305,23 @@ export class BaseDocumentsVisitor<
       )
       .withBlock(visitedOperationVariables).string;
 
-    return [operationVariables, operationResult].filter(r => r).join('\n\n');
+    const dependentTypesContent = this._parsedConfig.extractAllFieldsToTypes
+      ? selectionSetObjects.dependentTypes.map(
+          i =>
+            new DeclarationBlock(this._declarationBlockConfig)
+              .export()
+              .asKind('type')
+              .withName(i.name)
+              .withContent(i.content).string
+        )
+      : [];
+
+    return [
+      ...(dependentTypesContent.length > 0 ? [dependentTypesContent.join('\n')] : []),
+      operationVariables,
+      operationResult,
+    ]
+      .filter(r => r)
+      .join('\n\n');
   }
 }

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -28,6 +28,7 @@ export interface ParsedConfig {
   typesSuffix: string;
   addTypename: boolean;
   nonOptionalTypename: boolean;
+  extractAllFieldsToTypes: boolean;
   externalFragments: LoadedFragment[];
   fragmentImports: ImportDeclaration<FragmentImport>[];
   immutableTypes: boolean;
@@ -36,6 +37,7 @@ export interface ParsedConfig {
   allowEnumStringTypes: boolean;
   inlineFragmentTypes: InlineFragmentTypeOptions;
   emitLegacyCommonJSImports: boolean;
+  printFieldsOnNewLines: boolean;
 }
 
 export interface RawConfig {
@@ -371,6 +373,23 @@ export interface RawConfig {
    * Default it will be `true` this way it ensure that generated code works with [non-compliant bundlers](https://github.com/dotansimha/graphql-code-generator/issues/8065).
    */
   emitLegacyCommonJSImports?: boolean;
+
+  /**
+   * @default false
+   * @description Extract all field types to their own types, instead of inlining them.
+   * This helps to reduce type duplication, and makes type errors more readable.
+   * It can also significantly reduce the size of the generated code, the generation time,
+   * and the typechecking time.
+   */
+  extractAllFieldsToTypes?: boolean;
+
+  /**
+   * @default false
+   * @description If you prefer to have each field in generated types printed on a new line, set this to true.
+   * This can be useful for improving readability of the resulting types,
+   * without resorting to running tools like Prettier on the output.
+   */
+  printFieldsOnNewLines?: boolean;
 }
 
 export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig extends ParsedConfig = ParsedConfig> {
@@ -393,6 +412,8 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
       inlineFragmentTypes: rawConfig.inlineFragmentTypes ?? 'inline',
       emitLegacyCommonJSImports:
         rawConfig.emitLegacyCommonJSImports === undefined ? true : !!rawConfig.emitLegacyCommonJSImports,
+      extractAllFieldsToTypes: rawConfig.extractAllFieldsToTypes ?? false,
+      printFieldsOnNewLines: rawConfig.printFieldsOnNewLines ?? false,
       ...((additionalConfig || {}) as any),
     };
 

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/base.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/base.ts
@@ -1,4 +1,4 @@
-import { GraphQLInterfaceType, GraphQLNamedType, GraphQLObjectType, GraphQLOutputType } from 'graphql';
+import { GraphQLInterfaceType, GraphQLNamedType, GraphQLObjectType, GraphQLOutputType, Location } from 'graphql';
 import { AvoidOptionalsConfig, ConvertNameFn, NormalizedScalarsMap } from '../types.js';
 
 export type PrimitiveField = { isConditional: boolean; fieldName: string };
@@ -21,12 +21,18 @@ export type SelectionSetProcessorConfig = {
   ): string;
   wrapTypeWithModifiers(baseType: string, type: GraphQLOutputType | GraphQLNamedType): string;
   avoidOptionals?: AvoidOptionalsConfig | boolean;
+  printFieldsOnNewLines?: boolean;
 };
 
 export class BaseSelectionSetProcessor<Config extends SelectionSetProcessorConfig> {
+  typeCache = new Map<Location, Map<string, [string, string]>>();
+
   constructor(public config: Config) {}
 
   buildFieldsIntoObject(allObjectsMerged: string[]): string {
+    if (this.config.printFieldsOnNewLines) {
+      return `{\n  ${allObjectsMerged.join(',\n  ')}\n}`;
+    }
     return `{ ${allObjectsMerged.join(', ')} }`;
   }
 

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -43,6 +43,8 @@ import {
 } from './types.js';
 import {
   DeclarationBlock,
+  DeclarationBlockConfig,
+  getFieldNames,
   getFieldNodeNameValue,
   getPossibleTypes,
   hasConditionalDirectives,
@@ -59,8 +61,16 @@ type FragmentSpreadUsage = {
   fragmentDirectives?: DirectiveNode[];
 };
 
+interface DependentType {
+  name: string;
+  content: string;
+  isUnionType?: boolean;
+}
+
 type CollectedFragmentNode = (SelectionNode | FragmentSpreadUsage | DirectiveNode) & FragmentDirectives;
 type GroupedStringifiedTypes = Record<string, Array<string | { union: string[] }>>;
+
+const operationTypes: string[] = ['Query', 'Mutation', 'Subscription'];
 
 function isMetadataFieldName(name: string) {
   return ['__schema', '__type'].includes(name);
@@ -233,6 +243,11 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     };
   }
 
+  /**
+   * The `buildFragmentSpreadsUsage` method is used to collect fields from fragment spreads in the selection set.
+   * It creates a record of fragment spread usages, which includes the fragment name, type name, and the selection nodes
+   * inside the fragment.
+   */
   protected buildFragmentSpreadsUsage(spreads: FragmentSpreadNode[]): Record<string, FragmentSpreadUsage[]> {
     const selectionNodesByTypeName: Record<string, FragmentSpreadUsage[]> = {};
 
@@ -323,12 +338,13 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     }
   }
 
-  /**
-   * mustAddEmptyObject indicates that not all possible types on a union or interface field are covered.
-   */
-  protected _buildGroupedSelections(): { grouped: GroupedStringifiedTypes; mustAddEmptyObject: boolean } {
+  protected _buildGroupedSelections(parentName: string): {
+    grouped: GroupedStringifiedTypes;
+    dependentTypes: DependentType[];
+    mustAddEmptyObject: boolean;
+  } {
     if (!this._selectionSet?.selections || this._selectionSet.selections.length === 0) {
-      return { grouped: {}, mustAddEmptyObject: true };
+      return { grouped: {}, mustAddEmptyObject: true, dependentTypes: [] };
     }
 
     const selectionNodesByTypeName = this.flattenSelectionSet(this._selectionSet.selections);
@@ -338,6 +354,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
 
     const possibleTypes = getPossibleTypes(this._schema, this._parentSchemaType);
 
+    const dependentTypes: DependentType[] = [];
     if (!this._config.mergeFragmentTypes || this._config.inlineFragmentTypes === 'mask') {
       const grouped = possibleTypes.reduce<GroupedStringifiedTypes>((prev, type) => {
         const typeName = type.name;
@@ -351,9 +368,11 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
 
         prev[typeName] ||= [];
 
-        const { incrementalNodes, selectionNodes } = allNodes.reduce<{
+        // incrementalNodes are the ones flagged with @defer, meaning they become nullable
+        const { incrementalNodes, selectionNodes, fragmentSpreads } = allNodes.reduce<{
           selectionNodes: (SelectionNode | FragmentSpreadUsage)[];
           incrementalNodes: FragmentSpreadUsage[];
+          fragmentSpreads: string[];
         }>(
           (acc, node) => {
             if ('fragmentDirectives' in node && hasIncrementalDeliveryDirectives(node.fragmentDirectives)) {
@@ -363,42 +382,57 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
             }
             return acc;
           },
-          { selectionNodes: [], incrementalNodes: [] }
+          { selectionNodes: [], incrementalNodes: [], fragmentSpreads: [] }
         );
 
-        const { fields } = this.buildSelectionSet(schemaType, selectionNodes);
-
+        const { fields, dependentTypes: subDependentTypes } = this.buildSelectionSet(schemaType, selectionNodes, {
+          parentFieldName: this.buildParentFieldName(typeName, parentName),
+        });
         const transformedSet = this.selectionSetStringFromFields(fields);
+
         if (transformedSet) {
           prev[typeName].push(transformedSet);
-        } else {
+        }
+        dependentTypes.push(...subDependentTypes);
+        if (!transformedSet && !fragmentSpreads.length) {
           mustAddEmptyObject = true;
         }
 
         for (const incrementalNode of incrementalNodes) {
           if (this._config.inlineFragmentTypes === 'mask' && 'fragmentName' in incrementalNode) {
-            const { fields: incrementalFields } = this.buildSelectionSet(schemaType, [incrementalNode], {
-              unsetTypes: true,
-            });
-            prev[typeName].push(this.selectionSetStringFromFields(incrementalFields));
+            const { fields: incrementalFields, dependentTypes: incrementalDependentTypes } = this.buildSelectionSet(
+              schemaType,
+              [incrementalNode],
+              { unsetTypes: true, parentFieldName: parentName }
+            );
+            const incrementalSet = this.selectionSetStringFromFields(incrementalFields);
+            prev[typeName].push(incrementalSet);
+            dependentTypes.push(...incrementalDependentTypes);
 
             continue;
           }
-          const { fields: initialFields } = this.buildSelectionSet(schemaType, [incrementalNode]);
-          const { fields: subsequentFields } = this.buildSelectionSet(schemaType, [incrementalNode], {
-            unsetTypes: true,
-          });
+          const { fields: initialFields, dependentTypes: initialDependentTypes } = this.buildSelectionSet(
+            schemaType,
+            [incrementalNode],
+            { parentFieldName: parentName }
+          );
+
+          const { fields: subsequentFields, dependentTypes: subsequentDependentTypes } = this.buildSelectionSet(
+            schemaType,
+            [incrementalNode],
+            { unsetTypes: true, parentFieldName: parentName }
+          );
 
           const initialSet = this.selectionSetStringFromFields(initialFields);
           const subsequentSet = this.selectionSetStringFromFields(subsequentFields);
-
+          dependentTypes.push(...initialDependentTypes, ...subsequentDependentTypes);
           prev[typeName].push({ union: [initialSet, subsequentSet] });
         }
 
         return prev;
       }, {});
 
-      return { grouped, mustAddEmptyObject };
+      return { grouped, mustAddEmptyObject, dependentTypes };
     }
     // Accumulate a map of selected fields to the typenames that
     // share the exact same selected fields. When we find multiple
@@ -422,7 +456,14 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
 
       const selectionNodes = selectionNodesByTypeName.get(typeName) || [];
 
-      const { typeInfo, fields } = this.buildSelectionSet(schemaType, selectionNodes);
+      const {
+        typeInfo,
+        fields,
+        dependentTypes: subDependentTypes,
+      } = this.buildSelectionSet(schemaType, selectionNodes, {
+        parentFieldName: this.buildParentFieldName(typeName, parentName),
+      });
+      dependentTypes.push(...subDependentTypes);
 
       const key = this.selectionSetStringFromFields(fields);
       prev[key] = {
@@ -471,7 +512,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       return acc;
     }, {});
 
-    return { grouped: compacted, mustAddEmptyObject };
+    return { grouped: compacted, mustAddEmptyObject, dependentTypes };
   }
 
   protected selectionSetStringFromFields(fields: (string | NameAndType)[]): string | null {
@@ -487,7 +528,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
   protected buildSelectionSet(
     parentSchemaType: GraphQLObjectType,
     selectionNodes: Array<SelectionNode | FragmentSpreadUsage | DirectiveNode>,
-    options?: { unsetTypes: boolean }
+    options: { unsetTypes?: boolean; parentFieldName?: string }
   ) {
     const primitiveFields = new Map<string, FieldNode>();
     const primitiveAliasFields = new Map<string, FieldNode>();
@@ -588,17 +629,24 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     }
 
     const linkFields: LinkField[] = [];
+    const linkFieldsInterfaces: DependentType[] = [];
     for (const { field, selectedFieldType } of linkFieldSelectionSets.values()) {
       const realSelectedFieldType = getBaseType(selectedFieldType as any);
       const selectionSet = this.createNext(realSelectedFieldType, field.selectionSet);
+      const fieldName = field.alias?.value ?? field.name.value;
+      const selectionSetObjects = selectionSet.transformSelectionSet(
+        options.parentFieldName ? `${options.parentFieldName}_${fieldName}` : fieldName
+      );
+
+      linkFieldsInterfaces.push(...selectionSetObjects.dependentTypes);
       const isConditional = hasConditionalDirectives(field) || inlineFragmentConditional;
-      const isOptional = options?.unsetTypes;
+      const isOptional = options.unsetTypes;
       linkFields.push({
         alias: field.alias ? this._processor.config.formatNamedField(field.alias.value, selectedFieldType) : undefined,
         name: this._processor.config.formatNamedField(field.name.value, selectedFieldType, isConditional, isOptional),
         type: realSelectedFieldType.name,
         selectionSet: this._processor.config.wrapTypeWithModifiers(
-          selectionSet.transformSelectionSet().split(`\n`).join(`\n  `),
+          selectionSetObjects.mergedTypeString.split(`\n`).join(`\n  `),
           selectedFieldType
         ),
       });
@@ -624,7 +672,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
           isConditional: hasConditionalDirectives(field),
           fieldName: field.name.value,
         })),
-        options?.unsetTypes
+        options.unsetTypes
       ),
       ...this._processor.transformAliasesPrimitiveFields(
         parentSchemaType,
@@ -632,9 +680,9 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
           alias: field.alias.value,
           fieldName: field.name.value,
         })),
-        options?.unsetTypes
+        options.unsetTypes
       ),
-      ...this._processor.transformLinkFields(linkFields, options?.unsetTypes),
+      ...this._processor.transformLinkFields(linkFields, options.unsetTypes),
     ].filter(Boolean);
 
     const allStrings: string[] = transformed.filter(t => typeof t === 'string') as string[];
@@ -657,13 +705,13 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       } else if (this._config.inlineFragmentTypes === 'mask') {
         fields.push(
           `{ ' $fragmentRefs'?: { ${fragmentsSpreadUsages
-            .map(name => `'${name}': ${options?.unsetTypes ? `Incremental<${name}>` : name}`)
+            .map(name => `'${name}': ${options.unsetTypes ? `Incremental<${name}>` : name}`)
             .join(`;`)} } }`
         );
       }
     }
 
-    return { typeInfo: typeInfoField, fields };
+    return { typeInfo: typeInfoField, fields, dependentTypes: linkFieldsInterfaces };
   }
 
   protected buildTypeNameField(
@@ -698,89 +746,166 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
   }
 
   private getEmptyObjectTypeString(mustAddEmptyObject: boolean): string {
-    return mustAddEmptyObject ? ' | ' + this.getEmptyObjectType() : ``;
+    return mustAddEmptyObject ? this.getEmptyObjectType() : ``;
   }
 
-  public transformSelectionSet(): string {
-    const { grouped, mustAddEmptyObject } = this._buildGroupedSelections();
+  public transformSelectionSet(fieldName: string) {
+    const possibleTypesList = getPossibleTypes(this._schema, this._parentSchemaType);
+    const possibleTypes = possibleTypesList.map(v => v.name).sort();
+    const fieldSelections = [
+      ...getFieldNames({ selections: this._selectionSet.selections, loadedFragments: this._loadedFragments }),
+    ].sort();
+
+    // Optimization: Do not create new dependentTypes if fragment typename exists in cache
+    // 2-layer cache: LOC => Field Selection Type Combination => cachedTypeString
+    const objMap = this._processor.typeCache.get(this._selectionSet.loc) ?? new Map<string, [string, string]>();
+    this._processor.typeCache.set(this._selectionSet.loc, objMap);
+
+    const cacheHashKey = `${fieldSelections.join(',')} @ ${possibleTypes.join('|')}`;
+    const [cachedTypeString] = objMap.get(cacheHashKey) ?? [];
+    if (cachedTypeString) {
+      // reuse previously generated type, as it is identical
+      return {
+        mergedTypeString: cachedTypeString,
+        // there are no new dependent types, as this is a nth use of the same type
+        dependentTypes: [],
+      };
+    }
+    const result = this.transformSelectionSetUncached(fieldName);
+    objMap.set(cacheHashKey, [result.mergedTypeString, fieldName]);
+    if (this._selectionSet.loc) {
+      this._processor.typeCache.set(this._selectionSet.loc, objMap);
+    }
+    return result;
+  }
+
+  private transformSelectionSetUncached(fieldName: string): {
+    mergedTypeString: string;
+    dependentTypes: DependentType[];
+    isUnionType?: boolean;
+  } {
+    const { grouped, mustAddEmptyObject, dependentTypes: subDependentTypes } = this._buildGroupedSelections(fieldName);
 
     // This might happen in case we have an interface, that is being queries, without any GraphQL
     // "type" that implements it. It will lead to a runtime error, but we aim to try to reflect that in
     // build time as well.
     if (Object.keys(grouped).length === 0) {
-      return this.getUnknownType();
+      return {
+        mergedTypeString: this.getUnknownType(),
+        dependentTypes: subDependentTypes,
+      };
     }
 
-    return (
-      Object.keys(grouped)
-        .map(typeName => {
-          const relevant = grouped[typeName].filter(Boolean);
+    const dependentTypes = Object.keys(grouped)
+      .map(typeName => {
+        const relevant = grouped[typeName].filter(Boolean);
+        return relevant.map(objDefinition => {
+          const name = fieldName ? `${fieldName}_${typeName}` : typeName;
+          return {
+            name,
+            content: typeof objDefinition === 'string' ? objDefinition : objDefinition.union.join(' | '),
+            isUnionType: !!(typeof objDefinition !== 'string' && objDefinition.union.length > 1),
+          };
+        });
+      })
+      .filter(pairs => pairs.length > 0);
 
-          if (relevant.length === 0) {
-            return null;
-          }
+    const typeParts = [
+      ...dependentTypes.map(pair =>
+        pair
+          .map(({ name, content, isUnionType }) =>
+            // unions need to be wrapped, as intersections have higher precedence
+            this._config.extractAllFieldsToTypes ? name : isUnionType ? `(${content})` : content
+          )
+          .join(' & ')
+      ),
+      this.getEmptyObjectTypeString(mustAddEmptyObject),
+    ].filter(Boolean);
 
-          const res = relevant
-            .map(selectionObject => {
-              if (typeof selectionObject === 'string') return selectionObject;
+    const content = typeParts.join(' | ');
 
-              return '(' + selectionObject.union.join(' | ') + ')';
-            })
-            .join(' & ');
+    if (typeParts.length > 1 && this._config.extractAllFieldsToTypes) {
+      return {
+        mergedTypeString: fieldName,
+        dependentTypes: [
+          ...subDependentTypes,
+          ...dependentTypes.flat(1),
+          { name: fieldName, content, isUnionType: true },
+        ],
+      };
+    }
 
-          const hasUnions = grouped[typeName].filter(s => typeof s !== 'string' && s.union).length > 0;
-
-          return relevant.length > 1 && !hasUnions ? `( ${res} )` : res;
-        })
-        .filter(Boolean)
-        .join(' | ') + this.getEmptyObjectTypeString(mustAddEmptyObject)
-    );
+    return {
+      mergedTypeString: content,
+      dependentTypes: [...subDependentTypes, ...dependentTypes.flat(1)],
+      isUnionType: typeParts.length > 1,
+    };
   }
 
   public transformFragmentSelectionSetToTypes(
     fragmentName: string,
     fragmentSuffix: string,
-    declarationBlockConfig
+    declarationBlockConfig: DeclarationBlockConfig
   ): string {
-    const { grouped } = this._buildGroupedSelections();
+    const mergedTypeString = this.buildFragmentTypeName(fragmentName, fragmentSuffix);
+    const { grouped, dependentTypes } = this._buildGroupedSelections(mergedTypeString);
 
-    const subTypes: { name: string; content: string }[] = Object.keys(grouped)
-      .map(typeName => {
-        const possibleFields = grouped[typeName].filter(Boolean);
-        const declarationName = this.buildFragmentTypeName(fragmentName, fragmentSuffix, typeName);
+    const subTypes: DependentType[] = Object.keys(grouped).flatMap(typeName => {
+      const possibleFields = grouped[typeName].filter(Boolean);
+      const declarationName = this.buildFragmentTypeName(fragmentName, fragmentSuffix, typeName);
 
-        if (possibleFields.length === 0) {
-          if (!this._config.addTypename) {
-            return { name: declarationName, content: this.getEmptyObjectType() };
-          }
-
-          return null;
+      if (possibleFields.length === 0) {
+        if (!this._config.addTypename) {
+          return [{ name: declarationName, content: this.getEmptyObjectType() }];
         }
 
-        const content = possibleFields
-          .map(selectionObject => {
-            if (typeof selectionObject === 'string') return selectionObject;
+        return [];
+      }
 
-            return '(' + selectionObject.union.join(' | ') + ')';
-          })
-          .join(' & ');
+      const flatFields = possibleFields.map(selectionObject => {
+        if (typeof selectionObject === 'string') return { value: selectionObject };
+        return { value: selectionObject.union.join(' | '), isUnionType: true };
+      });
 
-        return { name: declarationName, content };
-      })
-      .filter(Boolean);
+      const content =
+        flatFields.length > 1
+          ? flatFields.map(({ value, isUnionType }) => (isUnionType ? `(${value})` : value)).join(' & ')
+          : flatFields.map(({ value }) => value).join(' & ');
+      return {
+        name: declarationName,
+        content,
+        isUnionType: false,
+      };
+    });
 
-    const fragmentTypeName = this.buildFragmentTypeName(fragmentName, fragmentSuffix);
     const fragmentMaskPartial =
-      this._config.inlineFragmentTypes === 'mask' ? ` & { ' $fragmentName'?: '${fragmentTypeName}' }` : '';
+      this._config.inlineFragmentTypes === 'mask' ? ` & { ' $fragmentName'?: '${mergedTypeString}' }` : '';
+
+    // TODO: unify with line 308 from base-documents-visitor
+    const dependentTypesContent = this._config.extractAllFieldsToTypes
+      ? dependentTypes.map(
+          i =>
+            new DeclarationBlock(declarationBlockConfig)
+              .export(true)
+              .asKind('type')
+              .withName(i.name)
+              .withContent(i.content).string
+        )
+      : [];
+
     if (subTypes.length === 1) {
-      return new DeclarationBlock(declarationBlockConfig)
-        .export()
-        .asKind('type')
-        .withName(fragmentTypeName)
-        .withContent(subTypes[0].content + fragmentMaskPartial).string;
+      return [
+        ...dependentTypesContent,
+        new DeclarationBlock(declarationBlockConfig)
+          .export()
+          .asKind('type')
+          .withName(mergedTypeString)
+          .withContent(subTypes[0].content + fragmentMaskPartial).string,
+      ].join('\n');
     }
 
     return [
+      ...dependentTypesContent,
       ...subTypes.map(
         t =>
           new DeclarationBlock(declarationBlockConfig)
@@ -796,7 +921,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       new DeclarationBlock(declarationBlockConfig)
         .export()
         .asKind('type')
-        .withName(fragmentTypeName)
+        .withName(mergedTypeString)
         .withContent(subTypes.map(t => t.name).join(' | ')).string,
     ].join('\n');
   }
@@ -804,7 +929,13 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
   protected buildFragmentTypeName(name: string, suffix: string, typeName = ''): string {
     return this._convertName(name, {
       useTypesPrefix: true,
-      suffix: typeName ? `_${typeName}_${suffix}` : suffix,
+      suffix: typeName && suffix ? `_${typeName}_${suffix}` : typeName ? `_${typeName}` : suffix,
     });
+  }
+
+  protected buildParentFieldName(typeName: string, parentName: string): string {
+    // queries/mutations/fragments are guaranteed to be unique type names,
+    // so we can skip affixing the field names with typeName
+    return operationTypes.includes(typeName) ? parentName : `${parentName}_${typeName}`;
   }
 }

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -26,7 +26,7 @@ import {
 import { RawConfig } from './base-visitor.js';
 import { parseMapper } from './mappers.js';
 import { DEFAULT_SCALARS } from './scalars.js';
-import { NormalizedScalarsMap, ParsedScalarsMap, ScalarsMap, FragmentDirectives } from './types.js';
+import { NormalizedScalarsMap, ParsedScalarsMap, ScalarsMap, FragmentDirectives, LoadedFragment } from './types.js';
 
 export const getConfigValue = <T = any>(value: T, defaultValue: T): T => {
   if (value === null || value === undefined) {
@@ -615,3 +615,55 @@ export function flatten<T>(array: Array<Array<T>>): Array<T> {
 export function unique<T>(array: Array<T>, key: (item: T) => string | number = item => item.toString()): Array<T> {
   return Object.values(array.reduce((acc, item) => ({ [key(item)]: item, ...acc }), {}));
 }
+
+function getFullPathFieldName(selection: FieldNode, parentName: string) {
+  const fullName =
+    'alias' in selection && selection.alias ? `${selection.alias.value}@${selection.name.value}` : selection.name.value;
+  return parentName ? `${parentName}.${fullName}` : fullName;
+}
+
+export const getFieldNames = ({
+  selections,
+  fieldNames = new Set(),
+  parentName = '',
+  loadedFragments,
+}: {
+  selections: readonly SelectionNode[];
+  fieldNames?: Set<string>;
+  parentName?: string;
+  loadedFragments: LoadedFragment[];
+}) => {
+  for (const selection of selections) {
+    switch (selection.kind) {
+      case Kind.FIELD: {
+        const fieldName = getFullPathFieldName(selection, parentName);
+        fieldNames.add(fieldName);
+        if (selection.selectionSet) {
+          getFieldNames({
+            selections: selection.selectionSet.selections,
+            fieldNames,
+            parentName: fieldName,
+            loadedFragments,
+          });
+        }
+        break;
+      }
+      case Kind.FRAGMENT_SPREAD: {
+        getFieldNames({
+          selections: loadedFragments
+            .filter(def => def.name === selection.name.value)
+            .flatMap(s => s.node.selectionSet.selections),
+          fieldNames,
+          parentName,
+          loadedFragments,
+        });
+        break;
+      }
+      case Kind.INLINE_FRAGMENT: {
+        getFieldNames({ selections: selection.selectionSet.selections, fieldNames, parentName, loadedFragments });
+        break;
+      }
+    }
+  }
+  return fieldNames;
+};

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -85,6 +85,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
         return wrapTypeWithModifiers(baseType, type, { wrapOptional, wrapArray });
       },
       avoidOptionals: this.config.avoidOptionals,
+      printFieldsOnNewLines: this.config.printFieldsOnNewLines,
     };
     const processor = new (preResolveTypes ? PreResolveTypesProcessor : TypeScriptSelectionSetProcessor)(
       processorConfig

--- a/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
+++ b/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
@@ -1,0 +1,1241 @@
+import { mergeOutputs, Types } from '@graphql-codegen/plugin-helpers';
+import { validateTs } from '@graphql-codegen/testing';
+import { buildSchema, parse } from 'graphql';
+import { plugin as tsPlugin } from '../../typescript/src/index.js';
+import { plugin, TypeScriptDocumentsPluginConfig } from '../src/index.js';
+
+describe('extractAllFieldsToTypes: true', () => {
+  const validate = async (content: Types.PluginOutput, config: any = {}, pluginSchema) => {
+    const m = mergeOutputs([await tsPlugin(pluginSchema, [], config, { outputFile: '' }), content]);
+    validateTs(m, undefined, undefined, undefined, []);
+
+    return m;
+  };
+
+  const dummyUserTestSchema = buildSchema(/* GraphQL */ `
+    scalar Date
+    type Query {
+      me: User
+    }
+    interface User {
+      id: ID!
+      joinDate: Date!
+    }
+    type DummyUser implements User {
+      id: ID!
+      joinDate: Date!
+    }
+    type ActiveUser implements User {
+      id: ID!
+      joinDate: Date!
+      isActive: Boolean!
+      parentUser: User!
+      thing: String!
+    }
+  `);
+
+  const dummyUserDoc = parse(/* GraphQL */ `
+    fragment UserFragment on User {
+      id
+      joinDate
+    }
+    fragment Me on User {
+      id
+      ...UserFragment
+      ... on ActiveUser {
+        isActive
+        parentUser {
+          ...UserFragment
+        }
+      }
+    }
+    query OverlappingFieldsMergingTest {
+      # this should be optimized to be: me { ...Me } since they're both selecting for 'id'
+      me {
+        id
+        ...Me
+      }
+    }
+    query NestedOverlappingFieldsMergingTest {
+      # an optimization here would be for these to merge,
+      # since ParentMe selects for the same things as the field selection in: me { id }
+      me {
+        ...Me
+        ... on ActiveUser {
+          isActive
+        }
+      }
+    }
+  `);
+
+  it('should extract types from queries', async () => {
+    const config: TypeScriptDocumentsPluginConfig = {
+      preResolveTypes: true,
+      extractAllFieldsToTypes: true,
+      printFieldsOnNewLines: true,
+      nonOptionalTypename: true,
+      dedupeOperationSuffix: true,
+    };
+    const { content } = await plugin(
+      dummyUserTestSchema,
+      [{ location: 'test-file.ts', document: dummyUserDoc }],
+      config,
+      { outputFile: '' }
+    );
+    expect(content).toMatchInlineSnapshot(`
+      "type UserFragment_DummyUser = {
+        __typename: 'DummyUser',
+        id: string,
+        joinDate: any
+      };
+
+      type UserFragment_ActiveUser = {
+        __typename: 'ActiveUser',
+        id: string,
+        joinDate: any
+      };
+
+      export type UserFragment = UserFragment_DummyUser | UserFragment_ActiveUser;
+
+      export type MeFragment_ActiveUser_parentUser_DummyUser = {
+        __typename: 'DummyUser',
+        id: string,
+        joinDate: any
+      };
+
+      export type MeFragment_ActiveUser_parentUser_ActiveUser = {
+        __typename: 'ActiveUser',
+        id: string,
+        joinDate: any
+      };
+
+      export type MeFragment_ActiveUser_parentUser = MeFragment_ActiveUser_parentUser_DummyUser | MeFragment_ActiveUser_parentUser_ActiveUser;
+
+      type Me_DummyUser_Fragment = {
+        __typename: 'DummyUser',
+        id: string,
+        joinDate: any
+      };
+
+      type Me_ActiveUser_Fragment = {
+        __typename: 'ActiveUser',
+        isActive: boolean,
+        id: string,
+        joinDate: any,
+        parentUser: MeFragment_ActiveUser_parentUser
+      };
+
+      export type MeFragment = Me_DummyUser_Fragment | Me_ActiveUser_Fragment;
+
+      export type OverlappingFieldsMergingTestQuery_me_DummyUser = {
+        __typename: 'DummyUser',
+        id: string,
+        joinDate: any
+      };
+
+      export type OverlappingFieldsMergingTestQuery_me_ActiveUser = {
+        __typename: 'ActiveUser',
+        id: string,
+        isActive: boolean,
+        joinDate: any,
+        parentUser: MeFragment_ActiveUser_parentUser
+      };
+
+      export type OverlappingFieldsMergingTestQuery_me = OverlappingFieldsMergingTestQuery_me_DummyUser | OverlappingFieldsMergingTestQuery_me_ActiveUser;
+
+      export type OverlappingFieldsMergingTestQuery_Query = {
+        __typename: 'Query',
+        me?: OverlappingFieldsMergingTestQuery_me | null
+      };
+
+
+      export type OverlappingFieldsMergingTestQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+      export type OverlappingFieldsMergingTestQuery = OverlappingFieldsMergingTestQuery_Query;
+
+      export type NestedOverlappingFieldsMergingTestQuery_me_DummyUser = {
+        __typename: 'DummyUser',
+        id: string,
+        joinDate: any
+      };
+
+      export type NestedOverlappingFieldsMergingTestQuery_me_ActiveUser = {
+        __typename: 'ActiveUser',
+        isActive: boolean,
+        id: string,
+        joinDate: any,
+        parentUser: MeFragment_ActiveUser_parentUser
+      };
+
+      export type NestedOverlappingFieldsMergingTestQuery_me = NestedOverlappingFieldsMergingTestQuery_me_DummyUser | NestedOverlappingFieldsMergingTestQuery_me_ActiveUser;
+
+      export type NestedOverlappingFieldsMergingTestQuery_Query = {
+        __typename: 'Query',
+        me?: NestedOverlappingFieldsMergingTestQuery_me | null
+      };
+
+
+      export type NestedOverlappingFieldsMergingTestQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+      export type NestedOverlappingFieldsMergingTestQuery = NestedOverlappingFieldsMergingTestQuery_Query;
+      "
+    `);
+
+    await validate(content, config, dummyUserTestSchema);
+  });
+
+  const complexTestSchemaWithUnionsAndInterfaces = buildSchema(/* GraphQL */ `
+    interface GenericCallSummary {
+      id: ID!
+      timestamp: String!
+      summary: String!
+      isTrusted: Boolean!
+    }
+
+    type CallerID {
+      phone: String!
+      formattedPhone: String!
+      name: String
+    }
+
+    enum CallType {
+      OUTGOING
+      INCOMING
+      VOICEMAIL
+      UNKNOWN
+    }
+
+    type TalkInteraction {
+      channel: String!
+      rel: String
+
+      type: CallType!
+
+      from: CallerID
+      to: CallerID
+    }
+
+    interface ConnectionNode {
+      id: ID!
+    }
+
+    interface ConversationEvent implements ConnectionNode {
+      id: ID!
+      timestamp: String!
+      originatedFrom: OriginatedFrom!
+    }
+
+    type BrokenConversationEvent implements ConversationEvent & ConnectionNode {
+      id: ID!
+      timestamp: String!
+
+      originatedFrom: OriginatedFrom!
+      extraField: String!
+    }
+
+    union OriginatedFrom =
+        EmailInteraction
+      | CustomChannelInteraction
+      | TalkInteraction
+      | NativeMessagingInteraction
+      | WhatsAppInteraction
+      | WeChatInteraction
+      | NotImplementedOriginatedFrom
+
+    type NotImplementedOriginatedFrom {
+      channel: String
+      rel: String
+    }
+
+    type EmailInteraction {
+      originalEmailURLPath: String!
+    }
+
+    interface ChannelInteraction {
+      externalId: String!
+      timestamp: String!
+      resourceType: String!
+      version: Int!
+    }
+
+    type CustomChannelInteraction implements ChannelInteraction {
+      externalId: String!
+      timestamp: String!
+      resourceType: String!
+      version: Int!
+    }
+
+    interface BrandedConversation {
+      conversationId: ID
+    }
+
+    type NativeMessagingInteraction implements BrandedConversation {
+      conversationId: ID
+    }
+
+    type WhatsAppInteraction implements BrandedConversation {
+      conversationId: ID
+    }
+
+    type WeChatInteraction implements BrandedConversation {
+      conversationId: ID
+    }
+
+    type ArchivedArticle {
+      id: ID!
+      title: String!
+      url: String!
+      htmlUrl: String!
+    }
+
+    type BotSolution implements ConnectionNode & ConversationEvent {
+      id: ID!
+      timestamp: String!
+      originatedFrom: OriginatedFrom!
+
+      article: ArchivedArticle!
+    }
+
+    type TalkPublicCallSummary implements ConnectionNode & ConversationEvent & GenericCallSummary {
+      id: ID!
+      timestamp: String!
+      summary: String!
+      isTrusted: Boolean!
+      originatedFrom: OriginatedFrom!
+    }
+  `);
+
+  const fragmentsOnComplexSchema = parse(/* GraphQL */ `
+    fragment ConversationBotSolution on BotSolution {
+      id
+      ...ConversationConversationEvent
+      article {
+        id
+        htmlUrl
+        title
+        url
+      }
+      originatedFrom {
+        ...ConversationOriginatedFrom
+      }
+    }
+
+    fragment ConversationGenericCallSummary on GenericCallSummary {
+      id
+      summary
+    }
+    fragment ConversationTalkInteraction on TalkInteraction {
+      channel
+      type
+    }
+    fragment ConversationConversationEvent on ConversationEvent {
+      __typename
+      id
+      timestamp
+      originatedFrom {
+        ...ConversationOriginatedFrom
+      }
+    }
+
+    fragment MessageEnvelopeData on OriginatedFrom {
+      ... on EmailInteraction {
+        originalEmailURLPath
+      }
+    }
+
+    fragment AnyChannelOriginatedFrom on CustomChannelInteraction {
+      externalId
+      timestamp
+      resourceType
+    }
+
+    fragment ConversationOriginatedFrom on OriginatedFrom {
+      __typename
+      ... on BrandedConversation {
+        conversationId
+      }
+      ...MessageEnvelopeData
+      ...AnyChannelOriginatedFrom
+    }
+
+    fragment ConversationTalkPublicCallSummary on TalkPublicCallSummary {
+      id
+      ...ConversationConversationEvent
+      ...ConversationGenericCallSummary
+      originatedFrom {
+        ... on TalkInteraction {
+          ...ConversationTalkInteraction
+        }
+      }
+    }
+  `);
+
+  it('should extract types from multiple fragments', async () => {
+    const config: TypeScriptDocumentsPluginConfig = {
+      preResolveTypes: true,
+      extractAllFieldsToTypes: true,
+      nonOptionalTypename: true,
+      dedupeOperationSuffix: true,
+    };
+    const { content } = await plugin(
+      complexTestSchemaWithUnionsAndInterfaces,
+      [{ location: 'test-file.ts', document: fragmentsOnComplexSchema }],
+      config,
+      { outputFile: '' }
+    );
+    expect(content).toMatchInlineSnapshot(`
+      "export type ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle = { __typename: 'ArchivedArticle', id: string, htmlUrl: string, title: string, url: string };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction = { __typename: 'EmailInteraction', originalEmailURLPath: string };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction = { __typename: 'CustomChannelInteraction', externalId: string, timestamp: string, resourceType: string };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction = { __typename: 'TalkInteraction' };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction = { __typename: 'NativeMessagingInteraction', conversationId?: string | null };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction = { __typename: 'WhatsAppInteraction', conversationId?: string | null };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction = { __typename: 'WeChatInteraction', conversationId?: string | null };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
+
+      export type ConversationBotSolutionFragment = { __typename: 'BotSolution', id: string, timestamp: string, article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle, originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom };
+
+      export type ConversationGenericCallSummaryFragment = { __typename: 'TalkPublicCallSummary', id: string, summary: string };
+
+      export type ConversationTalkInteractionFragment = { __typename: 'TalkInteraction', channel: string, type: CallType };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction = { __typename: 'EmailInteraction', originalEmailURLPath: string };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction = { __typename: 'CustomChannelInteraction', externalId: string, timestamp: string, resourceType: string };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction = { __typename: 'TalkInteraction' };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction = { __typename: 'NativeMessagingInteraction', conversationId?: string | null };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction = { __typename: 'WhatsAppInteraction', conversationId?: string | null };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction = { __typename: 'WeChatInteraction', conversationId?: string | null };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
+
+      type ConversationConversationEvent_BrokenConversationEvent_Fragment = { __typename: 'BrokenConversationEvent', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom };
+
+      type ConversationConversationEvent_BotSolution_Fragment = { __typename: 'BotSolution', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom };
+
+      type ConversationConversationEvent_TalkPublicCallSummary_Fragment = { __typename: 'TalkPublicCallSummary', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom };
+
+      export type ConversationConversationEventFragment = ConversationConversationEvent_BrokenConversationEvent_Fragment | ConversationConversationEvent_BotSolution_Fragment | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
+
+      type MessageEnvelopeData_EmailInteraction_Fragment = { __typename: 'EmailInteraction', originalEmailURLPath: string };
+
+      type MessageEnvelopeData_CustomChannelInteraction_Fragment = { __typename: 'CustomChannelInteraction' };
+
+      type MessageEnvelopeData_TalkInteraction_Fragment = { __typename: 'TalkInteraction' };
+
+      type MessageEnvelopeData_NativeMessagingInteraction_Fragment = { __typename: 'NativeMessagingInteraction' };
+
+      type MessageEnvelopeData_WhatsAppInteraction_Fragment = { __typename: 'WhatsAppInteraction' };
+
+      type MessageEnvelopeData_WeChatInteraction_Fragment = { __typename: 'WeChatInteraction' };
+
+      type MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_CustomChannelInteraction_Fragment | MessageEnvelopeData_TalkInteraction_Fragment | MessageEnvelopeData_NativeMessagingInteraction_Fragment | MessageEnvelopeData_WhatsAppInteraction_Fragment | MessageEnvelopeData_WeChatInteraction_Fragment | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
+
+      export type AnyChannelOriginatedFromFragment = { __typename: 'CustomChannelInteraction', externalId: string, timestamp: string, resourceType: string };
+
+      type ConversationOriginatedFrom_EmailInteraction_Fragment = { __typename: 'EmailInteraction', originalEmailURLPath: string };
+
+      type ConversationOriginatedFrom_CustomChannelInteraction_Fragment = { __typename: 'CustomChannelInteraction', externalId: string, timestamp: string, resourceType: string };
+
+      type ConversationOriginatedFrom_TalkInteraction_Fragment = { __typename: 'TalkInteraction' };
+
+      type ConversationOriginatedFrom_NativeMessagingInteraction_Fragment = { __typename: 'NativeMessagingInteraction', conversationId?: string | null };
+
+      type ConversationOriginatedFrom_WhatsAppInteraction_Fragment = { __typename: 'WhatsAppInteraction', conversationId?: string | null };
+
+      type ConversationOriginatedFrom_WeChatInteraction_Fragment = { __typename: 'WeChatInteraction', conversationId?: string | null };
+
+      type ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment | ConversationOriginatedFrom_WhatsAppInteraction_Fragment | ConversationOriginatedFrom_WeChatInteraction_Fragment | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = { __typename: 'EmailInteraction', originalEmailURLPath: string };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction = { __typename: 'CustomChannelInteraction', externalId: string, timestamp: string, resourceType: string };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction = { __typename: 'TalkInteraction', channel: string, type: CallType };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction = { __typename: 'NativeMessagingInteraction', conversationId?: string | null };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction = { __typename: 'WhatsAppInteraction', conversationId?: string | null };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction = { __typename: 'WeChatInteraction', conversationId?: string | null };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+
+      export type ConversationTalkPublicCallSummaryFragment = { __typename: 'TalkPublicCallSummary', id: string, timestamp: string, summary: string, originatedFrom: ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom };
+      "
+    `);
+
+    await validate(content, config, complexTestSchemaWithUnionsAndInterfaces);
+  });
+
+  it('should extract types from multiple fragments (mergeFragmentTypes: true)', async () => {
+    const config: TypeScriptDocumentsPluginConfig = {
+      preResolveTypes: true,
+      extractAllFieldsToTypes: true,
+      nonOptionalTypename: true,
+      dedupeOperationSuffix: true,
+      mergeFragmentTypes: true,
+    };
+    const { content } = await plugin(
+      complexTestSchemaWithUnionsAndInterfaces,
+      [{ location: 'test-file.ts', document: fragmentsOnComplexSchema }],
+      config,
+      { outputFile: '' }
+    );
+    expect(content).toMatchInlineSnapshot(`
+      "export type ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle = (
+        { id: string, htmlUrl: string, title: string, url: string }
+        & { __typename: 'ArchivedArticle' }
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction = (
+        { originalEmailURLPath: string }
+        & { __typename: 'EmailInteraction' }
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction = (
+        { externalId: string, timestamp: string, resourceType: string }
+        & { __typename: 'CustomChannelInteraction' }
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction_NotImplementedOriginatedFrom = { __typename: 'TalkInteraction' | 'NotImplementedOriginatedFrom' };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction = (
+        { conversationId?: string | null }
+        & { __typename: 'NativeMessagingInteraction' | 'WhatsAppInteraction' | 'WeChatInteraction' }
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction_NotImplementedOriginatedFrom | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction;
+
+      export type ConversationBotSolutionFragment = (
+        { id: string, timestamp: string, article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle, originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom }
+        & { __typename: 'BotSolution' }
+      );
+
+      export type ConversationGenericCallSummaryFragment = (
+        { id: string, summary: string }
+        & { __typename: 'TalkPublicCallSummary' }
+      );
+
+      export type ConversationTalkInteractionFragment = (
+        { channel: string, type: CallType }
+        & { __typename: 'TalkInteraction' }
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction = (
+        { originalEmailURLPath: string }
+        & { __typename: 'EmailInteraction' }
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction = (
+        { externalId: string, timestamp: string, resourceType: string }
+        & { __typename: 'CustomChannelInteraction' }
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction_NotImplementedOriginatedFrom = { __typename: 'TalkInteraction' | 'NotImplementedOriginatedFrom' };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction = (
+        { conversationId?: string | null }
+        & { __typename: 'NativeMessagingInteraction' | 'WhatsAppInteraction' | 'WeChatInteraction' }
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction_NotImplementedOriginatedFrom | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction;
+
+      export type ConversationConversationEventFragment = (
+        { id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom }
+        & { __typename: 'BrokenConversationEvent' | 'BotSolution' | 'TalkPublicCallSummary' }
+      );
+
+      type MessageEnvelopeData_EmailInteraction_Fragment = (
+        { originalEmailURLPath: string }
+        & { __typename: 'EmailInteraction' }
+      );
+
+      type MessageEnvelopeData_8FBboKcmuva72FpaH1zuPdoYyrlyvueTn9fqP1dFi_Fragment = { __typename: 'CustomChannelInteraction' | 'TalkInteraction' | 'NativeMessagingInteraction' | 'WhatsAppInteraction' | 'WeChatInteraction' | 'NotImplementedOriginatedFrom' };
+
+      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_8FBboKcmuva72FpaH1zuPdoYyrlyvueTn9fqP1dFi_Fragment;
+
+      export type AnyChannelOriginatedFromFragment = (
+        { externalId: string, timestamp: string, resourceType: string }
+        & { __typename: 'CustomChannelInteraction' }
+      );
+
+      type ConversationOriginatedFrom_EmailInteraction_Fragment = (
+        { originalEmailURLPath: string }
+        & { __typename: 'EmailInteraction' }
+      );
+
+      type ConversationOriginatedFrom_CustomChannelInteraction_Fragment = (
+        { externalId: string, timestamp: string, resourceType: string }
+        & { __typename: 'CustomChannelInteraction' }
+      );
+
+      type ConversationOriginatedFrom_TalkInteraction_NotImplementedOriginatedFrom_Fragment = { __typename: 'TalkInteraction' | 'NotImplementedOriginatedFrom' };
+
+      type ConversationOriginatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction_Fragment = (
+        { conversationId?: string | null }
+        & { __typename: 'NativeMessagingInteraction' | 'WhatsAppInteraction' | 'WeChatInteraction' }
+      );
+
+      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_NotImplementedOriginatedFrom_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction_Fragment;
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = (
+        { originalEmailURLPath: string }
+        & { __typename: 'EmailInteraction' }
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction = (
+        { externalId: string, timestamp: string, resourceType: string }
+        & { __typename: 'CustomChannelInteraction' }
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction = (
+        { channel: string, type: CallType }
+        & { __typename: 'TalkInteraction' }
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction = (
+        { conversationId?: string | null }
+        & { __typename: 'NativeMessagingInteraction' | 'WhatsAppInteraction' | 'WeChatInteraction' }
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+
+      export type ConversationTalkPublicCallSummaryFragment = (
+        { id: string, timestamp: string, summary: string, originatedFrom: ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom }
+        & { __typename: 'TalkPublicCallSummary' }
+      );
+      "
+    `);
+
+    await validate(content, config, complexTestSchemaWithUnionsAndInterfaces);
+  });
+
+  it("should extract types from multiple fragments (inlineFragmentTypes: 'combine')", async () => {
+    const config: TypeScriptDocumentsPluginConfig = {
+      preResolveTypes: true,
+      extractAllFieldsToTypes: true,
+      nonOptionalTypename: true,
+      dedupeOperationSuffix: true,
+      inlineFragmentTypes: 'combine',
+    };
+    const { content } = await plugin(
+      complexTestSchemaWithUnionsAndInterfaces,
+      [{ location: 'test-file.ts', document: fragmentsOnComplexSchema }],
+      config,
+      { outputFile: '' }
+    );
+    expect(content).toMatchInlineSnapshot(`
+      "export type ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle = { __typename: 'ArchivedArticle', id: string, htmlUrl: string, title: string, url: string };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction = (
+        { __typename: 'EmailInteraction' }
+        & ConversationOriginatedFrom_EmailInteraction_Fragment
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction = (
+        { __typename: 'CustomChannelInteraction' }
+        & ConversationOriginatedFrom_CustomChannelInteraction_Fragment
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction = (
+        { __typename: 'TalkInteraction' }
+        & ConversationOriginatedFrom_TalkInteraction_Fragment
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction = (
+        { __typename: 'NativeMessagingInteraction' }
+        & ConversationOriginatedFrom_NativeMessagingInteraction_Fragment
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction = (
+        { __typename: 'WhatsAppInteraction' }
+        & ConversationOriginatedFrom_WhatsAppInteraction_Fragment
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction = (
+        { __typename: 'WeChatInteraction' }
+        & ConversationOriginatedFrom_WeChatInteraction_Fragment
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom = (
+        { __typename: 'NotImplementedOriginatedFrom' }
+        & ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
+
+      export type ConversationBotSolutionFragment = (
+        { __typename: 'BotSolution', id: string, article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle, originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom }
+        & ConversationConversationEvent_BotSolution_Fragment
+      );
+
+      export type ConversationGenericCallSummaryFragment = { __typename: 'TalkPublicCallSummary', id: string, summary: string };
+
+      export type ConversationTalkInteractionFragment = { __typename: 'TalkInteraction', channel: string, type: CallType };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction = (
+        { __typename: 'EmailInteraction' }
+        & ConversationOriginatedFrom_EmailInteraction_Fragment
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction = (
+        { __typename: 'CustomChannelInteraction' }
+        & ConversationOriginatedFrom_CustomChannelInteraction_Fragment
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction = (
+        { __typename: 'TalkInteraction' }
+        & ConversationOriginatedFrom_TalkInteraction_Fragment
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction = (
+        { __typename: 'NativeMessagingInteraction' }
+        & ConversationOriginatedFrom_NativeMessagingInteraction_Fragment
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction = (
+        { __typename: 'WhatsAppInteraction' }
+        & ConversationOriginatedFrom_WhatsAppInteraction_Fragment
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction = (
+        { __typename: 'WeChatInteraction' }
+        & ConversationOriginatedFrom_WeChatInteraction_Fragment
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom = (
+        { __typename: 'NotImplementedOriginatedFrom' }
+        & ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
+
+      type ConversationConversationEvent_BrokenConversationEvent_Fragment = { __typename: 'BrokenConversationEvent', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom };
+
+      type ConversationConversationEvent_BotSolution_Fragment = { __typename: 'BotSolution', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom };
+
+      type ConversationConversationEvent_TalkPublicCallSummary_Fragment = { __typename: 'TalkPublicCallSummary', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom };
+
+      export type ConversationConversationEventFragment = ConversationConversationEvent_BrokenConversationEvent_Fragment | ConversationConversationEvent_BotSolution_Fragment | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
+
+      type MessageEnvelopeData_EmailInteraction_Fragment = { __typename: 'EmailInteraction', originalEmailURLPath: string };
+
+      type MessageEnvelopeData_CustomChannelInteraction_Fragment = { __typename: 'CustomChannelInteraction' };
+
+      type MessageEnvelopeData_TalkInteraction_Fragment = { __typename: 'TalkInteraction' };
+
+      type MessageEnvelopeData_NativeMessagingInteraction_Fragment = { __typename: 'NativeMessagingInteraction' };
+
+      type MessageEnvelopeData_WhatsAppInteraction_Fragment = { __typename: 'WhatsAppInteraction' };
+
+      type MessageEnvelopeData_WeChatInteraction_Fragment = { __typename: 'WeChatInteraction' };
+
+      type MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_CustomChannelInteraction_Fragment | MessageEnvelopeData_TalkInteraction_Fragment | MessageEnvelopeData_NativeMessagingInteraction_Fragment | MessageEnvelopeData_WhatsAppInteraction_Fragment | MessageEnvelopeData_WeChatInteraction_Fragment | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
+
+      export type AnyChannelOriginatedFromFragment = { __typename: 'CustomChannelInteraction', externalId: string, timestamp: string, resourceType: string };
+
+      type ConversationOriginatedFrom_EmailInteraction_Fragment = (
+        { __typename: 'EmailInteraction' }
+        & MessageEnvelopeData_EmailInteraction_Fragment
+      );
+
+      type ConversationOriginatedFrom_CustomChannelInteraction_Fragment = (
+        { __typename: 'CustomChannelInteraction' }
+        & MessageEnvelopeData_CustomChannelInteraction_Fragment
+        & AnyChannelOriginatedFromFragment
+      );
+
+      type ConversationOriginatedFrom_TalkInteraction_Fragment = (
+        { __typename: 'TalkInteraction' }
+        & MessageEnvelopeData_TalkInteraction_Fragment
+      );
+
+      type ConversationOriginatedFrom_NativeMessagingInteraction_Fragment = (
+        { __typename: 'NativeMessagingInteraction', conversationId?: string | null }
+        & MessageEnvelopeData_NativeMessagingInteraction_Fragment
+      );
+
+      type ConversationOriginatedFrom_WhatsAppInteraction_Fragment = (
+        { __typename: 'WhatsAppInteraction', conversationId?: string | null }
+        & MessageEnvelopeData_WhatsAppInteraction_Fragment
+      );
+
+      type ConversationOriginatedFrom_WeChatInteraction_Fragment = (
+        { __typename: 'WeChatInteraction', conversationId?: string | null }
+        & MessageEnvelopeData_WeChatInteraction_Fragment
+      );
+
+      type ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment = (
+        { __typename: 'NotImplementedOriginatedFrom' }
+        & MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment
+      );
+
+      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment | ConversationOriginatedFrom_WhatsAppInteraction_Fragment | ConversationOriginatedFrom_WeChatInteraction_Fragment | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = { __typename: 'EmailInteraction' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction = { __typename: 'CustomChannelInteraction' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction = (
+        { __typename: 'TalkInteraction' }
+        & ConversationTalkInteractionFragment
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction = { __typename: 'NativeMessagingInteraction' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction = { __typename: 'WhatsAppInteraction' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction = { __typename: 'WeChatInteraction' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+
+      export type ConversationTalkPublicCallSummaryFragment = (
+        { __typename: 'TalkPublicCallSummary', id: string, originatedFrom: ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom }
+        & ConversationConversationEvent_TalkPublicCallSummary_Fragment
+        & ConversationGenericCallSummaryFragment
+      );
+      "
+    `);
+
+    await validate(content, config, complexTestSchemaWithUnionsAndInterfaces);
+  });
+
+  it("should extract types from multiple fragments (inlineFragmentTypes: 'mask')", async () => {
+    const config: TypeScriptDocumentsPluginConfig = {
+      preResolveTypes: true,
+      extractAllFieldsToTypes: true,
+      nonOptionalTypename: true,
+      dedupeOperationSuffix: true,
+      inlineFragmentTypes: 'mask',
+    };
+    const { content } = await plugin(
+      complexTestSchemaWithUnionsAndInterfaces,
+      [{ location: 'test-file.ts', document: fragmentsOnComplexSchema }],
+      config,
+      { outputFile: '' }
+    );
+    expect(content).toMatchInlineSnapshot(`
+      "export type ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle = { __typename: 'ArchivedArticle', id: string, htmlUrl: string, title: string, url: string };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction = (
+        { __typename: 'EmailInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_EmailInteraction_Fragment': ConversationOriginatedFrom_EmailInteraction_Fragment } }
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction = (
+        { __typename: 'CustomChannelInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_CustomChannelInteraction_Fragment': ConversationOriginatedFrom_CustomChannelInteraction_Fragment } }
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction = (
+        { __typename: 'TalkInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_TalkInteraction_Fragment': ConversationOriginatedFrom_TalkInteraction_Fragment } }
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction = (
+        { __typename: 'NativeMessagingInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_NativeMessagingInteraction_Fragment': ConversationOriginatedFrom_NativeMessagingInteraction_Fragment } }
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction = (
+        { __typename: 'WhatsAppInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_WhatsAppInteraction_Fragment': ConversationOriginatedFrom_WhatsAppInteraction_Fragment } }
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction = (
+        { __typename: 'WeChatInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_WeChatInteraction_Fragment': ConversationOriginatedFrom_WeChatInteraction_Fragment } }
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom = (
+        { __typename: 'NotImplementedOriginatedFrom' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment': ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment } }
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
+
+      export type ConversationBotSolutionFragment = (
+        { __typename: 'BotSolution', id: string, article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle, originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom }
+        & { ' $fragmentRefs'?: { 'ConversationConversationEvent_BotSolution_Fragment': ConversationConversationEvent_BotSolution_Fragment } }
+      ) & { ' $fragmentName'?: 'ConversationBotSolutionFragment' };
+
+      export type ConversationGenericCallSummaryFragment = { __typename: 'TalkPublicCallSummary', id: string, summary: string } & { ' $fragmentName'?: 'ConversationGenericCallSummaryFragment' };
+
+      export type ConversationTalkInteractionFragment = { __typename: 'TalkInteraction', channel: string, type: CallType } & { ' $fragmentName'?: 'ConversationTalkInteractionFragment' };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction = (
+        { __typename: 'EmailInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_EmailInteraction_Fragment': ConversationOriginatedFrom_EmailInteraction_Fragment } }
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction = (
+        { __typename: 'CustomChannelInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_CustomChannelInteraction_Fragment': ConversationOriginatedFrom_CustomChannelInteraction_Fragment } }
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction = (
+        { __typename: 'TalkInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_TalkInteraction_Fragment': ConversationOriginatedFrom_TalkInteraction_Fragment } }
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction = (
+        { __typename: 'NativeMessagingInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_NativeMessagingInteraction_Fragment': ConversationOriginatedFrom_NativeMessagingInteraction_Fragment } }
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction = (
+        { __typename: 'WhatsAppInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_WhatsAppInteraction_Fragment': ConversationOriginatedFrom_WhatsAppInteraction_Fragment } }
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction = (
+        { __typename: 'WeChatInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_WeChatInteraction_Fragment': ConversationOriginatedFrom_WeChatInteraction_Fragment } }
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom = (
+        { __typename: 'NotImplementedOriginatedFrom' }
+        & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment': ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment } }
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
+
+      type ConversationConversationEvent_BrokenConversationEvent_Fragment = { __typename: 'BrokenConversationEvent', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom } & { ' $fragmentName'?: 'ConversationConversationEvent_BrokenConversationEvent_Fragment' };
+
+      type ConversationConversationEvent_BotSolution_Fragment = { __typename: 'BotSolution', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom } & { ' $fragmentName'?: 'ConversationConversationEvent_BotSolution_Fragment' };
+
+      type ConversationConversationEvent_TalkPublicCallSummary_Fragment = { __typename: 'TalkPublicCallSummary', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom } & { ' $fragmentName'?: 'ConversationConversationEvent_TalkPublicCallSummary_Fragment' };
+
+      export type ConversationConversationEventFragment = ConversationConversationEvent_BrokenConversationEvent_Fragment | ConversationConversationEvent_BotSolution_Fragment | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
+
+      type MessageEnvelopeData_EmailInteraction_Fragment = { __typename: 'EmailInteraction', originalEmailURLPath: string } & { ' $fragmentName'?: 'MessageEnvelopeData_EmailInteraction_Fragment' };
+
+      type MessageEnvelopeData_CustomChannelInteraction_Fragment = { __typename: 'CustomChannelInteraction' } & { ' $fragmentName'?: 'MessageEnvelopeData_CustomChannelInteraction_Fragment' };
+
+      type MessageEnvelopeData_TalkInteraction_Fragment = { __typename: 'TalkInteraction' } & { ' $fragmentName'?: 'MessageEnvelopeData_TalkInteraction_Fragment' };
+
+      type MessageEnvelopeData_NativeMessagingInteraction_Fragment = { __typename: 'NativeMessagingInteraction' } & { ' $fragmentName'?: 'MessageEnvelopeData_NativeMessagingInteraction_Fragment' };
+
+      type MessageEnvelopeData_WhatsAppInteraction_Fragment = { __typename: 'WhatsAppInteraction' } & { ' $fragmentName'?: 'MessageEnvelopeData_WhatsAppInteraction_Fragment' };
+
+      type MessageEnvelopeData_WeChatInteraction_Fragment = { __typename: 'WeChatInteraction' } & { ' $fragmentName'?: 'MessageEnvelopeData_WeChatInteraction_Fragment' };
+
+      type MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' } & { ' $fragmentName'?: 'MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment' };
+
+      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_CustomChannelInteraction_Fragment | MessageEnvelopeData_TalkInteraction_Fragment | MessageEnvelopeData_NativeMessagingInteraction_Fragment | MessageEnvelopeData_WhatsAppInteraction_Fragment | MessageEnvelopeData_WeChatInteraction_Fragment | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
+
+      export type AnyChannelOriginatedFromFragment = { __typename: 'CustomChannelInteraction', externalId: string, timestamp: string, resourceType: string } & { ' $fragmentName'?: 'AnyChannelOriginatedFromFragment' };
+
+      type ConversationOriginatedFrom_EmailInteraction_Fragment = (
+        { __typename: 'EmailInteraction' }
+        & { ' $fragmentRefs'?: { 'MessageEnvelopeData_EmailInteraction_Fragment': MessageEnvelopeData_EmailInteraction_Fragment } }
+      ) & { ' $fragmentName'?: 'ConversationOriginatedFrom_EmailInteraction_Fragment' };
+
+      type ConversationOriginatedFrom_CustomChannelInteraction_Fragment = (
+        { __typename: 'CustomChannelInteraction' }
+        & { ' $fragmentRefs'?: { 'MessageEnvelopeData_CustomChannelInteraction_Fragment': MessageEnvelopeData_CustomChannelInteraction_Fragment;'AnyChannelOriginatedFromFragment': AnyChannelOriginatedFromFragment } }
+      ) & { ' $fragmentName'?: 'ConversationOriginatedFrom_CustomChannelInteraction_Fragment' };
+
+      type ConversationOriginatedFrom_TalkInteraction_Fragment = (
+        { __typename: 'TalkInteraction' }
+        & { ' $fragmentRefs'?: { 'MessageEnvelopeData_TalkInteraction_Fragment': MessageEnvelopeData_TalkInteraction_Fragment } }
+      ) & { ' $fragmentName'?: 'ConversationOriginatedFrom_TalkInteraction_Fragment' };
+
+      type ConversationOriginatedFrom_NativeMessagingInteraction_Fragment = (
+        { __typename: 'NativeMessagingInteraction', conversationId?: string | null }
+        & { ' $fragmentRefs'?: { 'MessageEnvelopeData_NativeMessagingInteraction_Fragment': MessageEnvelopeData_NativeMessagingInteraction_Fragment } }
+      ) & { ' $fragmentName'?: 'ConversationOriginatedFrom_NativeMessagingInteraction_Fragment' };
+
+      type ConversationOriginatedFrom_WhatsAppInteraction_Fragment = (
+        { __typename: 'WhatsAppInteraction', conversationId?: string | null }
+        & { ' $fragmentRefs'?: { 'MessageEnvelopeData_WhatsAppInteraction_Fragment': MessageEnvelopeData_WhatsAppInteraction_Fragment } }
+      ) & { ' $fragmentName'?: 'ConversationOriginatedFrom_WhatsAppInteraction_Fragment' };
+
+      type ConversationOriginatedFrom_WeChatInteraction_Fragment = (
+        { __typename: 'WeChatInteraction', conversationId?: string | null }
+        & { ' $fragmentRefs'?: { 'MessageEnvelopeData_WeChatInteraction_Fragment': MessageEnvelopeData_WeChatInteraction_Fragment } }
+      ) & { ' $fragmentName'?: 'ConversationOriginatedFrom_WeChatInteraction_Fragment' };
+
+      type ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment = (
+        { __typename: 'NotImplementedOriginatedFrom' }
+        & { ' $fragmentRefs'?: { 'MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment': MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment } }
+      ) & { ' $fragmentName'?: 'ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment' };
+
+      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment | ConversationOriginatedFrom_WhatsAppInteraction_Fragment | ConversationOriginatedFrom_WeChatInteraction_Fragment | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = { __typename: 'EmailInteraction' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction = { __typename: 'CustomChannelInteraction' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction = (
+        { __typename: 'TalkInteraction' }
+        & { ' $fragmentRefs'?: { 'ConversationTalkInteractionFragment': ConversationTalkInteractionFragment } }
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction = { __typename: 'NativeMessagingInteraction' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction = { __typename: 'WhatsAppInteraction' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction = { __typename: 'WeChatInteraction' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+
+      export type ConversationTalkPublicCallSummaryFragment = (
+        { __typename: 'TalkPublicCallSummary', id: string, originatedFrom: ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom }
+        & { ' $fragmentRefs'?: { 'ConversationConversationEvent_TalkPublicCallSummary_Fragment': ConversationConversationEvent_TalkPublicCallSummary_Fragment;'ConversationGenericCallSummaryFragment': ConversationGenericCallSummaryFragment } }
+      ) & { ' $fragmentName'?: 'ConversationTalkPublicCallSummaryFragment' };
+      "
+    `);
+
+    await validate(content, config, complexTestSchemaWithUnionsAndInterfaces);
+  });
+
+  it('should extract types from multiple fragments (preResolveTypes: false)', async () => {
+    const config: TypeScriptDocumentsPluginConfig = {
+      preResolveTypes: false,
+      extractAllFieldsToTypes: true,
+      nonOptionalTypename: true,
+      dedupeOperationSuffix: true,
+    };
+    const { content } = await plugin(
+      complexTestSchemaWithUnionsAndInterfaces,
+      [{ location: 'test-file.ts', document: fragmentsOnComplexSchema }],
+      config,
+      { outputFile: '' }
+    );
+    expect(content).toMatchInlineSnapshot(`
+      "export type ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle = (
+        { __typename: 'ArchivedArticle' }
+        & Pick<ArchivedArticle, 'id' | 'htmlUrl' | 'title' | 'url'>
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction = (
+        { __typename: 'EmailInteraction' }
+        & Pick<EmailInteraction, 'originalEmailURLPath'>
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction = (
+        { __typename: 'CustomChannelInteraction' }
+        & Pick<CustomChannelInteraction, 'externalId' | 'timestamp' | 'resourceType'>
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction = { __typename: 'TalkInteraction' };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction = (
+        { __typename: 'NativeMessagingInteraction' }
+        & Pick<NativeMessagingInteraction, 'conversationId'>
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction = (
+        { __typename: 'WhatsAppInteraction' }
+        & Pick<WhatsAppInteraction, 'conversationId'>
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction = (
+        { __typename: 'WeChatInteraction' }
+        & Pick<WeChatInteraction, 'conversationId'>
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
+
+      export type ConversationBotSolutionFragment = (
+        { __typename: 'BotSolution' }
+        & Pick<BotSolution, 'id' | 'timestamp'>
+        & { article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle, originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom }
+      );
+
+      export type ConversationGenericCallSummaryFragment = (
+        { __typename: 'TalkPublicCallSummary' }
+        & Pick<TalkPublicCallSummary, 'id' | 'summary'>
+      );
+
+      export type ConversationTalkInteractionFragment = (
+        { __typename: 'TalkInteraction' }
+        & Pick<TalkInteraction, 'channel' | 'type'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction = (
+        { __typename: 'EmailInteraction' }
+        & Pick<EmailInteraction, 'originalEmailURLPath'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction = (
+        { __typename: 'CustomChannelInteraction' }
+        & Pick<CustomChannelInteraction, 'externalId' | 'timestamp' | 'resourceType'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction = { __typename: 'TalkInteraction' };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction = (
+        { __typename: 'NativeMessagingInteraction' }
+        & Pick<NativeMessagingInteraction, 'conversationId'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction = (
+        { __typename: 'WhatsAppInteraction' }
+        & Pick<WhatsAppInteraction, 'conversationId'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction = (
+        { __typename: 'WeChatInteraction' }
+        & Pick<WeChatInteraction, 'conversationId'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
+
+      type ConversationConversationEvent_BrokenConversationEvent_Fragment = (
+        { __typename: 'BrokenConversationEvent' }
+        & Pick<BrokenConversationEvent, 'id' | 'timestamp'>
+        & { originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom }
+      );
+
+      type ConversationConversationEvent_BotSolution_Fragment = (
+        { __typename: 'BotSolution' }
+        & Pick<BotSolution, 'id' | 'timestamp'>
+        & { originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom }
+      );
+
+      type ConversationConversationEvent_TalkPublicCallSummary_Fragment = (
+        { __typename: 'TalkPublicCallSummary' }
+        & Pick<TalkPublicCallSummary, 'id' | 'timestamp'>
+        & { originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom }
+      );
+
+      export type ConversationConversationEventFragment = ConversationConversationEvent_BrokenConversationEvent_Fragment | ConversationConversationEvent_BotSolution_Fragment | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
+
+      type MessageEnvelopeData_EmailInteraction_Fragment = (
+        { __typename: 'EmailInteraction' }
+        & Pick<EmailInteraction, 'originalEmailURLPath'>
+      );
+
+      type MessageEnvelopeData_CustomChannelInteraction_Fragment = { __typename: 'CustomChannelInteraction' };
+
+      type MessageEnvelopeData_TalkInteraction_Fragment = { __typename: 'TalkInteraction' };
+
+      type MessageEnvelopeData_NativeMessagingInteraction_Fragment = { __typename: 'NativeMessagingInteraction' };
+
+      type MessageEnvelopeData_WhatsAppInteraction_Fragment = { __typename: 'WhatsAppInteraction' };
+
+      type MessageEnvelopeData_WeChatInteraction_Fragment = { __typename: 'WeChatInteraction' };
+
+      type MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_CustomChannelInteraction_Fragment | MessageEnvelopeData_TalkInteraction_Fragment | MessageEnvelopeData_NativeMessagingInteraction_Fragment | MessageEnvelopeData_WhatsAppInteraction_Fragment | MessageEnvelopeData_WeChatInteraction_Fragment | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
+
+      export type AnyChannelOriginatedFromFragment = (
+        { __typename: 'CustomChannelInteraction' }
+        & Pick<CustomChannelInteraction, 'externalId' | 'timestamp' | 'resourceType'>
+      );
+
+      type ConversationOriginatedFrom_EmailInteraction_Fragment = (
+        { __typename: 'EmailInteraction' }
+        & Pick<EmailInteraction, 'originalEmailURLPath'>
+      );
+
+      type ConversationOriginatedFrom_CustomChannelInteraction_Fragment = (
+        { __typename: 'CustomChannelInteraction' }
+        & Pick<CustomChannelInteraction, 'externalId' | 'timestamp' | 'resourceType'>
+      );
+
+      type ConversationOriginatedFrom_TalkInteraction_Fragment = { __typename: 'TalkInteraction' };
+
+      type ConversationOriginatedFrom_NativeMessagingInteraction_Fragment = (
+        { __typename: 'NativeMessagingInteraction' }
+        & Pick<NativeMessagingInteraction, 'conversationId'>
+      );
+
+      type ConversationOriginatedFrom_WhatsAppInteraction_Fragment = (
+        { __typename: 'WhatsAppInteraction' }
+        & Pick<WhatsAppInteraction, 'conversationId'>
+      );
+
+      type ConversationOriginatedFrom_WeChatInteraction_Fragment = (
+        { __typename: 'WeChatInteraction' }
+        & Pick<WeChatInteraction, 'conversationId'>
+      );
+
+      type ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment | ConversationOriginatedFrom_WhatsAppInteraction_Fragment | ConversationOriginatedFrom_WeChatInteraction_Fragment | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = (
+        { __typename: 'EmailInteraction' }
+        & Pick<EmailInteraction, 'originalEmailURLPath'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction = (
+        { __typename: 'CustomChannelInteraction' }
+        & Pick<CustomChannelInteraction, 'externalId' | 'timestamp' | 'resourceType'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction = (
+        { __typename: 'TalkInteraction' }
+        & Pick<TalkInteraction, 'channel' | 'type'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction = (
+        { __typename: 'NativeMessagingInteraction' }
+        & Pick<NativeMessagingInteraction, 'conversationId'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction = (
+        { __typename: 'WhatsAppInteraction' }
+        & Pick<WhatsAppInteraction, 'conversationId'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction = (
+        { __typename: 'WeChatInteraction' }
+        & Pick<WeChatInteraction, 'conversationId'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+
+      export type ConversationTalkPublicCallSummaryFragment = (
+        { __typename: 'TalkPublicCallSummary' }
+        & Pick<TalkPublicCallSummary, 'id' | 'timestamp' | 'summary'>
+        & { originatedFrom: ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom }
+      );
+      "
+    `);
+
+    await validate(content, config, complexTestSchemaWithUnionsAndInterfaces);
+  });
+});

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -1851,18 +1851,18 @@ export * from "./gql.js";`);
         export type FooQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type FooQuery = { __typename?: 'Query', foo?: ( { __typename?: 'Foo' } & (
+        export type FooQuery = { __typename?: 'Query', foo?: { __typename?: 'Foo' } & (
             { __typename?: 'Foo' }
             & { ' $fragmentRefs'?: { 'FooFragment': Incremental<FooFragment> } }
-          ) ) | null };
+          ) | null };
 
         export type FoosQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type FoosQuery = { __typename?: 'Query', foos?: Array<( { __typename?: 'Foo' } & (
+        export type FoosQuery = { __typename?: 'Query', foos?: Array<{ __typename?: 'Foo' } & (
             { __typename?: 'Foo' }
             & { ' $fragmentRefs'?: { 'FooFragment': Incremental<FooFragment> } }
-          ) ) | null> | null };
+          ) | null> | null };
 
         export type FooFragment = { __typename?: 'Foo', value?: string | null } & { ' $fragmentName'?: 'FooFragment' };
 
@@ -1936,18 +1936,18 @@ export * from "./gql.js";`);
         export type FooQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type FooQuery = { __typename?: 'Query', foo?: ( { __typename?: 'Foo' } & (
+        export type FooQuery = { __typename?: 'Query', foo?: { __typename?: 'Foo' } & (
             { __typename?: 'Foo' }
             & { ' $fragmentRefs'?: { 'FooFragment': Incremental<FooFragment> } }
-          ) ) | null };
+          ) | null };
 
         export type FoosQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type FoosQuery = { __typename?: 'Query', foos?: Array<( { __typename?: 'Foo' } & (
+        export type FoosQuery = { __typename?: 'Query', foos?: Array<{ __typename?: 'Foo' } & (
             { __typename?: 'Foo' }
             & { ' $fragmentRefs'?: { 'FooFragment': Incremental<FooFragment> } }
-          ) ) | null> | null };
+          ) | null> | null };
 
         export type FooFragment = { __typename?: 'Foo', value?: string | null } & { ' $fragmentName'?: 'FooFragment' };
 
@@ -2021,18 +2021,18 @@ export * from "./gql.js";`);
         export type FooQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type FooQuery = { __typename?: 'Query', foo?: ( { __typename?: 'Foo' } & (
+        export type FooQuery = { __typename?: 'Query', foo?: { __typename?: 'Foo' } & (
             { __typename?: 'Foo' }
             & { ' $fragmentRefs'?: { 'FooFragment': Incremental<FooFragment> } }
-          ) ) | null };
+          ) | null };
 
         export type FoosQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type FoosQuery = { __typename?: 'Query', foos?: Array<( { __typename?: 'Foo' } & (
+        export type FoosQuery = { __typename?: 'Query', foos?: Array<{ __typename?: 'Foo' } & (
             { __typename?: 'Foo' }
             & { ' $fragmentRefs'?: { 'FooFragment': Incremental<FooFragment> } }
-          ) ) | null> | null };
+          ) | null> | null };
 
         export type FooFragment = { __typename?: 'Foo', value?: string | null } & { ' $fragmentName'?: 'FooFragment' };
 
@@ -2162,18 +2162,18 @@ export * from "./gql.js";`);
         export type FooQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type FooQuery = { __typename?: 'Query', foo?: ( { __typename?: 'Foo' } & (
+        export type FooQuery = { __typename?: 'Query', foo?: { __typename?: 'Foo' } & (
             { __typename?: 'Foo' }
             & { ' $fragmentRefs'?: { 'FooFragment': Incremental<FooFragment> } }
-          ) ) | null };
+          ) | null };
 
         export type FoosQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type FoosQuery = { __typename?: 'Query', foos?: Array<( { __typename?: 'Foo' } & (
+        export type FoosQuery = { __typename?: 'Query', foos?: Array<{ __typename?: 'Foo' } & (
             { __typename?: 'Foo' }
             & { ' $fragmentRefs'?: { 'FooFragment': Incremental<FooFragment> } }
-          ) ) | null> | null };
+          ) | null> | null };
 
         export type FooFragment = { __typename?: 'Foo', value?: string | null } & { ' $fragmentName'?: 'FooFragment' };
 


### PR DESCRIPTION
Related `stage/1-reproduction` issue: #7720

## Description

### Background

At Zendesk, we've been using `graphql-code-generator` for a few years now. Thank you to the creators and maintainers for the lovely tool! It's been a great help to have codegen work for us. 🥳 

As time went by, and our schemas and usage of GraphQL at the company has grown, we unfortunately started to experience increased codegen execution times, and TypeScript compilation times.

This has escalated to the point where engineers had to wait 4 minutes for codegen to complete on their high-spec engineering laptops, and the generated .ts files were over 35MB (yes, you read that right ❗). If that's not bad enough, executing TypeScript to typecheck our codebase on CI (`tsc --noEmit`) would take a whopping 6:36 minutes on the CI ‼️ 

Finally, we've hit a brick wall that just made us unable to make any changes to the schema. We stumbled upon issue #7720. 
We've tried to mitigated it by increasing node's heap size, and running codegen with a 12GB heap size (`--max-old-space-size=12288`).
But then we've hit another roadblock. Whenever we'd run TypeScript to typecheck our source code using the generated GraphQL file, we'd bump against a hard limit of V8 - there's a maximum number of entries a `Map` can hold:
```
RangeError: Map maximum size exceeded
```
Call stack indicated that this crash was coming from TypeScript trying to calculate an incredibly complex intersection type.

Since this was essentially blocking all GraphQL-related projects, me and my colleague (@xnanodax) set out to improve the performance of codegen. After some preliminary analysis it seemed that the problem stems from codegen generating the same types, over and over again. The resulting types have very deep nesting, and some extremely complex union types.

### The problem

Say you have a GraphQL interface with 50 implementing types. Within those 50 types, you have a field that's a union of 100 types.
Now you have a query that selects a field with those interfaces, and the interface has a field that includes the union.
What ends up happening, is that for every combination of 50 types and 100 implementations, the same type is generated over, and over again.
Not only they're not being cached in any way, these types are repeated inline in each combination, over and over again in the generated file. In the example case, you'd have 50 x 100 permutations = 5,000 repetitions of the **same exact type**, fully expanded and inlined in the resulting Fragment or operation types.

If you have many queries or uses of such fields, it's game over: `tsc` crashes, since you've reached hard limits of NodeJS.

### What we've done to fix this

- implement a caching mechanism that makes sure the type originating at the same location is never generated twice, as long as the combination of selected fields and possible types matches
- add a configuration property `extractAllFieldsToTypes: boolean` that makes codegen extract fields into their own types

When the property is `true`, each object field will have its own type generated. 
This means that the type will be reused by name if it already exists. This helps to take the 5,000 repetitions down to 1.

Since we didn't want to introduce breaking changes, this behavior is opt-in, though we think it would be a good idea to make it the default behavior in the next major version.

### Improvements

The results of this change are jaw-dropping:

| Metric | Before | After |
|--------|--------|--------|
| generated `graph.ts` filesize | 30.4MB | 3.9MB |
| CI run time of codegen CLI | ~**2:53** minutes (❗) | ~**19** seconds |
| CI run time of `tsc --noEmit` | ~**6:36** minutes (❗) | ~**1:16** minutes |

We've managed to save a significant amount of money on CI/CD, since we run `codegen` before every type of test (jest, eslint, typecheck, performance tests - and we parallelize heavily with 100s of runners spun simultaneously for each PR). The average step in our CI pipeline is faster **by 2.5 minutes**! Since some steps are run in sequence (first build, then UI tests), the full release pipeline is faster by **~5 minutes**. That's a tremendous saving, both financially and in reducing the overall time-to-deploy.

After this change we also found out that TS did not flag certain errors, because the union/intersection complexity was very high. This change helped us discover bugs in production code that were previously silently being ignored!

One more thing: for readability's sake, we've added a `printFieldsOnNewLines: boolean` configuration flag, which helps with readability of long, generated types, by placing each field on a separate line, rather than having the entire type generated on a single line, sometimes reaching tens of thousands of columns.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Aside from all the great performance benefits, and actually unblocking further development on our graph, we've noticed significant usability improvements: Understanding TS errors from types coming from codegen was often incredibly difficult, if not impossible. TS errors would often contain thousands of lines, with some IDEs not even able to display the error correctly. By giving these field interfaces names, it's significantly easier to parse what the error is about:

#### Before

The error is thousands of lines long, and you can't see it in full without copy & pasting it from VSCode to another file. It's extremely bad DX.

![before-px](https://github.com/dotansimha/graphql-code-generator/assets/24526717/1e3ba8d1-71f0-4b61-889b-251a3ab5baa8)

#### After

The error is short and sweet! All is clear.

<img width="1242" alt="after-px" src="https://github.com/dotansimha/graphql-code-generator/assets/24526717/8f241d17-6d03-47ab-9c00-1e571df45828">

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] We've been running this in production on our very large graph for the past month.
- [x] Added a test file: extract-all-types.spec.ts
- [x] Added a test based on the reproduction provided in #7720 - it doesn't OOM when `extractAllFieldsToTypes: true`, but does OOM with that property set to `false` (this hasn't changed).

**Test Environment**:

- OS: Linux and macOS
- `@graphql-codegen/...`: latest `master` (33f35a50f66ef897c305ea5a2bb8e29682b2237d)
- NodeJS: v18 LTS

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

### This PR

As far as this PR goes, if you have any comments or questions regarding how this is implemented, or would like to request some changes, me and @xnanodax can spend some dedicated time to make sure we can upstream our changes to your project.

### Further optimizations and suggested printer refactor

The way the final TypeScript code is currently produced in codegen is through manipulation of raw strings. In a way, the resulting code is generated eagerly, without abstractions for unions, intersections, or TS objects. This works okay in most cases, but the current design makes it very hard to add further performance optimizations to the resulting types, like automatic merging intersections of objects into flat objects. Intersections are heavier on the TypeScript compiler and increase memory usage. Object types are also slightly less performant than interfaces, and in the current implementation we cannot easily tell if the type contained in the string could be made into an TypeScript `interface`, or does it have to remain a `type` (because it contains unions).
Additionally, it can be challenging to reason about the types, as it's not clear what the underlying strings represent when manipulating them, making it easy to accidentally output invalid TypeScript.

To mitigate this, we have started [an experimental branch](https://github.com/zendesk/graphql-code-generator-with-improved-performance/pull/3) (a version that we've been using internally for the past month), which introduces a set of [helper classes](https://github.com/zendesk/graphql-code-generator-with-improved-performance/blob/bb/new-printer/packages/plugins/other/visitor-plugin-common/src/ts-printer.ts) to encapsulate unions, intersections, objects and other TS features. It's not as heavy as a full blown AST, but just enough to helps generate more performant TypeScript, and much cleaner output (by getting rid of the unnecessary intersections of objects).

We've started refactoring codegen's typescript-operations plugin to use these new helper classes in a separate branch, and we're seeing huge benefits in the cleaner/more performant generated output, however there's still a bunch of work left to be done to fully refactor all the remaining plugins and features.

Since this would be a much larger refactor than the fix in this PR, I first would like to get your feedback to see if this is a direction that you'd be willing to go in, so we don't commit to doing something you don't want to merge.

Example of the refactored code: [Before](https://github.com/zendesk/graphql-code-generator-with-improved-performance/blob/077f7bff8d5fd723b87204b47c8bf096aa72ade5/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts#L655-L663) vs [After](https://github.com/zendesk/graphql-code-generator-with-improved-performance/blob/8129a3008ca96b41cbec2ac30c79410aed968659/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts#L746-L773)

Please let me know if we can proceed with the refactor and further optimizations that it unlocks.