### PR TITLE
Add |undefined in the TypedDocumentString constructor to make it work with --isolatedDeclarations

### DIFF
--- a/.changeset/twenty-spiders-sell.md
+++ b/.changeset/twenty-spiders-sell.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/typed-document-node': patch
 ---
 
-Improve compatibility with tsc --isolatedDeclarations
+Allow explicit `undefined` in additional to optional arguments

--- a/.changeset/twenty-spiders-sell.md
+++ b/.changeset/twenty-spiders-sell.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typed-document-node': patch
+---
+
+Improve compatibility with tsc --isolatedDeclarations

--- a/examples/persisted-documents-string-mode/src/gql/graphql.ts
+++ b/examples/persisted-documents-string-mode/src/gql/graphql.ts
@@ -26,7 +26,7 @@ export class TypedDocumentString<TResult, TVariables>
 {
   __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
 
-  constructor(private value: string, public __meta__?: Record<string, any>) {
+  constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
     super(value);
   }
 

--- a/examples/react/tanstack-react-query/src/gql/graphql.ts
+++ b/examples/react/tanstack-react-query/src/gql/graphql.ts
@@ -45,7 +45,7 @@ export class TypedDocumentString<TResult, TVariables>
 {
   __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
 
-  constructor(private value: string, public __meta__?: Record<string, any>) {
+  constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
     super(value);
   }
 

--- a/examples/react/urql/src/gql/graphql.ts
+++ b/examples/react/urql/src/gql/graphql.ts
@@ -45,7 +45,7 @@ export class TypedDocumentString<TResult, TVariables>
 {
   __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
 
-  constructor(private value: string, public __meta__?: Record<string, any>) {
+  constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
     super(value);
   }
 

--- a/examples/typescript-graphql-request/src/gql/graphql.ts
+++ b/examples/typescript-graphql-request/src/gql/graphql.ts
@@ -58,7 +58,7 @@ export class TypedDocumentString<TResult, TVariables>
 {
   __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
 
-  constructor(private value: string, public __meta__?: Record<string, any>) {
+  constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
     super(value);
   }
 

--- a/packages/plugins/typescript/typed-document-node/src/index.ts
+++ b/packages/plugins/typescript/typed-document-node/src/index.ts
@@ -43,7 +43,7 @@ export class TypedDocumentString<TResult, TVariables>
 {
   __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
 
-  constructor(private value: string, public __meta__?: Record<string, any>) {
+  constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
     super(value);
   }
 

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -2209,7 +2209,7 @@ export * from "./gql.js";`);
         {
           __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
 
-          constructor(private value: string, public __meta__?: Record<string, any>) {
+          constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
             super(value);
           }
 
@@ -2338,7 +2338,7 @@ export * from "./gql.js";`);
         {
           __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
 
-          constructor(private value: string, public __meta__?: Record<string, any>) {
+          constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
             super(value);
           }
 
@@ -2463,7 +2463,7 @@ export * from "./gql.js";`);
         {
           __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
 
-          constructor(private value: string, public __meta__?: Record<string, any>) {
+          constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
             super(value);
           }
 
@@ -2727,7 +2727,7 @@ export * from "./gql.js";`);
         {
           __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
 
-          constructor(private value: string, public __meta__?: Record<string, any>) {
+          constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
             super(value);
           }
 


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

(Sorry, this seemed simple enough that the discussion may as well happen here. Feel free to reject it if this is the wrong fix or you don't want to support [--isolatedDeclarations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#isolated-declarations).)

## Description

Without this, building the generated types into a project that uses --isolatedDeclarations fails with

> Declaration emit for this parameter requires implicitly adding undefined to it's type. This is not supported with --isolatedDeclarations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- yarn build && yarn test
- Manually made this change in the generated code in my project and checked that it fixed the error.

I haven't rebuilt my code with the updated library to make sure that this change makes the change I expect to the generated code.

**Test Environment**:

- OS: https://en.wikipedia.org/wiki/GLinux
- "@graphql-codegen/client-preset": "^4.3.3",
- "@graphql-codegen/typescript": "^4.0.9",
- "@graphql-codegen/typescript-document-nodes": "^4.0.9",
- "typescript": "^5.6.2"
- NodeJS: 22

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
