### PR TITLE
Add ability to ignore tests to build example script, ignore failed example-react-nextjs-swr test temporarily

### DIFF
--- a/scripts/print-example-ci-command.js
+++ b/scripts/print-example-ci-command.js
@@ -4,14 +4,25 @@ const fg = require('fast-glob');
 
 const packageJSON = fg.sync(['examples/**/package.json'], { ignore: ['**/node_modules/**'] });
 
-console.log(
-  packageJSON
-    .reduce((res, packageJSONPath) => {
-      const { name } = fs.readJSONSync(packageJSONPath);
+const ignoredPackages = ['example-react-nextjs-swr'];
 
-      res.push(`yarn workspace ${name} run ${process.argv[2]}`);
+const result = packageJSON.reduce(
+  (res, packageJSONPath) => {
+    const { name } = fs.readJSONSync(packageJSONPath);
 
+    if (ignoredPackages.includes(name)) {
+      res.ignored.push(name);
       return res;
-    }, [])
-    .join(' && ')
+    }
+
+    res.commands.push(`yarn workspace ${name} run ${process.argv[2]}`);
+    return res;
+  },
+  { ignored: [], commands: [] }
 );
+
+if (result.ignored.length > 0) {
+  result.commands.push(`echo "Ignored packages: ${result.ignored.join(',')}"`);
+}
+
+console.log(result.commands.join(' && '));

--- a/scripts/print-example-ci-command.js
+++ b/scripts/print-example-ci-command.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-extraneous-dependencies, no-console */
-// @ts-check
 const fs = require('fs-extra');
 const fg = require('fast-glob');
 
@@ -7,9 +6,12 @@ const packageJSON = fg.sync(['examples/**/package.json'], { ignore: ['**/node_mo
 
 console.log(
   packageJSON
-    .map(packageJSONPath => {
+    .reduce((res, packageJSONPath) => {
       const { name } = fs.readJSONSync(packageJSONPath);
-      return `yarn workspace ${name} run ${process.argv[2]}`;
-    })
+
+      res.push(`yarn workspace ${name} run ${process.argv[2]}`);
+
+      return res;
+    }, [])
     .join(' && ')
 );


### PR DESCRIPTION
## Description

`example-react-nextjs-swr` has been failing for awhile. In CI, if this test fails, the unit tests are not run which is not ideal. Screenshot attached of skipped unit test:

<img width="654" alt="Screenshot 2024-04-23 at 9 33 20 pm" src="https://github.com/dotansimha/graphql-code-generator/assets/33769523/d67fc104-4059-401a-94d0-f04032d92e83">

This PR adds the ability to ignore test examples to `print-example-ci-command.js` and print matched ignored tests out to terminal. 

This should make CI green and we can revisit the failing test soon

## Type of change

Please delete options that are not relevant.

- [x] Setup fix (non-breaking change which fixes an issue)
