### PR TITLE
Add missing code block ending

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-documents-visitor.ts
@@ -172,6 +172,7 @@ export interface RawDocumentsConfig extends RawTypesConfig {
    *    },
    *  };
    *  export default config;
+   * ```
    */
   customDirectives?: CustomDirectivesConfig;
 }


### PR DESCRIPTION
_Note: Since this is a simple documentation fix, I didn't follow the pull request description template. I hope this is fine._

Currently, the missing code block ending leads to layout errors on https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-operations#customdirectives:

> ![image](https://github.com/user-attachments/assets/62ea8acc-6ea6-4a0b-adb8-958c92d23738)
