### PR TITLE
Update Components to 7.6.0 to use Hive-rebranding themed MDX link

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -72,7 +72,7 @@
     "@monaco-editor/react": "4.6.0",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-icons": "^1.3.0",
-    "@theguild/components": "7.5.0",
+    "@theguild/components": "7.6.0",
     "classnames": "2.5.1",
     "date-fns": "2.30.0",
     "dedent": "1.5.3",

--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -46,6 +46,7 @@ export default defineConfig({
   websiteName: 'GraphQL-Codegen',
   description: 'Generate anything from GraphQL schema & operations',
   logo: PRODUCTS.CODEGEN.logo({ className: 'w-8' }),
+  themeVersion: 'hive-rebranding',
   color: {
     hue: {
       dark: 67.1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4434,10 +4434,10 @@
   resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.10.8.tgz#975446a667755222f62884c19e5c3c66d959b8b4"
   integrity sha512-PBu00mtt95jbKFi6Llk9aik8bnR3tR/oQP1o3TSi+iG//+Q2RTIzCEgKkHG8BB86kxMNW6O8wku+Lmi+QFR6jA==
 
-"@theguild/components@7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@theguild/components/-/components-7.5.0.tgz#316877c0114a49e2b86c83c52243993f47abbd40"
-  integrity sha512-2lgg+kWQBGyAgl0948p65l9Qb7jy1RXPSdY9fUL9hQR53g0ea84+d1MffwlC5pWh7y0o6dcznSAXJZcFhJfJ0g==
+"@theguild/components@7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@theguild/components/-/components-7.6.0.tgz#e144649260bd461cad8372d68bc579c421548b6c"
+  integrity sha512-optsjn/l80iMj3IfIpnkBoTt5iYOWks5CsWQvqeSSagjzZEyUOtyEch02PNNj8dLL4WhjXWwIs9oxhLmuTg39A==
   dependencies:
     "@giscus/react" "3.0.0"
     "@next/bundle-analyzer" "15.1.0"


### PR DESCRIPTION
## Description

This PR brings in https://github.com/the-guild-org/docs/pull/1976 to fix text-decoration style in Neue Montreal in Safari.

I don't really like the contrast of the new blue with the current light mode background (it's a bit too low), so we might follow up with some more style tweaks later when the designers have a chance to take a look at it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
