### PR TITLE
docs: recommend the client and server preset

### DIFF
--- a/website/src/pages/plugins/typescript/typed-document-node.mdx
+++ b/website/src/pages/plugins/typescript/typed-document-node.mdx
@@ -9,8 +9,8 @@ import { pluginGetStaticProps } from '@/lib/plugin-get-static-props'
 export const getStaticProps = pluginGetStaticProps(__filename, { hasOperationsNote: true })
 
 <Callout>
-For new projects, we recommend using the [`client-preset`](/plugins/presets/preset-client), which uses `typed-document-node` under the hood.
-
+  This plugin is meant to be used for low-level use cases or as building block for presets.
+  <br /> For building a **GraphQL client application** we recommend using the [`client-preset`](/plugins/presets/preset-client).
 </Callout>
 
 <PluginHeader />

--- a/website/src/pages/plugins/typescript/typescript-operations.mdx
+++ b/website/src/pages/plugins/typescript/typescript-operations.mdx
@@ -3,9 +3,15 @@ title: typescript-operations
 description: Generate TypeScript operations from GraphQL queries. This plugin is based on the `typescript` plugin, but it generates operations instead of types.
 ---
 
+import { Callout } from '@theguild/components'
 import { PluginApiDocs, PluginHeader } from '@/components/plugin'
 import { pluginGetStaticProps } from '@/lib/plugin-get-static-props'
 export const getStaticProps = pluginGetStaticProps(__filename, { hasOperationsNote: true })
+
+<Callout>
+  This plugin is meant to be used for low-level use cases or as building block for presets.
+  <br /> For building a **GraphQL client application** we recommend using the [`client-preset`](/plugins/presets/preset-client).
+</Callout>
 
 <PluginHeader />
 <PluginApiDocs />

--- a/website/src/pages/plugins/typescript/typescript-resolvers.mdx
+++ b/website/src/pages/plugins/typescript/typescript-resolvers.mdx
@@ -8,6 +8,11 @@ import { PluginApiDocs, PluginHeader } from '@/components/plugin'
 import { pluginGetStaticProps } from '@/lib/plugin-get-static-props'
 export const getStaticProps = pluginGetStaticProps(__filename, { hasOperationsNote: true })
 
+<Callout>
+  This plugin is meant to be used for low-level use cases or as building block for presets.
+  <br /> For building a **GraphQL server schema** we recommend using the [`server-preset`](/docs/guides/graphql-server-apollo-yoga-with-server-preset).
+</Callout>
+
 <PluginHeader />
 
 <Callout>

--- a/website/src/pages/plugins/typescript/typescript.mdx
+++ b/website/src/pages/plugins/typescript/typescript.mdx
@@ -3,9 +3,18 @@ title: typescript
 description: TypeScript plugin. Adds support for TypeScript.
 ---
 
+import { Callout } from '@theguild/components'
 import { PluginApiDocs, PluginHeader } from '@/components/plugin'
 import { pluginGetStaticProps } from '@/lib/plugin-get-static-props'
 export const getStaticProps = pluginGetStaticProps(__filename)
 
+<Callout>
+  This plugin is meant to be used for low-level use cases or as building block for presets.
+  <br /> For building a **GraphQL client application** we recommend using the [`client-preset`](/plugins/presets/preset-client).
+  <br /> For building a **GraphQL server schema** we recommend using the
+  [`server-preset`](/docs/guides/graphql-server-apollo-yoga-with-server-preset).
+</Callout>
+
 <PluginHeader />
+
 <PluginApiDocs />


### PR DESCRIPTION
as discussed in the meeting we will now recommend client and/or server presets on top of the low-level plugin pages that got superseded by the presets.