### PR TITLE
[resolvers] Add `generateInternalResolversIfNeeded.__isTypeOf`

### DIFF
--- a/.changeset/fifty-dodos-marry.md
+++ b/.changeset/fifty-dodos-marry.md
@@ -7,5 +7,3 @@
 Add `generateInternalResolversIfNeeded` option
 
 This option can be used to generate more correct types for internal resolvers. For example, only generate `__resolveReference` if the federation object has a resolvable `@key`.
-
-In the future, this option can be extended to support other internal resolvers e.g. `__isTypeOf` is only generated for implementing types and union members.

--- a/.changeset/pink-rice-attack.md
+++ b/.changeset/pink-rice-attack.md
@@ -1,0 +1,9 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-resolvers': minor
+'@graphql-codegen/plugin-helpers': minor
+---
+
+Implement `generateInternalResolversIfNeeded.__isTypeOf` option
+
+When set to `true`, `__isTypeOf` resolver will only be generated for implementing types and union members.

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -394,7 +394,6 @@ export interface RawResolversConfig extends RawConfig {
    *        plugins: ['typescript', 'typescript-resolver', { add: { content: "import { DeepPartial } from 'utility-types';" } }],
    *        config: {
    *          defaultMapper: 'DeepPartial<{T}>',
-   *          avoidCheckingAbstractTypesRecursively: true // required if you have complex nested abstract types
    *        },
    *      },
    *    },

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -394,6 +394,7 @@ export interface RawResolversConfig extends RawConfig {
    *        plugins: ['typescript', 'typescript-resolver', { add: { content: "import { DeepPartial } from 'utility-types';" } }],
    *        config: {
    *          defaultMapper: 'DeepPartial<{T}>',
+   *          avoidCheckingAbstractTypesRecursively: true // required if you have complex nested abstract types
    *        },
    *      },
    *    },

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -130,5 +130,6 @@ export interface ResolversNonOptionalTypenameConfig {
 
 export interface GenerateInternalResolversIfNeededConfig {
   __resolveReference?: boolean;
+  __isTypeOf?: boolean;
 }
 export type NormalizedGenerateInternalResolversIfNeededConfig = Required<GenerateInternalResolversIfNeededConfig>;

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.interface.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.interface.spec.ts
@@ -406,4 +406,102 @@ describe('TypeScript Resolvers Plugin - Interfaces', () => {
       };
     `);
   });
+
+  it('if generateInternalResolversIfNeeded.__isTypeOf = false (default), generates __isTypeOf for all object types', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      interface Node {
+        id: ID!
+      }
+
+      type Cat implements Node {
+        id: ID!
+        name: String!
+      }
+
+      type Dog implements Node {
+        id: ID!
+        isGoodBoy: Boolean!
+      }
+
+      type Human {
+        _id: ID!
+      }
+    `);
+
+    const result = await plugin(schema, [], {}, { outputFile: '' });
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type CatResolvers<ContextType = any, ParentType extends ResolversParentTypes['Cat'] = ResolversParentTypes['Cat']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      }
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type DogResolvers<ContextType = any, ParentType extends ResolversParentTypes['Dog'] = ResolversParentTypes['Dog']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        isGoodBoy?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type HumanResolvers<ContextType = any, ParentType extends ResolversParentTypes['Human'] = ResolversParentTypes['Human']> = {
+        _id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+  });
+
+  it('if generateInternalResolversIfNeeded.__isTypeOf = true, generates __isTypeOf for only implementing object types', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      interface Node {
+        id: ID!
+      }
+
+      type Cat implements Node {
+        id: ID!
+        name: String!
+      }
+
+      type Dog implements Node {
+        id: ID!
+        isGoodBoy: Boolean!
+      }
+
+      type Human {
+        _id: ID!
+      }
+    `);
+
+    const result = await plugin(
+      schema,
+      [],
+      { generateInternalResolversIfNeeded: { __isTypeOf: true } },
+      { outputFile: '' }
+    );
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type CatResolvers<ContextType = any, ParentType extends ResolversParentTypes['Cat'] = ResolversParentTypes['Cat']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      }
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type DogResolvers<ContextType = any, ParentType extends ResolversParentTypes['Dog'] = ResolversParentTypes['Dog']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        isGoodBoy?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type HumanResolvers<ContextType = any, ParentType extends ResolversParentTypes['Human'] = ResolversParentTypes['Human']> = {
+        _id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+      };
+    `);
+  });
 });

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.union.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.union.spec.ts
@@ -94,4 +94,118 @@ describe('TypeScript Resolvers Plugin - Union', () => {
     expect(content.content).not.toBeSimilarStringTo(`export type ResolversUnionTypes`);
     expect(content.content).not.toBeSimilarStringTo(`export type ResolversUnionParentTypes`);
   });
+
+  it('if generateInternalResolversIfNeeded.__isTypeOf = false (default), generates __isTypeOf for all object types', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type MemberOne {
+        id: ID!
+      }
+
+      type MemberTwo {
+        id: ID!
+        name: String!
+      }
+
+      type MemberThree {
+        id: ID!
+        isMember: Boolean!
+      }
+
+      type Normal {
+        id: ID!
+      }
+    `);
+
+    const result = await plugin(schema, [], {}, { outputFile: '' });
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MemberOneResolvers<ContextType = any, ParentType extends ResolversParentTypes['MemberOne'] = ResolversParentTypes['MemberOne']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      }
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MemberTwoResolvers<ContextType = any, ParentType extends ResolversParentTypes['MemberTwo'] = ResolversParentTypes['MemberTwo']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MemberThreeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MemberThree'] = ResolversParentTypes['MemberThree']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        isMember?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type NormalResolvers<ContextType = any, ParentType extends ResolversParentTypes['Normal'] = ResolversParentTypes['Normal']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+  });
+
+  it('if generateInternalResolversIfNeeded.__isTypeOf = true, generates __isTypeOf for only union members', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type MemberOne {
+        id: ID!
+      }
+
+      type MemberTwo {
+        id: ID!
+        name: String!
+      }
+
+      type MemberThree {
+        id: ID!
+        isMember: Boolean!
+      }
+
+      union Union = MemberOne | MemberTwo | MemberThree
+
+      type Normal {
+        id: ID!
+      }
+    `);
+
+    const result = await plugin(
+      schema,
+      [],
+      { generateInternalResolversIfNeeded: { __isTypeOf: true } },
+      { outputFile: '' }
+    );
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MemberOneResolvers<ContextType = any, ParentType extends ResolversParentTypes['MemberOne'] = ResolversParentTypes['MemberOne']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      }
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MemberTwoResolvers<ContextType = any, ParentType extends ResolversParentTypes['MemberTwo'] = ResolversParentTypes['MemberTwo']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MemberThreeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MemberThree'] = ResolversParentTypes['MemberThree']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        isMember?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type NormalResolvers<ContextType = any, ParentType extends ResolversParentTypes['Normal'] = ResolversParentTypes['Normal']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+      };
+    `);
+  });
 });


### PR DESCRIPTION
## Description

This PR compliments https://github.com/dotansimha/graphql-code-generator/pull/9989 and should be merged after.
Previously, we always generate `__isTypeOf` type which means consumers may try to implement it, even when they don't have to.
This PR adds `generateInternalResolversIfNeeded.__isTypeOf` to conditionally generate this resolver only for implementing types or union members

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit test