### PR TITLE
fix: nullable filepath config

### DIFF
--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -346,7 +346,7 @@ export class CodegenContext {
   private _pluginContext: { [key: string]: any } = {};
 
   cwd: string;
-  filepath: string;
+  filepath?: string;
   profiler: Profiler;
   profilerOutput?: string;
   checkModeStaleFiles = [];

--- a/packages/graphql-codegen-cli/src/utils/patterns.ts
+++ b/packages/graphql-codegen-cli/src/utils/patterns.ts
@@ -119,7 +119,7 @@ export const makeGlobalPatternSet = (initialContext: CodegenContext) => {
   return {
     watch: sortPatterns([
       ...(typeof config.watch === 'boolean' ? [] : normalizeInstanceOrArray<string>(config.watch ?? [])),
-      relative(process.cwd(), initialContext.filepath),
+      ...(initialContext.filepath ? [relative(process.cwd(), initialContext.filepath)] : []),
     ]),
     schemas: sortPatterns(makePatternsFromSchemas(normalizeInstanceOrArray<Types.Schema>(config.schema))),
     documents: sortPatterns(


### PR DESCRIPTION
## Description

Filepath is an optionally provided param that is unnecessarily mandatory when the CLI is set to watch mode. This change reflects that in the typing and it's usage when setting watch patterns. This has been a problem since 4.x.

Related # (issue)
See https://github.com/dotansimha/graphql-code-generator/issues/9490

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not sure the easiest way to go about testing this locally. If I modify the node_module code to drop this reference to filepath, it works as expected. 

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I'm open to alternatives here. I also wonder if the `process.cwd()` that's used when filepath is provided should instead use the context's cwd. It's confusing to provide a param to override to cwd but then have it ignored. That change would definitely be breaking though, so I'm not inclined to lump it into this PR.