### PR TITLE
docs(typescript-react-apollo): Include fragment hooks section

### DIFF
--- a/website/src/pages/plugins/typescript/typescript-react-apollo.mdx
+++ b/website/src/pages/plugins/typescript/typescript-react-apollo.mdx
@@ -72,6 +72,28 @@ export const MyComponent: React.FC = () => {
 }
 ```
 
+### Generate Fragment Hook
+
+Codegen also supports generating [fragment hooks](https://www.apollographql.com/docs/react/data/fragments#usefragment) (supported from `@apollo/client` v3.8.0), you can turn it on this way:
+
+```ts filename="codegen.ts" {10}
+import type { CodegenConfig } from '@graphql-codegen/cli'
+
+const config: CodegenConfig = {
+  schema: 'YOUR_SCHEMA_HERE',
+  documents: './src/**/*.graphql',
+  generates: {
+    './generated-types.ts': {
+      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      config: {
+        withFragmentHooks: true
+      }
+    }
+  }
+}
+export default config
+```
+
 ### Generate Data Component
 
 Codegen also supports generating data Components (deprecated in `@apollo/client` v3), you can turn it on this way:


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Update documentation to include section on Apollo fragment hooks, support for which was added in https://github.com/dotansimha/graphql-code-generator-community/pull/483 but it is not present in docs 

Related https://github.com/dotansimha/graphql-code-generator-community/issues/482

## Type of change

- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

## How Has This Been Tested?

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
