### PR TITLE
Split large unions over multiple lines

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1105,54 +1105,58 @@ export class BaseResolversVisitor<
     memberTypes: readonly GraphQLObjectType[] | GraphQLObjectType[];
     isTypenameNonOptional: boolean;
   }): string {
+    const members = memberTypes
+      .map(type => {
+        const isTypeMapped = this.config.mappers[type.name];
+        // 1. If mapped without placehoder, just use it without doing extra checks
+        if (isTypeMapped && !hasPlaceholder(isTypeMapped.type)) {
+          return { typename: type.name, typeValue: isTypeMapped.type };
+        }
+
+        // 2. Work out value for type
+        // 2a. By default, use the typescript type
+        let typeValue = this.convertName(type.name, {}, true);
+
+        // 2b. Find fields to Omit if needed.
+        //  - If no field to Omit, "type with maybe Omit" is typescript type i.e. no Omit
+        //  - If there are fields to Omit, keep track of these "type with maybe Omit" to replace in original unionMemberValue
+        const fieldsToOmit = this.getRelevantFieldsToOmit({
+          schemaType: type,
+          getTypeToUse: baseType => `_RefType['${baseType}']`,
+        });
+        if (fieldsToOmit.length > 0) {
+          typeValue = this.replaceFieldsInType(typeValue, fieldsToOmit);
+        }
+
+        // 2c. If type is mapped with placeholder, use the "type with maybe Omit" as {T}
+        if (isTypeMapped && hasPlaceholder(isTypeMapped.type)) {
+          return { typename: type.name, typeValue: replacePlaceholder(isTypeMapped.type, typeValue) };
+        }
+
+        // 2d. If has default mapper with placeholder, use the "type with maybe Omit" as {T}
+        const hasDefaultMapper = !!this.config.defaultMapper?.type;
+        const isScalar = this.config.scalars[typeName];
+        if (hasDefaultMapper && hasPlaceholder(this.config.defaultMapper.type)) {
+          const finalTypename = isScalar ? this._getScalar(typeName) : typeValue;
+          return {
+            typename: type.name,
+            typeValue: replacePlaceholder(this.config.defaultMapper.type, finalTypename),
+          };
+        }
+
+        return { typename: type.name, typeValue };
+      })
+      .map(({ typename, typeValue }) => {
+        const nonOptionalTypenameModifier = isTypenameNonOptional ? ` & { __typename: '${typename}' }` : '';
+
+        return `( ${typeValue}${nonOptionalTypenameModifier} )`; // Must wrap every type in explicit "( )" to separate them
+      });
     const result =
-      memberTypes
-        .map(type => {
-          const isTypeMapped = this.config.mappers[type.name];
-          // 1. If mapped without placehoder, just use it without doing extra checks
-          if (isTypeMapped && !hasPlaceholder(isTypeMapped.type)) {
-            return { typename: type.name, typeValue: isTypeMapped.type };
-          }
-
-          // 2. Work out value for type
-          // 2a. By default, use the typescript type
-          let typeValue = this.convertName(type.name, {}, true);
-
-          // 2b. Find fields to Omit if needed.
-          //  - If no field to Omit, "type with maybe Omit" is typescript type i.e. no Omit
-          //  - If there are fields to Omit, keep track of these "type with maybe Omit" to replace in original unionMemberValue
-          const fieldsToOmit = this.getRelevantFieldsToOmit({
-            schemaType: type,
-            getTypeToUse: baseType => `_RefType['${baseType}']`,
-          });
-          if (fieldsToOmit.length > 0) {
-            typeValue = this.replaceFieldsInType(typeValue, fieldsToOmit);
-          }
-
-          // 2c. If type is mapped with placeholder, use the "type with maybe Omit" as {T}
-          if (isTypeMapped && hasPlaceholder(isTypeMapped.type)) {
-            return { typename: type.name, typeValue: replacePlaceholder(isTypeMapped.type, typeValue) };
-          }
-
-          // 2d. If has default mapper with placeholder, use the "type with maybe Omit" as {T}
-          const hasDefaultMapper = !!this.config.defaultMapper?.type;
-          const isScalar = this.config.scalars[typeName];
-          if (hasDefaultMapper && hasPlaceholder(this.config.defaultMapper.type)) {
-            const finalTypename = isScalar ? this._getScalar(typeName) : typeValue;
-            return {
-              typename: type.name,
-              typeValue: replacePlaceholder(this.config.defaultMapper.type, finalTypename),
-            };
-          }
-
-          return { typename: type.name, typeValue };
-        })
-        .map(({ typename, typeValue }) => {
-          const nonOptionalTypenameModifier = isTypenameNonOptional ? ` & { __typename: '${typename}' }` : '';
-
-          return `( ${typeValue}${nonOptionalTypenameModifier} )`; // Must wrap every type in explicit "( )" to separate them
-        })
-        .join(' | ') || 'never';
+      members.length === 0
+        ? 'never'
+        : this.config.printFieldsOnNewLines && members.length > 1
+        ? `\n    | ${members.join('\n    | ')}`
+        : members.join(' | ');
     return result;
   }
 

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1154,7 +1154,7 @@ export class BaseResolversVisitor<
     const result =
       members.length === 0
         ? 'never'
-        : this.config.printFieldsOnNewLines && members.length > 1
+        : members.length > 1
         ? `\n    | ${members.join('\n    | ')}`
         : members.join(' | ');
     return result;

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1155,7 +1155,7 @@ export class BaseResolversVisitor<
       members.length === 0
         ? 'never'
         : members.length > 1
-        ? `\n    | ${members.join('\n    | ')}`
+        ? `\n    | ${members.map(m => m.replace(/\n/g, '\n  ')).join('\n    | ')}\n  `
         : members.join(' | ');
     return result;
   }

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -947,7 +947,12 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
         .export()
         .asKind('type')
         .withName(mergedTypeString)
-        .withContent(subTypes.map(t => t.name).join(' | ')).string,
+        .withContent(
+          formatUnion(
+            this._config,
+            subTypes.map(t => t.name)
+          )
+        ).string,
     ].join('\n');
   }
 
@@ -963,4 +968,12 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
     // so we can skip affixing the field names with typeName
     return operationTypes.includes(typeName) ? parentName : `${parentName}_${typeName}`;
   }
+}
+
+function formatUnion(config: ParsedDocumentsConfig, members: string[]): string {
+  if (config.printFieldsOnNewLines && members.length > 1) {
+    return `\n  | ${members.join('\n  | ')}`;
+  } 
+    return members.join(' | ');
+  
 }

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -944,11 +944,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
         .export()
         .asKind('type')
         .withName(mergedTypeString)
-        .withContent(
-          formatUnion(
-            subTypes.map(t => t.name)
-          )
-        ).string,
+        .withContent(formatUnion(subTypes.map(t => t.name))).string,
     ].join('\n');
   }
 
@@ -968,7 +964,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
 
 function formatUnion(members: string[]): string {
   if (members.length > 1) {
-    return `\n  | ${members.join('\n  | ')}`;
+    return `\n  | ${members.map(m => m.replace(/\n/g, '\n  ')).join('\n  | ')}\n`;
   }
   return members.join(' | ');
 }

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -844,7 +844,10 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       this.getEmptyObjectTypeString(mustAddEmptyObject),
     ].filter(Boolean);
 
-    const content = typeParts.join(' | ');
+    const content =
+      this._config.printFieldsOnNewLines && typeParts.length > 1
+        ? `\n  | ${typeParts.join('\n  | ')}\n`
+        : typeParts.join(' | ');
 
     if (typeParts.length > 1 && this._config.extractAllFieldsToTypes) {
       return {

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -844,7 +844,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       this.getEmptyObjectTypeString(mustAddEmptyObject),
     ].filter(Boolean);
 
-    const content = formatUnion(this._config, typeParts);
+    const content = formatUnion(typeParts);
 
     if (typeParts.length > 1 && this._config.extractAllFieldsToTypes) {
       return {
@@ -946,7 +946,6 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
         .withName(mergedTypeString)
         .withContent(
           formatUnion(
-            this._config,
             subTypes.map(t => t.name)
           )
         ).string,
@@ -967,8 +966,8 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
   }
 }
 
-function formatUnion(config: ParsedDocumentsConfig, members: string[]): string {
-  if (config.printFieldsOnNewLines && members.length > 1) {
+function formatUnion(members: string[]): string {
+  if (members.length > 1) {
     return `\n  | ${members.join('\n  | ')}`;
   }
   return members.join(' | ');

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -844,10 +844,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
       this.getEmptyObjectTypeString(mustAddEmptyObject),
     ].filter(Boolean);
 
-    const content =
-      this._config.printFieldsOnNewLines && typeParts.length > 1
-        ? `\n  | ${typeParts.join('\n  | ')}\n`
-        : typeParts.join(' | ');
+    const content = formatUnion(this._config, typeParts);
 
     if (typeParts.length > 1 && this._config.extractAllFieldsToTypes) {
       return {

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -970,7 +970,6 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
 function formatUnion(config: ParsedDocumentsConfig, members: string[]): string {
   if (config.printFieldsOnNewLines && members.length > 1) {
     return `\n  | ${members.join('\n  | ')}`;
-  } 
-    return members.join(' | ');
-  
+  }
+  return members.join(' | ');
 }

--- a/packages/plugins/typescript/operations/src/ts-selection-set-processor.ts
+++ b/packages/plugins/typescript/operations/src/ts-selection-set-processor.ts
@@ -96,11 +96,7 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
 }
 
 /** Equivalent to `${transformName}<${target}, ${unionElements.join(' | ')}>`, but with line feeds if necessary */
-function formattedUnionTransform(
-  transformName: string,
-  target: string,
-  unionElements: string[]
-): string {
+function formattedUnionTransform(transformName: string, target: string, unionElements: string[]): string {
   if (unionElements.length > 3) {
     return `${transformName}<\n    ${target},\n    | ${unionElements.join('\n    | ')}\n  >`;
   }
@@ -110,7 +106,7 @@ function formattedUnionTransform(
 /** Equivalent to `{ ${selections.join(', ')} }`, but with line feeds if necessary */
 function formatSelections(selections: string[]): string {
   if (selections.length > 1) {
-    return `{\n    ${selections.join(',\n    ')},\n  }`;
+    return `{\n    ${selections.map(s => s.replace(/\n/g, '\n  ')).join(',\n    ')},\n  }`;
   }
   return `{ ${selections.join(', ')} }`;
 }

--- a/packages/plugins/typescript/operations/src/ts-selection-set-processor.ts
+++ b/packages/plugins/typescript/operations/src/ts-selection-set-processor.ts
@@ -25,20 +25,20 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
       });
 
     if (unsetTypes) {
-      return [`MakeEmpty<${parentName}, ${fields.map(field => `'${field.fieldName}'`).join(' | ')}>`];
+      const escapedFieldNames = fields.map(field => `'${field.fieldName}'`);
+      return [formattedUnionTransform(this.config, 'MakeEmpty', parentName, escapedFieldNames)];
     }
 
     let hasConditionals = false;
-    const conditilnalsList: string[] = [];
-    let resString = `Pick<${parentName}, ${fields
-      .map(field => {
-        if (field.isConditional) {
-          hasConditionals = true;
-          conditilnalsList.push(field.fieldName);
-        }
-        return `'${field.fieldName}'`;
-      })
-      .join(' | ')}>`;
+    const escapedConditionalsList: string[] = [];
+    const escapedFieldNames = fields.map(field => {
+      if (field.isConditional) {
+        hasConditionals = true;
+        escapedConditionalsList.push(`'${field.fieldName}'`);
+      }
+      return `'${field.fieldName}'`;
+    });
+    let resString = formattedUnionTransform(this.config, 'Pick', parentName, escapedFieldNames);
 
     if (hasConditionals) {
       const avoidOptional =
@@ -52,7 +52,7 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
       const transform = avoidOptional ? 'MakeMaybe' : 'MakeOptional';
       resString = `${
         this.config.namespacedImportName ? `${this.config.namespacedImportName}.` : ''
-      }${transform}<${resString}, ${conditilnalsList.map(field => `'${field}'`).join(' | ')}>`;
+      }${formattedUnionTransform(this.config, transform, resString, escapedConditionalsList)}`;
     }
     return [resString];
   }
@@ -75,18 +75,13 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
         useTypesPrefix: true,
       });
 
-    return [
-      `{ ${fields
-        .map(aliasedField => {
-          const value =
-            aliasedField.fieldName === '__typename'
-              ? `'${schemaType.name}'`
-              : `${parentName}['${aliasedField.fieldName}']`;
+    const selections = fields.map(aliasedField => {
+      const value =
+        aliasedField.fieldName === '__typename' ? `'${schemaType.name}'` : `${parentName}['${aliasedField.fieldName}']`;
 
-          return `${aliasedField.alias}: ${value}`;
-        })
-        .join(', ')} }`,
-    ];
+      return `${aliasedField.alias}: ${value}`;
+    });
+    return [formatSelections(this.config, selections)];
   }
 
   transformLinkFields(fields: LinkField[]): ProcessResult {
@@ -94,6 +89,29 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
       return [];
     }
 
-    return [`{ ${fields.map(field => `${field.alias || field.name}: ${field.selectionSet}`).join(', ')} }`];
+    const selections = fields.map(field => `${field.alias || field.name}: ${field.selectionSet}`);
+
+    return [formatSelections(this.config, selections)];
   }
+}
+
+/** Equivalent to `${transformName}<${target}, ${unionElements.join(' | ')}>`, but with line feeds if necessary */
+function formattedUnionTransform(
+  config: SelectionSetProcessorConfig,
+  transformName: string,
+  target: string,
+  unionElements: string[]
+): string {
+  if (config.printFieldsOnNewLines && unionElements.length > 3) {
+    return `${transformName}<\n    ${target},\n    | ${unionElements.join('\n    | ')}\n  >`;
+  }
+  return `${transformName}<${target}, ${unionElements.join(' | ')}>`;
+}
+
+/** Equivalent to `{ ${selections.join(', ')} }`, but with line feeds if necessary */
+function formatSelections(config: SelectionSetProcessorConfig, selections: string[]): string {
+  if (config.printFieldsOnNewLines && selections.length > 1) {
+    return `{\n    ${selections.join(',\n    ')},\n  }`;
+  }
+  return `{ ${selections.join(', ')} }`;
 }

--- a/packages/plugins/typescript/operations/src/ts-selection-set-processor.ts
+++ b/packages/plugins/typescript/operations/src/ts-selection-set-processor.ts
@@ -26,7 +26,7 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
 
     if (unsetTypes) {
       const escapedFieldNames = fields.map(field => `'${field.fieldName}'`);
-      return [formattedUnionTransform(this.config, 'MakeEmpty', parentName, escapedFieldNames)];
+      return [formattedUnionTransform('MakeEmpty', parentName, escapedFieldNames)];
     }
 
     let hasConditionals = false;
@@ -38,7 +38,7 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
       }
       return `'${field.fieldName}'`;
     });
-    let resString = formattedUnionTransform(this.config, 'Pick', parentName, escapedFieldNames);
+    let resString = formattedUnionTransform('Pick', parentName, escapedFieldNames);
 
     if (hasConditionals) {
       const avoidOptional =
@@ -52,7 +52,7 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
       const transform = avoidOptional ? 'MakeMaybe' : 'MakeOptional';
       resString = `${
         this.config.namespacedImportName ? `${this.config.namespacedImportName}.` : ''
-      }${formattedUnionTransform(this.config, transform, resString, escapedConditionalsList)}`;
+      }${formattedUnionTransform(transform, resString, escapedConditionalsList)}`;
     }
     return [resString];
   }
@@ -81,7 +81,7 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
 
       return `${aliasedField.alias}: ${value}`;
     });
-    return [formatSelections(this.config, selections)];
+    return [formatSelections(selections)];
   }
 
   transformLinkFields(fields: LinkField[]): ProcessResult {
@@ -91,26 +91,25 @@ export class TypeScriptSelectionSetProcessor extends BaseSelectionSetProcessor<S
 
     const selections = fields.map(field => `${field.alias || field.name}: ${field.selectionSet}`);
 
-    return [formatSelections(this.config, selections)];
+    return [formatSelections(selections)];
   }
 }
 
 /** Equivalent to `${transformName}<${target}, ${unionElements.join(' | ')}>`, but with line feeds if necessary */
 function formattedUnionTransform(
-  config: SelectionSetProcessorConfig,
   transformName: string,
   target: string,
   unionElements: string[]
 ): string {
-  if (config.printFieldsOnNewLines && unionElements.length > 3) {
+  if (unionElements.length > 3) {
     return `${transformName}<\n    ${target},\n    | ${unionElements.join('\n    | ')}\n  >`;
   }
   return `${transformName}<${target}, ${unionElements.join(' | ')}>`;
 }
 
 /** Equivalent to `{ ${selections.join(', ')} }`, but with line feeds if necessary */
-function formatSelections(config: SelectionSetProcessorConfig, selections: string[]): string {
-  if (config.printFieldsOnNewLines && selections.length > 1) {
+function formatSelections(selections: string[]): string {
+  if (selections.length > 1) {
     return `{\n    ${selections.join(',\n    ')},\n  }`;
   }
   return `{ ${selections.join(', ')} }`;

--- a/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
+++ b/packages/plugins/typescript/operations/tests/__snapshots__/ts-documents.spec.ts.snap
@@ -17,7 +17,12 @@ exports[`TypeScript Operations Plugin Issues #2699 - Issues with multiple interf
 }>;
 
 
-export type GetEntityBrandDataQuery = { __typename?: 'Query', node: { __typename: 'Company', active: boolean, id: string, createdAt: any, updatedAt: any, brandData?: { __typename?: 'EntityBrandData', active: boolean, browsable: boolean, title: string, alternateTitle?: string | null, description: string } | null, createdBy?: { __typename?: 'User', id: string, name: string } | null, updatedBy?: { __typename?: 'User', id: string, name: string } | null } | { __typename: 'Theater', active: boolean, id: string, createdAt: any, updatedAt: any, brandData?: { __typename?: 'EntityBrandData', active: boolean, browsable: boolean, title: string, alternateTitle?: string | null, description: string } | null, createdBy?: { __typename?: 'User', id: string, name: string } | null, updatedBy?: { __typename?: 'User', id: string, name: string } | null } | { __typename: 'Movie', id: string, createdAt: any, updatedAt: any, brandData?: { __typename?: 'EntityBrandData', active: boolean, browsable: boolean, title: string, alternateTitle?: string | null, description: string } | null, createdBy?: { __typename?: 'User', id: string, name: string } | null, updatedBy?: { __typename?: 'User', id: string, name: string } | null } | { __typename: 'User', id: string, createdAt: any, updatedAt: any, brandData?: { __typename?: 'EntityBrandData', active: boolean, browsable: boolean, title: string, alternateTitle?: string | null, description: string } | null, createdBy?: { __typename?: 'User', id: string, name: string } | null, updatedBy?: { __typename?: 'User', id: string, name: string } | null } };
+export type GetEntityBrandDataQuery = { __typename?: 'Query', node:
+    | { __typename: 'Company', active: boolean, id: string, createdAt: any, updatedAt: any, brandData?: { __typename?: 'EntityBrandData', active: boolean, browsable: boolean, title: string, alternateTitle?: string | null, description: string } | null, createdBy?: { __typename?: 'User', id: string, name: string } | null, updatedBy?: { __typename?: 'User', id: string, name: string } | null }
+    | { __typename: 'Theater', active: boolean, id: string, createdAt: any, updatedAt: any, brandData?: { __typename?: 'EntityBrandData', active: boolean, browsable: boolean, title: string, alternateTitle?: string | null, description: string } | null, createdBy?: { __typename?: 'User', id: string, name: string } | null, updatedBy?: { __typename?: 'User', id: string, name: string } | null }
+    | { __typename: 'Movie', id: string, createdAt: any, updatedAt: any, brandData?: { __typename?: 'EntityBrandData', active: boolean, browsable: boolean, title: string, alternateTitle?: string | null, description: string } | null, createdBy?: { __typename?: 'User', id: string, name: string } | null, updatedBy?: { __typename?: 'User', id: string, name: string } | null }
+    | { __typename: 'User', id: string, createdAt: any, updatedAt: any, brandData?: { __typename?: 'EntityBrandData', active: boolean, browsable: boolean, title: string, alternateTitle?: string | null, description: string } | null, createdBy?: { __typename?: 'User', id: string, name: string } | null, updatedBy?: { __typename?: 'User', id: string, name: string } | null }
+   };
 
 type EntityBrandData_Company_Fragment = { __typename?: 'Company', brandData?: { __typename?: 'EntityBrandData', active: boolean, browsable: boolean, title: string, alternateTitle?: string | null, description: string } | null };
 
@@ -27,7 +32,12 @@ type EntityBrandData_Movie_Fragment = { __typename?: 'Movie', brandData?: { __ty
 
 type EntityBrandData_User_Fragment = { __typename?: 'User', brandData?: { __typename?: 'EntityBrandData', active: boolean, browsable: boolean, title: string, alternateTitle?: string | null, description: string } | null };
 
-export type EntityBrandDataFragment = EntityBrandData_Company_Fragment | EntityBrandData_Theater_Fragment | EntityBrandData_Movie_Fragment | EntityBrandData_User_Fragment;
+export type EntityBrandDataFragment =
+  | EntityBrandData_Company_Fragment
+  | EntityBrandData_Theater_Fragment
+  | EntityBrandData_Movie_Fragment
+  | EntityBrandData_User_Fragment
+;
 
 type ElementMetadata_Company_Fragment = { __typename?: 'Company', createdAt: any, updatedAt: any, createdBy?: { __typename?: 'User', id: string, name: string } | null, updatedBy?: { __typename?: 'User', id: string, name: string } | null };
 
@@ -37,7 +47,12 @@ type ElementMetadata_Movie_Fragment = { __typename?: 'Movie', createdAt: any, up
 
 type ElementMetadata_User_Fragment = { __typename?: 'User', createdAt: any, updatedAt: any, createdBy?: { __typename?: 'User', id: string, name: string } | null, updatedBy?: { __typename?: 'User', id: string, name: string } | null };
 
-export type ElementMetadataFragment = ElementMetadata_Company_Fragment | ElementMetadata_Theater_Fragment | ElementMetadata_Movie_Fragment | ElementMetadata_User_Fragment;
+export type ElementMetadataFragment =
+  | ElementMetadata_Company_Fragment
+  | ElementMetadata_Theater_Fragment
+  | ElementMetadata_Movie_Fragment
+  | ElementMetadata_User_Fragment
+;
 "
 `;
 
@@ -54,7 +69,10 @@ exports[`TypeScript Operations Plugin Issues #3064 - fragments over interfaces c
 
 type Venue_Transport_Fragment = { __typename?: 'Transport', id: string };
 
-export type VenueFragment = Venue_Hotel_Fragment | Venue_Transport_Fragment;
+export type VenueFragment =
+  | Venue_Hotel_Fragment
+  | Venue_Transport_Fragment
+;
 
 export type QQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -118,7 +136,10 @@ type Venue_Hotel_Fragment = { __typename?: 'Hotel', id: string, gpsPosition: { _
 
 type Venue_Transport_Fragment = { __typename?: 'Transport', id: string };
 
-export type VenueFragment = Venue_Hotel_Fragment | Venue_Transport_Fragment;
+export type VenueFragment =
+  | Venue_Hotel_Fragment
+  | Venue_Transport_Fragment
+;
 
 export type QQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -139,13 +160,19 @@ exports[`TypeScript Operations Plugin Issues #6874 - generates types when parent
 "export type SnakeQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SnakeQueryQuery = { __typename?: 'Query', snake: { __typename?: 'Snake', name: string, features: { __typename?: 'SnakeFeatures', color: string, length: number } } | { __typename?: 'Error' } };
+export type SnakeQueryQuery = { __typename?: 'Query', snake:
+    | { __typename?: 'Snake', name: string, features: { __typename?: 'SnakeFeatures', color: string, length: number } }
+    | { __typename?: 'Error' }
+   };
 
 type AnimalFragment_Bat_Fragment = { __typename?: 'Bat', features: { __typename?: 'BatFeatures', color: string, wingspan: number } };
 
 type AnimalFragment_Snake_Fragment = { __typename?: 'Snake', features: { __typename?: 'SnakeFeatures', color: string, length: number } };
 
-export type AnimalFragmentFragment = AnimalFragment_Bat_Fragment | AnimalFragment_Snake_Fragment;
+export type AnimalFragmentFragment =
+  | AnimalFragment_Bat_Fragment
+  | AnimalFragment_Snake_Fragment
+;
 "
 `;
 
@@ -153,7 +180,10 @@ exports[`TypeScript Operations Plugin Issues #8793 selecting __typename should n
 "export type SnakeQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SnakeQueryQuery = { __typename: 'Query', snake: { __typename: 'Snake' } | { __typename: 'Error' } };
+export type SnakeQueryQuery = { __typename: 'Query', snake:
+    | { __typename: 'Snake' }
+    | { __typename: 'Error' }
+   };
 "
 `;
 
@@ -220,10 +250,13 @@ export type AaaQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type AaaQuery = (
   { __typename?: 'Query' }
-  & { user: (
-    { __typename?: 'User' }
-    & Pick<User, 'id'>
-  ) | { __typename?: 'Error' } }
+  & { user:
+    | (
+      { __typename?: 'User' }
+      & Pick<User, 'id'>
+    )
+    | { __typename?: 'Error' }
+   }
 );
 "
 `;
@@ -234,10 +267,13 @@ exports[`TypeScript Operations Plugin Selection Set Should generate the correct 
 
 export type Unnamed_1_Query = (
   { __typename?: 'Query' }
-  & { b?: Maybe<(
-    { __typename?: 'A' }
-    & Pick<A, 'id' | 'x'>
-  ) | { __typename?: 'B' }> }
+  & { b?: Maybe<
+    | (
+      { __typename?: 'A' }
+      & Pick<A, 'id' | 'x'>
+    )
+    | { __typename?: 'B' }
+  > }
 );
 
 export type AFragment = (
@@ -255,28 +291,46 @@ export type BFragment = (
 exports[`TypeScript Operations Plugin Selection Set Should have valid __typename usage and split types according to that (with usage) 1`] = `
 "type NetRoute_Ipv4Route_Fragment = (
   { __typename: 'IPV4Route' }
-  & { ipv4Address: Ipv4Route['address'], ipv4Gateway: Ipv4Route['gateway'] }
+  & {
+    ipv4Address: Ipv4Route['address'],
+    ipv4Gateway: Ipv4Route['gateway'],
+  }
 );
 
 type NetRoute_Ipv6Route_Fragment = (
   { __typename: 'IPV6Route' }
-  & { ipv6Address: Ipv6Route['address'], ipv6Gateway: Ipv6Route['gateway'] }
+  & {
+    ipv6Address: Ipv6Route['address'],
+    ipv6Gateway: Ipv6Route['gateway'],
+  }
 );
 
-export type NetRouteFragment = NetRoute_Ipv4Route_Fragment | NetRoute_Ipv6Route_Fragment;
+export type NetRouteFragment =
+  | NetRoute_Ipv4Route_Fragment
+  | NetRoute_Ipv6Route_Fragment
+;
 
 export type QqQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type QqQuery = (
   { __typename?: 'Query' }
-  & { routes: Array<(
-    { __typename: 'IPV4Route' }
-    & { ipv4Address: Ipv4Route['address'], ipv4Gateway: Ipv4Route['gateway'] }
-  ) | (
-    { __typename: 'IPV6Route' }
-    & { ipv6Address: Ipv6Route['address'], ipv6Gateway: Ipv6Route['gateway'] }
-  )> }
+  & { routes: Array<
+    | (
+      { __typename: 'IPV4Route' }
+      & {
+        ipv4Address: Ipv4Route['address'],
+        ipv4Gateway: Ipv4Route['gateway'],
+      }
+    )
+    | (
+      { __typename: 'IPV6Route' }
+      & {
+        ipv6Address: Ipv6Route['address'],
+        ipv6Gateway: Ipv6Route['gateway'],
+      }
+    )
+  > }
 );
 "
 `;
@@ -284,19 +338,31 @@ export type QqQuery = (
 exports[`TypeScript Operations Plugin Selection Set Should have valid __typename usage and split types according to that (with usage) 2`] = `
 "type NetRoute_Ipv4Route_Fragment = (
   { __typename: 'IPV4Route' }
-  & { ipv4Address: Ipv4Route['address'], ipv4Gateway: Ipv4Route['gateway'] }
+  & {
+    ipv4Address: Ipv4Route['address'],
+    ipv4Gateway: Ipv4Route['gateway'],
+  }
 );
 
 type NetRoute_Ipv6Route_Fragment = (
   { __typename: 'IPV6Route' }
-  & { ipv6Address: Ipv6Route['address'], ipv6Gateway: Ipv6Route['gateway'] }
+  & {
+    ipv6Address: Ipv6Route['address'],
+    ipv6Gateway: Ipv6Route['gateway'],
+  }
 );
 
-export type NetRouteFragment = NetRoute_Ipv4Route_Fragment | NetRoute_Ipv6Route_Fragment;
+export type NetRouteFragment =
+  | NetRoute_Ipv4Route_Fragment
+  | NetRoute_Ipv6Route_Fragment
+;
 
 export type TestFragment = (
   { __typename?: 'IPV6Route' }
-  & { ipv6Address: Ipv6Route['address'], ipv6Gateway: Ipv6Route['gateway'] }
+  & {
+    ipv6Address: Ipv6Route['address'],
+    ipv6Gateway: Ipv6Route['gateway'],
+  }
 );
 
 export type QqQueryVariables = Exact<{ [key: string]: never; }>;
@@ -304,13 +370,22 @@ export type QqQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type QqQuery = (
   { __typename?: 'Query' }
-  & { routes: Array<(
-    { __typename: 'IPV4Route' }
-    & { ipv4Address: Ipv4Route['address'], ipv4Gateway: Ipv4Route['gateway'] }
-  ) | (
-    { __typename: 'IPV6Route' }
-    & { ipv6Address: Ipv6Route['address'], ipv6Gateway: Ipv6Route['gateway'] }
-  )> }
+  & { routes: Array<
+    | (
+      { __typename: 'IPV4Route' }
+      & {
+        ipv4Address: Ipv4Route['address'],
+        ipv4Gateway: Ipv4Route['gateway'],
+      }
+    )
+    | (
+      { __typename: 'IPV6Route' }
+      & {
+        ipv6Address: Ipv6Route['address'],
+        ipv6Gateway: Ipv6Route['gateway'],
+      }
+    )
+  > }
 );
 "
 `;
@@ -336,20 +411,26 @@ type User_Jerry_Fragment = (
   & Pick<Jerry, 'id' | 'bar'>
 );
 
-export type UserFragment = User_Tom_Fragment | User_Jerry_Fragment;
+export type UserFragment =
+  | User_Tom_Fragment
+  | User_Jerry_Fragment
+;
 
 export type UserQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type UserQueryQuery = (
   { __typename?: 'Query' }
-  & { user?: Maybe<(
-    { __typename?: 'Tom' }
-    & Pick<Tom, 'id' | 'foo'>
-  ) | (
-    { __typename?: 'Jerry' }
-    & Pick<Jerry, 'id' | 'bar'>
-  )> }
+  & { user?: Maybe<
+    | (
+      { __typename?: 'Tom' }
+      & Pick<Tom, 'id' | 'foo'>
+    )
+    | (
+      { __typename?: 'Jerry' }
+      & Pick<Jerry, 'id' | 'bar'>
+    )
+  > }
 );
 "
 `;
@@ -397,17 +478,20 @@ export type SearchPopularQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type SearchPopularQuery = (
   { __typename?: 'Query' }
-  & { search?: Maybe<Array<(
-    { __typename?: 'Dimension' }
-    & Pick<Dimension, 'id'>
-  ) | (
-    { __typename?: 'DimValue' }
-    & Pick<DimValue, 'value'>
-    & { dimension?: Maybe<(
+  & { search?: Maybe<Array<
+    | (
       { __typename?: 'Dimension' }
       & Pick<Dimension, 'id'>
-    )> }
-  )>> }
+    )
+    | (
+      { __typename?: 'DimValue' }
+      & Pick<DimValue, 'value'>
+      & { dimension?: Maybe<(
+        { __typename?: 'Dimension' }
+        & Pick<Dimension, 'id'>
+      )> }
+    )
+  >> }
 );
 "
 `;
@@ -418,20 +502,24 @@ exports[`TypeScript Operations Plugin Union & Interfaces Should handle union sel
 
 export type UserQueryQuery = (
   { __typename?: 'Query' }
-  & { user: (
-    { __typename?: 'User' }
-    & Pick<User, 'login' | 'id'>
-  ) | (
-    { __typename?: 'Error2' }
-    & Pick<Error2, 'message'>
-  ) | (
-    { __typename?: 'Error3' }
-    & Pick<Error3, 'message'>
-    & { info?: Maybe<(
-      { __typename?: 'AdditionalInfo' }
-      & Pick<AdditionalInfo, 'message2' | 'message'>
-    )> }
-  ) }
+  & { user:
+    | (
+      { __typename?: 'User' }
+      & Pick<User, 'login' | 'id'>
+    )
+    | (
+      { __typename?: 'Error2' }
+      & Pick<Error2, 'message'>
+    )
+    | (
+      { __typename?: 'Error3' }
+      & Pick<Error3, 'message'>
+      & { info?: Maybe<(
+        { __typename?: 'AdditionalInfo' }
+        & Pick<AdditionalInfo, 'message2' | 'message'>
+      )> }
+    )
+   }
 );
 
 export type AdditionalInfoFragment = (
@@ -454,7 +542,11 @@ type UserResult1_Error3_Fragment = (
   )> }
 );
 
-export type UserResult1Fragment = UserResult1_User_Fragment | UserResult1_Error2_Fragment | UserResult1_Error3_Fragment;
+export type UserResult1Fragment =
+  | UserResult1_User_Fragment
+  | UserResult1_Error2_Fragment
+  | UserResult1_Error3_Fragment
+;
 
 type UserResult_User_Fragment = (
   { __typename?: 'User' }
@@ -468,7 +560,11 @@ type UserResult_Error2_Fragment = (
 
 type UserResult_Error3_Fragment = { __typename?: 'Error3' };
 
-export type UserResultFragment = UserResult_User_Fragment | UserResult_Error2_Fragment | UserResult_Error3_Fragment;
+export type UserResultFragment =
+  | UserResult_User_Fragment
+  | UserResult_Error2_Fragment
+  | UserResult_Error3_Fragment
+;
 "
 `;
 
@@ -532,20 +628,24 @@ export type UserQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type UserQueryQuery = (
   { __typename?: 'Query' }
-  & { user: (
-    { __typename?: 'User' }
-    & Pick<User, 'id' | 'login'>
-  ) | (
-    { __typename?: 'Error2' }
-    & Pick<Error2, 'message'>
-  ) | (
-    { __typename?: 'Error3' }
-    & Pick<Error3, 'message'>
-    & { info?: Maybe<(
-      { __typename?: 'AdditionalInfo' }
-      & Pick<AdditionalInfo, 'message2' | 'message'>
-    )> }
-  ) }
+  & { user:
+    | (
+      { __typename?: 'User' }
+      & Pick<User, 'id' | 'login'>
+    )
+    | (
+      { __typename?: 'Error2' }
+      & Pick<Error2, 'message'>
+    )
+    | (
+      { __typename?: 'Error3' }
+      & Pick<Error3, 'message'>
+      & { info?: Maybe<(
+        { __typename?: 'AdditionalInfo' }
+        & Pick<AdditionalInfo, 'message2' | 'message'>
+      )> }
+    )
+   }
 );
 
         function t(q: UserQueryQuery) {
@@ -629,20 +729,30 @@ export type UserQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type UserQueryQuery = (
   { __typename?: 'Query' }
-  & { user: (
-    { __typename?: 'User' }
-    & Pick<User, 'id' | 'test2' | 'login' | 'test'>
-  ) | (
-    { __typename?: 'Error2' }
-    & Pick<Error2, 'message'>
-  ) | (
-    { __typename?: 'Error3' }
-    & Pick<Error3, 'message'>
-    & { info?: Maybe<(
-      { __typename?: 'AdditionalInfo' }
-      & Pick<AdditionalInfo, 'message2' | 'message'>
-    )> }
-  ) }
+  & { user:
+    | (
+      { __typename?: 'User' }
+      & Pick<
+        User,
+        | 'id'
+        | 'test2'
+        | 'login'
+        | 'test'
+      >
+    )
+    | (
+      { __typename?: 'Error2' }
+      & Pick<Error2, 'message'>
+    )
+    | (
+      { __typename?: 'Error3' }
+      & Pick<Error3, 'message'>
+      & { info?: Maybe<(
+        { __typename?: 'AdditionalInfo' }
+        & Pick<AdditionalInfo, 'message2' | 'message'>
+      )> }
+    )
+   }
 );
 
         function t(q: UserQueryQuery) {

--- a/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
+++ b/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
@@ -113,8 +113,7 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type MeFragment_ActiveUser_parentUser =
         | MeFragment_ActiveUser_parentUser_DummyUser
-        | MeFragment_ActiveUser_parentUser_ActiveUser
-      ;
+        | MeFragment_ActiveUser_parentUser_ActiveUser;
 
       type Me_DummyUser_Fragment = {
         __typename: 'DummyUser',
@@ -150,8 +149,7 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type OverlappingFieldsMergingTestQuery_me =
         | OverlappingFieldsMergingTestQuery_me_DummyUser
-        | OverlappingFieldsMergingTestQuery_me_ActiveUser
-      ;
+        | OverlappingFieldsMergingTestQuery_me_ActiveUser;
 
       export type OverlappingFieldsMergingTestQuery_Query = {
         __typename: 'Query',
@@ -180,8 +178,7 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type NestedOverlappingFieldsMergingTestQuery_me =
         | NestedOverlappingFieldsMergingTestQuery_me_DummyUser
-        | NestedOverlappingFieldsMergingTestQuery_me_ActiveUser
-      ;
+        | NestedOverlappingFieldsMergingTestQuery_me_ActiveUser;
 
       export type NestedOverlappingFieldsMergingTestQuery_Query = {
         __typename: 'Query',
@@ -1314,8 +1311,7 @@ describe('extractAllFieldsToTypes: true', () => {
         | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction
         | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction
         | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction
-        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom
-      ;
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
 
       export type ConversationBotSolutionFragment = (
         { __typename: 'BotSolution' }
@@ -1372,8 +1368,7 @@ describe('extractAllFieldsToTypes: true', () => {
         | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction
         | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction
         | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction
-        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom
-      ;
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
 
       type ConversationConversationEvent_BrokenConversationEvent_Fragment = (
         { __typename: 'BrokenConversationEvent' }
@@ -1506,8 +1501,7 @@ describe('extractAllFieldsToTypes: true', () => {
         | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction
         | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction
         | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction
-        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom
-      ;
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
 
       export type ConversationTalkPublicCallSummaryFragment = (
         { __typename: 'TalkPublicCallSummary' }

--- a/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
+++ b/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
@@ -109,7 +109,10 @@ describe('extractAllFieldsToTypes: true', () => {
         joinDate: any
       };
 
-      export type MeFragment_ActiveUser_parentUser = MeFragment_ActiveUser_parentUser_DummyUser | MeFragment_ActiveUser_parentUser_ActiveUser;
+      export type MeFragment_ActiveUser_parentUser =
+        | MeFragment_ActiveUser_parentUser_DummyUser
+        | MeFragment_ActiveUser_parentUser_ActiveUser
+      ;
 
       type Me_DummyUser_Fragment = {
         __typename: 'DummyUser',
@@ -141,7 +144,10 @@ describe('extractAllFieldsToTypes: true', () => {
         parentUser: MeFragment_ActiveUser_parentUser
       };
 
-      export type OverlappingFieldsMergingTestQuery_me = OverlappingFieldsMergingTestQuery_me_DummyUser | OverlappingFieldsMergingTestQuery_me_ActiveUser;
+      export type OverlappingFieldsMergingTestQuery_me =
+        | OverlappingFieldsMergingTestQuery_me_DummyUser
+        | OverlappingFieldsMergingTestQuery_me_ActiveUser
+      ;
 
       export type OverlappingFieldsMergingTestQuery_Query = {
         __typename: 'Query',
@@ -168,7 +174,10 @@ describe('extractAllFieldsToTypes: true', () => {
         parentUser: MeFragment_ActiveUser_parentUser
       };
 
-      export type NestedOverlappingFieldsMergingTestQuery_me = NestedOverlappingFieldsMergingTestQuery_me_DummyUser | NestedOverlappingFieldsMergingTestQuery_me_ActiveUser;
+      export type NestedOverlappingFieldsMergingTestQuery_me =
+        | NestedOverlappingFieldsMergingTestQuery_me_DummyUser
+        | NestedOverlappingFieldsMergingTestQuery_me_ActiveUser
+      ;
 
       export type NestedOverlappingFieldsMergingTestQuery_Query = {
         __typename: 'Query',
@@ -1294,7 +1303,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom =
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationBotSolutionFragment = (
         { __typename: 'BotSolution' }
@@ -1344,7 +1361,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom =
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       type ConversationConversationEvent_BrokenConversationEvent_Fragment = (
         { __typename: 'BrokenConversationEvent' }
@@ -1453,7 +1478,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom =
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment = (
         { __typename: 'TalkPublicCallSummary' }

--- a/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
+++ b/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
@@ -97,7 +97,8 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type UserFragment =
         | UserFragment_DummyUser
-        | UserFragment_ActiveUser;
+        | UserFragment_ActiveUser
+      ;
 
       export type MeFragment_ActiveUser_parentUser_DummyUser = {
         __typename: 'DummyUser',
@@ -113,7 +114,8 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type MeFragment_ActiveUser_parentUser =
         | MeFragment_ActiveUser_parentUser_DummyUser
-        | MeFragment_ActiveUser_parentUser_ActiveUser;
+        | MeFragment_ActiveUser_parentUser_ActiveUser
+      ;
 
       type Me_DummyUser_Fragment = {
         __typename: 'DummyUser',
@@ -131,7 +133,8 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type MeFragment =
         | Me_DummyUser_Fragment
-        | Me_ActiveUser_Fragment;
+        | Me_ActiveUser_Fragment
+      ;
 
       export type OverlappingFieldsMergingTestQuery_me_DummyUser = {
         __typename: 'DummyUser',
@@ -149,7 +152,8 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type OverlappingFieldsMergingTestQuery_me =
         | OverlappingFieldsMergingTestQuery_me_DummyUser
-        | OverlappingFieldsMergingTestQuery_me_ActiveUser;
+        | OverlappingFieldsMergingTestQuery_me_ActiveUser
+      ;
 
       export type OverlappingFieldsMergingTestQuery_Query = {
         __typename: 'Query',
@@ -178,7 +182,8 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type NestedOverlappingFieldsMergingTestQuery_me =
         | NestedOverlappingFieldsMergingTestQuery_me_DummyUser
-        | NestedOverlappingFieldsMergingTestQuery_me_ActiveUser;
+        | NestedOverlappingFieldsMergingTestQuery_me_ActiveUser
+      ;
 
       export type NestedOverlappingFieldsMergingTestQuery_Query = {
         __typename: 'Query',
@@ -412,7 +417,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom =
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationBotSolutionFragment = { __typename: 'BotSolution', id: string, timestamp: string, article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle, originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom };
 
@@ -434,7 +447,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom =
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       type ConversationConversationEvent_BrokenConversationEvent_Fragment = { __typename: 'BrokenConversationEvent', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom };
 
@@ -442,7 +463,11 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type ConversationConversationEvent_TalkPublicCallSummary_Fragment = { __typename: 'TalkPublicCallSummary', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom };
 
-      export type ConversationConversationEventFragment = ConversationConversationEvent_BrokenConversationEvent_Fragment | ConversationConversationEvent_BotSolution_Fragment | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
+      export type ConversationConversationEventFragment =
+        | ConversationConversationEvent_BrokenConversationEvent_Fragment
+        | ConversationConversationEvent_BotSolution_Fragment
+        | ConversationConversationEvent_TalkPublicCallSummary_Fragment
+      ;
 
       type MessageEnvelopeData_EmailInteraction_Fragment = { __typename: 'EmailInteraction', originalEmailURLPath: string };
 
@@ -458,7 +483,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_CustomChannelInteraction_Fragment | MessageEnvelopeData_TalkInteraction_Fragment | MessageEnvelopeData_NativeMessagingInteraction_Fragment | MessageEnvelopeData_WhatsAppInteraction_Fragment | MessageEnvelopeData_WeChatInteraction_Fragment | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
+      export type MessageEnvelopeDataFragment =
+        | MessageEnvelopeData_EmailInteraction_Fragment
+        | MessageEnvelopeData_CustomChannelInteraction_Fragment
+        | MessageEnvelopeData_TalkInteraction_Fragment
+        | MessageEnvelopeData_NativeMessagingInteraction_Fragment
+        | MessageEnvelopeData_WhatsAppInteraction_Fragment
+        | MessageEnvelopeData_WeChatInteraction_Fragment
+        | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment
+      ;
 
       export type AnyChannelOriginatedFromFragment = { __typename: 'CustomChannelInteraction', externalId: string, timestamp: string, resourceType: string };
 
@@ -476,7 +509,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment | ConversationOriginatedFrom_WhatsAppInteraction_Fragment | ConversationOriginatedFrom_WeChatInteraction_Fragment | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
+      export type ConversationOriginatedFromFragment =
+        | ConversationOriginatedFrom_EmailInteraction_Fragment
+        | ConversationOriginatedFrom_CustomChannelInteraction_Fragment
+        | ConversationOriginatedFrom_TalkInteraction_Fragment
+        | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment
+        | ConversationOriginatedFrom_WhatsAppInteraction_Fragment
+        | ConversationOriginatedFrom_WeChatInteraction_Fragment
+        | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = { __typename: 'EmailInteraction', originalEmailURLPath: string };
 
@@ -492,7 +533,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom =
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment = { __typename: 'TalkPublicCallSummary', id: string, timestamp: string, summary: string, originatedFrom: ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom };
       "
@@ -538,7 +587,12 @@ describe('extractAllFieldsToTypes: true', () => {
         & { __typename: 'NativeMessagingInteraction' | 'WhatsAppInteraction' | 'WeChatInteraction' }
       );
 
-      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction_NotImplementedOriginatedFrom | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction;
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom =
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction_NotImplementedOriginatedFrom
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction
+      ;
 
       export type ConversationBotSolutionFragment = (
         { id: string, timestamp: string, article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle, originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom }
@@ -572,7 +626,12 @@ describe('extractAllFieldsToTypes: true', () => {
         & { __typename: 'NativeMessagingInteraction' | 'WhatsAppInteraction' | 'WeChatInteraction' }
       );
 
-      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction_NotImplementedOriginatedFrom | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction;
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom =
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction_NotImplementedOriginatedFrom
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction
+      ;
 
       export type ConversationConversationEventFragment = (
         { id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom }
@@ -586,7 +645,10 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type MessageEnvelopeData_8FBboKcmuva72FpaH1zuPdoYyrlyvueTn9fqP1dFi_Fragment = { __typename: 'CustomChannelInteraction' | 'TalkInteraction' | 'NativeMessagingInteraction' | 'WhatsAppInteraction' | 'WeChatInteraction' | 'NotImplementedOriginatedFrom' };
 
-      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_8FBboKcmuva72FpaH1zuPdoYyrlyvueTn9fqP1dFi_Fragment;
+      export type MessageEnvelopeDataFragment =
+        | MessageEnvelopeData_EmailInteraction_Fragment
+        | MessageEnvelopeData_8FBboKcmuva72FpaH1zuPdoYyrlyvueTn9fqP1dFi_Fragment
+      ;
 
       export type AnyChannelOriginatedFromFragment = (
         { externalId: string, timestamp: string, resourceType: string }
@@ -610,7 +672,12 @@ describe('extractAllFieldsToTypes: true', () => {
         & { __typename: 'NativeMessagingInteraction' | 'WhatsAppInteraction' | 'WeChatInteraction' }
       );
 
-      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_NotImplementedOriginatedFrom_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction_Fragment;
+      export type ConversationOriginatedFromFragment =
+        | ConversationOriginatedFrom_EmailInteraction_Fragment
+        | ConversationOriginatedFrom_CustomChannelInteraction_Fragment
+        | ConversationOriginatedFrom_TalkInteraction_NotImplementedOriginatedFrom_Fragment
+        | ConversationOriginatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction_Fragment
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = (
         { originalEmailURLPath: string }
@@ -634,7 +701,13 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom =
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction_WhatsAppInteraction_WeChatInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment = (
         { id: string, timestamp: string, summary: string, originatedFrom: ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom }
@@ -698,7 +771,15 @@ describe('extractAllFieldsToTypes: true', () => {
         & ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment
       );
 
-      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom =
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationBotSolutionFragment = (
         { __typename: 'BotSolution', id: string, article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle, originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom }
@@ -744,7 +825,15 @@ describe('extractAllFieldsToTypes: true', () => {
         & ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment
       );
 
-      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom =
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       type ConversationConversationEvent_BrokenConversationEvent_Fragment = { __typename: 'BrokenConversationEvent', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom };
 
@@ -752,7 +841,11 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type ConversationConversationEvent_TalkPublicCallSummary_Fragment = { __typename: 'TalkPublicCallSummary', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom };
 
-      export type ConversationConversationEventFragment = ConversationConversationEvent_BrokenConversationEvent_Fragment | ConversationConversationEvent_BotSolution_Fragment | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
+      export type ConversationConversationEventFragment =
+        | ConversationConversationEvent_BrokenConversationEvent_Fragment
+        | ConversationConversationEvent_BotSolution_Fragment
+        | ConversationConversationEvent_TalkPublicCallSummary_Fragment
+      ;
 
       type MessageEnvelopeData_EmailInteraction_Fragment = { __typename: 'EmailInteraction', originalEmailURLPath: string };
 
@@ -768,7 +861,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_CustomChannelInteraction_Fragment | MessageEnvelopeData_TalkInteraction_Fragment | MessageEnvelopeData_NativeMessagingInteraction_Fragment | MessageEnvelopeData_WhatsAppInteraction_Fragment | MessageEnvelopeData_WeChatInteraction_Fragment | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
+      export type MessageEnvelopeDataFragment =
+        | MessageEnvelopeData_EmailInteraction_Fragment
+        | MessageEnvelopeData_CustomChannelInteraction_Fragment
+        | MessageEnvelopeData_TalkInteraction_Fragment
+        | MessageEnvelopeData_NativeMessagingInteraction_Fragment
+        | MessageEnvelopeData_WhatsAppInteraction_Fragment
+        | MessageEnvelopeData_WeChatInteraction_Fragment
+        | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment
+      ;
 
       export type AnyChannelOriginatedFromFragment = { __typename: 'CustomChannelInteraction', externalId: string, timestamp: string, resourceType: string };
 
@@ -808,7 +909,15 @@ describe('extractAllFieldsToTypes: true', () => {
         & MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment
       );
 
-      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment | ConversationOriginatedFrom_WhatsAppInteraction_Fragment | ConversationOriginatedFrom_WeChatInteraction_Fragment | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
+      export type ConversationOriginatedFromFragment =
+        | ConversationOriginatedFrom_EmailInteraction_Fragment
+        | ConversationOriginatedFrom_CustomChannelInteraction_Fragment
+        | ConversationOriginatedFrom_TalkInteraction_Fragment
+        | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment
+        | ConversationOriginatedFrom_WhatsAppInteraction_Fragment
+        | ConversationOriginatedFrom_WeChatInteraction_Fragment
+        | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = { __typename: 'EmailInteraction' };
 
@@ -827,7 +936,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom =
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment = (
         { __typename: 'TalkPublicCallSummary', id: string, originatedFrom: ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom }
@@ -892,7 +1009,15 @@ describe('extractAllFieldsToTypes: true', () => {
         & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment': ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment } }
       );
 
-      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom =
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationBotSolutionFragment = (
         { __typename: 'BotSolution', id: string, article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle, originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom }
@@ -938,7 +1063,15 @@ describe('extractAllFieldsToTypes: true', () => {
         & { ' $fragmentRefs'?: { 'ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment': ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment } }
       );
 
-      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom =
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       type ConversationConversationEvent_BrokenConversationEvent_Fragment = { __typename: 'BrokenConversationEvent', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom } & { ' $fragmentName'?: 'ConversationConversationEvent_BrokenConversationEvent_Fragment' };
 
@@ -946,7 +1079,11 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type ConversationConversationEvent_TalkPublicCallSummary_Fragment = { __typename: 'TalkPublicCallSummary', id: string, timestamp: string, originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom } & { ' $fragmentName'?: 'ConversationConversationEvent_TalkPublicCallSummary_Fragment' };
 
-      export type ConversationConversationEventFragment = ConversationConversationEvent_BrokenConversationEvent_Fragment | ConversationConversationEvent_BotSolution_Fragment | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
+      export type ConversationConversationEventFragment =
+        | ConversationConversationEvent_BrokenConversationEvent_Fragment
+        | ConversationConversationEvent_BotSolution_Fragment
+        | ConversationConversationEvent_TalkPublicCallSummary_Fragment
+      ;
 
       type MessageEnvelopeData_EmailInteraction_Fragment = { __typename: 'EmailInteraction', originalEmailURLPath: string } & { ' $fragmentName'?: 'MessageEnvelopeData_EmailInteraction_Fragment' };
 
@@ -962,7 +1099,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' } & { ' $fragmentName'?: 'MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment' };
 
-      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_CustomChannelInteraction_Fragment | MessageEnvelopeData_TalkInteraction_Fragment | MessageEnvelopeData_NativeMessagingInteraction_Fragment | MessageEnvelopeData_WhatsAppInteraction_Fragment | MessageEnvelopeData_WeChatInteraction_Fragment | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
+      export type MessageEnvelopeDataFragment =
+        | MessageEnvelopeData_EmailInteraction_Fragment
+        | MessageEnvelopeData_CustomChannelInteraction_Fragment
+        | MessageEnvelopeData_TalkInteraction_Fragment
+        | MessageEnvelopeData_NativeMessagingInteraction_Fragment
+        | MessageEnvelopeData_WhatsAppInteraction_Fragment
+        | MessageEnvelopeData_WeChatInteraction_Fragment
+        | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment
+      ;
 
       export type AnyChannelOriginatedFromFragment = { __typename: 'CustomChannelInteraction', externalId: string, timestamp: string, resourceType: string } & { ' $fragmentName'?: 'AnyChannelOriginatedFromFragment' };
 
@@ -1001,7 +1146,15 @@ describe('extractAllFieldsToTypes: true', () => {
         & { ' $fragmentRefs'?: { 'MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment': MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment } }
       ) & { ' $fragmentName'?: 'ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment' };
 
-      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment | ConversationOriginatedFrom_WhatsAppInteraction_Fragment | ConversationOriginatedFrom_WeChatInteraction_Fragment | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
+      export type ConversationOriginatedFromFragment =
+        | ConversationOriginatedFrom_EmailInteraction_Fragment
+        | ConversationOriginatedFrom_CustomChannelInteraction_Fragment
+        | ConversationOriginatedFrom_TalkInteraction_Fragment
+        | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment
+        | ConversationOriginatedFrom_WhatsAppInteraction_Fragment
+        | ConversationOriginatedFrom_WeChatInteraction_Fragment
+        | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = { __typename: 'EmailInteraction' };
 
@@ -1020,7 +1173,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom =
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment = (
         { __typename: 'TalkPublicCallSummary', id: string, originatedFrom: ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom }
@@ -1048,7 +1209,13 @@ describe('extractAllFieldsToTypes: true', () => {
     expect(content).toMatchInlineSnapshot(`
       "export type ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle = (
         { __typename: 'ArchivedArticle' }
-        & Pick<ArchivedArticle, 'id' | 'htmlUrl' | 'title' | 'url'>
+        & Pick<
+          ArchivedArticle,
+          | 'id'
+          | 'htmlUrl'
+          | 'title'
+          | 'url'
+        >
       );
 
       export type ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction = (
@@ -1080,12 +1247,23 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom =
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationBotSolutionFragment = (
         { __typename: 'BotSolution' }
         & Pick<BotSolution, 'id' | 'timestamp'>
-        & { article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle, originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom }
+        & {
+          article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle,
+          originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom,
+        }
       );
 
       export type ConversationGenericCallSummaryFragment = (
@@ -1127,7 +1305,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom =
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       type ConversationConversationEvent_BrokenConversationEvent_Fragment = (
         { __typename: 'BrokenConversationEvent' }
@@ -1147,7 +1333,11 @@ describe('extractAllFieldsToTypes: true', () => {
         & { originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom }
       );
 
-      export type ConversationConversationEventFragment = ConversationConversationEvent_BrokenConversationEvent_Fragment | ConversationConversationEvent_BotSolution_Fragment | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
+      export type ConversationConversationEventFragment =
+        | ConversationConversationEvent_BrokenConversationEvent_Fragment
+        | ConversationConversationEvent_BotSolution_Fragment
+        | ConversationConversationEvent_TalkPublicCallSummary_Fragment
+      ;
 
       type MessageEnvelopeData_EmailInteraction_Fragment = (
         { __typename: 'EmailInteraction' }
@@ -1166,7 +1356,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_CustomChannelInteraction_Fragment | MessageEnvelopeData_TalkInteraction_Fragment | MessageEnvelopeData_NativeMessagingInteraction_Fragment | MessageEnvelopeData_WhatsAppInteraction_Fragment | MessageEnvelopeData_WeChatInteraction_Fragment | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
+      export type MessageEnvelopeDataFragment =
+        | MessageEnvelopeData_EmailInteraction_Fragment
+        | MessageEnvelopeData_CustomChannelInteraction_Fragment
+        | MessageEnvelopeData_TalkInteraction_Fragment
+        | MessageEnvelopeData_NativeMessagingInteraction_Fragment
+        | MessageEnvelopeData_WhatsAppInteraction_Fragment
+        | MessageEnvelopeData_WeChatInteraction_Fragment
+        | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment
+      ;
 
       export type AnyChannelOriginatedFromFragment = (
         { __typename: 'CustomChannelInteraction' }
@@ -1202,7 +1400,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment | ConversationOriginatedFrom_WhatsAppInteraction_Fragment | ConversationOriginatedFrom_WeChatInteraction_Fragment | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
+      export type ConversationOriginatedFromFragment =
+        | ConversationOriginatedFrom_EmailInteraction_Fragment
+        | ConversationOriginatedFrom_CustomChannelInteraction_Fragment
+        | ConversationOriginatedFrom_TalkInteraction_Fragment
+        | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment
+        | ConversationOriginatedFrom_WhatsAppInteraction_Fragment
+        | ConversationOriginatedFrom_WeChatInteraction_Fragment
+        | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = (
         { __typename: 'EmailInteraction' }
@@ -1236,7 +1442,15 @@ describe('extractAllFieldsToTypes: true', () => {
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom =
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment = (
         { __typename: 'TalkPublicCallSummary' }
@@ -1311,7 +1525,8 @@ describe('extractAllFieldsToTypes: true', () => {
         | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction
         | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction
         | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction
-        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
+        | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationBotSolutionFragment = (
         { __typename: 'BotSolution' }
@@ -1368,7 +1583,8 @@ describe('extractAllFieldsToTypes: true', () => {
         | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction
         | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction
         | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction
-        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
+        | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       type ConversationConversationEvent_BrokenConversationEvent_Fragment = (
         { __typename: 'BrokenConversationEvent' }
@@ -1391,7 +1607,8 @@ describe('extractAllFieldsToTypes: true', () => {
       export type ConversationConversationEventFragment =
         | ConversationConversationEvent_BrokenConversationEvent_Fragment
         | ConversationConversationEvent_BotSolution_Fragment
-        | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
+        | ConversationConversationEvent_TalkPublicCallSummary_Fragment
+      ;
 
       type MessageEnvelopeData_EmailInteraction_Fragment = (
         { __typename: 'EmailInteraction' }
@@ -1417,7 +1634,8 @@ describe('extractAllFieldsToTypes: true', () => {
         | MessageEnvelopeData_NativeMessagingInteraction_Fragment
         | MessageEnvelopeData_WhatsAppInteraction_Fragment
         | MessageEnvelopeData_WeChatInteraction_Fragment
-        | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
+        | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment
+      ;
 
       export type AnyChannelOriginatedFromFragment = (
         { __typename: 'CustomChannelInteraction' }
@@ -1460,7 +1678,8 @@ describe('extractAllFieldsToTypes: true', () => {
         | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment
         | ConversationOriginatedFrom_WhatsAppInteraction_Fragment
         | ConversationOriginatedFrom_WeChatInteraction_Fragment
-        | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
+        | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = (
         { __typename: 'EmailInteraction' }
@@ -1501,7 +1720,8 @@ describe('extractAllFieldsToTypes: true', () => {
         | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction
         | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction
         | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction
-        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+        | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom
+      ;
 
       export type ConversationTalkPublicCallSummaryFragment = (
         { __typename: 'TalkPublicCallSummary' }

--- a/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
+++ b/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
@@ -1238,4 +1238,231 @@ describe('extractAllFieldsToTypes: true', () => {
 
     await validate(content, config, complexTestSchemaWithUnionsAndInterfaces);
   });
+
+  it('should extract types from multiple fragments (preResolveTypes: false, printFieldsOnNewlines: true)', async () => {
+    const config: TypeScriptDocumentsPluginConfig = {
+      preResolveTypes: false,
+      extractAllFieldsToTypes: true,
+      nonOptionalTypename: true,
+      dedupeOperationSuffix: true,
+      printFieldsOnNewLines: true,
+    };
+    const { content } = await plugin(
+      complexTestSchemaWithUnionsAndInterfaces,
+      [{ location: 'test-file.ts', document: fragmentsOnComplexSchema }],
+      config,
+      { outputFile: '' }
+    );
+    expect(content).toMatchInlineSnapshot(`
+      "export type ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle = (
+        { __typename: 'ArchivedArticle' }
+        & Pick<
+          ArchivedArticle,
+          | 'id'
+          | 'htmlUrl'
+          | 'title'
+          | 'url'
+        >
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction = (
+        { __typename: 'EmailInteraction' }
+        & Pick<EmailInteraction, 'originalEmailURLPath'>
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction = (
+        { __typename: 'CustomChannelInteraction' }
+        & Pick<CustomChannelInteraction, 'externalId' | 'timestamp' | 'resourceType'>
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction = { __typename: 'TalkInteraction' };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction = (
+        { __typename: 'NativeMessagingInteraction' }
+        & Pick<NativeMessagingInteraction, 'conversationId'>
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction = (
+        { __typename: 'WhatsAppInteraction' }
+        & Pick<WhatsAppInteraction, 'conversationId'>
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction = (
+        { __typename: 'WeChatInteraction' }
+        & Pick<WeChatInteraction, 'conversationId'>
+      );
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationBotSolutionFragment_BotSolution_originatedFrom = ConversationBotSolutionFragment_BotSolution_originatedFrom_EmailInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_CustomChannelInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_TalkInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NativeMessagingInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WhatsAppInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_WeChatInteraction | ConversationBotSolutionFragment_BotSolution_originatedFrom_NotImplementedOriginatedFrom;
+
+      export type ConversationBotSolutionFragment = (
+        { __typename: 'BotSolution' }
+        & Pick<BotSolution, 'id' | 'timestamp'>
+        & {
+          article: ConversationBotSolutionFragment_BotSolution_article_ArchivedArticle,
+          originatedFrom: ConversationBotSolutionFragment_BotSolution_originatedFrom,
+        }
+      );
+
+      export type ConversationGenericCallSummaryFragment = (
+        { __typename: 'TalkPublicCallSummary' }
+        & Pick<TalkPublicCallSummary, 'id' | 'summary'>
+      );
+
+      export type ConversationTalkInteractionFragment = (
+        { __typename: 'TalkInteraction' }
+        & Pick<TalkInteraction, 'channel' | 'type'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction = (
+        { __typename: 'EmailInteraction' }
+        & Pick<EmailInteraction, 'originalEmailURLPath'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction = (
+        { __typename: 'CustomChannelInteraction' }
+        & Pick<CustomChannelInteraction, 'externalId' | 'timestamp' | 'resourceType'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction = { __typename: 'TalkInteraction' };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction = (
+        { __typename: 'NativeMessagingInteraction' }
+        & Pick<NativeMessagingInteraction, 'conversationId'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction = (
+        { __typename: 'WhatsAppInteraction' }
+        & Pick<WhatsAppInteraction, 'conversationId'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction = (
+        { __typename: 'WeChatInteraction' }
+        & Pick<WeChatInteraction, 'conversationId'>
+      );
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom = ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_EmailInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_CustomChannelInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_TalkInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NativeMessagingInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WhatsAppInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_WeChatInteraction | ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom_NotImplementedOriginatedFrom;
+
+      type ConversationConversationEvent_BrokenConversationEvent_Fragment = (
+        { __typename: 'BrokenConversationEvent' }
+        & Pick<BrokenConversationEvent, 'id' | 'timestamp'>
+        & { originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom }
+      );
+
+      type ConversationConversationEvent_BotSolution_Fragment = (
+        { __typename: 'BotSolution' }
+        & Pick<BotSolution, 'id' | 'timestamp'>
+        & { originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom }
+      );
+
+      type ConversationConversationEvent_TalkPublicCallSummary_Fragment = (
+        { __typename: 'TalkPublicCallSummary' }
+        & Pick<TalkPublicCallSummary, 'id' | 'timestamp'>
+        & { originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom }
+      );
+
+      export type ConversationConversationEventFragment = ConversationConversationEvent_BrokenConversationEvent_Fragment | ConversationConversationEvent_BotSolution_Fragment | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
+
+      type MessageEnvelopeData_EmailInteraction_Fragment = (
+        { __typename: 'EmailInteraction' }
+        & Pick<EmailInteraction, 'originalEmailURLPath'>
+      );
+
+      type MessageEnvelopeData_CustomChannelInteraction_Fragment = { __typename: 'CustomChannelInteraction' };
+
+      type MessageEnvelopeData_TalkInteraction_Fragment = { __typename: 'TalkInteraction' };
+
+      type MessageEnvelopeData_NativeMessagingInteraction_Fragment = { __typename: 'NativeMessagingInteraction' };
+
+      type MessageEnvelopeData_WhatsAppInteraction_Fragment = { __typename: 'WhatsAppInteraction' };
+
+      type MessageEnvelopeData_WeChatInteraction_Fragment = { __typename: 'WeChatInteraction' };
+
+      type MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_CustomChannelInteraction_Fragment | MessageEnvelopeData_TalkInteraction_Fragment | MessageEnvelopeData_NativeMessagingInteraction_Fragment | MessageEnvelopeData_WhatsAppInteraction_Fragment | MessageEnvelopeData_WeChatInteraction_Fragment | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
+
+      export type AnyChannelOriginatedFromFragment = (
+        { __typename: 'CustomChannelInteraction' }
+        & Pick<CustomChannelInteraction, 'externalId' | 'timestamp' | 'resourceType'>
+      );
+
+      type ConversationOriginatedFrom_EmailInteraction_Fragment = (
+        { __typename: 'EmailInteraction' }
+        & Pick<EmailInteraction, 'originalEmailURLPath'>
+      );
+
+      type ConversationOriginatedFrom_CustomChannelInteraction_Fragment = (
+        { __typename: 'CustomChannelInteraction' }
+        & Pick<CustomChannelInteraction, 'externalId' | 'timestamp' | 'resourceType'>
+      );
+
+      type ConversationOriginatedFrom_TalkInteraction_Fragment = { __typename: 'TalkInteraction' };
+
+      type ConversationOriginatedFrom_NativeMessagingInteraction_Fragment = (
+        { __typename: 'NativeMessagingInteraction' }
+        & Pick<NativeMessagingInteraction, 'conversationId'>
+      );
+
+      type ConversationOriginatedFrom_WhatsAppInteraction_Fragment = (
+        { __typename: 'WhatsAppInteraction' }
+        & Pick<WhatsAppInteraction, 'conversationId'>
+      );
+
+      type ConversationOriginatedFrom_WeChatInteraction_Fragment = (
+        { __typename: 'WeChatInteraction' }
+        & Pick<WeChatInteraction, 'conversationId'>
+      );
+
+      type ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment | ConversationOriginatedFrom_WhatsAppInteraction_Fragment | ConversationOriginatedFrom_WeChatInteraction_Fragment | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = (
+        { __typename: 'EmailInteraction' }
+        & Pick<EmailInteraction, 'originalEmailURLPath'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction = (
+        { __typename: 'CustomChannelInteraction' }
+        & Pick<CustomChannelInteraction, 'externalId' | 'timestamp' | 'resourceType'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction = (
+        { __typename: 'TalkInteraction' }
+        & Pick<TalkInteraction, 'channel' | 'type'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction = (
+        { __typename: 'NativeMessagingInteraction' }
+        & Pick<NativeMessagingInteraction, 'conversationId'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction = (
+        { __typename: 'WhatsAppInteraction' }
+        & Pick<WhatsAppInteraction, 'conversationId'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction = (
+        { __typename: 'WeChatInteraction' }
+        & Pick<WeChatInteraction, 'conversationId'>
+      );
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom = { __typename: 'NotImplementedOriginatedFrom' };
+
+      export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom = ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_CustomChannelInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_TalkInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NativeMessagingInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WhatsAppInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_WeChatInteraction | ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_NotImplementedOriginatedFrom;
+
+      export type ConversationTalkPublicCallSummaryFragment = (
+        { __typename: 'TalkPublicCallSummary' }
+        & Pick<TalkPublicCallSummary, 'id' | 'timestamp' | 'summary'>
+        & { originatedFrom: ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom }
+      );
+      "
+    `);
+
+    await validate(content, config, complexTestSchemaWithUnionsAndInterfaces);
+  });
 });

--- a/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
+++ b/packages/plugins/typescript/operations/tests/extract-all-types.spec.ts
@@ -95,7 +95,9 @@ describe('extractAllFieldsToTypes: true', () => {
         joinDate: any
       };
 
-      export type UserFragment = UserFragment_DummyUser | UserFragment_ActiveUser;
+      export type UserFragment =
+        | UserFragment_DummyUser
+        | UserFragment_ActiveUser;
 
       export type MeFragment_ActiveUser_parentUser_DummyUser = {
         __typename: 'DummyUser',
@@ -128,7 +130,9 @@ describe('extractAllFieldsToTypes: true', () => {
         parentUser: MeFragment_ActiveUser_parentUser
       };
 
-      export type MeFragment = Me_DummyUser_Fragment | Me_ActiveUser_Fragment;
+      export type MeFragment =
+        | Me_DummyUser_Fragment
+        | Me_ActiveUser_Fragment;
 
       export type OverlappingFieldsMergingTestQuery_me_DummyUser = {
         __typename: 'DummyUser',
@@ -1389,7 +1393,10 @@ describe('extractAllFieldsToTypes: true', () => {
         & { originatedFrom: ConversationConversationEventFragment_BrokenConversationEvent_originatedFrom }
       );
 
-      export type ConversationConversationEventFragment = ConversationConversationEvent_BrokenConversationEvent_Fragment | ConversationConversationEvent_BotSolution_Fragment | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
+      export type ConversationConversationEventFragment =
+        | ConversationConversationEvent_BrokenConversationEvent_Fragment
+        | ConversationConversationEvent_BotSolution_Fragment
+        | ConversationConversationEvent_TalkPublicCallSummary_Fragment;
 
       type MessageEnvelopeData_EmailInteraction_Fragment = (
         { __typename: 'EmailInteraction' }
@@ -1408,7 +1415,14 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type MessageEnvelopeDataFragment = MessageEnvelopeData_EmailInteraction_Fragment | MessageEnvelopeData_CustomChannelInteraction_Fragment | MessageEnvelopeData_TalkInteraction_Fragment | MessageEnvelopeData_NativeMessagingInteraction_Fragment | MessageEnvelopeData_WhatsAppInteraction_Fragment | MessageEnvelopeData_WeChatInteraction_Fragment | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
+      export type MessageEnvelopeDataFragment =
+        | MessageEnvelopeData_EmailInteraction_Fragment
+        | MessageEnvelopeData_CustomChannelInteraction_Fragment
+        | MessageEnvelopeData_TalkInteraction_Fragment
+        | MessageEnvelopeData_NativeMessagingInteraction_Fragment
+        | MessageEnvelopeData_WhatsAppInteraction_Fragment
+        | MessageEnvelopeData_WeChatInteraction_Fragment
+        | MessageEnvelopeData_NotImplementedOriginatedFrom_Fragment;
 
       export type AnyChannelOriginatedFromFragment = (
         { __typename: 'CustomChannelInteraction' }
@@ -1444,7 +1458,14 @@ describe('extractAllFieldsToTypes: true', () => {
 
       type ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment = { __typename: 'NotImplementedOriginatedFrom' };
 
-      export type ConversationOriginatedFromFragment = ConversationOriginatedFrom_EmailInteraction_Fragment | ConversationOriginatedFrom_CustomChannelInteraction_Fragment | ConversationOriginatedFrom_TalkInteraction_Fragment | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment | ConversationOriginatedFrom_WhatsAppInteraction_Fragment | ConversationOriginatedFrom_WeChatInteraction_Fragment | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
+      export type ConversationOriginatedFromFragment =
+        | ConversationOriginatedFrom_EmailInteraction_Fragment
+        | ConversationOriginatedFrom_CustomChannelInteraction_Fragment
+        | ConversationOriginatedFrom_TalkInteraction_Fragment
+        | ConversationOriginatedFrom_NativeMessagingInteraction_Fragment
+        | ConversationOriginatedFrom_WhatsAppInteraction_Fragment
+        | ConversationOriginatedFrom_WeChatInteraction_Fragment
+        | ConversationOriginatedFrom_NotImplementedOriginatedFrom_Fragment;
 
       export type ConversationTalkPublicCallSummaryFragment_TalkPublicCallSummary_originatedFrom_EmailInteraction = (
         { __typename: 'EmailInteraction' }

--- a/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.spec.ts
@@ -984,10 +984,18 @@ describe('TypeScript Operations Plugin', () => {
       });
 
       expect(content).toContain(
-        `export type Q1Query = { search: Array<{ __typename: 'Movie', id: string, title: string } | { __typename: 'Person', id: string, name: string }> };`
+        `\
+export type Q1Query = { search: Array<
+    | { __typename: 'Movie', id: string, title: string }
+    | { __typename: 'Person', id: string, name: string }
+  > };`
       );
       expect(content).toContain(
-        `export type Q2Query = { search: Array<{ __typename: 'Movie', id: string, title: string } | { __typename: 'Person', id: string, name: string }> };`
+        `\
+export type Q2Query = { search: Array<
+    | { __typename: 'Movie', id: string, title: string }
+    | { __typename: 'Person', id: string, name: string }
+  > };`
       );
       await validate(content, config, testSchema);
     });
@@ -5332,12 +5340,21 @@ function test(q: GetEntityBrandDataQuery): void {
 
         type CatFragment_Wolf_Fragment = {};
 
-        export type CatFragmentFragment = CatFragment_Duck_Fragment | CatFragment_Lion_Fragment | CatFragment_Puma_Fragment | CatFragment_Wolf_Fragment;
+        export type CatFragmentFragment =
+          | CatFragment_Duck_Fragment
+          | CatFragment_Lion_Fragment
+          | CatFragment_Puma_Fragment
+          | CatFragment_Wolf_Fragment
+        ;
 
         export type KittyQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type KittyQuery = { animals: Array<{ id: string } | { id: string } | {}> };
+        export type KittyQuery = { animals: Array<
+            | { id: string }
+            | { id: string }
+            | {}
+          > };
         "
       `);
     });
@@ -5402,12 +5419,22 @@ function test(q: GetEntityBrandDataQuery): void {
 
         type CatFragment_Wolf_Fragment = { __typename?: 'Wolf' };
 
-        export type CatFragmentFragment = CatFragment_Duck_Fragment | CatFragment_Lion_Fragment | CatFragment_Puma_Fragment | CatFragment_Wolf_Fragment;
+        export type CatFragmentFragment =
+          | CatFragment_Duck_Fragment
+          | CatFragment_Lion_Fragment
+          | CatFragment_Puma_Fragment
+          | CatFragment_Wolf_Fragment
+        ;
 
         export type KittyQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type KittyQuery = { __typename?: 'Query', animals: Array<{ __typename?: 'Duck' } | { __typename?: 'Lion', id: string } | { __typename?: 'Puma', id: string } | { __typename?: 'Wolf' }> };
+        export type KittyQuery = { __typename?: 'Query', animals: Array<
+            | { __typename?: 'Duck' }
+            | { __typename?: 'Lion', id: string }
+            | { __typename?: 'Puma', id: string }
+            | { __typename?: 'Wolf' }
+          > };
         "
       `);
     });
@@ -5884,16 +5911,20 @@ function test(q: GetEntityBrandDataQuery): void {
         "export type GetPeopleQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-        export type GetPeopleQuery = { __typename?: 'Query', people: (
-            { __typename?: 'Character' }
-            & { ' $fragmentRefs'?: { 'PeopleInfo_Character_Fragment': PeopleInfo_Character_Fragment } }
-          ) | (
-            { __typename?: 'Jedi' }
-            & { ' $fragmentRefs'?: { 'PeopleInfo_Jedi_Fragment': PeopleInfo_Jedi_Fragment } }
-          ) | (
-            { __typename?: 'Droid' }
-            & { ' $fragmentRefs'?: { 'PeopleInfo_Droid_Fragment': PeopleInfo_Droid_Fragment } }
-          ) };
+        export type GetPeopleQuery = { __typename?: 'Query', people:
+            | (
+              { __typename?: 'Character' }
+              & { ' $fragmentRefs'?: { 'PeopleInfo_Character_Fragment': PeopleInfo_Character_Fragment } }
+            )
+            | (
+              { __typename?: 'Jedi' }
+              & { ' $fragmentRefs'?: { 'PeopleInfo_Jedi_Fragment': PeopleInfo_Jedi_Fragment } }
+            )
+            | (
+              { __typename?: 'Droid' }
+              & { ' $fragmentRefs'?: { 'PeopleInfo_Droid_Fragment': PeopleInfo_Droid_Fragment } }
+            )
+           };
 
         type PeopleInfo_Character_Fragment = { __typename?: 'Character', name?: string | null } & { ' $fragmentName'?: 'PeopleInfo_Character_Fragment' };
 
@@ -5901,7 +5932,11 @@ function test(q: GetEntityBrandDataQuery): void {
 
         type PeopleInfo_Droid_Fragment = { __typename?: 'Droid', model?: string | null } & { ' $fragmentName'?: 'PeopleInfo_Droid_Fragment' };
 
-        export type PeopleInfoFragment = PeopleInfo_Character_Fragment | PeopleInfo_Jedi_Fragment | PeopleInfo_Droid_Fragment;
+        export type PeopleInfoFragment =
+          | PeopleInfo_Character_Fragment
+          | PeopleInfo_Jedi_Fragment
+          | PeopleInfo_Droid_Fragment
+        ;
         "
       `);
     });

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -353,6 +353,265 @@ export type DirectiveResolvers<ContextType = any> = ResolversObject<{
       "
 `;
 
+exports[`TypeScript Resolvers Plugin Config namespacedImportName - should work correctly with imported namespaced type (printFieldsOnNewLines: true) 1`] = `
+"import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
+export type WithIndex<TObject> = TObject & Record<string, any>;
+export type ResolversObject<TObject> = WithIndex<TObject>;
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Types.Maybe<TTypes> | Promise<Types.Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping of union types */
+export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
+  ChildUnion:
+    | ( Omit<Types.Child, 'parent'> & { parent?: Types.Maybe<_RefType['MyType']> } )
+    | ( Types.MyOtherType );
+  MyUnion:
+    | ( Omit<Types.MyType, 'unionChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']> } )
+    | ( Types.MyOtherType );
+}>;
+
+/** Mapping of interface types */
+export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
+  Node: ( Types.SomeNode );
+  AnotherNode:
+    | ( Omit<Types.AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']> } )
+    | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
+  WithChild:
+    | ( Omit<Types.AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']> } )
+    | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
+  WithChildren: ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
+}>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = ResolversObject<{
+  MyType: ResolverTypeWrapper<Omit<Types.MyType, 'unionChild'> & { unionChild?: Types.Maybe<ResolversTypes['ChildUnion']> }>;
+  String: ResolverTypeWrapper<Types.Scalars['String']['output']>;
+  Child: ResolverTypeWrapper<Omit<Types.Child, 'parent'> & { parent?: Types.Maybe<ResolversTypes['MyType']> }>;
+  MyOtherType: ResolverTypeWrapper<Types.MyOtherType>;
+  ChildUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['ChildUnion']>;
+  Query: ResolverTypeWrapper<{}>;
+  Subscription: ResolverTypeWrapper<{}>;
+  Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
+  ID: ResolverTypeWrapper<Types.Scalars['ID']['output']>;
+  SomeNode: ResolverTypeWrapper<Types.SomeNode>;
+  AnotherNode: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AnotherNode']>;
+  WithChild: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChild']>;
+  WithChildren: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['WithChildren']>;
+  AnotherNodeWithChild: ResolverTypeWrapper<Omit<Types.AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Types.Maybe<ResolversTypes['ChildUnion']>, interfaceChild?: Types.Maybe<ResolversTypes['Node']> }>;
+  AnotherNodeWithAll: ResolverTypeWrapper<Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<ResolversTypes['ChildUnion']>, unionChildren: Array<ResolversTypes['ChildUnion']>, interfaceChild?: Types.Maybe<ResolversTypes['Node']>, interfaceChildren: Array<ResolversTypes['Node']> }>;
+  MyUnion: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['MyUnion']>;
+  MyScalar: ResolverTypeWrapper<Types.Scalars['MyScalar']['output']>;
+  Int: ResolverTypeWrapper<Types.Scalars['Int']['output']>;
+  Boolean: ResolverTypeWrapper<Types.Scalars['Boolean']['output']>;
+}>;
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = ResolversObject<{
+  MyType: Omit<Types.MyType, 'unionChild'> & { unionChild?: Types.Maybe<ResolversParentTypes['ChildUnion']> };
+  String: Types.Scalars['String']['output'];
+  Child: Omit<Types.Child, 'parent'> & { parent?: Types.Maybe<ResolversParentTypes['MyType']> };
+  MyOtherType: Types.MyOtherType;
+  ChildUnion: ResolversUnionTypes<ResolversParentTypes>['ChildUnion'];
+  Query: {};
+  Subscription: {};
+  Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
+  ID: Types.Scalars['ID']['output'];
+  SomeNode: Types.SomeNode;
+  AnotherNode: ResolversInterfaceTypes<ResolversParentTypes>['AnotherNode'];
+  WithChild: ResolversInterfaceTypes<ResolversParentTypes>['WithChild'];
+  WithChildren: ResolversInterfaceTypes<ResolversParentTypes>['WithChildren'];
+  AnotherNodeWithChild: Omit<Types.AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Types.Maybe<ResolversParentTypes['ChildUnion']>, interfaceChild?: Types.Maybe<ResolversParentTypes['Node']> };
+  AnotherNodeWithAll: Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<ResolversParentTypes['ChildUnion']>, unionChildren: Array<ResolversParentTypes['ChildUnion']>, interfaceChild?: Types.Maybe<ResolversParentTypes['Node']>, interfaceChildren: Array<ResolversParentTypes['Node']> };
+  MyUnion: ResolversUnionTypes<ResolversParentTypes>['MyUnion'];
+  MyScalar: Types.Scalars['MyScalar']['output'];
+  Int: Types.Scalars['Int']['output'];
+  Boolean: Types.Scalars['Boolean']['output'];
+}>;
+
+export type MyDirectiveDirectiveArgs = {
+  arg: Types.Scalars['Int']['input'];
+  arg2: Types.Scalars['String']['input'];
+  arg3: Types.Scalars['Boolean']['input'];
+};
+
+export type MyDirectiveDirectiveResolver<Result, Parent, ContextType = any, Args = MyDirectiveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type AuthenticatedDirectiveArgs = { };
+
+export type AuthenticatedDirectiveResolver<Result, Parent, ContextType = any, Args = AuthenticatedDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type MyTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyType'] = ResolversParentTypes['MyType']> = ResolversObject<{
+  foo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  otherType?: Resolver<Types.Maybe<ResolversTypes['MyOtherType']>, ParentType, ContextType>;
+  withArgs?: Resolver<Types.Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<Types.MyTypeWithArgsArgs, 'arg2'>>;
+  unionChild?: Resolver<Types.Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type ChildResolvers<ContextType = any, ParentType extends ResolversParentTypes['Child'] = ResolversParentTypes['Child']> = ResolversObject<{
+  bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  parent?: Resolver<Types.Maybe<ResolversTypes['MyType']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type MyOtherTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyOtherType'] = ResolversParentTypes['MyOtherType']> = ResolversObject<{
+  bar?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type ChildUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['ChildUnion'] = ResolversParentTypes['ChildUnion']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'Child' | 'MyOtherType', ParentType, ContextType>;
+}>;
+
+export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
+  something?: Resolver<ResolversTypes['MyType'], ParentType, ContextType>;
+}>;
+
+export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = ResolversObject<{
+  somethingChanged?: SubscriptionResolver<Types.Maybe<ResolversTypes['MyOtherType']>, "somethingChanged", ParentType, ContextType>;
+}>;
+
+export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+}>;
+
+export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type AnotherNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['AnotherNode'] = ResolversParentTypes['AnotherNode']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'AnotherNodeWithChild' | 'AnotherNodeWithAll', ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+}>;
+
+export type WithChildResolvers<ContextType = any, ParentType extends ResolversParentTypes['WithChild'] = ResolversParentTypes['WithChild']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'AnotherNodeWithChild' | 'AnotherNodeWithAll', ParentType, ContextType>;
+  unionChild?: Resolver<Types.Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
+  node?: Resolver<Types.Maybe<ResolversTypes['AnotherNode']>, ParentType, ContextType>;
+}>;
+
+export type WithChildrenResolvers<ContextType = any, ParentType extends ResolversParentTypes['WithChildren'] = ResolversParentTypes['WithChildren']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'AnotherNodeWithAll', ParentType, ContextType>;
+  unionChildren?: Resolver<Array<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
+  nodes?: Resolver<Array<ResolversTypes['AnotherNode']>, ParentType, ContextType>;
+}>;
+
+export type AnotherNodeWithChildResolvers<ContextType = any, ParentType extends ResolversParentTypes['AnotherNodeWithChild'] = ResolversParentTypes['AnotherNodeWithChild']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  unionChild?: Resolver<Types.Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
+  interfaceChild?: Resolver<Types.Maybe<ResolversTypes['Node']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type AnotherNodeWithAllResolvers<ContextType = any, ParentType extends ResolversParentTypes['AnotherNodeWithAll'] = ResolversParentTypes['AnotherNodeWithAll']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  unionChild?: Resolver<Types.Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
+  unionChildren?: Resolver<Array<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
+  interfaceChild?: Resolver<Types.Maybe<ResolversTypes['Node']>, ParentType, ContextType>;
+  interfaceChildren?: Resolver<Array<ResolversTypes['Node']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type MyUnionResolvers<ContextType = any, ParentType extends ResolversParentTypes['MyUnion'] = ResolversParentTypes['MyUnion']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'MyType' | 'MyOtherType', ParentType, ContextType>;
+}>;
+
+export interface MyScalarScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['MyScalar'], any> {
+  name: 'MyScalar';
+}
+
+export type Resolvers<ContextType = any> = ResolversObject<{
+  MyType?: MyTypeResolvers<ContextType>;
+  Child?: ChildResolvers<ContextType>;
+  MyOtherType?: MyOtherTypeResolvers<ContextType>;
+  ChildUnion?: ChildUnionResolvers<ContextType>;
+  Query?: QueryResolvers<ContextType>;
+  Subscription?: SubscriptionResolvers<ContextType>;
+  Node?: NodeResolvers<ContextType>;
+  SomeNode?: SomeNodeResolvers<ContextType>;
+  AnotherNode?: AnotherNodeResolvers<ContextType>;
+  WithChild?: WithChildResolvers<ContextType>;
+  WithChildren?: WithChildrenResolvers<ContextType>;
+  AnotherNodeWithChild?: AnotherNodeWithChildResolvers<ContextType>;
+  AnotherNodeWithAll?: AnotherNodeWithAllResolvers<ContextType>;
+  MyUnion?: MyUnionResolvers<ContextType>;
+  MyScalar?: GraphQLScalarType;
+}>;
+
+export type DirectiveResolvers<ContextType = any> = ResolversObject<{
+  myDirective?: MyDirectiveDirectiveResolver<any, any, ContextType>;
+  authenticated?: AuthenticatedDirectiveResolver<any, any, ContextType>;
+}>;
+"
+`;
+
 exports[`TypeScript Resolvers Plugin Config namespacedImportName - should work correctly with imported namespaced type 1`] = `
 "import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -168,15 +168,27 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping of union types */
 export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
-  ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<_RefType['MyType']> } ) | ( MyOtherType );
-  MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<_RefType['ChildUnion']> } ) | ( MyOtherType );
+  ChildUnion:
+    | ( Omit<Child, 'parent'> & { parent?: Maybe<_RefType['MyType']> } )
+    | ( MyOtherType )
+  ;
+  MyUnion:
+    | ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<_RefType['ChildUnion']> } )
+    | ( MyOtherType )
+  ;
 }>;
 
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
   Node: ( SomeNode );
-  AnotherNode: ( Omit<AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Maybe<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
-  WithChild: ( Omit<AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Maybe<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
+  AnotherNode:
+    | ( Omit<AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Maybe<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']> } )
+    | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } )
+  ;
+  WithChild:
+    | ( Omit<AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Maybe<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']> } )
+    | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } )
+  ;
   WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
 }>;
 
@@ -429,10 +441,12 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
   ChildUnion:
     | ( Omit<Types.Child, 'parent'> & { parent?: Types.Maybe<_RefType['MyType']> } )
-    | ( Types.MyOtherType );
+    | ( Types.MyOtherType )
+  ;
   MyUnion:
     | ( Omit<Types.MyType, 'unionChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']> } )
-    | ( Types.MyOtherType );
+    | ( Types.MyOtherType )
+  ;
 }>;
 
 /** Mapping of interface types */
@@ -440,10 +454,12 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = 
   Node: ( Types.SomeNode );
   AnotherNode:
     | ( Omit<Types.AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']> } )
-    | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
+    | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } )
+  ;
   WithChild:
     | ( Omit<Types.AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']> } )
-    | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
+    | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } )
+  ;
   WithChildren: ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
 }>;
 
@@ -686,15 +702,27 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping of union types */
 export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
-  ChildUnion: ( Omit<Types.Child, 'parent'> & { parent?: Types.Maybe<_RefType['MyType']> } ) | ( Types.MyOtherType );
-  MyUnion: ( Omit<Types.MyType, 'unionChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']> } ) | ( Types.MyOtherType );
+  ChildUnion:
+    | ( Omit<Types.Child, 'parent'> & { parent?: Types.Maybe<_RefType['MyType']> } )
+    | ( Types.MyOtherType )
+  ;
+  MyUnion:
+    | ( Omit<Types.MyType, 'unionChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']> } )
+    | ( Types.MyOtherType )
+  ;
 }>;
 
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
   Node: ( Types.SomeNode );
-  AnotherNode: ( Omit<Types.AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']> } ) | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
-  WithChild: ( Omit<Types.AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']> } ) | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
+  AnotherNode:
+    | ( Omit<Types.AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']> } )
+    | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } )
+  ;
+  WithChild:
+    | ( Omit<Types.AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']> } )
+    | ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } )
+  ;
   WithChildren: ( Omit<Types.AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Types.Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Types.Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
 }>;
 
@@ -1031,15 +1059,27 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping of union types */
 export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
-  ChildUnion: ( Omit<Child, 'parent'> & { parent?: Maybe<_RefType['MyType']> } ) | ( MyOtherType );
-  MyUnion: ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<_RefType['ChildUnion']> } ) | ( MyOtherType );
+  ChildUnion:
+    | ( Omit<Child, 'parent'> & { parent?: Maybe<_RefType['MyType']> } )
+    | ( MyOtherType )
+  ;
+  MyUnion:
+    | ( Omit<MyType, 'unionChild'> & { unionChild?: Maybe<_RefType['ChildUnion']> } )
+    | ( MyOtherType )
+  ;
 }>;
 
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
   Node: ( SomeNode );
-  AnotherNode: ( Omit<AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Maybe<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
-  WithChild: ( Omit<AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Maybe<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']> } ) | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
+  AnotherNode:
+    | ( Omit<AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Maybe<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']> } )
+    | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } )
+  ;
+  WithChild:
+    | ( Omit<AnotherNodeWithChild, 'unionChild' | 'interfaceChild'> & { unionChild?: Maybe<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']> } )
+    | ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } )
+  ;
   WithChildren: ( Omit<AnotherNodeWithAll, 'unionChild' | 'unionChildren' | 'interfaceChild' | 'interfaceChildren'> & { unionChild?: Maybe<_RefType['ChildUnion']>, unionChildren: Array<_RefType['ChildUnion']>, interfaceChild?: Maybe<_RefType['Node']>, interfaceChildren: Array<_RefType['Node']> } );
 }>;
 

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -152,6 +152,18 @@ describe('TypeScript Resolvers Plugin', () => {
       expect(content).toMatchSnapshot();
     });
 
+    it('namespacedImportName - should work correctly with imported namespaced type (printFieldsOnNewLines: true)', async () => {
+      const config = {
+        noSchemaStitching: true,
+        useIndexSignature: true,
+        namespacedImportName: 'Types',
+        printFieldsOnNewLines: true,
+      };
+      const result = await plugin(resolversTestingSchema, [], config, { outputFile: '' });
+      const content = mergeOutputs([result]);
+      expect(content).toMatchSnapshot();
+    });
+
     it('directiveResolverMappings - should generate correct types (inline definition)', async () => {
       const config = {
         noSchemaStitching: true,

--- a/packages/utils/graphql-codegen-testing/src/index.ts
+++ b/packages/utils/graphql-codegen-testing/src/index.ts
@@ -21,8 +21,9 @@ function compareStrings(a: string, b: string): boolean {
 
 expect.extend({
   toBeSimilarStringTo(received: string, expected: string) {
-    const strippedReceived = oneLine`${received}`.replace(/\s\s+/g, ' ');
-    const strippedExpected = oneLine`${expected}`.replace(/\s\s+/g, ' ');
+    // Ignore whitespace and trailing commas
+    const strippedReceived = oneLine`${received}`.replace(/\s\s+/g, ' ').replace(/\s*,(\s*[)}])/, '$1');
+    const strippedExpected = oneLine`${expected}`.replace(/\s\s+/g, ' ').replace(/\s*,(\s*[)}])/, '$1');
 
     if (compareStrings(strippedReceived, strippedExpected)) {
       return {

--- a/packages/utils/graphql-codegen-testing/src/index.ts
+++ b/packages/utils/graphql-codegen-testing/src/index.ts
@@ -19,11 +19,25 @@ function compareStrings(a: string, b: string): boolean {
   return a.includes(b);
 }
 
+/** Ignore whitespace, trailing commas, and leading pipes */
+function similarize(str: string): string {
+  return (
+    oneLine`${str}`
+      // Trim trailing commas
+      .replace(/\s*,(\s*[)}])/g, '$1')
+      // Remove leading pipes
+      .replace(/([<:,=(])\s*(?:\|\s*)?/g, '$1')
+      // Remove spaces around brackets and semicolons
+      .replace(/\s*([[\](){}<>;])\s*/g, '$1')
+      // Replace multiple spaces with a single space
+      .replace(/\s\s+/g, ' ')
+  );
+}
+
 expect.extend({
   toBeSimilarStringTo(received: string, expected: string) {
-    // Ignore whitespace and trailing commas
-    const strippedReceived = oneLine`${received}`.replace(/\s\s+/g, ' ').replace(/\s*,(\s*[)}])/, '$1');
-    const strippedExpected = oneLine`${expected}`.replace(/\s\s+/g, ' ').replace(/\s*,(\s*[)}])/, '$1');
+    const strippedReceived = similarize(received);
+    const strippedExpected = similarize(expected);
 
     if (compareStrings(strippedReceived, strippedExpected)) {
       return {


### PR DESCRIPTION
_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

:heavy_check_mark: Acknowledged. Think of this _as_ the issue, to open the discussion via demonstration.

**Please ignore whitespace changes when reviewing this PR.**

## Description

To make `git` management of changes easier, it's nice if lines aren't too long. Some of the lines emitted by graphql-code-generator can be excessively large which results in hard to review diffs. This PR aims to introduce newline splits in a few more places to make changes more surgical.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tests have been updated.

**Test Environment**:

- OS: Ubuntu 24.04
- `master` branch
- NodeJS: v20.18.0

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

Notes:

- `TypeScript GraphQL Request tests › works without variables` and `TypeScript GraphQL Request tests › returns first 3 entries` tests fail locally for me on `master`. I have not investigated.
- This is to open a discussion so I've not made doc edits yet.

## Further comments

I've currently gated this behind the `printFieldsOnNewLines` setting which seems related; I don't know if you'd want separate settings for each change, or a more general `useNewlinesForUnions` setting, or...?

This is also not an exhaustive change that adds newlines to all unions.