### PR TITLE
Persisted document custom hash function

### DIFF
--- a/.changeset/spicy-starfishes-press.md
+++ b/.changeset/spicy-starfishes-press.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/client-preset": patch
+"website": patch
+---
+
+Added configuration to allow for custom hash functions for persisted documents in the client preset

--- a/.changeset/spicy-starfishes-press.md
+++ b/.changeset/spicy-starfishes-press.md
@@ -4,3 +4,27 @@
 ---
 
 Added configuration to allow for custom hash functions for persisted documents in the client preset
+
+### Example
+```ts filename="codegen.ts" {10-12}
+import { type CodegenConfig } from '@graphql-codegen/cli'
+
+const config: CodegenConfig = {
+  schema: 'schema.graphql',
+  documents: ['src/**/*.tsx'],
+  generates: {
+    './src/gql/': {
+      preset: 'client',
+      presetConfig: {
+        persistedDocuments: {
+          hashAlgorithm: operation => {
+            const shasum = crypto.createHash('sha512')
+            shasum.update(operation)
+            return shasum.digest('hex')
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/packages/presets/client/src/persisted-documents.ts
+++ b/packages/presets/client/src/persisted-documents.ts
@@ -1,11 +1,17 @@
-import * as crypto from 'crypto';
 import { printExecutableGraphQLDocument } from '@graphql-tools/documents';
-import { type DocumentNode, Kind, visit } from 'graphql';
+import * as crypto from 'crypto';
+import { Kind, visit, type DocumentNode } from 'graphql';
 
 /**
  * This function generates a hash from a document node.
  */
-export function generateDocumentHash(operation: string, algorithm: 'sha1' | 'sha256' | (string & {})): string {
+export function generateDocumentHash(
+  operation: string,
+  algorithm: 'sha1' | 'sha256' | (string & {}) | ((operation: string) => string)
+): string {
+  if (typeof algorithm === 'function') {
+    return algorithm(operation);
+  }
   const shasum = crypto.createHash(algorithm);
   shasum.update(operation);
   return shasum.digest('hex');

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -1711,7 +1711,7 @@ export * from "./gql.js";`);
             preset,
             presetConfig: {
               persistedDocuments: {
-                hashFunction: (operation: string) => {
+                hashAlgorithm: (operation: string) => {
                   return operation.replace(/\s/g, '');
                 },
               },
@@ -1795,7 +1795,7 @@ export * from "./gql.js";`);
             preset,
             presetConfig: {
               persistedDocuments: {
-                hashFunction: (operation: string) => {
+                hashAlgorithm: (operation: string) => {
                   const shasum = crypto.createHash('sha256');
                   shasum.update(operation);
                   return shasum.digest('hex');

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -1,10 +1,11 @@
-import * as fs from 'fs';
-import path from 'path';
 import { executeCodegen } from '@graphql-codegen/cli';
 import { mergeOutputs } from '@graphql-codegen/plugin-helpers';
 import { validateTs } from '@graphql-codegen/testing';
-import { addTypenameSelectionDocumentTransform, preset } from '../src/index.js';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
 import { print } from 'graphql';
+import path from 'path';
+import { addTypenameSelectionDocumentTransform, preset } from '../src/index.js';
 
 describe('client-preset', () => {
   it('can generate simple examples uppercase names', async () => {
@@ -1690,6 +1691,177 @@ export * from "./gql.js";`);
         export const BDocument = {"__meta__":{"hash":"a62a11aa72041e38d8c12ef77e1e7c208d9605db60bb5abb1717e8af98e4b410"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
       `);
     });
+
+    // This test serves to demonstrate that the custom hash function can perform arbitrary logic
+    // Removing whitespace has no real-world application but clearly shows the custom hash function is being used
+    it('custom hash remove whitespace', async () => {
+      const result = await executeCodegen({
+        schema: [
+          /* GraphQL */ `
+            type Query {
+              a: String
+              b: String
+              c: String
+            }
+          `,
+        ],
+        documents: path.join(__dirname, 'fixtures/simple-uppercase-operation-name.ts'),
+        generates: {
+          'out1/': {
+            preset,
+            presetConfig: {
+              persistedDocuments: {
+                hashFunction: (operation: string) => {
+                  return operation.replace(/\s/g, '');
+                },
+              },
+            },
+          },
+        },
+        emitLegacyCommonJSImports: false,
+      });
+
+      expect(result).toHaveLength(5);
+
+      const persistedDocuments = result.find(file => file.filename === 'out1/persisted-documents.json');
+
+      expect(persistedDocuments.content).toMatchInlineSnapshot(`
+        "{
+          "queryA{a}": "query A { a }",
+          "queryB{b}": "query B { b }"
+        }"
+      `);
+
+      const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
+      expect(graphqlFile.content).toMatchInlineSnapshot(`
+        "/* eslint-disable */
+        import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+        export type Maybe<T> = T | null;
+        export type InputMaybe<T> = Maybe<T>;
+        export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+        export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+        export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+        export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+        export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+        /** All built-in and custom scalars, mapped to their actual values */
+        export type Scalars = {
+          ID: { input: string; output: string; }
+          String: { input: string; output: string; }
+          Boolean: { input: boolean; output: boolean; }
+          Int: { input: number; output: number; }
+          Float: { input: number; output: number; }
+        };
+
+        export type Query = {
+          __typename?: 'Query';
+          a?: Maybe<Scalars['String']['output']>;
+          b?: Maybe<Scalars['String']['output']>;
+          c?: Maybe<Scalars['String']['output']>;
+        };
+
+        export type AQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type AQuery = { __typename?: 'Query', a?: string | null };
+
+        export type BQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type BQuery = { __typename?: 'Query', b?: string | null };
+
+        export type CFragment = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragment' };
+
+        export const CFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
+        export const ADocument = {"__meta__":{"hash":"queryA{a}"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
+        export const BDocument = {"__meta__":{"hash":"queryB{b}"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
+      `);
+    });
+
+    // Tests that the custom hash function can replicate the logic and behavior by re-implementing the existing hash function (for sha256)
+    it('custom hash sha256', async () => {
+      const result = await executeCodegen({
+        schema: [
+          /* GraphQL */ `
+            type Query {
+              a: String
+              b: String
+              c: String
+            }
+          `,
+        ],
+        documents: path.join(__dirname, 'fixtures/simple-uppercase-operation-name.ts'),
+        generates: {
+          'out1/': {
+            preset,
+            presetConfig: {
+              persistedDocuments: {
+                hashFunction: (operation: string) => {
+                  const shasum = crypto.createHash('sha256');
+                  shasum.update(operation);
+                  return shasum.digest('hex');
+                },
+              },
+            },
+          },
+        },
+        emitLegacyCommonJSImports: false,
+      });
+
+      expect(result).toHaveLength(5);
+
+      const persistedDocuments = result.find(file => file.filename === 'out1/persisted-documents.json');
+
+      expect(persistedDocuments.content).toMatchInlineSnapshot(`
+        "{
+          "7d0eedabb966107835cf307a0ebaf93b5d2cb8c30228611ffe3d27a53c211a0c": "query A { a }",
+          "a62a11aa72041e38d8c12ef77e1e7c208d9605db60bb5abb1717e8af98e4b410": "query B { b }"
+        }"
+      `);
+
+      const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
+      expect(graphqlFile.content).toMatchInlineSnapshot(`
+        "/* eslint-disable */
+        import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+        export type Maybe<T> = T | null;
+        export type InputMaybe<T> = Maybe<T>;
+        export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+        export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+        export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+        export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+        export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+        /** All built-in and custom scalars, mapped to their actual values */
+        export type Scalars = {
+          ID: { input: string; output: string; }
+          String: { input: string; output: string; }
+          Boolean: { input: boolean; output: boolean; }
+          Int: { input: number; output: number; }
+          Float: { input: number; output: number; }
+        };
+
+        export type Query = {
+          __typename?: 'Query';
+          a?: Maybe<Scalars['String']['output']>;
+          b?: Maybe<Scalars['String']['output']>;
+          c?: Maybe<Scalars['String']['output']>;
+        };
+
+        export type AQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type AQuery = { __typename?: 'Query', a?: string | null };
+
+        export type BQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+        export type BQuery = { __typename?: 'Query', b?: string | null };
+
+        export type CFragment = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragment' };
+
+        export const CFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragment, unknown>;
+        export const ADocument = {"__meta__":{"hash":"7d0eedabb966107835cf307a0ebaf93b5d2cb8c30228611ffe3d27a53c211a0c"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;
+        export const BDocument = {"__meta__":{"hash":"a62a11aa72041e38d8c12ef77e1e7c208d9605db60bb5abb1717e8af98e4b410"},"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuery, BQueryVariables>;"
+      `);
+    });
   });
 
   it('correctly handle fragment references', async () => {
@@ -2573,53 +2745,53 @@ export * from "./gql.js";`);
           Int: { input: number; output: number; }
           Float: { input: number; output: number; }
         };
-        
+
         export type Mutation = {
           __typename?: 'Mutation';
           createRegion?: Maybe<Region>;
         };
-        
-        
+
+
         export type MutationCreateRegionArgs = {
           regionDescription: Scalars['String']['input'];
         };
-        
+
         export type Query = {
           __typename?: 'Query';
           regions?: Maybe<Array<Maybe<Region>>>;
         };
-        
+
         export type Region = {
           __typename?: 'Region';
           regionDescription: Scalars['String']['output'];
           regionId: Scalars['Int']['output'];
         };
-        
+
         export type Subscription = {
           __typename?: 'Subscription';
           onRegionCreated: Region;
         };
-        
+
         export type OnRegionCreatedSubscriptionVariables = Exact<{ [key: string]: never; }>;
-        
-        
+
+
         export type OnRegionCreatedSubscription = { __typename?: 'Subscription', onRegionCreated: { __typename: 'Region', regionId: number, regionDescription: string } };
-        
+
         export class TypedDocumentString<TResult, TVariables>
           extends String
           implements DocumentTypeDecoration<TResult, TVariables>
         {
           __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
-        
+
           constructor(private value: string, public __meta__?: Record<string, any>) {
             super(value);
           }
-        
+
           toString(): string & DocumentTypeDecoration<TResult, TVariables> {
             return this.value;
           }
         }
-        
+
         export const OnRegionCreatedDocument = new TypedDocumentString(\`
             subscription onRegionCreated {
           onRegionCreated {

--- a/website/src/pages/plugins/presets/preset-client.mdx
+++ b/website/src/pages/plugins/presets/preset-client.mdx
@@ -514,6 +514,31 @@ const config: CodegenConfig = {
 }
 ```
 
+Instead of using a preset algorithm, you can also provide your own hash function.
+
+```ts filename="codegen.ts" {10-12}
+import { type CodegenConfig } from '@graphql-codegen/cli'
+
+const config: CodegenConfig = {
+  schema: 'schema.graphql',
+  documents: ['src/**/*.tsx'],
+  generates: {
+    './src/gql/': {
+      preset: 'client',
+      presetConfig: {
+        persistedDocuments: {
+          hashAlgorithm: operation => {
+            const shasum = crypto.createHash('sha512')
+            shasum.update(operation)
+            return shasum.digest('hex')
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### Normalized Caches (urql and Apollo Client)
 
 Urql is a popular GraphQL client that utilizes a normalized cache.


### PR DESCRIPTION
## Description

This features allows for customization of the `hashAlgorithm` configuration for persisted documents in the client preset. This mitigates the need to support additional future algorithms beyond `sha1` and `sha256` and gives developers full flexibility for generating document hashes, unlocking new use-cases. 

Related #9994

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Added three new test cases to `client-preset.spec.ts`. Ran `yarn test client-preset`.

- `custom hash remove whitespace` - This test case demonstrates basic functionality in a human-readable manner. Since the output is just the operation without whitespace, it's easy to tell if the custom hash function is broken.
- `custom hash sha256` - This test case replicates the existing test case `hashAlgorithm="sha256"` to ensure identical results.
- `custom hash docs sha512` - This test case demonstrates a realistic, real-world use-case and was chosen as the example for the docs. 

**Test Environment**:

- OS: MacOS
- `@graphql-codegen/...`:
- NodeJS: v18.18.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules