### PR TITLE
Passthrough `onlyOperationTypes` and `onlyEnumTypes` in client-preset

### DIFF
--- a/.changeset/swift-wasps-beam.md
+++ b/.changeset/swift-wasps-beam.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/client-preset': minor
+---
+
+client-preset generated output is configurable with onlyOperationTypes and onlyEnumTypes

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -133,6 +133,8 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       avoidOptionals: options.config.avoidOptionals,
       documentMode: options.config.documentMode,
       skipTypeNameForRoot: options.config.skipTypeNameForRoot,
+      onlyOperationTypes: options.config.onlyOperationTypes,
+      onlyEnumTypes: options.config.onlyEnumTypes,
     };
 
     const visitor = new ClientSideBaseVisitor(options.schemaAst!, [], options.config, options.config);


### PR DESCRIPTION
## Description

Passes through the `onlyOperationTypes` and `onlyEnumTypes` config options for the client preset.

`onlyOperationTypes` defaults to `false` however it would be useful focusing type generation on just the operations, reducing bundle size and developer error (a frequent one for us, building dependency on the wrong types).

As discussed in https://github.com/dotansimha/graphql-code-generator/discussions/8693

## Type of change

New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
