### PR TITLE
Switch to use stable SWAPI endpoint in examples

### DIFF
--- a/examples/react/apollo-client-swc-plugin/codegen.ts
+++ b/examples/react/apollo-client-swc-plugin/codegen.ts
@@ -2,7 +2,7 @@
 import { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.tsx', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/react/apollo-client-swc-plugin/codegen.ts
+++ b/examples/react/apollo-client-swc-plugin/codegen.ts
@@ -2,7 +2,7 @@
 import { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.tsx', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/react/apollo-client-swc-plugin/src/main.tsx
+++ b/examples/react/apollo-client-swc-plugin/src/main.tsx
@@ -5,7 +5,7 @@ import App from './App';
 import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
 
 const client = new ApolloClient({
-  uri: 'https://swapi-graphql.netlify.app/graphql',
+  uri: 'https://graphql.org/graphql/',
   cache: new InMemoryCache(),
 });
 

--- a/examples/react/apollo-client-swc-plugin/src/main.tsx
+++ b/examples/react/apollo-client-swc-plugin/src/main.tsx
@@ -5,7 +5,7 @@ import App from './App';
 import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
 
 const client = new ApolloClient({
-  uri: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  uri: 'https://swapi-graphql.netlify.app/graphql',
   cache: new InMemoryCache(),
 });
 

--- a/examples/react/apollo-client/codegen.ts
+++ b/examples/react/apollo-client/codegen.ts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.tsx'],
   generates: {
     './src/gql/': {

--- a/examples/react/apollo-client/codegen.ts
+++ b/examples/react/apollo-client/codegen.ts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.tsx'],
   generates: {
     './src/gql/': {

--- a/examples/react/apollo-client/src/main.tsx
+++ b/examples/react/apollo-client/src/main.tsx
@@ -5,7 +5,7 @@ import App from './App';
 import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
 
 const client = new ApolloClient({
-  uri: 'https://swapi-graphql.netlify.app/graphql',
+  uri: 'https://graphql.org/graphql/',
   cache: new InMemoryCache(),
 });
 

--- a/examples/react/apollo-client/src/main.tsx
+++ b/examples/react/apollo-client/src/main.tsx
@@ -5,7 +5,7 @@ import App from './App';
 import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
 
 const client = new ApolloClient({
-  uri: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  uri: 'https://swapi-graphql.netlify.app/graphql',
   cache: new InMemoryCache(),
 });
 

--- a/examples/react/http-executor/codegen.ts
+++ b/examples/react/http-executor/codegen.ts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.tsx'],
   generates: {
     './src/gql/': {

--- a/examples/react/http-executor/codegen.ts
+++ b/examples/react/http-executor/codegen.ts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.tsx'],
   generates: {
     './src/gql/': {

--- a/examples/react/http-executor/src/App.tsx
+++ b/examples/react/http-executor/src/App.tsx
@@ -5,7 +5,7 @@ import Film from './Film';
 import { graphql, DocumentType } from './gql';
 
 const executor = buildHTTPExecutor({
-  endpoint: 'https://swapi-graphql.netlify.app/graphql',
+  endpoint: 'https://graphql.org/graphql/',
 });
 
 const AllFilmsWithVariablesQuery = graphql(/* GraphQL */ `
@@ -21,7 +21,7 @@ const AllFilmsWithVariablesQuery = graphql(/* GraphQL */ `
 `);
 
 // we could also define a client:
-// `const client = new GraphQLClient('https://swapi-graphql.netlify.app/graphql')`
+// `const client = new GraphQLClient('https://graphql.org/graphql/')`
 // and use:
 // `client.request(allFilmsWithVariablesQueryDocument, { first: 10 })`
 

--- a/examples/react/http-executor/src/App.tsx
+++ b/examples/react/http-executor/src/App.tsx
@@ -5,7 +5,7 @@ import Film from './Film';
 import { graphql, DocumentType } from './gql';
 
 const executor = buildHTTPExecutor({
-  endpoint: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  endpoint: 'https://swapi-graphql.netlify.app/graphql',
 });
 
 const AllFilmsWithVariablesQuery = graphql(/* GraphQL */ `
@@ -21,7 +21,7 @@ const AllFilmsWithVariablesQuery = graphql(/* GraphQL */ `
 `);
 
 // we could also define a client:
-// `const client = new GraphQLClient('https://swapi-graphql.netlify.app/.netlify/functions/index')`
+// `const client = new GraphQLClient('https://swapi-graphql.netlify.app/graphql')`
 // and use:
 // `client.request(allFilmsWithVariablesQueryDocument, { first: 10 })`
 

--- a/examples/react/nextjs-swr/codegen.ts
+++ b/examples/react/nextjs-swr/codegen.ts
@@ -2,7 +2,7 @@
 import { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['components/**/*.tsx', 'pages/**/*.tsx'],
   generates: {
     './gql/': {

--- a/examples/react/nextjs-swr/codegen.ts
+++ b/examples/react/nextjs-swr/codegen.ts
@@ -2,7 +2,7 @@
 import { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['components/**/*.tsx', 'pages/**/*.tsx'],
   generates: {
     './gql/': {

--- a/examples/react/nextjs-swr/hooks/use-query.ts
+++ b/examples/react/nextjs-swr/hooks/use-query.ts
@@ -5,7 +5,7 @@ import { ASTNode, ExecutionResult, Kind, OperationDefinitionNode } from 'graphql
 import useSWR from 'swr';
 
 const executor = buildHTTPExecutor({
-  endpoint: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  endpoint: 'https://swapi-graphql.netlify.app/graphql',
 });
 
 const isOperationDefinition = (def: ASTNode): def is OperationDefinitionNode => def.kind === Kind.OPERATION_DEFINITION;

--- a/examples/react/nextjs-swr/hooks/use-query.ts
+++ b/examples/react/nextjs-swr/hooks/use-query.ts
@@ -5,7 +5,7 @@ import { ASTNode, ExecutionResult, Kind, OperationDefinitionNode } from 'graphql
 import useSWR from 'swr';
 
 const executor = buildHTTPExecutor({
-  endpoint: 'https://swapi-graphql.netlify.app/graphql',
+  endpoint: 'https://graphql.org/graphql/',
 });
 
 const isOperationDefinition = (def: ASTNode): def is OperationDefinitionNode => def.kind === Kind.OPERATION_DEFINITION;

--- a/examples/react/tanstack-react-query/codegen.ts
+++ b/examples/react/tanstack-react-query/codegen.ts
@@ -2,7 +2,7 @@
 import { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.tsx', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/react/tanstack-react-query/codegen.ts
+++ b/examples/react/tanstack-react-query/codegen.ts
@@ -2,7 +2,7 @@
 import { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.tsx', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/react/tanstack-react-query/src/use-graphql.ts
+++ b/examples/react/tanstack-react-query/src/use-graphql.ts
@@ -14,7 +14,7 @@ export function useGraphQL<TResult, TVariables>(
       variables,
     ] as const,
     async ({ queryKey }) => {
-      return fetch('https://swapi-graphql.netlify.app/.netlify/functions/index', {
+      return fetch('https://swapi-graphql.netlify.app/graphql', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/examples/react/tanstack-react-query/src/use-graphql.ts
+++ b/examples/react/tanstack-react-query/src/use-graphql.ts
@@ -14,7 +14,7 @@ export function useGraphQL<TResult, TVariables>(
       variables,
     ] as const,
     async ({ queryKey }) => {
-      return fetch('https://swapi-graphql.netlify.app/graphql', {
+      return fetch('https://graphql.org/graphql/', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/examples/react/urql/codegen.ts
+++ b/examples/react/urql/codegen.ts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.tsx', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/react/urql/codegen.ts
+++ b/examples/react/urql/codegen.ts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.tsx', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/react/urql/src/main.tsx
+++ b/examples/react/urql/src/main.tsx
@@ -6,7 +6,7 @@ import './main.css';
 import App from './App';
 
 const client = createClient({
-  url: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  url: 'https://swapi-graphql.netlify.app/graphql',
 });
 
 const root = ReactDOM.createRoot(document.getElementById('app') as HTMLElement);

--- a/examples/react/urql/src/main.tsx
+++ b/examples/react/urql/src/main.tsx
@@ -6,7 +6,7 @@ import './main.css';
 import App from './App';
 
 const client = createClient({
-  url: 'https://swapi-graphql.netlify.app/graphql',
+  url: 'https://graphql.org/graphql/',
 });
 
 const root = ReactDOM.createRoot(document.getElementById('app') as HTMLElement);

--- a/examples/typescript-esm/codegen.cjs
+++ b/examples/typescript-esm/codegen.cjs
@@ -2,7 +2,7 @@
 
 /** @type {import("@graphql-codegen/cli").CodegenConfig} */
 const config = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.ts'],
   emitLegacyCommonJSImports: false,
   generates: {

--- a/examples/typescript-esm/codegen.cjs
+++ b/examples/typescript-esm/codegen.cjs
@@ -2,7 +2,7 @@
 
 /** @type {import("@graphql-codegen/cli").CodegenConfig} */
 const config = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.ts'],
   emitLegacyCommonJSImports: false,
   generates: {

--- a/examples/typescript-esm/src/main.ts
+++ b/examples/typescript-esm/src/main.ts
@@ -32,7 +32,7 @@ const AllPeopleWithVariablesQueryDocument = graphql(/* GraphQL */ `
   }
 `);
 
-const apiUrl = 'https://swapi-graphql.netlify.app/graphql';
+const apiUrl = 'https://graphql.org/graphql/';
 
 executeOperation(apiUrl, AllPeopleQueryDocument).then(res => {
   if (res.errors) {

--- a/examples/typescript-esm/src/main.ts
+++ b/examples/typescript-esm/src/main.ts
@@ -32,7 +32,7 @@ const AllPeopleWithVariablesQueryDocument = graphql(/* GraphQL */ `
   }
 `);
 
-const apiUrl = 'https://swapi-graphql.netlify.app/.netlify/functions/index';
+const apiUrl = 'https://swapi-graphql.netlify.app/graphql';
 
 executeOperation(apiUrl, AllPeopleQueryDocument).then(res => {
   if (res.errors) {

--- a/examples/typescript-graphql-request/codegen.ts
+++ b/examples/typescript-graphql-request/codegen.ts
@@ -2,7 +2,7 @@
 import { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.ts'],
   generates: {
     './src/gql/': {

--- a/examples/typescript-graphql-request/codegen.ts
+++ b/examples/typescript-graphql-request/codegen.ts
@@ -2,7 +2,7 @@
 import { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.ts'],
   generates: {
     './src/gql/': {

--- a/examples/typescript-graphql-request/package.json
+++ b/examples/typescript-graphql-request/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "graphql": "16.9.0",
-    "graphql-yoga": "5.7.0"
+    "graphql-yoga": "5.7.0",
+    "graphql-request": "5.2.0"
   },
   "scripts": {
     "codegen": "graphql-codegen --config codegen.ts",

--- a/examples/typescript-graphql-request/package.json
+++ b/examples/typescript-graphql-request/package.json
@@ -9,8 +9,7 @@
   },
   "dependencies": {
     "graphql": "16.9.0",
-    "graphql-yoga": "5.7.0",
-    "graphql-request": "5.2.0"
+    "graphql-yoga": "5.7.0"
   },
   "scripts": {
     "codegen": "graphql-codegen --config codegen.ts",

--- a/examples/typescript-graphql-request/src/main.ts
+++ b/examples/typescript-graphql-request/src/main.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-import { GraphQLClient } from 'graphql-request';
 import { graphql } from './gql';
 import { AllPeopleQueryQuery } from './gql/graphql';
 
@@ -35,14 +33,17 @@ const AllPeopleWithVariablesQueryDocument = graphql(/* GraphQL */ `
 
 const apiUrl = 'https://graphql.org/graphql/';
 
-const client = new GraphQLClient(apiUrl);
-
 export const getPeople = async (first?: number) => {
-  let res: AllPeopleQueryQuery;
-  if (first) {
-    res = await client.request(AllPeopleWithVariablesQueryDocument.toString(), { first });
-  } else {
-    res = await client.request(AllPeopleQueryDocument.toString());
-  }
-  return res?.allPeople?.edges;
+  const request = first
+    ? { query: AllPeopleWithVariablesQueryDocument.toString(), variables: { first } }
+    : { query: AllPeopleQueryDocument.toString() };
+
+  const response = await fetch(apiUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+
+  const res: AllPeopleQueryQuery = (await response.json()).data;
+  return res.allPeople?.edges;
 };

--- a/examples/typescript-graphql-request/src/main.ts
+++ b/examples/typescript-graphql-request/src/main.ts
@@ -1,3 +1,4 @@
+import { GraphQLClient } from 'graphql-request';
 import { graphql } from './gql';
 import { AllPeopleQueryQuery } from './gql/graphql';
 
@@ -33,17 +34,14 @@ const AllPeopleWithVariablesQueryDocument = graphql(/* GraphQL */ `
 
 const apiUrl = 'https://graphql.org/graphql/';
 
+const client = new GraphQLClient(apiUrl);
+
 export const getPeople = async (first?: number) => {
-  const request = first
-    ? { query: AllPeopleWithVariablesQueryDocument.toString(), variables: { first } }
-    : { query: AllPeopleQueryDocument.toString() };
-
-  const response = await fetch(apiUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(request),
-  });
-
-  const res: AllPeopleQueryQuery = (await response.json()).data;
-  return res.allPeople?.edges;
+  let res: AllPeopleQueryQuery;
+  if (first) {
+    res = await client.request(AllPeopleWithVariablesQueryDocument.toString(), { first });
+  } else {
+    res = await client.request(AllPeopleQueryDocument.toString());
+  }
+  return res?.allPeople?.edges;
 };

--- a/examples/typescript-graphql-request/src/main.ts
+++ b/examples/typescript-graphql-request/src/main.ts
@@ -33,7 +33,7 @@ const AllPeopleWithVariablesQueryDocument = graphql(/* GraphQL */ `
   }
 `);
 
-const apiUrl = 'https://swapi-graphql.netlify.app/graphql';
+const apiUrl = 'https://graphql.org/graphql/';
 
 const client = new GraphQLClient(apiUrl);
 

--- a/examples/typescript-graphql-request/src/main.ts
+++ b/examples/typescript-graphql-request/src/main.ts
@@ -33,7 +33,7 @@ const AllPeopleWithVariablesQueryDocument = graphql(/* GraphQL */ `
   }
 `);
 
-const apiUrl = 'https://swapi-graphql.netlify.app/.netlify/functions/index';
+const apiUrl = 'https://swapi-graphql.netlify.app/graphql';
 
 const client = new GraphQLClient(apiUrl);
 

--- a/examples/vite/vite-react-cts/codegen.cts
+++ b/examples/vite/vite-react-cts/codegen.cts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.tsx'],
   generates: {
     './src/gql/': {

--- a/examples/vite/vite-react-cts/codegen.cts
+++ b/examples/vite/vite-react-cts/codegen.cts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.tsx'],
   generates: {
     './src/gql/': {

--- a/examples/vite/vite-react-cts/src/main.tsx
+++ b/examples/vite/vite-react-cts/src/main.tsx
@@ -5,7 +5,7 @@ import { graphql } from './gql';
 import { ApolloClient, InMemoryCache, ApolloProvider, useQuery } from '@apollo/client';
 
 const client = new ApolloClient({
-  uri: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  uri: 'https://swapi-graphql.netlify.app/graphql',
   cache: new InMemoryCache(),
 });
 

--- a/examples/vite/vite-react-cts/src/main.tsx
+++ b/examples/vite/vite-react-cts/src/main.tsx
@@ -5,7 +5,7 @@ import { graphql } from './gql';
 import { ApolloClient, InMemoryCache, ApolloProvider, useQuery } from '@apollo/client';
 
 const client = new ApolloClient({
-  uri: 'https://swapi-graphql.netlify.app/graphql',
+  uri: 'https://graphql.org/graphql/',
   cache: new InMemoryCache(),
 });
 

--- a/examples/vite/vite-react-mts/codegen.mts
+++ b/examples/vite/vite-react-mts/codegen.mts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.tsx'],
   generates: {
     './src/gql/': {

--- a/examples/vite/vite-react-mts/codegen.mts
+++ b/examples/vite/vite-react-mts/codegen.mts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.tsx'],
   generates: {
     './src/gql/': {

--- a/examples/vite/vite-react-mts/src/main.tsx
+++ b/examples/vite/vite-react-mts/src/main.tsx
@@ -5,7 +5,7 @@ import { graphql } from './gql';
 import { ApolloClient, InMemoryCache, ApolloProvider, useQuery } from '@apollo/client';
 
 const client = new ApolloClient({
-  uri: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  uri: 'https://swapi-graphql.netlify.app/graphql',
   cache: new InMemoryCache(),
 });
 

--- a/examples/vite/vite-react-mts/src/main.tsx
+++ b/examples/vite/vite-react-mts/src/main.tsx
@@ -5,7 +5,7 @@ import { graphql } from './gql';
 import { ApolloClient, InMemoryCache, ApolloProvider, useQuery } from '@apollo/client';
 
 const client = new ApolloClient({
-  uri: 'https://swapi-graphql.netlify.app/graphql',
+  uri: 'https://graphql.org/graphql/',
   cache: new InMemoryCache(),
 });
 

--- a/examples/vite/vite-react-ts/codegen.ts
+++ b/examples/vite/vite-react-ts/codegen.ts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.tsx'],
   generates: {
     './src/gql/': {

--- a/examples/vite/vite-react-ts/codegen.ts
+++ b/examples/vite/vite-react-ts/codegen.ts
@@ -2,7 +2,7 @@
 import { type CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.tsx'],
   generates: {
     './src/gql/': {

--- a/examples/vite/vite-react-ts/src/main.tsx
+++ b/examples/vite/vite-react-ts/src/main.tsx
@@ -5,7 +5,7 @@ import { graphql } from './gql';
 import { ApolloClient, InMemoryCache, ApolloProvider, useQuery } from '@apollo/client';
 
 const client = new ApolloClient({
-  uri: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  uri: 'https://swapi-graphql.netlify.app/graphql',
   cache: new InMemoryCache(),
 });
 

--- a/examples/vite/vite-react-ts/src/main.tsx
+++ b/examples/vite/vite-react-ts/src/main.tsx
@@ -5,7 +5,7 @@ import { graphql } from './gql';
 import { ApolloClient, InMemoryCache, ApolloProvider, useQuery } from '@apollo/client';
 
 const client = new ApolloClient({
-  uri: 'https://swapi-graphql.netlify.app/graphql',
+  uri: 'https://graphql.org/graphql/',
   cache: new InMemoryCache(),
 });
 

--- a/examples/vue/apollo-composable/codegen.ts
+++ b/examples/vue/apollo-composable/codegen.ts
@@ -1,7 +1,7 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.vue', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/vue/apollo-composable/codegen.ts
+++ b/examples/vue/apollo-composable/codegen.ts
@@ -1,7 +1,7 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.vue', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/vue/apollo-composable/src/main.ts
+++ b/examples/vue/apollo-composable/src/main.ts
@@ -5,7 +5,7 @@ import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client/core';
 import App from './App.vue';
 
 const httpLink = new HttpLink({
-  uri: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  uri: 'https://swapi-graphql.netlify.app/graphql',
 });
 
 // Create the apollo client

--- a/examples/vue/apollo-composable/src/main.ts
+++ b/examples/vue/apollo-composable/src/main.ts
@@ -5,7 +5,7 @@ import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client/core';
 import App from './App.vue';
 
 const httpLink = new HttpLink({
-  uri: 'https://swapi-graphql.netlify.app/graphql',
+  uri: 'https://graphql.org/graphql/',
 });
 
 // Create the apollo client

--- a/examples/vue/urql/codegen.ts
+++ b/examples/vue/urql/codegen.ts
@@ -1,7 +1,7 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.vue', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/vue/urql/codegen.ts
+++ b/examples/vue/urql/codegen.ts
@@ -1,7 +1,7 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.vue', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/vue/urql/src/main.ts
+++ b/examples/vue/urql/src/main.ts
@@ -5,7 +5,7 @@ import App from './App.vue';
 const app = createApp(App);
 
 app.use(urql, {
-  url: 'https://swapi-graphql.netlify.app/graphql',
+  url: 'https://graphql.org/graphql/',
   exchanges: [cacheExchange, fetchExchange],
 });
 

--- a/examples/vue/urql/src/main.ts
+++ b/examples/vue/urql/src/main.ts
@@ -5,7 +5,7 @@ import App from './App.vue';
 const app = createApp(App);
 
 app.use(urql, {
-  url: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  url: 'https://swapi-graphql.netlify.app/graphql',
   exchanges: [cacheExchange, fetchExchange],
 });
 

--- a/examples/vue/villus/codegen.ts
+++ b/examples/vue/villus/codegen.ts
@@ -1,7 +1,7 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.vue', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/vue/villus/codegen.ts
+++ b/examples/vue/villus/codegen.ts
@@ -1,7 +1,7 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.vue', '!src/gql/**/*'],
   generates: {
     './src/gql/': {

--- a/examples/vue/villus/src/App.vue
+++ b/examples/vue/villus/src/App.vue
@@ -5,7 +5,7 @@ import FilmItem from './components/FilmItem.vue';
 import { computed } from 'vue';
 
 useClient({
-  url: 'https://swapi-graphql.netlify.app/graphql',
+  url: 'https://graphql.org/graphql/',
 });
 
 const { data } = useQuery({

--- a/examples/vue/villus/src/App.vue
+++ b/examples/vue/villus/src/App.vue
@@ -5,7 +5,7 @@ import FilmItem from './components/FilmItem.vue';
 import { computed } from 'vue';
 
 useClient({
-  url: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  url: 'https://swapi-graphql.netlify.app/graphql',
 });
 
 const { data } = useQuery({

--- a/packages/presets/client/CHANGELOG.md
+++ b/packages/presets/client/CHANGELOG.md
@@ -566,7 +566,7 @@
   import { CodegenConfig } from '@graphql-codegen/cli'
 
   const config: CodegenConfig = {
-    schema: 'https://swapi-graphql.netlify.app/graphql',
+    schema: 'https://graphql.org/graphql/',
     documents: ['src/**/*.tsx'],
     ignoreNoDocuments: true, // for better experience with the watcher
     generates: {
@@ -614,7 +614,7 @@
   import { CodegenConfig } from '@graphql-codegen/cli'
 
   const config: CodegenConfig = {
-    schema: 'https://swapi-graphql.netlify.app/graphql',
+    schema: 'https://graphql.org/graphql/',
     documents: ['src/**/*.tsx'],
     ignoreNoDocuments: true, // for better experience with the watcher
     generates: {

--- a/packages/presets/client/CHANGELOG.md
+++ b/packages/presets/client/CHANGELOG.md
@@ -566,7 +566,7 @@
   import { CodegenConfig } from '@graphql-codegen/cli'
 
   const config: CodegenConfig = {
-    schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+    schema: 'https://swapi-graphql.netlify.app/graphql',
     documents: ['src/**/*.tsx'],
     ignoreNoDocuments: true, // for better experience with the watcher
     generates: {
@@ -614,7 +614,7 @@
   import { CodegenConfig } from '@graphql-codegen/cli'
 
   const config: CodegenConfig = {
-    schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+    schema: 'https://swapi-graphql.netlify.app/graphql',
     documents: ['src/**/*.tsx'],
     ignoreNoDocuments: true, // for better experience with the watcher
     generates: {

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -25,7 +25,7 @@ export type ClientPresetConfig = {
    * @exampleMarkdown
    * ```tsx
    * const config = {
-   *    schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+   *    schema: 'https://swapi-graphql.netlify.app/graphql',
    *    documents: ['src/**\/*.tsx', '!src\/gql/**\/*'],
    *    generates: {
    *       './src/gql/': {
@@ -49,7 +49,7 @@ export type ClientPresetConfig = {
    * @exampleMarkdown
    * ```tsx
    * const config = {
-   *    schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+   *    schema: 'https://swapi-graphql.netlify.app/graphql',
    *    documents: ['src/**\/*.tsx', '!src\/gql/**\/*'],
    *    generates: {
    *       './src/gql/': {

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -25,7 +25,7 @@ export type ClientPresetConfig = {
    * @exampleMarkdown
    * ```tsx
    * const config = {
-   *    schema: 'https://swapi-graphql.netlify.app/graphql',
+   *    schema: 'https://graphql.org/graphql/',
    *    documents: ['src/**\/*.tsx', '!src\/gql/**\/*'],
    *    generates: {
    *       './src/gql/': {
@@ -49,7 +49,7 @@ export type ClientPresetConfig = {
    * @exampleMarkdown
    * ```tsx
    * const config = {
-   *    schema: 'https://swapi-graphql.netlify.app/graphql',
+   *    schema: 'https://graphql.org/graphql/',
    *    documents: ['src/**\/*.tsx', '!src\/gql/**\/*'],
    *    generates: {
    *       './src/gql/': {

--- a/website/src/pages/docs/guides/react-query.mdx
+++ b/website/src/pages/docs/guides/react-query.mdx
@@ -44,7 +44,7 @@ contents:
 import type { CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.tsx'],
   ignoreNoDocuments: true,
   generates: {
@@ -170,7 +170,7 @@ export async function execute<TResult, TVariables>(
   query: TypedDocumentString<TResult, TVariables>,
   ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
 ) {
-  const response = await fetch('https://swapi-graphql.netlify.app/.netlify/functions/index', {
+  const response = await fetch('https://swapi-graphql.netlify.app/graphql', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/website/src/pages/docs/guides/react-query.mdx
+++ b/website/src/pages/docs/guides/react-query.mdx
@@ -44,7 +44,7 @@ contents:
 import type { CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.tsx'],
   ignoreNoDocuments: true,
   generates: {
@@ -170,7 +170,7 @@ export async function execute<TResult, TVariables>(
   query: TypedDocumentString<TResult, TVariables>,
   ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
 ) {
-  const response = await fetch('https://swapi-graphql.netlify.app/graphql', {
+  const response = await fetch('https://graphql.org/graphql/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -8,7 +8,7 @@ import { Tabs, Callout } from '@theguild/components'
 
 GraphQL Code Generator provides a unified way to get TypeScript types from GraphQL operations for [most modern GraphQL clients and frameworks](#appendix-ii-compatibility).
 
-This guide is built using the [Star wars films demo API](https://swapi-graphql.netlify.app/graphql).
+This guide is built using the [Star wars films demo API](https://graphql.org/graphql/).
 
 We will build a simple GraphQL front-end app using the following Query to fetch the list of Star Wars films:
 
@@ -62,7 +62,7 @@ Then provide the corresponding framework-specific configuration:
 import type { CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.tsx'],
   ignoreNoDocuments: true, // for better experience with the watcher
   generates: {
@@ -83,7 +83,7 @@ export default config
 import type { CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.vue'],
   ignoreNoDocuments: true, // for better experience with the watcher
   generates: {
@@ -184,7 +184,7 @@ const allFilmsWithVariablesQueryDocument = graphql(/* GraphQL */ `
 function App() {
   // `data` is typed!
   const { data } = useQuery(['films'], async () =>
-    request('https://swapi-graphql.netlify.app/graphql', allFilmsWithVariablesQueryDocument, {
+    request('https://graphql.org/graphql/', allFilmsWithVariablesQueryDocument, {
       first: 10 // variables are typed too!
     })
   )
@@ -535,11 +535,7 @@ export function useGraphQL<TResult, TVariables>(
   ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
 ): UseQueryResult<TResult> {
   return useQuery([(document.definitions[0] as any).name.value, variables], async ({ queryKey }) =>
-    request(
-      'https://swapi-graphql.netlify.app/graphql',
-      document,
-      queryKey[1] ? queryKey[1] : undefined
-    )
+    request('https://graphql.org/graphql/', document, queryKey[1] ? queryKey[1] : undefined)
   )
 }
 ```
@@ -623,7 +619,7 @@ export function useGraphQL<TResult, TVariables>(
   ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
 ): UseQueryResult<ExecutionResult<TResult>> {
   return useQuery([(document.definitions[0] as any).name.value, variables], () =>
-    customFetcher('https://swapi-graphql.netlify.app/graphql', document, variables)
+    customFetcher('https://graphql.org/graphql/', document, variables)
   )
 }
 ```

--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -8,7 +8,7 @@ import { Tabs, Callout } from '@theguild/components'
 
 GraphQL Code Generator provides a unified way to get TypeScript types from GraphQL operations for [most modern GraphQL clients and frameworks](#appendix-ii-compatibility).
 
-This guide is built using the [Star wars films demo API](https://swapi-graphql.netlify.app/.netlify/functions/index).
+This guide is built using the [Star wars films demo API](https://swapi-graphql.netlify.app/graphql).
 
 We will build a simple GraphQL front-end app using the following Query to fetch the list of Star Wars films:
 
@@ -62,7 +62,7 @@ Then provide the corresponding framework-specific configuration:
 import type { CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.tsx'],
   ignoreNoDocuments: true, // for better experience with the watcher
   generates: {
@@ -83,7 +83,7 @@ export default config
 import type { CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.vue'],
   ignoreNoDocuments: true, // for better experience with the watcher
   generates: {
@@ -184,7 +184,7 @@ const allFilmsWithVariablesQueryDocument = graphql(/* GraphQL */ `
 function App() {
   // `data` is typed!
   const { data } = useQuery(['films'], async () =>
-    request('https://swapi-graphql.netlify.app/.netlify/functions/index', allFilmsWithVariablesQueryDocument, {
+    request('https://swapi-graphql.netlify.app/graphql', allFilmsWithVariablesQueryDocument, {
       first: 10 // variables are typed too!
     })
   )
@@ -536,7 +536,7 @@ export function useGraphQL<TResult, TVariables>(
 ): UseQueryResult<TResult> {
   return useQuery([(document.definitions[0] as any).name.value, variables], async ({ queryKey }) =>
     request(
-      'https://swapi-graphql.netlify.app/.netlify/functions/index',
+      'https://swapi-graphql.netlify.app/graphql',
       document,
       queryKey[1] ? queryKey[1] : undefined
     )
@@ -623,7 +623,7 @@ export function useGraphQL<TResult, TVariables>(
   ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
 ): UseQueryResult<ExecutionResult<TResult>> {
   return useQuery([(document.definitions[0] as any).name.value, variables], () =>
-    customFetcher('https://swapi-graphql.netlify.app/.netlify/functions/index', document, variables)
+    customFetcher('https://swapi-graphql.netlify.app/graphql', document, variables)
   )
 }
 ```

--- a/website/src/pages/docs/guides/vanilla-typescript.mdx
+++ b/website/src/pages/docs/guides/vanilla-typescript.mdx
@@ -60,7 +60,7 @@ contents:
 import type { CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  schema: 'https://swapi-graphql.netlify.app/graphql',
   documents: ['src/**/*.ts'],
   ignoreNoDocuments: true,
   generates: {
@@ -187,7 +187,7 @@ export async function execute<TResult, TVariables>(
   query: TypedDocumentString<TResult, TVariables>,
   ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
 ) {
-  const response = await fetch('https://swapi-graphql.netlify.app/.netlify/functions/index', {
+  const response = await fetch('https://swapi-graphql.netlify.app/graphql', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/website/src/pages/docs/guides/vanilla-typescript.mdx
+++ b/website/src/pages/docs/guides/vanilla-typescript.mdx
@@ -60,7 +60,7 @@ contents:
 import type { CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {
-  schema: 'https://swapi-graphql.netlify.app/graphql',
+  schema: 'https://graphql.org/graphql/',
   documents: ['src/**/*.ts'],
   ignoreNoDocuments: true,
   generates: {
@@ -187,7 +187,7 @@ export async function execute<TResult, TVariables>(
   query: TypedDocumentString<TResult, TVariables>,
   ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
 ) {
-  const response = await fetch('https://swapi-graphql.netlify.app/graphql', {
+  const response = await fetch('https://graphql.org/graphql/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Description

https://github.com/graphql/swapi-graphql recently moved to a new endpoint, so this PR updates the endpoint references. 
Some tests were failing because they were using the old endpoint

## Type of change

- [x] Fix CI