### PR TITLE
feat: add description for `--check` flag to build options

### DIFF
--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -249,6 +249,10 @@ export function buildOptions() {
       type: 'boolean' as const,
       default: false,
     },
+    check: {
+      describe: 'Enable dry-run mode to check if some new changes are detected',
+      type: 'boolean' as const,
+    },
     d: {
       alias: 'debug',
       describe: 'Print debug logs to stdout',


### PR DESCRIPTION
## Description

I added description for `--check` flag to CLI build options help.

Related #10224

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] When you build and run with the `--help` flag, the build options with the added description for the `--check` flag will be displayed

**Test Environment**:

- OS: Ubuntu 24.04.1 LTS
- `@graphql-codegen/...`: latest
- NodeJS: 20

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
