### PR TITLE
fix(client-preset): forward `skipTypeNameForRoot` option

### DIFF
--- a/.changeset/slimy-years-behave.md
+++ b/.changeset/slimy-years-behave.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-codegen/client-preset': patch
+'@graphql-codegen/client-preset': minor
 ---
 
 foward skipTypeNameForRoot to client-preset

--- a/.changeset/slimy-years-behave.md
+++ b/.changeset/slimy-years-behave.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/client-preset': patch
+---
+
+foward skipTypeNameForRoot to client-preset

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -132,6 +132,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       nonOptionalTypename: options.config.nonOptionalTypename,
       avoidOptionals: options.config.avoidOptionals,
       documentMode: options.config.documentMode,
+      skipTypeNameForRoot: options.config.skipTypeNameForRoot,
     };
 
     const visitor = new ClientSideBaseVisitor(options.schemaAst!, [], options.config, options.config);


### PR DESCRIPTION
## Description

Forwarded `typescript-operations`'s `skipTypeNameForRoot` option to `client-preset`

Related #10135

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Ran local test `yarn test-and-build`
- [x] Tried in my project adding this line will generate types without root type name like `__typename: 'Query'`

**Test Environment**:

- OS: macOS 14.6.1
- NodeJS: 20.15.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

