### PR TITLE
[CI] Let unit tests in parallel with examples test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,6 @@ jobs:
     needs:
       - lint
       - prettier-check
-      - dev-tests
       - esm
     strategy:
       matrix:


### PR DESCRIPTION
## Description

Currently, we run unit tests after examples tests (a.k.a. `dev-tests` step in CI ). This has a few quirks: 
- Examples tests take ~9mins whilst unit tests take ~2mins, so the total time to run tests sequentially is >11mins
- If examples tests fail, unit tests are not run. We recently had issues with examples tests, so unit tests were not run, and we didn't realise there were issues in unit tests after some package updates.

This PR removes examples tests as the dependency for unit tests:
- This should cut CI by 2mins
- This should show failing unit tests even when examples tests fail

| Before | After |
| -- | -- |
| <img width="874" alt="Screenshot 2024-04-25 at 9 54 45 pm" src="https://github.com/dotansimha/graphql-code-generator/assets/33769523/5d754585-f21e-47c4-bbcb-227333abc2a1"> | <img width="874" alt="Screenshot 2024-04-25 at 9 54 49 pm" src="https://github.com/dotansimha/graphql-code-generator/assets/33769523/9789dc90-a6b7-470a-adb0-4d88373a068d"> |

## Type of change

Please delete options that are not relevant.

- [x] Repo setup fix (non-breaking change which fixes an issue)

