### PR TITLE
Fix React Query doc

### DIFF
--- a/website/src/pages/docs/guides/react-query.mdx
+++ b/website/src/pages/docs/guides/react-query.mdx
@@ -177,7 +177,7 @@ export async function execute<TResult, TVariables>(
       Accept: 'application/graphql-response+json'
     },
     body: JSON.stringify({
-      query: document,
+      query,
       variables
     })
   })


### PR DESCRIPTION
## Description

This is a small fix to React Query doc: `document` is a variable that is not in the example function. It should be `query` instead.
