### PR TITLE
fix(typescript-operations): properly handle aliased conditionals

### DIFF
--- a/.changeset/mighty-doors-stare.md
+++ b/.changeset/mighty-doors-stare.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-operations': patch
+---
+
+properly handle aliased conditionals

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/base.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/base.ts
@@ -2,7 +2,7 @@ import { GraphQLInterfaceType, GraphQLNamedType, GraphQLObjectType, GraphQLOutpu
 import { AvoidOptionalsConfig, ConvertNameFn, NormalizedScalarsMap } from '../types.js';
 
 export type PrimitiveField = { isConditional: boolean; fieldName: string };
-export type PrimitiveAliasedFields = { alias: string; fieldName: string };
+export type PrimitiveAliasedFields = { isConditional: boolean; alias: string; fieldName: string };
 export type LinkField = { alias: string; name: string; type: string; selectionSet: string };
 export type NameAndType = { name: string; type: string };
 export type ProcessResult = null | Array<NameAndType | string>;

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/pre-resolve-types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-processor/pre-resolve-types.ts
@@ -101,7 +101,12 @@ export class PreResolveTypesProcessor extends BaseSelectionSetProcessor<Selectio
           });
       }
 
-      const name = this.config.formatNamedField(aliasedField.alias, fieldObj.type, undefined, unsetTypes);
+      const name = this.config.formatNamedField(
+        aliasedField.alias,
+        fieldObj.type,
+        aliasedField.isConditional,
+        unsetTypes
+      );
       if (unsetTypes) {
         return {
           type: 'never',

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -642,7 +642,9 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       const isConditional = hasConditionalDirectives(field) || inlineFragmentConditional;
       const isOptional = options.unsetTypes;
       linkFields.push({
-        alias: field.alias ? this._processor.config.formatNamedField(field.alias.value, selectedFieldType) : undefined,
+        alias: field.alias
+          ? this._processor.config.formatNamedField(field.alias.value, selectedFieldType, isConditional, isOptional)
+          : undefined,
         name: this._processor.config.formatNamedField(field.name.value, selectedFieldType, isConditional, isOptional),
         type: realSelectedFieldType.name,
         selectionSet: this._processor.config.wrapTypeWithModifiers(
@@ -679,6 +681,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
         Array.from(primitiveAliasFields.values()).map(field => ({
           alias: field.alias.value,
           fieldName: field.name.value,
+          isConditional: hasConditionalDirectives(field),
         })),
         options.unsetTypes
       ),


### PR DESCRIPTION
## Description

We use GraphQL code generator heavily at our company and today ran into an issue where a field was conditional (using `@include` directive) but the types show it as being always present in the response.

Related issue: https://github.com/dotansimha/graphql-code-generator/issues/8461

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added a unit test to `ts-documents.spec.ts`

**Test Environment**:

- OS: Sonoma
- NodeJS: v16.13.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

It's not clear if this fix wasn't made earlier. Was there some limitation that previous fixes ran into? I don't see any discussion in the original issue. 
