### PR TITLE
docs: latest GraphQLSP needs no config

### DIFF
--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -498,10 +498,7 @@ after installing the package (`npm i -D @0no-co/graphqlsp`):
     "plugins": [
       {
         "name": "@0no-co/graphqlsp",
-        "schema": "./schema.graphql",
-        "disableTypegen": true,
-        "templateIsCallExpression": true,
-        "template": "graphql"
+        "schema": "./schema.graphql"
       }
     ]
   }


### PR DESCRIPTION
## Description

In GraphQLSP > 1.0.0, we don't require any config to support the `client-preset`, tracking field usage will default to true and so will checking for co-located fragments.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

