### PR TITLE
Have gql-tag-operations generate the type for document registry

### DIFF
--- a/.changeset/olive-geckos-relax.md
+++ b/.changeset/olive-geckos-relax.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/gql-tag-operations": patch
+---
+
+Have gql-tag-operations generate the type for document registry

--- a/dev-test/gql-tag-operations-masking/gql/gql.ts
+++ b/dev-test/gql-tag-operations-masking/gql/gql.ts
@@ -13,7 +13,13 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  fragment TweetFragment on Tweet {\n    id\n    body\n    ...TweetAuthorFragment\n  }\n': typeof types.TweetFragmentFragmentDoc;
+  '\n  fragment TweetAuthorFragment on Tweet {\n    id\n    author {\n      id\n      username\n    }\n  }\n': typeof types.TweetAuthorFragmentFragmentDoc;
+  '\n  fragment TweetsFragment on Query {\n    Tweets {\n      id\n      ...TweetFragment\n    }\n  }\n': typeof types.TweetsFragmentFragmentDoc;
+  '\n  query TweetAppQuery {\n    ...TweetsFragment\n  }\n': typeof types.TweetAppQueryDocument;
+};
+const documents: Documents = {
   '\n  fragment TweetFragment on Tweet {\n    id\n    body\n    ...TweetAuthorFragment\n  }\n':
     types.TweetFragmentFragmentDoc,
   '\n  fragment TweetAuthorFragment on Tweet {\n    id\n    author {\n      id\n      username\n    }\n  }\n':

--- a/dev-test/gql-tag-operations-urql/gql/gql.ts
+++ b/dev-test/gql-tag-operations-urql/gql/gql.ts
@@ -13,7 +13,12 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n': typeof types.FooDocument;
+  '\n  fragment Lel on Tweet {\n    id\n    body\n  }\n': typeof types.LelFragmentDoc;
+  '\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n': typeof types.BarDocument;
+};
+const documents: Documents = {
   '\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n': types.FooDocument,
   '\n  fragment Lel on Tweet {\n    id\n    body\n  }\n': types.LelFragmentDoc,
   '\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n': types.BarDocument,

--- a/dev-test/gql-tag-operations/gql/gql.ts
+++ b/dev-test/gql-tag-operations/gql/gql.ts
@@ -13,7 +13,12 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n': typeof types.FooDocument;
+  '\n  fragment Lel on Tweet {\n    id\n    body\n  }\n': typeof types.LelFragmentDoc;
+  '\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n': typeof types.BarDocument;
+};
+const documents: Documents = {
   '\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n': types.FooDocument,
   '\n  fragment Lel on Tweet {\n    id\n    body\n  }\n': types.LelFragmentDoc,
   '\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n': types.BarDocument,

--- a/dev-test/gql-tag-operations/graphql/gql.ts
+++ b/dev-test/gql-tag-operations/graphql/gql.ts
@@ -13,7 +13,12 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n': typeof types.FooDocument;
+  '\n  fragment Lel on Tweet {\n    id\n    body\n  }\n': typeof types.LelFragmentDoc;
+  '\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n': typeof types.BarDocument;
+};
+const documents: Documents = {
   '\n  query Foo {\n    Tweets {\n      id\n    }\n  }\n': types.FooDocument,
   '\n  fragment Lel on Tweet {\n    id\n    body\n  }\n': types.LelFragmentDoc,
   '\n  query Bar {\n    Tweets {\n      ...Lel\n    }\n  }\n': types.BarDocument,

--- a/examples/persisted-documents-string-mode/src/gql/gql.ts
+++ b/examples/persisted-documents-string-mode/src/gql/gql.ts
@@ -12,7 +12,10 @@ import * as types from './graphql';
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query HelloQuery {\n    hello\n  }\n': typeof types.HelloQueryDocument;
+};
+const documents: Documents = {
   '\n  query HelloQuery {\n    hello\n  }\n': types.HelloQueryDocument,
 };
 

--- a/examples/persisted-documents/src/gql/gql.ts
+++ b/examples/persisted-documents/src/gql/gql.ts
@@ -13,7 +13,10 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query HelloQuery {\n    hello\n  }\n': typeof types.HelloQueryDocument;
+};
+const documents: Documents = {
   '\n  query HelloQuery {\n    hello\n  }\n': types.HelloQueryDocument,
 };
 

--- a/examples/react/apollo-client-defer/src/gql/gql.ts
+++ b/examples/react/apollo-client-defer/src/gql/gql.ts
@@ -13,7 +13,11 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  fragment SlowFieldFragment on Query {\n    slowField(waitFor: 5000)\n  }\n': typeof types.SlowFieldFragmentFragmentDoc;
+  '\n  query SlowAndFastFieldWithDefer {\n    fastField\n    ...SlowFieldFragment @defer\n\n    ... @defer {\n      inlinedSlowField: slowField(waitFor: 5000)\n    }\n  }\n': typeof types.SlowAndFastFieldWithDeferDocument;
+};
+const documents: Documents = {
   '\n  fragment SlowFieldFragment on Query {\n    slowField(waitFor: 5000)\n  }\n': types.SlowFieldFragmentFragmentDoc,
   '\n  query SlowAndFastFieldWithDefer {\n    fastField\n    ...SlowFieldFragment @defer\n\n    ... @defer {\n      inlinedSlowField: slowField(waitFor: 5000)\n    }\n  }\n':
     types.SlowAndFastFieldWithDeferDocument,

--- a/examples/react/apollo-client-swc-plugin/src/gql/gql.ts
+++ b/examples/react/apollo-client-swc-plugin/src/gql/gql.ts
@@ -13,7 +13,11 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n': typeof types.AllFilmsWithVariablesQueryDocument;
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+};
+const documents: Documents = {
   '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n':
     types.AllFilmsWithVariablesQueryDocument,
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':

--- a/examples/react/apollo-client/src/gql/gql.ts
+++ b/examples/react/apollo-client/src/gql/gql.ts
@@ -13,7 +13,11 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n': typeof types.AllFilmsWithVariablesQueryDocument;
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+};
+const documents: Documents = {
   '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n':
     types.AllFilmsWithVariablesQueryDocument,
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':

--- a/examples/react/http-executor/src/gql/gql.ts
+++ b/examples/react/http-executor/src/gql/gql.ts
@@ -13,7 +13,11 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n': typeof types.AllFilmsWithVariablesQueryDocument;
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+};
+const documents: Documents = {
   '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n':
     types.AllFilmsWithVariablesQueryDocument,
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':

--- a/examples/react/nextjs-swr/gql/gql.ts
+++ b/examples/react/nextjs-swr/gql/gql.ts
@@ -13,7 +13,11 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+  '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n': typeof types.AllFilmsWithVariablesQueryDocument;
+};
+const documents: Documents = {
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':
     types.FilmItemFragmentDoc,
   '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n':

--- a/examples/react/tanstack-react-query/src/gql/gql.ts
+++ b/examples/react/tanstack-react-query/src/gql/gql.ts
@@ -12,7 +12,11 @@ import * as types from './graphql';
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n': typeof types.AllFilmsWithVariablesQueryDocument;
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+};
+const documents: Documents = {
   '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n':
     types.AllFilmsWithVariablesQueryDocument,
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':

--- a/examples/react/urql/src/gql/gql.ts
+++ b/examples/react/urql/src/gql/gql.ts
@@ -12,7 +12,11 @@ import * as types from './graphql';
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query allFilmsWithVariablesQuery199($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n': typeof types.AllFilmsWithVariablesQuery199Document;
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+};
+const documents: Documents = {
   '\n  query allFilmsWithVariablesQuery199($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n':
     types.AllFilmsWithVariablesQuery199Document,
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':

--- a/examples/typescript-esm/src/gql/gql.ts
+++ b/examples/typescript-esm/src/gql/gql.ts
@@ -13,7 +13,11 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query AllPeopleQuery {\n    allPeople(first: 5) {\n      edges {\n        node {\n          name\n          homeworld {\n            name\n          }\n        }\n      }\n    }\n  }\n': typeof types.AllPeopleQueryDocument;
+  '\n  query AllPeopleWithVariablesQuery($first: Int!) {\n    allPeople(first: $first) {\n      edges {\n        node {\n          name\n          homeworld {\n            name\n          }\n        }\n      }\n    }\n  }\n': typeof types.AllPeopleWithVariablesQueryDocument;
+};
+const documents: Documents = {
   '\n  query AllPeopleQuery {\n    allPeople(first: 5) {\n      edges {\n        node {\n          name\n          homeworld {\n            name\n          }\n        }\n      }\n    }\n  }\n':
     types.AllPeopleQueryDocument,
   '\n  query AllPeopleWithVariablesQuery($first: Int!) {\n    allPeople(first: $first) {\n      edges {\n        node {\n          name\n          homeworld {\n            name\n          }\n        }\n      }\n    }\n  }\n':

--- a/examples/typescript-graphql-request/src/gql/gql.ts
+++ b/examples/typescript-graphql-request/src/gql/gql.ts
@@ -12,7 +12,11 @@ import * as types from './graphql';
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query AllPeopleQuery {\n    allPeople(first: 5) {\n      edges {\n        node {\n          name\n          homeworld {\n            name\n          }\n        }\n      }\n    }\n  }\n': typeof types.AllPeopleQueryDocument;
+  '\n  query AllPeopleWithVariablesQuery($first: Int!) {\n    allPeople(first: $first) {\n      edges {\n        node {\n          name\n          homeworld {\n            name\n          }\n        }\n      }\n    }\n  }\n': typeof types.AllPeopleWithVariablesQueryDocument;
+};
+const documents: Documents = {
   '\n  query AllPeopleQuery {\n    allPeople(first: 5) {\n      edges {\n        node {\n          name\n          homeworld {\n            name\n          }\n        }\n      }\n    }\n  }\n':
     types.AllPeopleQueryDocument,
   '\n  query AllPeopleWithVariablesQuery($first: Int!) {\n    allPeople(first: $first) {\n      edges {\n        node {\n          name\n          homeworld {\n            name\n          }\n        }\n      }\n    }\n  }\n':

--- a/examples/vite/vite-react-cts/src/gql/gql.ts
+++ b/examples/vite/vite-react-cts/src/gql/gql.ts
@@ -13,7 +13,11 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+  '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n': typeof types.AllFilmsWithVariablesQueryDocument;
+};
+const documents: Documents = {
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':
     types.FilmItemFragmentDoc,
   '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n':

--- a/examples/vite/vite-react-mts/src/gql/gql.ts
+++ b/examples/vite/vite-react-mts/src/gql/gql.ts
@@ -13,7 +13,11 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+  '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n': typeof types.AllFilmsWithVariablesQueryDocument;
+};
+const documents: Documents = {
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':
     types.FilmItemFragmentDoc,
   '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n':

--- a/examples/vite/vite-react-ts/src/gql/gql.ts
+++ b/examples/vite/vite-react-ts/src/gql/gql.ts
@@ -13,7 +13,11 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+  '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n': typeof types.AllFilmsWithVariablesQueryDocument;
+};
+const documents: Documents = {
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':
     types.FilmItemFragmentDoc,
   '\n  query allFilmsWithVariablesQuery($first: Int!) {\n    allFilms(first: $first) {\n      edges {\n        node {\n          ...FilmItem\n        }\n      }\n    }\n  }\n':

--- a/examples/vue/apollo-composable/src/gql/gql.ts
+++ b/examples/vue/apollo-composable/src/gql/gql.ts
@@ -13,7 +13,11 @@ import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n    query allFilmsWithVariablesQuery($first: Int!) {\n      allFilms(first: $first) {\n        edges {\n          node {\n            ...FilmItem\n          }\n        }\n      }\n    }\n  ': typeof types.AllFilmsWithVariablesQueryDocument;
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+};
+const documents: Documents = {
   '\n    query allFilmsWithVariablesQuery($first: Int!) {\n      allFilms(first: $first) {\n        edges {\n          node {\n            ...FilmItem\n          }\n        }\n      }\n    }\n  ':
     types.AllFilmsWithVariablesQueryDocument,
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':

--- a/examples/vue/urql/src/gql/gql.ts
+++ b/examples/vue/urql/src/gql/gql.ts
@@ -13,7 +13,11 @@ import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n    query allFilmsWithVariablesQuery($first: Int!) {\n      allFilms(first: $first) {\n        edges {\n          node {\n            ...FilmItem\n          }\n        }\n      }\n    }\n  ': typeof types.AllFilmsWithVariablesQueryDocument;
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+};
+const documents: Documents = {
   '\n    query allFilmsWithVariablesQuery($first: Int!) {\n      allFilms(first: $first) {\n        edges {\n          node {\n            ...FilmItem\n          }\n        }\n      }\n    }\n  ':
     types.AllFilmsWithVariablesQueryDocument,
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':

--- a/examples/vue/villus/src/gql/gql.ts
+++ b/examples/vue/villus/src/gql/gql.ts
@@ -13,7 +13,11 @@ import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n    query allFilmsWithVariablesQuery($first: Int!) {\n      allFilms(first: $first) {\n        edges {\n          node {\n            ...FilmItem\n          }\n        }\n      }\n    }\n  ': typeof types.AllFilmsWithVariablesQueryDocument;
+  '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n': typeof types.FilmItemFragmentDoc;
+};
+const documents: Documents = {
   '\n    query allFilmsWithVariablesQuery($first: Int!) {\n      allFilms(first: $first) {\n        edges {\n          node {\n            ...FilmItem\n          }\n        }\n      }\n    }\n  ':
     types.AllFilmsWithVariablesQueryDocument,
   '\n  fragment FilmItem on Film {\n    id\n    title\n    releaseDate\n    producers\n  }\n':

--- a/examples/yoga-tests/src/gql/gql.ts
+++ b/examples/yoga-tests/src/gql/gql.ts
@@ -13,7 +13,11 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n      query HelloQuery {\n        hello\n      }\n    ': typeof types.HelloQueryDocument;
+  '\n      mutation EchoMutation($message: String!) {\n        echo(message: $message)\n      }\n    ': typeof types.EchoMutationDocument;
+};
+const documents: Documents = {
   '\n      query HelloQuery {\n        hello\n      }\n    ': types.HelloQueryDocument,
   '\n      mutation EchoMutation($message: String!) {\n        echo(message: $message)\n      }\n    ':
     types.EchoMutationDocument,

--- a/packages/plugins/typescript/gql-tag-operations/src/index.ts
+++ b/packages/plugins/typescript/gql-tag-operations/src/index.ts
@@ -143,27 +143,24 @@ function getDocumentRegistryChunk(sourcesWithOperations: Array<SourceWithOperati
   // It's possible for there to be duplicate sourceOperations, this set will ensure we have unique records for our document registry
   const linesDupCheck = new Set<string>();
   lines.push(
-    `/**\n * Map of all GraphQL operations in the project.\n *\n * This map has several performance disadvantages:\n`
+    `/**\n * Map of all GraphQL operations in the project.\n *\n * This map has several performance disadvantages:\n`,
+    ` * 1. It is not tree-shakeable, so it will include all operations in the project.\n`,
+    ` * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.\n`,
+    ` * 3. It does not support dead code elimination, so it will add unused operations.\n *\n`,
+    ` * Therefore it is highly recommended to use the babel or swc plugin for production.\n`,
+    ` * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size\n */\n`,
+    `type Documents = {\n`
   );
-  lines.push(` * 1. It is not tree-shakeable, so it will include all operations in the project.\n`);
-  lines.push(` * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.\n`);
-  lines.push(` * 3. It does not support dead code elimination, so it will add unused operations.\n *\n`);
-  lines.push(` * Therefore it is highly recommended to use the babel or swc plugin for production.\n`);
-  lines.push(
-    ` * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size\n */\n`
-  );
-  lines.push(`type Documents = {\n`);
   for (const { operations, ...rest } of sourcesWithOperations) {
     const originalString = rest.source.rawSDL;
     const operation = operations[0];
     const aboutToPushLine = `    ${JSON.stringify(originalString)}: typeof types.${operation.initialName},\n`;
     if (!linesDupCheck.has(aboutToPushLine)) {
-        lines.push(aboutToPushLine);
-        linesDupCheck.add(aboutToPushLine);
+      lines.push(aboutToPushLine);
+      linesDupCheck.add(aboutToPushLine);
     }
   }
-  lines.push(`};\n`);
-  lines.push(`const documents: Documents = {\n`);
+  lines.push(`};\n`, `const documents: Documents = {\n`);
   for (const { operations, ...rest } of sourcesWithOperations) {
     const originalString = rest.source.rawSDL!;
     const operation = operations[0];

--- a/packages/plugins/typescript/gql-tag-operations/src/index.ts
+++ b/packages/plugins/typescript/gql-tag-operations/src/index.ts
@@ -139,27 +139,42 @@ export const plugin: PluginFunction<{
 };
 
 function getDocumentRegistryChunk(sourcesWithOperations: Array<SourceWithOperations> = []) {
-  const lines = new Set<string>();
-  lines.add(
+  const lines = new Array<string>();
+  // It's possible for there to be duplicate sourceOperations, this set will ensure we have unique records for our document registry
+  const linesDupCheck = new Set<string>();
+  lines.push(
     `/**\n * Map of all GraphQL operations in the project.\n *\n * This map has several performance disadvantages:\n`
   );
-  lines.add(` * 1. It is not tree-shakeable, so it will include all operations in the project.\n`);
-  lines.add(` * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.\n`);
-  lines.add(` * 3. It does not support dead code elimination, so it will add unused operations.\n *\n`);
-  lines.add(` * Therefore it is highly recommended to use the babel or swc plugin for production.\n`);
-  lines.add(
+  lines.push(` * 1. It is not tree-shakeable, so it will include all operations in the project.\n`);
+  lines.push(` * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.\n`);
+  lines.push(` * 3. It does not support dead code elimination, so it will add unused operations.\n *\n`);
+  lines.push(` * Therefore it is highly recommended to use the babel or swc plugin for production.\n`);
+  lines.push(
     ` * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size\n */\n`
   );
-  lines.add(`const documents = {\n`);
-
+  lines.push(`type Documents = {\n`);
+  for (const { operations, ...rest } of sourcesWithOperations) {
+    const originalString = rest.source.rawSDL;
+    const operation = operations[0];
+    const aboutToPushLine = `    ${JSON.stringify(originalString)}: typeof types.${operation.initialName},\n`;
+    if (!linesDupCheck.has(aboutToPushLine)) {
+        lines.push(aboutToPushLine);
+        linesDupCheck.add(aboutToPushLine);
+    }
+  }
+  lines.push(`};\n`);
+  lines.push(`const documents: Documents = {\n`);
   for (const { operations, ...rest } of sourcesWithOperations) {
     const originalString = rest.source.rawSDL!;
     const operation = operations[0];
-
-    lines.add(`    ${JSON.stringify(originalString)}: types.${operation.initialName},\n`);
+    const aboutToPushLine = `    ${JSON.stringify(originalString)}: types.${operation.initialName},\n`;
+    if (!linesDupCheck.has(aboutToPushLine)) {
+      lines.push(aboutToPushLine);
+      linesDupCheck.add(aboutToPushLine);
+    }
   }
 
-  lines.add(`};\n`);
+  lines.push(`};\n`);
 
   return lines;
 }

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -51,7 +51,12 @@ export * from "./gql";`);
        * Therefore it is highly recommended to use the babel or swc plugin for production.
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
-      const documents = {
+      type Documents = {
+          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+      };
+      const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
@@ -139,7 +144,12 @@ export * from "./gql";`);
        * Therefore it is highly recommended to use the babel or swc plugin for production.
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
-      const documents = {
+      type Documents = {
+          "\\n  query a {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query b {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+      };
+      const documents: Documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query b {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
@@ -219,7 +229,12 @@ export * from "./gql";`);
        * Therefore it is highly recommended to use the babel or swc plugin for production.
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
-      const documents = {
+      type Documents = {
+          "\\n  query a {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query b {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+      };
+      const documents: Documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query b {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
@@ -300,7 +315,12 @@ export * from "./gql";`);
        * Therefore it is highly recommended to use the babel or swc plugin for production.
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
-      const documents = {
+      type Documents = {
+          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+      };
+      const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
@@ -431,7 +451,12 @@ export * from "./gql";`);
        * Therefore it is highly recommended to use the babel or swc plugin for production.
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
-      const documents = {
+      type Documents = {
+          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+      };
+      const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
@@ -647,7 +672,10 @@ export * from "./gql";`);
        * Therefore it is highly recommended to use the babel or swc plugin for production.
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
-      const documents = {
+      type Documents = {
+          "\\n  query a {\\n    a\\n  }\\n": typeof types.ADocument,
+      };
+      const documents: Documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
       };
 
@@ -710,7 +738,7 @@ export * from "./gql";`);
       export const ADocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"a"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"a"}}]}}]} as unknown as DocumentNode<AQuery, AQueryVariables>;"
     `);
 
-    expect(gqlFile.content.match(/query a {/g).length).toBe(3);
+    expect(gqlFile.content.match(/query a {/g).length).toBe(4);
   });
 
   describe('fragment masking', () => {
@@ -761,7 +789,12 @@ export * from "./gql";`);
          * Therefore it is highly recommended to use the babel or swc plugin for production.
          * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
          */
-        const documents = {
+        type Documents = {
+            "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
+            "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
+            "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+        };
+        const documents: Documents = {
             "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
             "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
             "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
@@ -1109,7 +1142,12 @@ export * from "./gql.js";`);
        * Therefore it is highly recommended to use the babel or swc plugin for production.
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
-      const documents = {
+      type Documents = {
+          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+      };
+      const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query B {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
@@ -2784,7 +2822,12 @@ export * from "./gql.js";`);
          * Therefore it is highly recommended to use the babel or swc plugin for production.
          * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
          */
-        const documents = {
+        type Documents = {
+            "\\n  query Foo {\\n    foo {\\n      ...Foo\\n    }\\n  }\\n": typeof types.FooDocument,
+            "\\n  query Foos {\\n    foos {\\n      ...Foo\\n    }\\n  }\\n": typeof types.FoosDocument,
+            "\\n  fragment Foo on Foo {\\n    value\\n  }\\n": typeof types.FooFragmentDoc,
+        };
+        const documents: Documents = {
             "\\n  query Foo {\\n    foo {\\n      ...Foo\\n    }\\n  }\\n": types.FooDocument,
             "\\n  query Foos {\\n    foos {\\n      ...Foo\\n    }\\n  }\\n": types.FoosDocument,
             "\\n  fragment Foo on Foo {\\n    value\\n  }\\n": types.FooFragmentDoc,

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -52,9 +52,9 @@ export * from "./gql";`);
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
       type Documents = {
-          "\n  query A {\n    a\n  }\n": typeof types.ADocument,
-          "\n  query B {\n    b\n  }\n": typeof types.BDocument,
-          "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
+          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
       };
       const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
@@ -144,12 +144,12 @@ export * from "./gql";`);
        * Therefore it is highly recommended to use the babel or swc plugin for production.
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
-        type Documents = {
-            "\n  query a {\n    a\n  }\n": typeof types.ADocument,
-            "\n  query b {\n    b\n  }\n": typeof types.BDocument,
-            "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
-        };
-        const documents: Documents = {
+      type Documents = {
+          "\\n  query a {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query b {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+      };
+      const documents: Documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query b {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
@@ -229,12 +229,12 @@ export * from "./gql";`);
        * Therefore it is highly recommended to use the babel or swc plugin for production.
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
-        type Documents = {
-            "\n  query a {\n    a\n  }\n": typeof types.ADocument,
-            "\n  query b {\n    b\n  }\n": typeof types.BDocument,
-            "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
-        };
-        const documents: Documents = {
+      type Documents = {
+          "\\n  query a {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query b {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+      };
+      const documents: Documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query b {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
@@ -316,9 +316,9 @@ export * from "./gql";`);
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
       type Documents = {
-          "\n  query A {\n    a\n  }\n": typeof types.ADocument,
-          "\n  query B {\n    b\n  }\n": typeof types.BDocument,
-          "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
+          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
       };
       const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
@@ -452,9 +452,9 @@ export * from "./gql";`);
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
       type Documents = {
-          "\n  query A {\n    a\n  }\n": typeof types.ADocument,
-          "\n  query B {\n    b\n  }\n": typeof types.BDocument,
-          "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
+          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
       };
       const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
@@ -673,7 +673,7 @@ export * from "./gql";`);
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
       type Documents = {
-          "\n  query a {\n    a\n  }\n": typeof types.ADocument,
+          "\\n  query a {\\n    a\\n  }\\n": typeof types.ADocument,
       };
       const documents: Documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
@@ -790,9 +790,9 @@ export * from "./gql";`);
          * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
          */
         type Documents = {
-            "\n  query A {\n    a\n  }\n": typeof types.ADocument,
-            "\n  query B {\n    b\n  }\n": typeof types.BDocument,
-            "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
+            "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
+            "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
+            "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
         };
         const documents: Documents = {
             "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
@@ -1143,9 +1143,9 @@ export * from "./gql.js";`);
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
       type Documents = {
-          "\n  query A {\n    a\n  }\n": typeof types.ADocument,
-          "\n  query B {\n    b\n  }\n": typeof types.BDocument,
-          "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
+          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
+          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
       };
       const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
@@ -2823,9 +2823,9 @@ export * from "./gql.js";`);
          * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
          */
         type Documents = {
-            "\n  query Foo {\n    foo {\n      ...Foo\n    }\n  }\n": typeof types.FooDocument,
-            "\n  query Foos {\n    foos {\n      ...Foo\n    }\n  }\n": typeof types.FoosDocument,
-            "\n  fragment Foo on Foo {\n    value\n  }\n": typeof types.FooFragmentDoc,
+            "\\n  query Foo {\\n    foo {\\n      ...Foo\\n    }\\n  }\\n": typeof types.FooDocument,
+            "\\n  query Foos {\\n    foos {\\n      ...Foo\\n    }\\n  }\\n": typeof types.FoosDocument,
+            "\\n  fragment Foo on Foo {\\n    value\\n  }\\n": typeof types.FooFragmentDoc,
         };
         const documents: Documents = {
             "\\n  query Foo {\\n    foo {\\n      ...Foo\\n    }\\n  }\\n": types.FooDocument,

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -52,9 +52,9 @@ export * from "./gql";`);
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
       type Documents = {
-          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
-          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
-          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+          "\n  query A {\n    a\n  }\n": typeof types.ADocument,
+          "\n  query B {\n    b\n  }\n": typeof types.BDocument,
+          "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
       };
       const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
@@ -144,12 +144,12 @@ export * from "./gql";`);
        * Therefore it is highly recommended to use the babel or swc plugin for production.
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
-      type Documents = {
-          "\\n  query a {\\n    a\\n  }\\n": typeof types.ADocument,
-          "\\n  query b {\\n    b\\n  }\\n": typeof types.BDocument,
-          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
-      };
-      const documents: Documents = {
+        type Documents = {
+            "\n  query a {\n    a\n  }\n": typeof types.ADocument,
+            "\n  query b {\n    b\n  }\n": typeof types.BDocument,
+            "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
+        };
+        const documents: Documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query b {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
@@ -229,12 +229,12 @@ export * from "./gql";`);
        * Therefore it is highly recommended to use the babel or swc plugin for production.
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
-      type Documents = {
-          "\\n  query a {\\n    a\\n  }\\n": typeof types.ADocument,
-          "\\n  query b {\\n    b\\n  }\\n": typeof types.BDocument,
-          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
-      };
-      const documents: Documents = {
+        type Documents = {
+            "\n  query a {\n    a\n  }\n": typeof types.ADocument,
+            "\n  query b {\n    b\n  }\n": typeof types.BDocument,
+            "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
+        };
+        const documents: Documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
           "\\n  query b {\\n    b\\n  }\\n": types.BDocument,
           "\\n  fragment C on Query {\\n    c\\n  }\\n": types.CFragmentDoc,
@@ -316,9 +316,9 @@ export * from "./gql";`);
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
       type Documents = {
-          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
-          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
-          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+          "\n  query A {\n    a\n  }\n": typeof types.ADocument,
+          "\n  query B {\n    b\n  }\n": typeof types.BDocument,
+          "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
       };
       const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
@@ -452,9 +452,9 @@ export * from "./gql";`);
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
       type Documents = {
-          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
-          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
-          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+          "\n  query A {\n    a\n  }\n": typeof types.ADocument,
+          "\n  query B {\n    b\n  }\n": typeof types.BDocument,
+          "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
       };
       const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
@@ -673,7 +673,7 @@ export * from "./gql";`);
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
       type Documents = {
-          "\\n  query a {\\n    a\\n  }\\n": typeof types.ADocument,
+          "\n  query a {\n    a\n  }\n": typeof types.ADocument,
       };
       const documents: Documents = {
           "\\n  query a {\\n    a\\n  }\\n": types.ADocument,
@@ -790,9 +790,9 @@ export * from "./gql";`);
          * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
          */
         type Documents = {
-            "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
-            "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
-            "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+            "\n  query A {\n    a\n  }\n": typeof types.ADocument,
+            "\n  query B {\n    b\n  }\n": typeof types.BDocument,
+            "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
         };
         const documents: Documents = {
             "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
@@ -1143,9 +1143,9 @@ export * from "./gql.js";`);
        * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
        */
       type Documents = {
-          "\\n  query A {\\n    a\\n  }\\n": typeof types.ADocument,
-          "\\n  query B {\\n    b\\n  }\\n": typeof types.BDocument,
-          "\\n  fragment C on Query {\\n    c\\n  }\\n": typeof types.CFragmentDoc,
+          "\n  query A {\n    a\n  }\n": typeof types.ADocument,
+          "\n  query B {\n    b\n  }\n": typeof types.BDocument,
+          "\n  fragment C on Query {\n    c\n  }\n": typeof types.CFragmentDoc,
       };
       const documents: Documents = {
           "\\n  query A {\\n    a\\n  }\\n": types.ADocument,
@@ -2823,9 +2823,9 @@ export * from "./gql.js";`);
          * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
          */
         type Documents = {
-            "\\n  query Foo {\\n    foo {\\n      ...Foo\\n    }\\n  }\\n": typeof types.FooDocument,
-            "\\n  query Foos {\\n    foos {\\n      ...Foo\\n    }\\n  }\\n": typeof types.FoosDocument,
-            "\\n  fragment Foo on Foo {\\n    value\\n  }\\n": typeof types.FooFragmentDoc,
+            "\n  query Foo {\n    foo {\n      ...Foo\n    }\n  }\n": typeof types.FooDocument,
+            "\n  query Foos {\n    foos {\n      ...Foo\n    }\n  }\n": typeof types.FoosDocument,
+            "\n  fragment Foo on Foo {\n    value\n  }\n": typeof types.FooFragmentDoc,
         };
         const documents: Documents = {
             "\\n  query Foo {\\n    foo {\\n      ...Foo\\n    }\\n  }\\n": types.FooDocument,


### PR DESCRIPTION
## Description

Add type generation to gql-tag-operation

Related # (issue)
https://github.com/dotansimha/graphql-code-generator/issues/10191

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Works as a yarn patch. This upstream the fix

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

