### PR TITLE
change documents type from array to object when no operations are found

### DIFF
--- a/packages/plugins/typescript/gql-tag-operations/src/index.ts
+++ b/packages/plugins/typescript/gql-tag-operations/src/index.ts
@@ -82,7 +82,7 @@ export const plugin: PluginFunction<{
     if (sourcesWithOperations.length > 0) {
       code.push([...getDocumentRegistryChunk(sourcesWithOperations)].join(''));
     } else {
-      code.push('const documents = [];');
+      code.push('const documents = {};');
     }
 
     code.push(

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -1208,7 +1208,7 @@ export * from "./gql.js";`);
         import * as types from './graphql.js';
         import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
-        const documents = [];
+        const documents = {};
         /**
          * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
          *


### PR DESCRIPTION
## Description

As mentioned in #10031, when using client preset, map of operations is an empty array when no operations are found. Because of this, noImplicitAny check does not pass.

This PR change the map from an empty array to an empty object.

Related #10031

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
