### PR TITLE
[resolvers][federation] Add `__resolveReference` to applicable `Interface` entities, fix Interface types having non-meta resolver fields

### DIFF
--- a/.changeset/loud-suits-admire.md
+++ b/.changeset/loud-suits-admire.md
@@ -1,0 +1,10 @@
+---
+'@graphql-codegen/visitor-plugin-common': major
+'@graphql-codegen/typescript-resolvers': major
+'@graphql-codegen/plugin-helpers': major
+---
+
+Ensure Federation Interfaces have `__resolveReference` if they are resolvable entities
+
+BREAKING CHANGES: Deprecate `onlyResolveTypeForInterfaces` because majority of use cases cannot implement resolvers in Interfaces.
+BREAKING CHANGES: Deprecate `generateInternalResolversIfNeeded.__resolveReference` because types do not have `__resolveReference` if they are not Federation entities or are not resolvable. Users should not have to manually set this option. This option was put in to wait for this major version.

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1,4 +1,4 @@
-import { ApolloFederation, checkObjectTypeFederationDetails, getBaseType } from '@graphql-codegen/plugin-helpers';
+import { ApolloFederation, type FederationMeta, getBaseType } from '@graphql-codegen/plugin-helpers';
 import { getRootTypeNames } from '@graphql-tools/utils';
 import autoBind from 'auto-bind';
 import {
@@ -78,13 +78,15 @@ export interface ParsedResolversConfig extends ParsedConfig {
   allResolversTypeName: string;
   internalResolversPrefix: string;
   generateInternalResolversIfNeeded: NormalizedGenerateInternalResolversIfNeededConfig;
-  onlyResolveTypeForInterfaces: boolean;
   directiveResolverMappings: Record<string, string>;
   resolversNonOptionalTypename: ResolversNonOptionalTypenameConfig;
   avoidCheckingAbstractTypesRecursively: boolean;
 }
 
-type FieldDefinitionPrintFn = (parentName: string, avoidResolverOptionals: boolean) => string | null;
+type FieldDefinitionPrintFn = (
+  parentName: string,
+  avoidResolverOptionals: boolean
+) => { value: string | null; meta: { federation?: { isResolveReference: boolean } } };
 export interface RootResolver {
   content: string;
   generatedResolverTypes: {
@@ -584,20 +586,13 @@ export interface RawResolversConfig extends RawConfig {
   internalResolversPrefix?: string;
   /**
    * @type object
-   * @default { __resolveReference: false }
+   * @default {}
    * @description If relevant internal resolvers are set to `true`, the resolver type will only be generated if the right conditions are met.
    * Enabling this allows a more correct type generation for the resolvers.
    * For example:
    * - `__isTypeOf` is generated for implementing types and union members
-   * - `__resolveReference` is generated for federation types that have at least one resolvable `@key` directive
    */
   generateInternalResolversIfNeeded?: GenerateInternalResolversIfNeededConfig;
-  /**
-   * @type boolean
-   * @default false
-   * @description Turning this flag to `true` will generate resolver signature that has only `resolveType` for interfaces, forcing developers to write inherited type resolvers in the type itself.
-   */
-  onlyResolveTypeForInterfaces?: boolean;
   /**
    * @description Makes `__typename` of resolver mappings non-optional without affecting the base types.
    * @default false
@@ -700,7 +695,8 @@ export class BaseResolversVisitor<
     rawConfig: TRawConfig,
     additionalConfig: TPluginConfig,
     private _schema: GraphQLSchema,
-    defaultScalars: NormalizedScalarsMap = DEFAULT_SCALARS
+    defaultScalars: NormalizedScalarsMap = DEFAULT_SCALARS,
+    federationMeta: FederationMeta = {}
   ) {
     super(rawConfig, {
       immutableTypes: getConfigValue(rawConfig.immutableTypes, false),
@@ -714,7 +710,6 @@ export class BaseResolversVisitor<
         mapOrStr: rawConfig.enumValues,
       }),
       addUnderscoreToArgsType: getConfigValue(rawConfig.addUnderscoreToArgsType, false),
-      onlyResolveTypeForInterfaces: getConfigValue(rawConfig.onlyResolveTypeForInterfaces, false),
       contextType: parseMapper(rawConfig.contextType || 'any', 'ContextType'),
       fieldContextTypes: getConfigValue(rawConfig.fieldContextTypes, []),
       directiveContextTypes: getConfigValue(rawConfig.directiveContextTypes, []),
@@ -729,9 +724,7 @@ export class BaseResolversVisitor<
       mappers: transformMappers(rawConfig.mappers || {}, rawConfig.mapperTypeSuffix),
       scalars: buildScalarsFromConfig(_schema, rawConfig, defaultScalars),
       internalResolversPrefix: getConfigValue(rawConfig.internalResolversPrefix, '__'),
-      generateInternalResolversIfNeeded: {
-        __resolveReference: rawConfig.generateInternalResolversIfNeeded?.__resolveReference ?? false,
-      },
+      generateInternalResolversIfNeeded: {},
       resolversNonOptionalTypename: normalizeResolversNonOptionalTypename(
         getConfigValue(rawConfig.resolversNonOptionalTypename, false)
       ),
@@ -740,7 +733,11 @@ export class BaseResolversVisitor<
     } as TPluginConfig);
 
     autoBind(this);
-    this._federation = new ApolloFederation({ enabled: this.config.federation, schema: this.schema });
+    this._federation = new ApolloFederation({
+      enabled: this.config.federation,
+      schema: this.schema,
+      meta: federationMeta,
+    });
     this._rootTypeNames = getRootTypeNames(_schema);
     this._variablesTransformer = new OperationVariablesToObject(
       this.scalars,
@@ -1358,7 +1355,9 @@ export class BaseResolversVisitor<
 
                 const federationMeta = this._federation.getMeta()[schemaTypeName];
                 if (federationMeta) {
-                  userDefinedTypes[schemaTypeName].federation = federationMeta;
+                  userDefinedTypes[schemaTypeName].federation = {
+                    hasResolveReference: federationMeta.hasResolveReference,
+                  };
                 }
               }
 
@@ -1474,9 +1473,10 @@ export class BaseResolversVisitor<
       const baseType = getBaseTypeNode(original.type);
       const realType = baseType.name.value;
       const parentType = this.schema.getType(parentName);
+      const meta: ReturnType<FieldDefinitionPrintFn>['meta'] = {};
 
       if (this._federation.skipField({ fieldNode: original, parentType })) {
-        return null;
+        return { value: null, meta };
       }
 
       const contextType = this.getContextType(parentName, node);
@@ -1516,7 +1516,7 @@ export class BaseResolversVisitor<
         }
       }
 
-      const parentTypeSignature = this._federation.transformParentType({
+      const parentTypeSignature = this._federation.transformFieldParentType({
         fieldNode: original,
         parentType,
         parentTypeSignature: this.getParentTypeForSignature(node),
@@ -1545,29 +1545,22 @@ export class BaseResolversVisitor<
       };
 
       if (this._federation.isResolveReferenceField(node)) {
-        if (this.config.generateInternalResolversIfNeeded.__resolveReference) {
-          const federationDetails = checkObjectTypeFederationDetails(
-            parentType.astNode as ObjectTypeDefinitionNode,
-            this._schema
-          );
-
-          if (!federationDetails || federationDetails.resolvableKeyDirectives.length === 0) {
-            return '';
-          }
+        if (!this._federation.getMeta()[parentType.name].hasResolveReference) {
+          return { value: '', meta };
         }
-
-        this._federation.setMeta(parentType.name, { hasResolveReference: true });
         signature.type = 'ReferenceResolver';
-        if (signature.genericTypes.length >= 3) {
-          signature.genericTypes = signature.genericTypes.slice(0, 3);
-        }
+        signature.genericTypes = [mappedTypeKey, parentTypeSignature, contextType];
+        meta.federation = { isResolveReference: true };
       }
 
-      return indent(
-        `${signature.name}${signature.modifier}: ${signature.type}<${signature.genericTypes.join(
-          ', '
-        )}>${this.getPunctuation(declarationKind)}`
-      );
+      return {
+        value: indent(
+          `${signature.name}${signature.modifier}: ${signature.type}<${signature.genericTypes.join(
+            ', '
+          )}>${this.getPunctuation(declarationKind)}`
+        ),
+        meta,
+      };
     };
   }
 
@@ -1628,7 +1621,7 @@ export class BaseResolversVisitor<
           (rootType === 'mutation' && this.config.avoidOptionals.mutation) ||
           (rootType === 'subscription' && this.config.avoidOptionals.subscription) ||
           (rootType === false && this.config.avoidOptionals.resolvers)
-      );
+      ).value;
     });
 
     if (!rootType) {
@@ -1645,10 +1638,11 @@ export class BaseResolversVisitor<
       `ContextType = ${this.config.contextType.type}`,
       this.transformParentGenericType(parentType),
     ];
-    if (this._federation.getMeta()[typeName]) {
-      const typeRef = `${this.convertName('FederationTypes')}['${typeName}']`;
-      genericTypes.push(`FederationType extends ${typeRef} = ${typeRef}`);
-    }
+    this._federation.addFederationTypeGenericIfApplicable({
+      genericTypes,
+      federationTypesType: this.convertName('FederationTypes'),
+      typeName,
+    });
 
     const block = new DeclarationBlock(this._declarationBlockConfig)
       .export()
@@ -1837,25 +1831,44 @@ export class BaseResolversVisitor<
     }
 
     const parentType = this.getParentTypeToUse(typeName);
+
+    const genericTypes: string[] = [
+      `ContextType = ${this.config.contextType.type}`,
+      this.transformParentGenericType(parentType),
+    ];
+    this._federation.addFederationTypeGenericIfApplicable({
+      genericTypes,
+      federationTypesType: this.convertName('FederationTypes'),
+      typeName,
+    });
+
     const possibleTypes = implementingTypes.map(name => `'${name}'`).join(' | ') || 'null';
-    const fields = this.config.onlyResolveTypeForInterfaces ? [] : node.fields || [];
+
+    // An Interface has __resolveType resolver, and no other fields.
+    const blockFields: string[] = [
+      indent(
+        `${this.config.internalResolversPrefix}resolveType${
+          this.config.optionalResolveType ? '?' : ''
+        }: TypeResolveFn<${possibleTypes}, ParentType, ContextType>${this.getPunctuation(declarationKind)}`
+      ),
+    ];
+
+    // An Interface in Federation may have the additional __resolveReference resolver, if resolvable.
+    // So, we filter out the normal fields declared on the Interface and add the __resolveReference resolver.
+    const fields = (node.fields as unknown as FieldDefinitionPrintFn[]).map(f =>
+      f(typeName, this.config.avoidOptionals.resolvers)
+    );
+    for (const field of fields) {
+      if (field.meta.federation?.isResolveReference) {
+        blockFields.push(field.value);
+      }
+    }
 
     return new DeclarationBlock(this._declarationBlockConfig)
       .export()
       .asKind(declarationKind)
-      .withName(name, `<ContextType = ${this.config.contextType.type}, ${this.transformParentGenericType(parentType)}>`)
-      .withBlock(
-        [
-          indent(
-            `${this.config.internalResolversPrefix}resolveType${
-              this.config.optionalResolveType ? '?' : ''
-            }: TypeResolveFn<${possibleTypes}, ParentType, ContextType>${this.getPunctuation(declarationKind)}`
-          ),
-          ...(fields as unknown as FieldDefinitionPrintFn[]).map(f =>
-            f(typeName, this.config.avoidOptionals.resolvers)
-          ),
-        ].join('\n')
-      ).string;
+      .withName(name, `<${genericTypes.join(', ')}>`)
+      .withBlock(blockFields.join('\n')).string;
   }
 
   SchemaDefinition() {

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -139,7 +139,5 @@ export interface CustomDirectivesConfig {
   apolloUnmask?: boolean;
 }
 
-export interface GenerateInternalResolversIfNeededConfig {
-  __resolveReference?: boolean;
-}
+export interface GenerateInternalResolversIfNeededConfig {}
 export type NormalizedGenerateInternalResolversIfNeededConfig = Required<GenerateInternalResolversIfNeededConfig>;

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -75,8 +75,14 @@ export type Resolver${capitalizedDirectiveName}WithResolve<TResult, TParent, TCo
     }
   }
 
-  const transformedSchema = config.federation ? addFederationReferencesToSchema(schema) : schema;
-  const visitor = new TypeScriptResolversVisitor({ ...config, directiveResolverMappings }, transformedSchema);
+  const { transformedSchema, federationMeta } = config.federation
+    ? addFederationReferencesToSchema(schema)
+    : { transformedSchema: schema, federationMeta: {} };
+  const visitor = new TypeScriptResolversVisitor(
+    { ...config, directiveResolverMappings },
+    transformedSchema,
+    federationMeta
+  );
   const namespacedImportPrefix = visitor.config.namespacedImportName ? `${visitor.config.namespacedImportName}.` : '';
 
   const astNode = getCachedDocumentNodeFromSchema(transformedSchema);

--- a/packages/plugins/typescript/resolvers/src/visitor.ts
+++ b/packages/plugins/typescript/resolvers/src/visitor.ts
@@ -2,10 +2,12 @@ import { TypeScriptOperationVariablesToObject } from '@graphql-codegen/typescrip
 import {
   BaseResolversVisitor,
   DeclarationKind,
+  DEFAULT_SCALARS,
   getConfigValue,
   normalizeAvoidOptionals,
   ParsedResolversConfig,
 } from '@graphql-codegen/visitor-plugin-common';
+import type { FederationMeta } from '@graphql-codegen/plugin-helpers';
 import autoBind from 'auto-bind';
 import { EnumTypeDefinitionNode, GraphQLSchema, ListTypeNode, NamedTypeNode, NonNullTypeNode } from 'graphql';
 import { TypeScriptResolversPluginConfig } from './config.js';
@@ -24,7 +26,7 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<
   TypeScriptResolversPluginConfig,
   ParsedTypeScriptResolversConfig
 > {
-  constructor(pluginConfig: TypeScriptResolversPluginConfig, schema: GraphQLSchema) {
+  constructor(pluginConfig: TypeScriptResolversPluginConfig, schema: GraphQLSchema, federationMeta: FederationMeta) {
     super(
       pluginConfig,
       {
@@ -34,7 +36,9 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<
         allowParentTypeOverride: getConfigValue(pluginConfig.allowParentTypeOverride, false),
         optionalInfoArgument: getConfigValue(pluginConfig.optionalInfoArgument, false),
       } as ParsedTypeScriptResolversConfig,
-      schema
+      schema,
+      DEFAULT_SCALARS,
+      federationMeta
     );
     autoBind(this);
     this.setVariablesTransformer(

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -272,7 +272,6 @@ export type SubscriptionResolvers<ContextType = any, ParentType = ResolversParen
 
 export type NodeResolvers<ContextType = any, ParentType = ResolversParentTypes['Node']> = ResolversObject<{
   __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 }>;
 
 export type SomeNodeResolvers<ContextType = any, ParentType = ResolversParentTypes['SomeNode']> = ResolversObject<{
@@ -282,19 +281,14 @@ export type SomeNodeResolvers<ContextType = any, ParentType = ResolversParentTyp
 
 export type AnotherNodeResolvers<ContextType = any, ParentType = ResolversParentTypes['AnotherNode']> = ResolversObject<{
   __resolveType: TypeResolveFn<'AnotherNodeWithChild' | 'AnotherNodeWithAll', ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 }>;
 
 export type WithChildResolvers<ContextType = any, ParentType = ResolversParentTypes['WithChild']> = ResolversObject<{
   __resolveType: TypeResolveFn<'AnotherNodeWithChild' | 'AnotherNodeWithAll', ParentType, ContextType>;
-  unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
-  node?: Resolver<Maybe<ResolversTypes['AnotherNode']>, ParentType, ContextType>;
 }>;
 
 export type WithChildrenResolvers<ContextType = any, ParentType = ResolversParentTypes['WithChildren']> = ResolversObject<{
   __resolveType: TypeResolveFn<'AnotherNodeWithAll', ParentType, ContextType>;
-  unionChildren?: Resolver<Array<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
-  nodes?: Resolver<Array<ResolversTypes['AnotherNode']>, ParentType, ContextType>;
 }>;
 
 export type AnotherNodeWithChildResolvers<ContextType = any, ParentType = ResolversParentTypes['AnotherNodeWithChild']> = ResolversObject<{
@@ -532,7 +526,6 @@ export type SubscriptionResolvers<ContextType = any, ParentType extends Resolver
 
 export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = ResolversObject<{
   __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 }>;
 
 export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = ResolversObject<{
@@ -542,19 +535,14 @@ export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversPar
 
 export type AnotherNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['AnotherNode'] = ResolversParentTypes['AnotherNode']> = ResolversObject<{
   __resolveType: TypeResolveFn<'AnotherNodeWithChild' | 'AnotherNodeWithAll', ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 }>;
 
 export type WithChildResolvers<ContextType = any, ParentType extends ResolversParentTypes['WithChild'] = ResolversParentTypes['WithChild']> = ResolversObject<{
   __resolveType: TypeResolveFn<'AnotherNodeWithChild' | 'AnotherNodeWithAll', ParentType, ContextType>;
-  unionChild?: Resolver<Types.Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
-  node?: Resolver<Types.Maybe<ResolversTypes['AnotherNode']>, ParentType, ContextType>;
 }>;
 
 export type WithChildrenResolvers<ContextType = any, ParentType extends ResolversParentTypes['WithChildren'] = ResolversParentTypes['WithChildren']> = ResolversObject<{
   __resolveType: TypeResolveFn<'AnotherNodeWithAll', ParentType, ContextType>;
-  unionChildren?: Resolver<Array<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
-  nodes?: Resolver<Array<ResolversTypes['AnotherNode']>, ParentType, ContextType>;
 }>;
 
 export type AnotherNodeWithChildResolvers<ContextType = any, ParentType extends ResolversParentTypes['AnotherNodeWithChild'] = ResolversParentTypes['AnotherNodeWithChild']> = ResolversObject<{
@@ -878,7 +866,6 @@ export type SubscriptionResolvers<ContextType = any, ParentType extends Resolver
 
 export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = ResolversObject<{
   __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 }>;
 
 export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['SomeNode'] = ResolversParentTypes['SomeNode']> = ResolversObject<{
@@ -888,19 +875,14 @@ export type SomeNodeResolvers<ContextType = any, ParentType extends ResolversPar
 
 export type AnotherNodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['AnotherNode'] = ResolversParentTypes['AnotherNode']> = ResolversObject<{
   __resolveType: TypeResolveFn<'AnotherNodeWithChild' | 'AnotherNodeWithAll', ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 }>;
 
 export type WithChildResolvers<ContextType = any, ParentType extends ResolversParentTypes['WithChild'] = ResolversParentTypes['WithChild']> = ResolversObject<{
   __resolveType: TypeResolveFn<'AnotherNodeWithChild' | 'AnotherNodeWithAll', ParentType, ContextType>;
-  unionChild?: Resolver<Maybe<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
-  node?: Resolver<Maybe<ResolversTypes['AnotherNode']>, ParentType, ContextType>;
 }>;
 
 export type WithChildrenResolvers<ContextType = any, ParentType extends ResolversParentTypes['WithChildren'] = ResolversParentTypes['WithChildren']> = ResolversObject<{
   __resolveType: TypeResolveFn<'AnotherNodeWithAll', ParentType, ContextType>;
-  unionChildren?: Resolver<Array<ResolversTypes['ChildUnion']>, ParentType, ContextType>;
-  nodes?: Resolver<Array<ResolversTypes['AnotherNode']>, ParentType, ContextType>;
 }>;
 
 export type AnotherNodeWithChildResolvers<ContextType = any, ParentType extends ResolversParentTypes['AnotherNodeWithChild'] = ResolversParentTypes['AnotherNodeWithChild']> = ResolversObject<{

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.config.avoidOptionals.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.config.avoidOptionals.spec.ts
@@ -53,7 +53,6 @@ describe('TypeScript Resolvers Plugin - config.avoidOptionals', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.interface.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.interface.spec.ts
@@ -1,0 +1,198 @@
+import '@graphql-codegen/testing';
+import { generate } from './utils';
+
+describe('TypeScript Resolvers Plugin + Apollo Federation - Interface', () => {
+  it('generates __resolveReference for Interfaces with @key', async () => {
+    const federatedSchema = /* GraphQL */ `
+      type Query {
+        me: Person
+      }
+
+      interface Person @key(fields: "id") {
+        id: ID!
+        name: PersonName!
+      }
+
+      type User implements Person @key(fields: "id") {
+        id: ID!
+        name: PersonName!
+      }
+
+      type Admin implements Person @key(fields: "id") {
+        id: ID!
+        name: PersonName!
+        canImpersonate: Boolean!
+      }
+
+      type PersonName {
+        first: String!
+        last: String!
+      }
+    `;
+
+    const content = await generate({
+      schema: federatedSchema,
+      config: {
+        federation: true,
+      },
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      "import { GraphQLResolveInfo } from 'graphql';
+
+
+      export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+      export type ReferenceResolver<TResult, TReference, TContext> = (
+            reference: TReference,
+            context: TContext,
+            info: GraphQLResolveInfo
+          ) => Promise<TResult> | TResult;
+
+            type ScalarCheck<T, S> = S extends true ? T : NullableCheck<T, S>;
+            type NullableCheck<T, S> = Maybe<T> extends T ? Maybe<ListCheck<NonNullable<T>, S>> : ListCheck<T, S>;
+            type ListCheck<T, S> = T extends (infer U)[] ? NullableCheck<U, S>[] : GraphQLRecursivePick<T, S>;
+            export type GraphQLRecursivePick<T, S> = { [K in keyof T & keyof S]: ScalarCheck<T[K], S[K]> };
+          
+
+      export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+        resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+      };
+      export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+      export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+        parent: TParent,
+        args: TArgs,
+        context: TContext,
+        info: GraphQLResolveInfo
+      ) => Promise<TResult> | TResult;
+
+      export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+        parent: TParent,
+        args: TArgs,
+        context: TContext,
+        info: GraphQLResolveInfo
+      ) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+      export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+        parent: TParent,
+        args: TArgs,
+        context: TContext,
+        info: GraphQLResolveInfo
+      ) => TResult | Promise<TResult>;
+
+      export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+        subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+        resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+      }
+
+      export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+        subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+        resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+      }
+
+      export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+        | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+        | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+      export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+        | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+        | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+      export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+        parent: TParent,
+        context: TContext,
+        info: GraphQLResolveInfo
+      ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+      export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+
+      export type NextResolverFn<T> = () => Promise<T>;
+
+      export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+        next: NextResolverFn<TResult>,
+        parent: TParent,
+        args: TArgs,
+        context: TContext,
+        info: GraphQLResolveInfo
+      ) => TResult | Promise<TResult>;
+
+      /** Mapping of federation types */
+      export type FederationTypes = {
+        Person: Person;
+        User: User;
+        Admin: Admin;
+      };
+
+
+      /** Mapping of interface types */
+      export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
+        Person: ( User ) | ( Admin );
+      };
+
+      /** Mapping between all available schema types and the resolvers types */
+      export type ResolversTypes = {
+        Query: ResolverTypeWrapper<{}>;
+        Person: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Person']>;
+        ID: ResolverTypeWrapper<Scalars['ID']['output']>;
+        User: ResolverTypeWrapper<User>;
+        Admin: ResolverTypeWrapper<Admin>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+        PersonName: ResolverTypeWrapper<PersonName>;
+        String: ResolverTypeWrapper<Scalars['String']['output']>;
+      };
+
+      /** Mapping between all available schema types and the resolvers parents */
+      export type ResolversParentTypes = {
+        Query: {};
+        Person: ResolversInterfaceTypes<ResolversParentTypes>['Person'];
+        ID: Scalars['ID']['output'];
+        User: User;
+        Admin: Admin;
+        Boolean: Scalars['Boolean']['output'];
+        PersonName: PersonName;
+        String: Scalars['String']['output'];
+      };
+
+      export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+        me?: Resolver<Maybe<ResolversTypes['Person']>, ParentType, ContextType>;
+      };
+
+      export type PersonResolvers<ContextType = any, ParentType extends ResolversParentTypes['Person'] = ResolversParentTypes['Person'], FederationType extends FederationTypes['Person'] = FederationTypes['Person']> = {
+        __resolveType: TypeResolveFn<'User' | 'Admin', ParentType, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Person']>, { __typename: 'Person' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+      };
+
+      export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<ResolversTypes['PersonName'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+
+      export type AdminResolvers<ContextType = any, ParentType extends ResolversParentTypes['Admin'] = ResolversParentTypes['Admin'], FederationType extends FederationTypes['Admin'] = FederationTypes['Admin']> = {
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Admin']>, { __typename: 'Admin' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<ResolversTypes['PersonName'], ParentType, ContextType>;
+        canImpersonate?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+
+      export type PersonNameResolvers<ContextType = any, ParentType extends ResolversParentTypes['PersonName'] = ResolversParentTypes['PersonName']> = {
+        first?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        last?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+
+      export type Resolvers<ContextType = any> = {
+        Query?: QueryResolvers<ContextType>;
+        Person?: PersonResolvers<ContextType>;
+        User?: UserResolvers<ContextType>;
+        Admin?: AdminResolvers<ContextType>;
+        PersonName?: PersonNameResolvers<ContextType>;
+      };
+
+      "
+    `);
+  });
+});

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
@@ -135,8 +135,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
     // MultipleNonResolvableResolvers does NOT have __resolveReference because all keys are non-resolvable
     expect(content).toBeSimilarStringTo(`
-    export type MultipleNonResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['MultipleNonResolvable'] = ResolversParentTypes['MultipleNonResolvable'], FederationType extends FederationTypes['MultipleNonResolvable'] = FederationTypes['MultipleNonResolvable']> = {
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['MultipleNonResolvable']>, FederationType, ContextType>;
+    export type MultipleNonResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['MultipleNonResolvable'] = ResolversParentTypes['MultipleNonResolvable']> = {
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
@@ -24,7 +24,7 @@ function generate({ schema, config }: { schema: string; config: TypeScriptResolv
 }
 
 describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
-  describe('adds __resolveReference', () => {
+  it('generates __resolveReference for object types with resolvable @key', async () => {
     const federatedSchema = /* GraphQL */ `
       type Query {
         allUsers: [User]
@@ -76,141 +76,15 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       }
     `;
 
-    it('when generateInternalResolversIfNeeded.__resolveReference = false, generates optional __resolveReference for object types with @key', async () => {
-      const content = await generate({
-        schema: federatedSchema,
-        config: {
-          federation: true,
-        },
-      });
-
-      expect(content).toBeSimilarStringTo(`
-    export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-      id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-      username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-    };
-  `);
-
-      expect(content).toBeSimilarStringTo(`
-    export type SingleResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['SingleResolvable'] = ResolversParentTypes['SingleResolvable'], FederationType extends FederationTypes['SingleResolvable'] = FederationTypes['SingleResolvable']> = {
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['SingleResolvable']>, { __typename: 'SingleResolvable' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-      id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-    };
-  `);
-
-      expect(content).toBeSimilarStringTo(`
-    export type SingleNonResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['SingleNonResolvable'] = ResolversParentTypes['SingleNonResolvable'], FederationType extends FederationTypes['SingleNonResolvable'] = FederationTypes['SingleNonResolvable']> = {
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['SingleNonResolvable']>, FederationType, ContextType>;
-      id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-    };
-  `);
-
-      expect(content).toBeSimilarStringTo(`
-    export type AtLeastOneResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['AtLeastOneResolvable'] = ResolversParentTypes['AtLeastOneResolvable'], FederationType extends FederationTypes['AtLeastOneResolvable'] = FederationTypes['AtLeastOneResolvable']> = {
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['AtLeastOneResolvable']>, { __typename: 'AtLeastOneResolvable' } & GraphQLRecursivePick<FederationType, {"id2":true}>, ContextType>;
-      id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-    };
-  `);
-
-      expect(content).toBeSimilarStringTo(`
-    export type MixedResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['MixedResolvable'] = ResolversParentTypes['MixedResolvable'],  FederationType extends FederationTypes['MixedResolvable'] = FederationTypes['MixedResolvable']> = {
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['MixedResolvable']>, { __typename: 'MixedResolvable' } & (GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"id2":true}>), ContextType>;
-      id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-    };
-  `);
-
-      expect(content).toBeSimilarStringTo(`
-    export type MultipleNonResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['MultipleNonResolvable'] = ResolversParentTypes['MultipleNonResolvable'], FederationType extends FederationTypes['MultipleNonResolvable'] = FederationTypes['MultipleNonResolvable']> = {
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['MultipleNonResolvable']>, FederationType, ContextType>;
-      id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-    };
-  `);
-
-      // Book does NOT have __resolveReference because it doesn't have @key
-      expect(content).toBeSimilarStringTo(`
-    export type BookResolvers<ContextType = any, ParentType extends ResolversParentTypes['Book'] = ResolversParentTypes['Book']> = {
-      id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-    };
-  `);
+    const content = await generate({
+      schema: federatedSchema,
+      config: {
+        federation: true,
+      },
     });
 
-    it('when generateInternalResolversIfNeeded.__resolveReference = true, generates required __resolveReference for object types with resolvable @key', async () => {
-      const federatedSchema = /* GraphQL */ `
-        type Query {
-          allUsers: [User]
-        }
-
-        type User @key(fields: "id") {
-          id: ID!
-          name: String
-          username: String
-        }
-
-        type Book {
-          id: ID!
-        }
-
-        type SingleResolvable @key(fields: "id", resolvable: true) {
-          id: ID!
-        }
-
-        type SingleNonResolvable @key(fields: "id", resolvable: false) {
-          id: ID!
-        }
-
-        type AtLeastOneResolvable
-          @key(fields: "id", resolvable: false)
-          @key(fields: "id2", resolvable: true)
-          @key(fields: "id3", resolvable: false) {
-          id: ID!
-          id2: ID!
-          id3: ID!
-        }
-
-        type MixedResolvable
-          @key(fields: "id")
-          @key(fields: "id2", resolvable: true)
-          @key(fields: "id3", resolvable: false) {
-          id: ID!
-          id2: ID!
-          id3: ID!
-        }
-
-        type MultipleNonResolvable
-          @key(fields: "id", resolvable: false)
-          @key(fields: "id2", resolvable: false)
-          @key(fields: "id3", resolvable: false) {
-          id: ID!
-          id2: ID!
-          id3: ID!
-        }
-      `;
-
-      const content = await generate({
-        schema: federatedSchema,
-        config: {
-          federation: true,
-          generateInternalResolversIfNeeded: { __resolveReference: true },
-        },
-      });
-
-      // User should have __resolveReference because it has resolvable @key (by default)
-      expect(content).toBeSimilarStringTo(`
+    // User should have __resolveReference because it has resolvable @key (by default)
+    expect(content).toBeSimilarStringTo(`
     export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
       __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -220,8 +94,8 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     };
   `);
 
-      // SingleResolvable has __resolveReference because it has resolvable: true
-      expect(content).toBeSimilarStringTo(`
+    // SingleResolvable has __resolveReference because it has resolvable: true
+    expect(content).toBeSimilarStringTo(`
     export type SingleResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['SingleResolvable'] = ResolversParentTypes['SingleResolvable'], FederationType extends FederationTypes['SingleResolvable'] = FederationTypes['SingleResolvable']> = {
       __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['SingleResolvable']>, { __typename: 'SingleResolvable' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -229,16 +103,16 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     };
   `);
 
-      // SingleNonResolvable does NOT have __resolveReference because it has resolvable: false
-      expect(content).toBeSimilarStringTo(`
+    // SingleNonResolvable does NOT have __resolveReference because it has resolvable: false
+    expect(content).toBeSimilarStringTo(`
     export type SingleNonResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['SingleNonResolvable'] = ResolversParentTypes['SingleNonResolvable']> = {
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     };
   `);
 
-      // AtLeastOneResolvable has __resolveReference because it at least one resolvable
-      expect(content).toBeSimilarStringTo(`
+    // AtLeastOneResolvable has __resolveReference because it at least one resolvable
+    expect(content).toBeSimilarStringTo(`
     export type AtLeastOneResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['AtLeastOneResolvable'] = ResolversParentTypes['AtLeastOneResolvable'], FederationType extends FederationTypes['AtLeastOneResolvable'] = FederationTypes['AtLeastOneResolvable']> = {
       __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['AtLeastOneResolvable']>, { __typename: 'AtLeastOneResolvable' } & GraphQLRecursivePick<FederationType, {"id2":true}>, ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -248,8 +122,8 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     };
   `);
 
-      // MixedResolvable has __resolveReference and references for resolvable keys
-      expect(content).toBeSimilarStringTo(`
+    // MixedResolvable has __resolveReference and references for resolvable keys
+    expect(content).toBeSimilarStringTo(`
     export type MixedResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['MixedResolvable'] = ResolversParentTypes['MixedResolvable'], FederationType extends FederationTypes['MixedResolvable'] = FederationTypes['MixedResolvable']> = {
       __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['MixedResolvable']>, { __typename: 'MixedResolvable' } & (GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"id2":true}>), ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -259,9 +133,10 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     };
   `);
 
-      // MultipleNonResolvableResolvers does NOT have __resolveReference because all keys are non-resolvable
-      expect(content).toBeSimilarStringTo(`
-    export type MultipleNonResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['MultipleNonResolvable'] = ResolversParentTypes['MultipleNonResolvable']> = {
+    // MultipleNonResolvableResolvers does NOT have __resolveReference because all keys are non-resolvable
+    expect(content).toBeSimilarStringTo(`
+    export type MultipleNonResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['MultipleNonResolvable'] = ResolversParentTypes['MultipleNonResolvable'], FederationType extends FederationTypes['MultipleNonResolvable'] = FederationTypes['MultipleNonResolvable']> = {
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['MultipleNonResolvable']>, FederationType, ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -269,14 +144,13 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     };
   `);
 
-      // Book does NOT have __resolveReference because it doesn't have @key
-      expect(content).toBeSimilarStringTo(`
+    // Book does NOT have __resolveReference because it doesn't have @key
+    expect(content).toBeSimilarStringTo(`
     export type BookResolvers<ContextType = any, ParentType extends ResolversParentTypes['Book'] = ResolversParentTypes['Book']> = {
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     };
   `);
-    });
   });
 
   it('should support extend keyword', async () => {
@@ -495,50 +369,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
         __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
-    `);
-  });
-
-  it.skip('should handle interface types', async () => {
-    const federatedSchema = /* GraphQL */ `
-      type Query {
-        people: [Person]
-      }
-
-      extend interface Person @key(fields: "name { first last }") {
-        name: Name! @external
-        age: Int @requires(fields: "name")
-      }
-
-      extend type User implements Person @key(fields: "name { first last }") {
-        name: Name! @external
-        age: Int @requires(fields: "name { first last }")
-        username: String
-      }
-
-      type Admin implements Person @key(fields: "name { first last }") {
-        name: Name! @external
-        age: Int @requires(fields: "name { first last }")
-        permissions: [String!]!
-      }
-
-      extend type Name {
-        first: String! @external
-        last: String! @external
-      }
-    `;
-
-    const content = await generate({
-      schema: federatedSchema,
-      config: {
-        federation: true,
-      },
-    });
-
-    expect(content).toBeSimilarStringTo(`
-    export type PersonResolvers<ContextType = any, ParentType extends ResolversParentTypes['Person'] = ResolversParentTypes['Person']> = {
-      __resolveType: TypeResolveFn<'User' | 'Admin', ParentType, ContextType>;
-      age?: Resolver<Maybe<ResolversTypes['Int']>, { __typename: 'User' | 'Admin' } & GraphQLRecursivePick<ParentType, {"name":{"first":true,"last":true}}>, ContextType>;
-    };
     `);
   });
 
@@ -763,132 +593,68 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).not.toContain('GraphQLScalarType');
   });
 
-  describe('meta - generates federation meta correctly', () => {
-    const federatedSchema = /* GraphQL */ `
-      scalar _FieldSet
-      directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+  describe('meta', () => {
+    it('generates federation meta correctly', async () => {
+      const federatedSchema = /* GraphQL */ `
+        scalar _FieldSet
+        directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
 
-      type Query {
-        user: UserPayload!
-        allUsers: [User]
-      }
-
-      type User @key(fields: "id") {
-        id: ID!
-        name: String
-        username: String
-      }
-
-      interface Node {
-        id: ID!
-      }
-
-      type UserOk {
-        id: ID!
-      }
-      type UserError {
-        message: String!
-      }
-      union UserPayload = UserOk | UserError
-
-      enum Country {
-        FR
-        US
-      }
-
-      type NotResolvable @key(fields: "id", resolvable: false) {
-        id: ID!
-      }
-
-      type Resolvable @key(fields: "id", resolvable: true) {
-        id: ID!
-      }
-
-      type MultipleResolvable
-        @key(fields: "id")
-        @key(fields: "id2", resolvable: true)
-        @key(fields: "id3", resolvable: false) {
-        id: ID!
-        id2: ID!
-        id3: ID!
-      }
-
-      type MultipleNonResolvable
-        @key(fields: "id", resolvable: false)
-        @key(fields: "id2", resolvable: false)
-        @key(fields: "id3", resolvable: false) {
-        id: ID!
-        id2: ID!
-        id3: ID!
-      }
-    `;
-
-    it('when generateInternalResolversIfNeeded.__resolveReference = false', async () => {
-      const result = await plugin(buildSchema(federatedSchema), [], { federation: true }, { outputFile: '' });
-
-      expect(result.meta?.generatedResolverTypes).toMatchInlineSnapshot(`
-        Object {
-          "resolversMap": Object {
-            "name": "Resolvers",
-          },
-          "userDefined": Object {
-            "MultipleNonResolvable": Object {
-              "federation": Object {
-                "hasResolveReference": true,
-              },
-              "name": "MultipleNonResolvableResolvers",
-            },
-            "MultipleResolvable": Object {
-              "federation": Object {
-                "hasResolveReference": true,
-              },
-              "name": "MultipleResolvableResolvers",
-            },
-            "Node": Object {
-              "name": "NodeResolvers",
-            },
-            "NotResolvable": Object {
-              "federation": Object {
-                "hasResolveReference": true,
-              },
-              "name": "NotResolvableResolvers",
-            },
-            "Query": Object {
-              "name": "QueryResolvers",
-            },
-            "Resolvable": Object {
-              "federation": Object {
-                "hasResolveReference": true,
-              },
-              "name": "ResolvableResolvers",
-            },
-            "User": Object {
-              "federation": Object {
-                "hasResolveReference": true,
-              },
-              "name": "UserResolvers",
-            },
-            "UserError": Object {
-              "name": "UserErrorResolvers",
-            },
-            "UserOk": Object {
-              "name": "UserOkResolvers",
-            },
-            "UserPayload": Object {
-              "name": "UserPayloadResolvers",
-            },
-          },
+        type Query {
+          user: UserPayload!
+          allUsers: [User]
         }
-      `);
-    });
 
-    it('when generateInternalResolversIfNeeded.__resolveReference = true', async () => {
-      const result = await plugin(
-        buildSchema(federatedSchema),
-        [],
-        { federation: true, generateInternalResolversIfNeeded: { __resolveReference: true } },
-        { outputFile: '' }
-      );
+        type User @key(fields: "id") {
+          id: ID!
+          name: String
+          username: String
+        }
+
+        interface Node {
+          id: ID!
+        }
+
+        type UserOk {
+          id: ID!
+        }
+        type UserError {
+          message: String!
+        }
+        union UserPayload = UserOk | UserError
+
+        enum Country {
+          FR
+          US
+        }
+
+        type NotResolvable @key(fields: "id", resolvable: false) {
+          id: ID!
+        }
+
+        type Resolvable @key(fields: "id", resolvable: true) {
+          id: ID!
+        }
+
+        type MultipleResolvable
+          @key(fields: "id")
+          @key(fields: "id2", resolvable: true)
+          @key(fields: "id3", resolvable: false) {
+          id: ID!
+          id2: ID!
+          id3: ID!
+        }
+
+        type MultipleNonResolvable
+          @key(fields: "id", resolvable: false)
+          @key(fields: "id2", resolvable: false)
+          @key(fields: "id3", resolvable: false) {
+          id: ID!
+          id2: ID!
+          id3: ID!
+        }
+      `;
+
+      const result = await plugin(buildSchema(federatedSchema), [], { federation: true }, { outputFile: '' });
 
       expect(result.meta?.generatedResolverTypes).toMatchInlineSnapshot(`
         Object {

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.interface.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.interface.spec.ts
@@ -162,7 +162,6 @@ describe('TypeScript Resolvers Plugin - Interfaces', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<null, ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
   });

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.mapping.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.mapping.spec.ts
@@ -1265,7 +1265,6 @@ describe('TypeScript Resolvers Plugin - Mapping', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
@@ -1348,7 +1347,6 @@ describe('TypeScript Resolvers Plugin - Mapping', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
@@ -1429,7 +1427,6 @@ describe('TypeScript Resolvers Plugin - Mapping', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
@@ -1499,7 +1496,6 @@ describe('TypeScript Resolvers Plugin - Mapping', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
@@ -1569,7 +1565,6 @@ describe('TypeScript Resolvers Plugin - Mapping', () => {
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.spec.ts
@@ -85,19 +85,6 @@ describe('TypeScript Resolvers Plugin', () => {
   });
 
   describe('Config', () => {
-    it('onlyResolveTypeForInterfaces - should allow to have only resolveType for interfaces', async () => {
-      const config = {
-        onlyResolveTypeForInterfaces: true,
-      };
-      const result = await plugin(resolversTestingSchema, [], config, { outputFile: '' });
-      const content = await resolversTestingValidate(result, config, resolversTestingSchema);
-
-      expect(content).toBeSimilarStringTo(`
-      export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
-        __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-      };`);
-    });
-
     it('optionalInfoArgument - should allow to have optional info argument', async () => {
       const config = {
         noSchemaStitching: true,
@@ -655,7 +642,6 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType?: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
   });
@@ -705,7 +691,6 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
@@ -778,7 +763,6 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
@@ -869,7 +853,6 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
@@ -944,7 +927,6 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = MyCustomCtx, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
@@ -1018,7 +1000,6 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
@@ -1093,7 +1074,6 @@ __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = ContextType, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         __resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 
@@ -2360,7 +2340,6 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
     expect(result.content).toBeSimilarStringTo(`
       export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
         resolveType: TypeResolveFn<'SomeNode', ParentType, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       };
     `);
 


### PR DESCRIPTION
TODO: video walkthrough

## Description

This PR ensures correct types for Interfaces:

### 1. `__resolveReference` are generated for Interface entities

Federation Checklist: https://github.com/dotansimha/graphql-code-generator/issues/10206

```graphql
interface User @key(fields: "id") { # must generate `__resolveReference` for User
  # User fields
}
```

https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/entities/interfaces#example-schemas

### 2. Interfaces do not have non-meta resolvers

Related PR: https://github.com/dotansimha/graphql-code-generator/pull/5666

```graphql
interface User { 
  # fields below should not be generated for User interface because they are never called.
  # Implementing types fields are called instead
  id: ID!
  name: String!
}
```

## Breaking Changes

As part of this work, we remove unnecessary config that could generate wrong types for both Federation and normal use cases:

- BREAKING CHANGES: Deprecate `onlyResolveTypeForInterfaces` because majority of use cases cannot implement resolvers in Interfaces.
- BREAKING CHANGES: Deprecate `generateInternalResolversIfNeeded.__resolveReference` because types do not have `__resolveReference` if they are not Federation entities or are not resolvable. Users should not have to manually set this option. This option was put in to wait for this major version.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Unit test
