### PR TITLE
Fix `resolveReference` being generated as required when using `generateInternalResolversIfNeeded.__resolveReference`

### DIFF
--- a/.changeset/orange-pillows-decide.md
+++ b/.changeset/orange-pillows-decide.md
@@ -1,0 +1,10 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-resolvers': patch
+---
+
+Fix generateInternalResolversIfNeeded.\_\_resolveReference making the resolver required
+
+`__resolveReference`'s default behaviour when not declared is to pass the ref to subsequent resolvers i.e. becoming the `parent`. So, it means we don't have to make this resolver required.
+
+This patch makes `__resolveReference` optional when `generateInternalResolversIfNeeded.__resolveReference` is set to true.

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1531,7 +1531,6 @@ export class BaseResolversVisitor<
           if (!federationDetails || federationDetails.resolvableKeyDirectives.length === 0) {
             return '';
           }
-          signature.modifier = ''; // if a federation type has resolvable @key, then it should be required
         }
 
         this._federation.setMeta(parentType.name, { hasResolveReference: true });

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
@@ -212,7 +212,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       // User should have __resolveReference because it has resolvable @key (by default)
       expect(content).toBeSimilarStringTo(`
     export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
-      __resolveReference: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -223,7 +223,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       // SingleResolvable has __resolveReference because it has resolvable: true
       expect(content).toBeSimilarStringTo(`
     export type SingleResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['SingleResolvable'] = ResolversParentTypes['SingleResolvable']> = {
-      __resolveReference: ReferenceResolver<Maybe<ResolversTypes['SingleResolvable']>, { __typename: 'SingleResolvable' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['SingleResolvable']>, { __typename: 'SingleResolvable' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     };
@@ -240,7 +240,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       // AtLeastOneResolvable has __resolveReference because it at least one resolvable
       expect(content).toBeSimilarStringTo(`
     export type AtLeastOneResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['AtLeastOneResolvable'] = ResolversParentTypes['AtLeastOneResolvable']> = {
-      __resolveReference: ReferenceResolver<Maybe<ResolversTypes['AtLeastOneResolvable']>, { __typename: 'AtLeastOneResolvable' } & GraphQLRecursivePick<ParentType, {"id2":true}>, ContextType>;
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['AtLeastOneResolvable']>, { __typename: 'AtLeastOneResolvable' } & GraphQLRecursivePick<ParentType, {"id2":true}>, ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -251,7 +251,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       // MixedResolvable has __resolveReference and references for resolvable keys
       expect(content).toBeSimilarStringTo(`
     export type MixedResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['MixedResolvable'] = ResolversParentTypes['MixedResolvable']> = {
-      __resolveReference: ReferenceResolver<Maybe<ResolversTypes['MixedResolvable']>, { __typename: 'MixedResolvable' } & (GraphQLRecursivePick<ParentType, {"id":true}> | GraphQLRecursivePick<ParentType, {"id2":true}>), ContextType>;
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['MixedResolvable']>, { __typename: 'MixedResolvable' } & (GraphQLRecursivePick<ParentType, {"id":true}> | GraphQLRecursivePick<ParentType, {"id2":true}>), ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;


### PR DESCRIPTION
## Description

First implementation is https://github.com/dotansimha/graphql-code-generator/pull/9989

`__resolveReference`'s default behaviour when not declared is to pass the ref to subsequent resolvers i.e. becoming the `parent`. So, it means we don't have to make this resolver required.

This patch makes `__resolveReference` optional when `generateInternalResolversIfNeeded.__resolveReference` is set to true.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit test