### PR TITLE
feat(plugin/typescript-resolvers): Add allowSemanticNonNull option

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1401,6 +1401,10 @@ export class BaseResolversVisitor<
     return `ParentType extends ${parentType} = ${parentType}`;
   }
 
+  protected tranceformSemanticNonNull(type: string): string {
+    return type;
+  }
+
   FieldDefinition(node: FieldDefinitionNode, key: string | number, parent: any): FieldDefinitionPrintFn {
     const hasArguments = node.arguments && node.arguments.length > 0;
     const declarationKind = 'type';
@@ -1457,7 +1461,13 @@ export class BaseResolversVisitor<
         parentType,
         parentTypeSignature: this.getParentTypeForSignature(node),
       });
-      const mappedTypeKey = isSubscriptionType ? `${mappedType}, "${node.name}"` : mappedType;
+
+      const isSemanticNonNull = node.directives.find(directive => (directive.name as any) === 'semanticNonNull');
+      const mappedTypeKey = isSubscriptionType
+        ? `${mappedType}, "${node.name}"`
+        : isSemanticNonNull
+        ? this.tranceformSemanticNonNull(mappedType)
+        : mappedType;
 
       const directiveMappings =
         node.directives

--- a/packages/plugins/typescript/resolvers/src/config.ts
+++ b/packages/plugins/typescript/resolvers/src/config.ts
@@ -250,4 +250,26 @@ export interface TypeScriptResolversPluginConfig extends RawResolversConfig {
    * ```
    */
   makeResolverTypeCallable?: boolean;
+  /**
+   * @description If set to `true`, field resolvers annotated by `@semanticNonNull` directive get prohibited to return nullish value
+   *
+   * @exampleMarkdown
+   * ```ts filename="codegen.ts"
+   *  import type { CodegenConfig } from '@graphql-codegen/cli';
+   *
+   *  const config: CodegenConfig = {
+   *    // ...
+   *    generates: {
+   *      'path/to/file.ts': {
+   *        plugins: ['typescript', 'typescript-resolvers'],
+   *        config: {
+   *          allowSemanticNonNull: true
+   *        },
+   *      },
+   *    },
+   *  };
+   *  export default config;
+   * ```
+   */
+  allowSemanticNonNull?: boolean;
 }

--- a/packages/plugins/typescript/resolvers/src/visitor.ts
+++ b/packages/plugins/typescript/resolvers/src/visitor.ts
@@ -25,6 +25,7 @@ export interface ParsedTypeScriptResolversConfig extends ParsedResolversConfig {
   wrapFieldDefinitions: boolean;
   allowParentTypeOverride: boolean;
   optionalInfoArgument: boolean;
+  allowSemanticNonNull: boolean;
 }
 
 export class TypeScriptResolversVisitor extends BaseResolversVisitor<
@@ -40,6 +41,7 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<
         wrapFieldDefinitions: getConfigValue(pluginConfig.wrapFieldDefinitions, false),
         allowParentTypeOverride: getConfigValue(pluginConfig.allowParentTypeOverride, false),
         optionalInfoArgument: getConfigValue(pluginConfig.optionalInfoArgument, false),
+        allowSemanticNonNull: getConfigValue(pluginConfig.allowSemanticNonNull, false),
       } as ParsedTypeScriptResolversConfig,
       schema
     );
@@ -73,6 +75,13 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<
     }
 
     return `ParentType extends ${parentType} = ${parentType}`;
+  }
+
+  protected tranceformSemanticNonNull(type: string): string {
+    if (this.config.allowSemanticNonNull) {
+      return this.clearOptional(super.tranceformSemanticNonNull(type));
+    }
+    return super.tranceformSemanticNonNull(type);
   }
 
   protected formatRootResolver(schemaTypeName: string, resolverType: string, declarationKind: DeclarationKind): string {


### PR DESCRIPTION
## Description

Related #10151 .

Added a new option for plugin/typescript-resolvers, `allowSemanticNonNull`.

Several GraphQL frameworks work with `@semanticNonNull` schema directive:

- https://relay.dev/docs/guides/semantic-nullability/#proposed-solution
- https://www.apollographql.com/docs/kotlin/advanced/nullability/#semanticnonnull

If `allowSemanticNonNull` option is set to `true`, field resolver annotated by `@semanticNonNull` gets prohibited to return nullish.

For example:

```gql
type User {
  name: String @semanticNonNull
}
```

The above schema and `allowSemanticNonNull: true` generates the following resolver type:

```ts
export type UserResolvers<ContextType = BaseContext, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
};
```

```ts
import type { UserResolvers } from "./_gql_gen_generated_/"

export const User = {
  name:  () => {
    // @ts-expect-error
    return null;
  }
} satisfies UserResolvers
```


<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Testing

**Test Environment**:

- OS: macos Sonoma
- NodeJS: v20.14.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
