### PR TITLE
feat(typescript-operations): Add option 'combineFragmentNames' to combine only certain fragments when inlineFragmentTypes is 'inline'

### DIFF
--- a/.changeset/chatty-rats-fly.md
+++ b/.changeset/chatty-rats-fly.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-operations': patch
+---
+
+Add option 'combineFragmentNames' to combine only certain fragments when inlineFragmentTypes is 'inline'

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -598,7 +598,11 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
         continue;
       }
 
-      if (this._config.inlineFragmentTypes === 'combine' || this._config.inlineFragmentTypes === 'mask') {
+      if (
+        this._config.inlineFragmentTypes === 'combine' ||
+        this._config.inlineFragmentTypes === 'mask' ||
+        this._config.combineFragmentNames.includes(selectionNode.fragmentName)
+      ) {
         fragmentsSpreadUsages.push(selectionNode.typeName);
         continue;
       }
@@ -703,7 +707,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     const fields = [...allStrings, mergedObjectsAsString].filter(Boolean);
 
     if (fragmentsSpreadUsages.length) {
-      if (this._config.inlineFragmentTypes === 'combine') {
+      if (this._config.inlineFragmentTypes === 'combine' || this._config.combineFragmentNames.length > 0) {
         fields.push(...fragmentsSpreadUsages);
       } else if (this._config.inlineFragmentTypes === 'mask') {
         fields.push(

--- a/website/public/config.schema.json
+++ b/website/public/config.schema.json
@@ -651,8 +651,21 @@
           "description": "Whether fragment types should be inlined into other operations.\n\"inline\" is the default behavior and will perform deep inlining fragment types within operation type definitions.\n\"combine\" is the previous behavior that uses fragment type references without inlining the types (and might cause issues with deeply nested fragment that uses list types).\nDefault value: \"inline\"",
           "type": "string"
         },
+        "combineFragmentNames": {
+          "description": "List of fragment names that should combined into other operations.\nThis option is only relevant when `inlineFragmentTypes` is set to `inline`.\nDefault value: \"\"",
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "emitLegacyCommonJSImports": {
           "description": "Emit legacy common js imports.\nDefault it will be `true` this way it ensure that generated code works with [non-compliant bundlers](https://github.com/dotansimha/graphql-code-generator/issues/8065).\nDefault value: \"true\"",
+          "type": "boolean"
+        },
+        "extractAllFieldsToTypes": {
+          "description": "Extract all field types to their own types, instead of inlining them.\nThis helps to reduce type duplication, and makes type errors more readable.\nIt can also significantly reduce the size of the generated code, the generation time,\nand the typechecking time.\nDefault value: \"false\"",
+          "type": "boolean"
+        },
+        "printFieldsOnNewLines": {
+          "description": "If you prefer to have each field in generated types printed on a new line, set this to true.\nThis can be useful for improving readability of the resulting types,\nwithout resorting to running tools like Prettier on the output.\nDefault value: \"false\"",
           "type": "boolean"
         }
       }
@@ -827,8 +840,21 @@
           "description": "Whether fragment types should be inlined into other operations.\n\"inline\" is the default behavior and will perform deep inlining fragment types within operation type definitions.\n\"combine\" is the previous behavior that uses fragment type references without inlining the types (and might cause issues with deeply nested fragment that uses list types).\nDefault value: \"inline\"",
           "type": "string"
         },
+        "combineFragmentNames": {
+          "description": "List of fragment names that should combined into other operations.\nThis option is only relevant when `inlineFragmentTypes` is set to `inline`.\nDefault value: \"\"",
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "emitLegacyCommonJSImports": {
           "description": "Emit legacy common js imports.\nDefault it will be `true` this way it ensure that generated code works with [non-compliant bundlers](https://github.com/dotansimha/graphql-code-generator/issues/8065).\nDefault value: \"true\"",
+          "type": "boolean"
+        },
+        "extractAllFieldsToTypes": {
+          "description": "Extract all field types to their own types, instead of inlining them.\nThis helps to reduce type duplication, and makes type errors more readable.\nIt can also significantly reduce the size of the generated code, the generation time,\nand the typechecking time.\nDefault value: \"false\"",
+          "type": "boolean"
+        },
+        "printFieldsOnNewLines": {
+          "description": "If you prefer to have each field in generated types printed on a new line, set this to true.\nThis can be useful for improving readability of the resulting types,\nwithout resorting to running tools like Prettier on the output.\nDefault value: \"false\"",
           "type": "boolean"
         }
       }
@@ -1629,8 +1655,21 @@
           "description": "Whether fragment types should be inlined into other operations.\n\"inline\" is the default behavior and will perform deep inlining fragment types within operation type definitions.\n\"combine\" is the previous behavior that uses fragment type references without inlining the types (and might cause issues with deeply nested fragment that uses list types).\nDefault value: \"inline\"",
           "type": "string"
         },
+        "combineFragmentNames": {
+          "description": "List of fragment names that should combined into other operations.\nThis option is only relevant when `inlineFragmentTypes` is set to `inline`.\nDefault value: \"\"",
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "emitLegacyCommonJSImports": {
           "description": "Emit legacy common js imports.\nDefault it will be `true` this way it ensure that generated code works with [non-compliant bundlers](https://github.com/dotansimha/graphql-code-generator/issues/8065).\nDefault value: \"true\"",
+          "type": "boolean"
+        },
+        "extractAllFieldsToTypes": {
+          "description": "Extract all field types to their own types, instead of inlining them.\nThis helps to reduce type duplication, and makes type errors more readable.\nIt can also significantly reduce the size of the generated code, the generation time,\nand the typechecking time.\nDefault value: \"false\"",
+          "type": "boolean"
+        },
+        "printFieldsOnNewLines": {
+          "description": "If you prefer to have each field in generated types printed on a new line, set this to true.\nThis can be useful for improving readability of the resulting types,\nwithout resorting to running tools like Prettier on the output.\nDefault value: \"false\"",
           "type": "boolean"
         }
       }
@@ -2697,7 +2736,7 @@
           "description": "Declares how DocumentNode are created:\n\n- `graphQLTag`: `graphql-tag` or other modules (check `gqlImport`) will be used to generate document nodes. If this is used, document nodes are generated on client side i.e. the module used to generate this will be shipped to the client\n- `documentNode`: document nodes will be generated as objects when we generate the templates.\n- `documentNodeImportFragments`: Similar to documentNode except it imports external fragments instead of embedding them.\n- `external`: document nodes are imported from an external file. To be used with `importDocumentNodeExternallyFrom`\n\nNote that some plugins (like `typescript-graphql-request`) also supports `string` for this parameter.\nDefault value: \"graphQLTag\""
         },
         "optimizeDocumentNode": {
-          "description": "If you are using `documentNode: documentMode | documentNodeImportFragments`, you can set this to `true` to apply document optimizations for your GraphQL document.\nThis will remove all \"loc\" and \"description\" fields from the compiled document, and will remove all empty arrays (such as `directives`, `arguments` and `variableDefinitions`).\nDefault value: \"true\"",
+          "description": "If you are using `documentMode: documentNode | documentNodeImportFragments`, you can set this to `true` to apply document optimizations for your GraphQL document.\nThis will remove all \"loc\" and \"description\" fields from the compiled document, and will remove all empty arrays (such as `directives`, `arguments` and `variableDefinitions`).\nDefault value: \"true\"",
           "type": "boolean"
         },
         "importOperationTypesFrom": {
@@ -2750,8 +2789,21 @@
           "description": "Whether fragment types should be inlined into other operations.\n\"inline\" is the default behavior and will perform deep inlining fragment types within operation type definitions.\n\"combine\" is the previous behavior that uses fragment type references without inlining the types (and might cause issues with deeply nested fragment that uses list types).\nDefault value: \"inline\"",
           "type": "string"
         },
+        "combineFragmentNames": {
+          "description": "List of fragment names that should combined into other operations.\nThis option is only relevant when `inlineFragmentTypes` is set to `inline`.\nDefault value: \"\"",
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "emitLegacyCommonJSImports": {
           "description": "Emit legacy common js imports.\nDefault it will be `true` this way it ensure that generated code works with [non-compliant bundlers](https://github.com/dotansimha/graphql-code-generator/issues/8065).\nDefault value: \"true\"",
+          "type": "boolean"
+        },
+        "extractAllFieldsToTypes": {
+          "description": "Extract all field types to their own types, instead of inlining them.\nThis helps to reduce type duplication, and makes type errors more readable.\nIt can also significantly reduce the size of the generated code, the generation time,\nand the typechecking time.\nDefault value: \"false\"",
+          "type": "boolean"
+        },
+        "printFieldsOnNewLines": {
+          "description": "If you prefer to have each field in generated types printed on a new line, set this to true.\nThis can be useful for improving readability of the resulting types,\nwithout resorting to running tools like Prettier on the output.\nDefault value: \"false\"",
           "type": "boolean"
         }
       }


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

The default 'inline' behavior for `inlineFragmentTypes` causes our project generated file to reach 12M
After some testing, 'combine' wasn't the right option for us either.
We really preferred 'inline' however we had 1 or 2 HUGE fragments used everywhere.
By not inlining those few fragments we could bring down the resulting generated file to ~3.5M 
We've been working with a patch of the package for years now and I thought it be time to contribute back upstream in case others hit a similar issue.


<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Been running this in production for years now.
Wrote a unit test to show the usage.

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I initially wanted to extend the type of `inlineFragmentTypes` to either `'inline' | 'combine' | 'mask' | string[]` or `'inline' | 'combine' | 'mask' | { type: 'inline', except?: string[] }`
These types are confusing and "hard-ish" to describe in json schema.
So I decided to make a new option instead with a runtime validation since I believe this option is broken when `inlineFragmentTypes = 'mask'`
