### PR TITLE
[typescript-resolvers] Add meta field to typescript-resolvers plugin's output

### DIFF
--- a/.changeset/curvy-lobsters-kneel.md
+++ b/.changeset/curvy-lobsters-kneel.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/plugin-helpers': patch
+---
+
+Update plugin output type to allow option `meta` field

--- a/.changeset/new-radios-flash.md
+++ b/.changeset/new-radios-flash.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-resolvers': patch
+---
+
+Update typescript-resolvers to report generated resolver types in the run to meta field in the output

--- a/.changeset/new-radios-flash.md
+++ b/.changeset/new-radios-flash.md
@@ -1,6 +1,6 @@
 ---
-'@graphql-codegen/visitor-plugin-common': patch
-'@graphql-codegen/typescript-resolvers': patch
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-resolvers': minor
 ---
 
 Update typescript-resolvers to report generated resolver types in the run to meta field in the output

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -3039,4 +3039,101 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
       };
     `);
   });
+
+  it('generates meta correctly', async () => {
+    const result = await plugin(
+      buildSchema(/* GraphQL */ `
+        type Query {
+          user(id: ID!): User
+          post(id: ID!): Post
+        }
+
+        type Mutation {
+          createUser(name: String!): CreateUserPayload!
+        }
+
+        interface Node {
+          id: ID!
+        }
+        type Post implements Node {
+          id: ID!
+          author: User
+        }
+        type User implements Node {
+          id: ID!
+          name: String
+        }
+
+        type CreateUserOk {
+          user: User!
+        }
+
+        type CreateUserError {
+          error: ErrorType!
+        }
+
+        union CreateUserPayload = CreateUserOk | CreateUserError
+
+        enum ErrorType {
+          FORBIDDEN_ERROR
+          INTERNAL_ERROR
+        }
+      `),
+      [],
+      {
+        namingConvention: 'change-case-all#snakeCase',
+        enumValues: {
+          ErrorType: {
+            FORBIDDEN_ERROR: '403',
+            INTERNAL_ERROR: '500',
+          },
+        },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result.content).toContain(`export type create_user_error_resolvers`);
+    expect(result.content).toContain(`export type create_user_ok_resolvers`);
+    expect(result.content).toContain(`export type create_user_payload_resolvers`);
+    expect(result.content).toContain(`export type error_type_resolvers`);
+    expect(result.content).toContain(`export type mutation_resolvers`);
+    expect(result.content).toContain(`export type node_resolvers`);
+    expect(result.content).toContain(`export type post_resolvers`);
+    expect(result.content).toContain(`export type query_resolvers`);
+    expect(result.content).toContain(`export type user_resolvers`);
+
+    expect(result.meta).toMatchInlineSnapshot(`
+      Object {
+        "generatedResolverTypes": Object {
+          "CreateUserError": Object {
+            "name": "create_user_error_resolvers",
+          },
+          "CreateUserOk": Object {
+            "name": "create_user_ok_resolvers",
+          },
+          "CreateUserPayload": Object {
+            "name": "create_user_payload_resolvers",
+          },
+          "ErrorType": Object {
+            "name": "error_type_resolvers",
+          },
+          "Mutation": Object {
+            "name": "mutation_resolvers",
+          },
+          "Node": Object {
+            "name": "node_resolvers",
+          },
+          "Post": Object {
+            "name": "post_resolvers",
+          },
+          "Query": Object {
+            "name": "query_resolvers",
+          },
+          "User": Object {
+            "name": "user_resolvers",
+          },
+        },
+      }
+    `);
+  });
 });

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -549,7 +549,12 @@ export namespace Types {
     noSilentErrors?: boolean;
   }
 
-  export type ComplexPluginOutput = { content: string; prepend?: string[]; append?: string[] };
+  export type ComplexPluginOutput<M = Record<string, unknown>> = {
+    content: string;
+    prepend?: string[];
+    append?: string[];
+    meta?: M;
+  };
   export type PluginOutput = string | ComplexPluginOutput;
   export type HookFunction = (...args: any[]) => void | Promise<void>;
   export type HookAlterFunction = (...args: any[]) => void | string | Promise<void | string>;


### PR DESCRIPTION
## Description

Currently, we don't know easily _what_ has been generated from the run without parsing through the output's content. 

This PR adds a new optional `meta` to allow plugins to report certain things about the run.

This PR also makes `@graphql-codegen/typescript-resolvers` report generated resolver type names - after applying `namingConvention` - to `meta`. This allows plugins/presets (e.g. Server Preset) that relies on `@graphql-codegen/typescript-resolvers` plugin to import the generated resolver types without trying to match the `namingConvention` logic manually.

## Type of change

Please delete options that are not relevant.

- [x] New interal feature

## How Has This Been Tested?

- [x] Unit test
