### PR TITLE
test(client-preset): custom suffix with `namingConvention`

### DIFF
--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -182,6 +182,138 @@ export * from "./gql";`);
     expect(graphqlFile).toBeDefined();
   });
 
+  it('can generate simple examples uppercase names with custom suffix', async () => {
+    const result = await executeCodegen({
+      schema: [
+        /* GraphQL */ `
+          type Query {
+            a: String
+            b: String
+            c: String
+          }
+        `,
+      ],
+      documents: path.join(__dirname, 'fixtures/simple-uppercase-operation-name.ts'),
+      generates: {
+        'out1/': {
+          preset,
+        },
+      },
+      config: {
+        namingConvention: name => `${name}Suffix`,
+      },
+    });
+
+    expect(result).toHaveLength(4);
+
+    // index.ts (re-exports)
+    const indexFile = result.find(file => file.filename === 'out1/index.ts');
+    expect(indexFile.content).toEqual(`export * from "./fragment-masking";
+export * from "./gql";`);
+
+    // gql.ts
+    const gqlFile = result.find(file => file.filename === 'out1/gql.ts');
+    expect(gqlFile.content).toMatchInlineSnapshot(`
+      "/* eslint-disable */
+      import * as types from './graphql';
+      import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+
+      /**
+       * Map of all GraphQL operations in the project.
+       *
+       * This map has several performance disadvantages:
+       * 1. It is not tree-shakeable, so it will include all operations in the project.
+       * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+       * 3. It does not support dead code elimination, so it will add unused operations.
+       *
+       * Therefore it is highly recommended to use the babel or swc plugin for production.
+       */
+      const documents = {
+          "\\n  query A {\\n    a\\n  }\\n": types.ADocumentSuffix,
+          "\\n  query B {\\n    b\\n  }\\n": types.BDocumentSuffix,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDocSuffix,
+      };
+
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       *
+       *
+       * @example
+       * \`\`\`ts
+       * const query = graphql(\`query GetUser($id: ID!) { user(id: $id) { name } }\`);
+       * \`\`\`
+       *
+       * The query argument is unknown!
+       * Please regenerate the types.
+       */
+      export function graphql(source: string): unknown;
+
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
+      export function graphql(source: "\\n  query A {\\n    a\\n  }\\n"): (typeof documents)["\\n  query A {\\n    a\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
+      export function graphql(source: "\\n  query B {\\n    b\\n  }\\n"): (typeof documents)["\\n  query B {\\n    b\\n  }\\n"];
+      /**
+       * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+       */
+      export function graphql(source: "\\n  fragment C on Query {\\n    c\\n  }\\n"): (typeof documents)["\\n  fragment C on Query {\\n    c\\n  }\\n"];
+
+      export function graphql(source: string) {
+        return (documents as any)[source] ?? {};
+      }
+
+      export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;"
+    `);
+
+    // graphql.ts
+    const graphqlFile = result.find(file => file.filename === 'out1/graphql.ts');
+    expect(graphqlFile.content).toMatchInlineSnapshot(`
+      "/* eslint-disable */
+      import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+      export type Maybe<T> = T | null;
+      export type InputMaybe<T> = Maybe<T>;
+      export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+      export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+      export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+      export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+      export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+      /** All built-in and custom scalars, mapped to their actual values */
+      export type Scalars = {
+        ID: { input: string; output: string; }
+        String: { input: string; output: string; }
+        Boolean: { input: boolean; output: boolean; }
+        Int: { input: number; output: number; }
+        Float: { input: number; output: number; }
+      };
+
+      export type QuerySuffix = {
+        __typename?: 'Query';
+        a?: Maybe<Scalars['String']['output']>;
+        b?: Maybe<Scalars['String']['output']>;
+        c?: Maybe<Scalars['String']['output']>;
+      };
+
+      export type AQueryVariablesSuffix = Exact<{ [key: string]: never; }>;
+
+
+      export type AQuerySuffix = { __typename?: 'Query', a?: string | null };
+
+      export type BQueryVariablesSuffix = Exact<{ [key: string]: never; }>;
+
+
+      export type BQuerySuffix = { __typename?: 'Query', b?: string | null };
+
+      export type CFragmentSuffix = { __typename?: 'Query', c?: string | null } & { ' $fragmentName'?: 'CFragmentSuffix' };
+
+      export const CFragmentDocSuffix = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"C"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"c"}}]}}]} as unknown as DocumentNode<CFragmentSuffix, unknown>;
+      export const ADocumentSuffix = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"A"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuerySuffix, AQueryVariablesSuffix>;
+      export const BDocumentSuffix = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"B"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"b"}}]}}]} as unknown as DocumentNode<BQuerySuffix, BQueryVariablesSuffix>;"
+    `);
+  });
+
   it('generates \\n regardless of whether the source contains LF or CRLF', async () => {
     const result = await executeCodegen({
       schema: [


### PR DESCRIPTION
## Description

When handling anonymous operation name, `BaseDocumentsVisitor` calls the `convertName()` method twice. This leads to duplicated suffix if a user provide a custom `namingConvention` function.

Related #10012 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

https://stackblitz.com/edit/gql-codgen-13f1zd

![image](https://github.com/dotansimha/graphql-code-generator/assets/110041780/57140ccc-7b5e-4544-b745-50fb589c0bfb)

## How Has This Been Tested?

I have described the problem in the related issue. The test added in this PR will reflect that.

**Test Environment**:

- OS: Linux 6.8 Fedora Linux 40 (Workstation Edition)
- NodeJS: 20.14.0
- `graphql` version: 16.8.2
- `@graphql-codegen/cli` version: 5.0.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The main problem that I want to address is that the operation name does not match with itself inside Typed Document Node.