### PR TITLE
Excluded the __typename from the root node of subscriptions when using addTypenameSelectionDocumentTransform with documentTransforms

### DIFF
--- a/.changeset/light-clocks-rhyme.md
+++ b/.changeset/light-clocks-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/client-preset': minor
+---
+
+The \_\_typename should not be added to the root node of a subscription when using addTypenameSelectionDocumentTransform with documentTransforms since a single root node is expected and the code generator fails because of that (refer to https://spec.graphql.org/draft/#sec-Single-root-field)

--- a/packages/presets/client/src/add-typename-selection-document-transform.ts
+++ b/packages/presets/client/src/add-typename-selection-document-transform.ts
@@ -12,10 +12,13 @@ export const addTypenameSelectionDocumentTransform: Types.DocumentTransformObjec
       document: document.document
         ? visit(document.document, {
             SelectionSet(node, _, parent) {
-              const isSubscriptionRoot = typeof((parent as ASTNode)?.kind) === 'string' &&
-                (parent as ASTNode).kind === 'OperationDefinition' && (parent as OperationDefinitionNode).operation === 'subscription';
+              const isSubscriptionRoot =
+                typeof (parent as ASTNode)?.kind === 'string' &&
+                (parent as ASTNode).kind === 'OperationDefinition' &&
+                (parent as OperationDefinitionNode).operation === 'subscription';
               if (
-                !isSubscriptionRoot && !node.selections.find(selection => selection.kind === 'Field' && selection.name.value === '__typename')
+                !isSubscriptionRoot &&
+                !node.selections.find(selection => selection.kind === 'Field' && selection.name.value === '__typename')
               ) {
                 return {
                   ...node,

--- a/packages/presets/client/src/add-typename-selection-document-transform.ts
+++ b/packages/presets/client/src/add-typename-selection-document-transform.ts
@@ -1,8 +1,8 @@
-import { Kind, visit } from 'graphql';
+import { ASTNode, OperationDefinitionNode, Kind, visit } from 'graphql';
 import { Types } from '@graphql-codegen/plugin-helpers';
 
 /**
- * Automatically adds `__typename` selections to every object type in your GraphQL document.
+ * Automatically adds `__typename` selections to every object type in your GraphQL document except the root node in subscriptions since a single root field is expected (https://spec.graphql.org/draft/#sec-Single-root-field).
  * This is useful for GraphQL Clients such as Apollo Client or urql that need typename information for their cache to function.
  */
 export const addTypenameSelectionDocumentTransform: Types.DocumentTransformObject = {
@@ -11,9 +11,11 @@ export const addTypenameSelectionDocumentTransform: Types.DocumentTransformObjec
       ...document,
       document: document.document
         ? visit(document.document, {
-            SelectionSet(node) {
+            SelectionSet(node, _, parent) {
+              const isSubscriptionRoot = typeof((parent as ASTNode)?.kind) === 'string' &&
+                (parent as ASTNode).kind === 'OperationDefinition' && (parent as OperationDefinitionNode).operation === 'subscription';
               if (
-                !node.selections.find(selection => selection.kind === 'Field' && selection.name.value === '__typename')
+                !isSubscriptionRoot && !node.selections.find(selection => selection.kind === 'Field' && selection.name.value === '__typename')
               ) {
                 return {
                   ...node,

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { executeCodegen } from '@graphql-codegen/cli';
 import { mergeOutputs } from '@graphql-codegen/plugin-helpers';
 import { validateTs } from '@graphql-codegen/testing';
-import { preset } from '../src/index.js';
+import { addTypenameSelectionDocumentTransform, preset } from '../src/index.js';
 import { print } from 'graphql';
 
 describe('client-preset', () => {
@@ -2511,6 +2511,124 @@ export * from "./gql.js";`);
             ...MovieFragment
             ...EpisodeFragment
           }\`) as unknown as TypedDocumentString<VideoQuery, VideoQueryVariables>;
+      `);
+    });
+
+    it('correctly skips the typename addition for the root node for subscriptions', async () => {
+      const result = await executeCodegen({
+        schema: [
+          /* GraphQL */ `
+            schema {
+              query: Query
+              mutation: Mutation
+              subscription: Subscription
+            }
+
+            type Region {
+              regionId: Int!
+              regionDescription: String!
+            }
+
+            type Subscription {
+              onRegionCreated: Region!
+            }
+
+            type Query {
+              regions: [Region]
+            }
+
+            type Mutation {
+              createRegion(regionDescription: String!): Region
+            }
+          `,
+        ],
+        documents: path.join(__dirname, 'fixtures/subscription-root-node.ts'),
+        generates: {
+          'out1/': {
+            preset,
+            config: {
+              documentMode: 'string',
+            },
+            documentTransforms: [addTypenameSelectionDocumentTransform],
+          },
+        },
+      });
+
+      const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
+      expect(graphqlFile.content).toBeSimilarStringTo(`
+        /* eslint-disable */
+        import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';
+        export type Maybe<T> = T | null;
+        export type InputMaybe<T> = Maybe<T>;
+        export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+        export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+        export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+        export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+        export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+        /** All built-in and custom scalars, mapped to their actual values */
+        export type Scalars = {
+          ID: { input: string; output: string; }
+          String: { input: string; output: string; }
+          Boolean: { input: boolean; output: boolean; }
+          Int: { input: number; output: number; }
+          Float: { input: number; output: number; }
+        };
+        
+        export type Mutation = {
+          __typename?: 'Mutation';
+          createRegion?: Maybe<Region>;
+        };
+        
+        
+        export type MutationCreateRegionArgs = {
+          regionDescription: Scalars['String']['input'];
+        };
+        
+        export type Query = {
+          __typename?: 'Query';
+          regions?: Maybe<Array<Maybe<Region>>>;
+        };
+        
+        export type Region = {
+          __typename?: 'Region';
+          regionDescription: Scalars['String']['output'];
+          regionId: Scalars['Int']['output'];
+        };
+        
+        export type Subscription = {
+          __typename?: 'Subscription';
+          onRegionCreated: Region;
+        };
+        
+        export type OnRegionCreatedSubscriptionVariables = Exact<{ [key: string]: never; }>;
+        
+        
+        export type OnRegionCreatedSubscription = { __typename?: 'Subscription', onRegionCreated: { __typename: 'Region', regionId: number, regionDescription: string } };
+        
+        export class TypedDocumentString<TResult, TVariables>
+          extends String
+          implements DocumentTypeDecoration<TResult, TVariables>
+        {
+          __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
+        
+          constructor(private value: string, public __meta__?: Record<string, any>) {
+            super(value);
+          }
+        
+          toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+            return this.value;
+          }
+        }
+        
+        export const OnRegionCreatedDocument = new TypedDocumentString(\`
+            subscription onRegionCreated {
+          onRegionCreated {
+            __typename
+            regionId
+            regionDescription
+          }
+        }
+            \`) as unknown as TypedDocumentString<OnRegionCreatedSubscription, OnRegionCreatedSubscriptionVariables>;
       `);
     });
   });

--- a/packages/presets/client/tests/fixtures/subscription-root-node.ts
+++ b/packages/presets/client/tests/fixtures/subscription-root-node.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+//@ts-ignore
+import gql from 'gql-tag';
+
+const Subscription = gql(`
+  subscription onRegionCreated {
+    onRegionCreated{
+      regionId
+      regionDescription
+    }
+  }
+`);

--- a/packages/presets/client/tests/fixtures/subscription-root-node.ts
+++ b/packages/presets/client/tests/fixtures/subscription-root-node.ts
@@ -2,7 +2,7 @@
 //@ts-ignore
 import gql from 'gql-tag';
 
-const Subscription = gql(`
+gql(`
   subscription onRegionCreated {
     onRegionCreated{
       regionId


### PR DESCRIPTION
## Description

The `__typename` should not be added to the root node of a subscription when using `addTypenameSelectionDocumentTransform` with `documentTransforms` since a single root node is expected and the code generator fails because of that (refer to [the specification](https://spec.graphql.org/draft/#sec-Single-root-field)).

Related # (issue)

dotansimha/graphql-code-generator#9888

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Sandbox:

[Issue Sandbox](https://github.com/Sojaner/graphql-code-generator-issue-sandbox-template)

## How Has This Been Tested?

The fix is also included in the issue sandbox. The code can be run in 3 setups for testing:
1. `yarn generate` which doesn't use the document transformer and works fine
2. `yarn generate --add-typenames` which uses the current faulty document transformer and fails
3. `yarn generate --add-fixed-typenames` which uses my fixed version of the document transformer and works fine

**Test Environment**:

- OS: Windows
- `@graphql-codegen/client-preset`: 4.2.4
- NodeJS: 20.11.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
