### PR TITLE
add fragmentsOrder config to hasura-allow-list Config API Reference

### DIFF
--- a/website/public/config.schema.json
+++ b/website/public/config.schema.json
@@ -3453,6 +3453,11 @@
         "globalFragments": {
           "description": "Whether to source fragments per-document, or globally. If set, will enforce fragment name uniqueness\nDefault value: \"false\"",
           "type": "boolean"
+        },
+        "fragmentsOrder": {
+          "description": "Order sourced fragments per-document, or globally. When set to \"document\", the fragments will be ordered as ther appear in the document\nDefault value: \"global\"",
+          "enum": ["global", "document"],
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
## Description

hasura-allow-list plugin Config API Reference is missing the fragmentsOrder description.

Related # (issue)[https://github.com/dotansimha/graphql-code-generator-community/pull/452]


<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Added fragmentsOrder config property to Config API Reference for hasura-allow-list plugin.
