### PR TITLE
Add generated resolversMap to typescript-resolvers plugin meta

### DIFF
--- a/.changeset/forty-cooks-build.md
+++ b/.changeset/forty-cooks-build.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-resolvers': minor
+---
+
+Add generated resolvers map type name to typescript-resolvers plugin meta

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1264,12 +1264,18 @@ export class BaseResolversVisitor<
     return this._hasFederation;
   }
 
-  public getRootResolver(): { content: string; generatedResolverTypes: Record<string, { name: string }> } {
+  public getRootResolver(): {
+    content: string;
+    generatedResolverTypes: {
+      resolversMap: { name: string };
+      userDefined: Record<string, { name: string }>;
+    };
+  } {
     const name = this.convertName(this.config.allResolversTypeName);
     const declarationKind = 'type';
     const contextType = `<ContextType = ${this.config.contextType.type}>`;
 
-    const generatedResolverTypes: Record<string, { name: string }> = {};
+    const userDefinedTypes: Record<string, { name: string }> = {};
     const content = [
       new DeclarationBlock(this._declarationBlockConfig)
         .export()
@@ -1281,7 +1287,7 @@ export class BaseResolversVisitor<
               const resolverType = this._collectedResolvers[schemaTypeName];
 
               if (resolverType.baseGeneratedTypename) {
-                generatedResolverTypes[schemaTypeName] = { name: resolverType.baseGeneratedTypename };
+                userDefinedTypes[schemaTypeName] = { name: resolverType.baseGeneratedTypename };
               }
 
               return indent(this.formatRootResolver(schemaTypeName, resolverType.typename, declarationKind));
@@ -1292,7 +1298,10 @@ export class BaseResolversVisitor<
 
     return {
       content,
-      generatedResolverTypes,
+      generatedResolverTypes: {
+        resolversMap: { name },
+        userDefined: userDefinedTypes,
+      },
     };
   }
 

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -14,7 +14,12 @@ const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1)
 
 export const plugin: PluginFunction<
   TypeScriptResolversPluginConfig,
-  Types.ComplexPluginOutput<{ generatedResolverTypes: Record<string, { name: string }> }>
+  Types.ComplexPluginOutput<{
+    generatedResolverTypes: {
+      resolversMap: { name: string };
+      userDefined: Record<string, { name: string }>;
+    };
+  }>
 > = (schema: GraphQLSchema, documents: Types.DocumentFile[], config: TypeScriptResolversPluginConfig) => {
   const imports = [];
   if (!config.customResolveInfo) {

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -3092,6 +3092,18 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
       { outputFile: '' }
     );
 
+    expect(result.content).toBeSimilarStringTo(`
+      export type resolvers<ContextType = any> = {
+        Query?: query_resolvers<ContextType>;
+        Mutation?: mutation_resolvers<ContextType>;
+        Node?: node_resolvers<ContextType>;
+        Post?: post_resolvers<ContextType>;
+        User?: user_resolvers<ContextType>;
+        CreateUserOk?: create_user_ok_resolvers<ContextType>;
+        CreateUserError?: create_user_error_resolvers<ContextType>;
+        CreateUserPayload?: create_user_payload_resolvers<ContextType>;
+        ErrorType?: error_type_resolvers;
+      };`);
     expect(result.content).toContain(`export type create_user_error_resolvers`);
     expect(result.content).toContain(`export type create_user_ok_resolvers`);
     expect(result.content).toContain(`export type create_user_payload_resolvers`);
@@ -3105,32 +3117,37 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     expect(result.meta).toMatchInlineSnapshot(`
       Object {
         "generatedResolverTypes": Object {
-          "CreateUserError": Object {
-            "name": "create_user_error_resolvers",
+          "resolversMap": Object {
+            "name": "resolvers",
           },
-          "CreateUserOk": Object {
-            "name": "create_user_ok_resolvers",
-          },
-          "CreateUserPayload": Object {
-            "name": "create_user_payload_resolvers",
-          },
-          "ErrorType": Object {
-            "name": "error_type_resolvers",
-          },
-          "Mutation": Object {
-            "name": "mutation_resolvers",
-          },
-          "Node": Object {
-            "name": "node_resolvers",
-          },
-          "Post": Object {
-            "name": "post_resolvers",
-          },
-          "Query": Object {
-            "name": "query_resolvers",
-          },
-          "User": Object {
-            "name": "user_resolvers",
+          "userDefined": Object {
+            "CreateUserError": Object {
+              "name": "create_user_error_resolvers",
+            },
+            "CreateUserOk": Object {
+              "name": "create_user_ok_resolvers",
+            },
+            "CreateUserPayload": Object {
+              "name": "create_user_payload_resolvers",
+            },
+            "ErrorType": Object {
+              "name": "error_type_resolvers",
+            },
+            "Mutation": Object {
+              "name": "mutation_resolvers",
+            },
+            "Node": Object {
+              "name": "node_resolvers",
+            },
+            "Post": Object {
+              "name": "post_resolvers",
+            },
+            "Query": Object {
+              "name": "query_resolvers",
+            },
+            "User": Object {
+              "name": "user_resolvers",
+            },
           },
         },
       }


### PR DESCRIPTION
## Description

This PR extends `typescript-resolvers` plugin's meta to have the generated resolver map type. This is useful for Server Preset as it needs to refer to this type when generating `resolvers.generated.ts`

This changes the meta shape slightly to have user defined types in the schema under `generatedResolvers.userDefined` instead of `generatedResolvers`. New shape:

```ts
meta: {
  generatedResolverTypes: {
      resolversMap: { name: string };
      userDefined: Record<string, { name: string }>;
    }
}
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated unit test
