### PR TITLE
Only compute `ClientSideBaseVisitor`'s `fragmentsGraph` once, at instantiation time

### DIFF
--- a/.changeset/rotten-eels-eat.md
+++ b/.changeset/rotten-eels-eat.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Only compute ClientSideBaseVisitor's fragmentsGraph once at instantiation time

--- a/.changeset/rotten-eels-eat.md
+++ b/.changeset/rotten-eels-eat.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/visitor-plugin-common': patch
 ---
 
-Only compute ClientSideBaseVisitor's fragmentsGraph once at instantiation time
+Improve code generation performance by computing `ClientSideBaseVisitor`'s `fragmentsGraph` once at instantiation time.

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -251,7 +251,8 @@ export class ClientSideBaseVisitor<
 
   private _onExecutableDocumentNode?: Unstable_OnExecutableDocumentNode;
   private _omitDefinitions?: boolean;
-  private _fragments: Map<string, LoadedFragment>;
+  private readonly _fragments: ReadonlyMap<string, LoadedFragment>;
+  private readonly fragmentsGraph: DepGraph<LoadedFragment>;
 
   constructor(
     protected _schema: GraphQLSchema,
@@ -289,6 +290,7 @@ export class ClientSideBaseVisitor<
     this._onExecutableDocumentNode = (rawConfig as any).unstable_onExecutableDocumentNode;
     this._omitDefinitions = (rawConfig as any).unstable_omitDefinitions;
     this._fragments = new Map(fragments.map(fragment => [fragment.name, fragment]));
+    this.fragmentsGraph = this._getFragmentsGraph();
     autoBind(this);
   }
 
@@ -519,7 +521,7 @@ export class ClientSideBaseVisitor<
     )};`;
   }
 
-  private get fragmentsGraph(): DepGraph<LoadedFragment> {
+  private _getFragmentsGraph(): DepGraph<LoadedFragment> {
     const graph = new DepGraph<LoadedFragment>({ circular: true });
 
     for (const fragment of this._fragments.values()) {


### PR DESCRIPTION
## Description

As mentioned in https://github.com/dotansimha/graphql-code-generator/issues/10018, `ClientSideBaseVisitor`'s `fragmentsGraph` is implemented as a getter, despite not depending on anything that changes after the class is first instantiated. Turning `fragmentsGraph` into a static property improved build time from ~130s to ~50s in a big monorepo.

This PR does that and it makes field `fragmentsGraph` depends on (`_fragments`) read-only to make sure we don't break the assumption behind pre-computing the former.

Related: #10018

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

- Run codegen on a mid-sized project using `client-preset` and measure the build time
- Make the change to only compute `fragmentsGraph` once per `ClientSideBaseVisitor` instance
- Run codegen again and compare the build time

**Test Environment**:

- OS: macOS
- NodeJS: 18.18.2
- `graphql` version: 16.2.0
- `@graphql-codegen/client-preset` version(s): 4.2.6
- `@graphql-codegen/visitor-plugin-common` version(s): 2.13.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
