### PR TITLE
Updates Client Preset Persisted Documents documentation with hashAlgorithm options

### DIFF
--- a/website/src/pages/plugins/presets/preset-client.mdx
+++ b/website/src/pages/plugins/presets/preset-client.mdx
@@ -490,7 +490,26 @@ const response = await fetch('http://yoga/graphql', {
 console.log(response.status)
 console.log(await response.json())
 ```
+To override the default hash algorithm of sha1 set `persistedDocuments.hashAlgorithm`
 
+```ts filename="codegen.ts" {10-12}
+import { type CodegenConfig } from '@graphql-codegen/cli'
+
+const config: CodegenConfig = {
+  schema: 'schema.graphql',
+  documents: ['src/**/*.tsx'],
+  generates: {
+    './src/gql/': {
+      preset: 'client',
+      presetConfig: {
+        persistedDocuments: {
+          hashAlgorithm: 'sha256',      
+	},
+      }
+    }
+  }
+}
+```
 ### Normalized Caches (urql and Apollo Client)
 
 Urql is a popular GraphQL client that utilizes a normalized cache.

--- a/website/src/pages/plugins/presets/preset-client.mdx
+++ b/website/src/pages/plugins/presets/preset-client.mdx
@@ -490,6 +490,7 @@ const response = await fetch('http://yoga/graphql', {
 console.log(response.status)
 console.log(await response.json())
 ```
+
 To override the default hash algorithm of sha1 set `persistedDocuments.hashAlgorithm`
 
 ```ts filename="codegen.ts" {10-12}
@@ -503,13 +504,14 @@ const config: CodegenConfig = {
       preset: 'client',
       presetConfig: {
         persistedDocuments: {
-          hashAlgorithm: 'sha256',      
-	},
+          hashAlgorithm: 'sha256'
+        }
       }
     }
   }
 }
 ```
+
 ### Normalized Caches (urql and Apollo Client)
 
 Urql is a popular GraphQL client that utilizes a normalized cache.

--- a/website/src/pages/plugins/presets/preset-client.mdx
+++ b/website/src/pages/plugins/presets/preset-client.mdx
@@ -491,6 +491,8 @@ console.log(response.status)
 console.log(await response.json())
 ```
 
+### Hashing algorithm
+
 To override the default hash algorithm of sha1 set `persistedDocuments.hashAlgorithm`
 
 ```ts filename="codegen.ts" {10-12}


### PR DESCRIPTION
Updates Client Preset - Persisted Documents documentation

## Description

Updates documentation with `persistedDocuments.hashAlgorithm` options example from https://github.com/dotansimha/graphql-code-generator/pull/9353

Related # (issue)

* https://github.com/dotansimha/graphql-code-generator/issues/9759

## Type of change

Please delete options that are not relevant.
- [ ] This change requires a documentation update


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules