### PR TITLE
fix(visitor-plugin-common): avoid reading from null values

### DIFF
--- a/.changeset/perfect-forks-flash.md
+++ b/.changeset/perfect-forks-flash.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Avoid reading from null values when selection sets only contain fragments.

--- a/dev-test/codegen.ts
+++ b/dev-test/codegen.ts
@@ -221,6 +221,17 @@ const config: CodegenConfig = {
       preset: 'client',
       presetConfig: { fragmentMasking: true },
     },
+    './dev-test/test-null-value/result.d.ts': {
+      schema: './dev-test/test-null-value/schema.graphql',
+      documents: ['./dev-test/test-null-value/query.ts'],
+      plugins: ['typescript', 'typescript-operations'],
+      config: {
+        // The combination of these two flags caused the following issue:
+        // https://github.com/dotansimha/graphql-code-generator/pull/9709
+        skipTypename: true,
+        mergeFragmentTypes: true,
+      },
+    },
   },
 };
 

--- a/dev-test/test-null-value/query.ts
+++ b/dev-test/test-null-value/query.ts
@@ -1,0 +1,16 @@
+export const MY_QUERY = /* GraphQL */ `
+  fragment CartLine on CartLine {
+    id
+    quantity
+  }
+
+  query Test {
+    cart {
+      lines {
+        nodes {
+          ...CartLine
+        }
+      }
+    }
+  }
+`;

--- a/dev-test/test-null-value/result.d.ts
+++ b/dev-test/test-null-value/result.d.ts
@@ -1,0 +1,50 @@
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+};
+
+export type BaseCartLine = {
+  id: Scalars['String']['output'];
+  quantity: Scalars['Int']['output'];
+};
+
+export type BaseCartLineConnection = {
+  id: Scalars['String']['output'];
+  nodes: Array<BaseCartLine>;
+};
+
+export type Cart = {
+  id: Scalars['String']['output'];
+  lines: BaseCartLineConnection;
+};
+
+export type CartLine = BaseCartLine & {
+  id: Scalars['String']['output'];
+  quantity: Scalars['Int']['output'];
+};
+
+export type ComponentizableCartLine = BaseCartLine & {
+  id: Scalars['String']['output'];
+  quantity: Scalars['Int']['output'];
+};
+
+export type QueryRoot = {
+  cart?: Maybe<Cart>;
+};
+
+export type CartLineFragment = { id: string; quantity: number };
+
+export type TestQueryVariables = Exact<{ [key: string]: never }>;
+
+export type TestQuery = { cart?: { lines: { nodes: Array<{ id: string; quantity: number }> } } | null };

--- a/dev-test/test-null-value/schema.graphql
+++ b/dev-test/test-null-value/schema.graphql
@@ -1,0 +1,32 @@
+schema {
+  query: QueryRoot
+}
+
+interface BaseCartLine {
+  id: String!
+  quantity: Int!
+}
+
+type BaseCartLineConnection {
+  id: String!
+  nodes: [BaseCartLine!]!
+}
+
+type Cart {
+  id: String!
+  lines: BaseCartLineConnection!
+}
+
+type CartLine implements BaseCartLine {
+  id: String!
+  quantity: Int!
+}
+
+type ComponentizableCartLine implements BaseCartLine {
+  id: String!
+  quantity: Int!
+}
+
+type QueryRoot {
+  cart: Cart
+}

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -714,7 +714,6 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     return (
       Object.keys(grouped)
         .map(typeName => {
-          const hasUnions = grouped[typeName].filter(s => typeof s !== 'string' && s.union).length > 0;
           const relevant = grouped[typeName].filter(Boolean);
 
           if (relevant.length === 0) {
@@ -728,6 +727,8 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
               return '(' + selectionObject.union.join(' | ') + ')';
             })
             .join(' & ');
+
+          const hasUnions = grouped[typeName].filter(s => typeof s !== 'string' && s.union).length > 0;
 
           return relevant.length > 1 && !hasUnions ? `( ${res} )` : res;
         })


### PR DESCRIPTION
## Description

tl;dr `visitor-plugin-common` tries to read from a variable that can be null in some situations. It's probably hard to reproduce since I'm using custom stuff. However, the change in this PR is just making the code more robust by moving 1 line that reads from a variable after an existing null check.

---

While working on codegen for Shopify/Hydrogen, I found that the following fragment breaks when using `typescript-operation` in `@graphql-codegen/cli` v4 and v5. It used to work in v3.3.1:

```ts
const CART_QUERY_FRAGMENT = `#graphql
  fragment CartLine on CartLine {
    id
    quantity
  }
  fragment CartApiQuery on Cart {
    id
    lines {
      nodes {
        ...CartLine
      }
    }
  }
`
```

It throws with `[Codegen] Cannot read properties of null (reading 'union')`, which comes from [this line](https://github.com/dotansimha/graphql-code-generator/blob/04d8781ff80b816a5735f86360559e1657108595/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts#L717):

```
const hasUnions = grouped[typeName].filter(s => typeof s !== 'string' && s.union).length > 0;
```

In the code above, `grouped` contains the following data:

```js
{
  grouped: {
    CartLine: [ "Pick<StorefrontAPI.CartLine, 'id' | 'quantity'>" ],
    ComponentizableCartLine: [ null ]
  }
}
```

The fragment for CartLine is correct, but the selection set for "nodes {...}" (ComponentizableCartLine here) has a null value which probably wasn't there in 3.3.1. Even though the type says it should be a string, truth is it can also be null because that's what is returned [here](https://github.com/dotansimha/graphql-code-generator/blob/04d8781ff80b816a5735f86360559e1657108595/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/base.ts#L35).

It works when adding anything next to the fragment spread (the null value becomes a string):

```ts
const CART_QUERY_FRAGMENT = `#graphql
  fragment CartLine on CartLine {
    id
    quantity
  }
  fragment CartApiQuery on Cart {
    id
    lines {
      nodes {
        id # <=== anything here makes it work
        ...CartLine
      }
    }
  }
`
```


I'm not sure what changed since 3.3.1, perhaps it's the type of data that comes from other packages different from `visitor-plugin-common`, but I think it's not bad to make this package more robust and filter out null values.

The change in this PR is simply moving the offending line a few lines below after an existing check for null values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Quite a manual test, but the code change is just making it more robust so it can't break anything else.

**Test Environment**:

- OS: macOS Ventura 13.5.2
- `@graphql-codegen/...`: ^5
- NodeJS: 18.12.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

