### PR TITLE
Allow .graphqls as extension for schema-ast

### DIFF
--- a/.changeset/forty-ears-rule.md
+++ b/.changeset/forty-ears-rule.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/schema-ast': minor
+---
+
+Allow .graphqls as schema extension

--- a/packages/plugins/other/schema-ast/src/index.ts
+++ b/packages/plugins/other/schema-ast/src/index.ts
@@ -130,7 +130,7 @@ export const validate: PluginValidateFn<any> = async (
 ) => {
   const singlePlugin = allPlugins.length === 1;
 
-  const allowedExtensions = ['.graphql', '.gql'];
+  const allowedExtensions = ['.graphql', '.gql', '.graphqls'];
   const isAllowedExtension = allowedExtensions.includes(extname(outputFile));
 
   if (singlePlugin && !isAllowedExtension) {

--- a/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
+++ b/packages/plugins/other/schema-ast/tests/schema-ast.spec.ts
@@ -22,7 +22,7 @@ describe('Schema AST', () => {
         throw new Error(SHOULD_THROW_ERROR);
       } catch (e) {
         expect(e.message).not.toBe(SHOULD_THROW_ERROR);
-        expect(e.message).toBe('Plugin "schema-ast" requires extension to be ".graphql" or ".gql"!');
+        expect(e.message).toBe('Plugin "schema-ast" requires extension to be ".graphql" or ".gql" or ".graphqls"!');
       }
     });
 
@@ -61,6 +61,21 @@ describe('Schema AST', () => {
 
     it('Should allow .gql extension when its the only plugin', async () => {
       const fileName = 'output.gql';
+      const plugins: Types.ConfiguredPlugin[] = [
+        {
+          'schema-ast': {},
+        },
+      ];
+
+      try {
+        await validate(null, null, null, fileName, plugins);
+      } catch (e) {
+        expect(true).toBeFalsy();
+      }
+    });
+
+    it('Should allow .graphqls extension when its the only plugin', async () => {
+      const fileName = 'output.graphqls';
       const plugins: Types.ConfiguredPlugin[] = [
         {
           'schema-ast': {},


### PR DESCRIPTION
## Description

Allow .graphqls as extension for `schema-ast` plugin.

This is currently the unofficial extension for GraphQL schema files, and there's a push to make it the official extension.
