### PR TITLE
Split examples test for speed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,10 +57,6 @@ jobs:
           git diff --exit-code -- dev-test/
   dev-tests:
     name: Examples
-    strategy:
-      matrix:
-        run_group: [1, 2, 3, 4]
-        run_group_total: [4]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -73,16 +69,16 @@ jobs:
         run: yarn build
         env:
           CI: true
-      - name: Generate and Diff Codegen Artifacts ${{ matrix.run_group }}/${{ matrix.run_group_total }}
+      - name: Generate and Diff Codegen Artifacts
         run: |
-          RUN_GROUP=${{ matrix.run_group }} RUN_GROUP_TOTAL=${{ matrix.run_group_total }} yarn examples:codegen
+          yarn examples:codegen
           git diff --exit-code -- examples/
-      - name: Build Examples ${{ matrix.run_group }}/${{ matrix.run_group_total }}
+      - name: Build Examples
         run: |
-          RUN_GROUP=${{ matrix.run_group }} RUN_GROUP_TOTAL=${{ matrix.run_group_total }} yarn examples:build
-      - name: End2End Test Examples ${{ matrix.run_group }}/${{ matrix.run_group_total }}
+          yarn examples:build
+      - name: End2End Test Examples
         run: |
-          RUN_GROUP=${{ matrix.run_group }} RUN_GROUP_TOTAL=${{ matrix.run_group_total }} yarn examples:test:end2end
+          yarn examples:test:end2end
   dev-tests-swc:
     name: Examples - SWC
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,10 @@ jobs:
           git diff --exit-code -- dev-test/
   dev-tests:
     name: Examples
+    strategy:
+      matrix:
+        run_group: [1, 2, 3, 4]
+        run_group_total: [4]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -78,16 +82,16 @@ jobs:
         run: yarn build
         env:
           CI: true
-      - name: Generate and Diff Codegen Artifacts
+      - name: Generate and Diff Codegen Artifacts ${{ matrix.run_group }}/${{ matrix.run_group_total }}
         run: |
-          yarn examples:codegen
+          RUN_GROUP=${{ matrix.run_group }} RUN_GROUP_TOTAL=${{ matrix.run_group_total }} yarn examples:codegen
           git diff --exit-code -- examples/
-      - name: Build Examples
+      - name: Build Examples ${{ matrix.run_group }}/${{ matrix.run_group_total }}
         run: |
-          yarn examples:build
-      - name: End2End Test Examples
+          RUN_GROUP=${{ matrix.run_group }} RUN_GROUP_TOTAL=${{ matrix.run_group_total }} yarn examples:build
+      - name: End2End Test Examples ${{ matrix.run_group }}/${{ matrix.run_group_total }}
         run: |
-          yarn examples:test:end2end
+          RUN_GROUP=${{ matrix.run_group }} RUN_GROUP_TOTAL=${{ matrix.run_group_total }} yarn examples:test:end2end
   esm:
     name: Testing exports integrity
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,15 +69,6 @@ jobs:
         uses: the-guild-org/shared-config/setup@main
         with:
           nodeVersion: 18
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.65.0
-          target: wasm32-wasi
-          override: true
-      - name: Build SWC plugin
-        working-directory: ./packages/presets/swc-plugin
-        run: |
-          npm run build-wasm
       - name: Build
         run: yarn build
         env:
@@ -92,6 +83,39 @@ jobs:
       - name: End2End Test Examples ${{ matrix.run_group }}/${{ matrix.run_group_total }}
         run: |
           RUN_GROUP=${{ matrix.run_group }} RUN_GROUP_TOTAL=${{ matrix.run_group_total }} yarn examples:test:end2end
+  dev-tests-swc:
+    name: Examples - SWC
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup env
+        uses: the-guild-org/shared-config/setup@main
+        with:
+          nodeVersion: 18
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.65.0
+          target: wasm32-wasi
+          override: true
+      - name: Build SWC plugin
+        working-directory: ./packages/presets/swc-plugin
+        run: |
+          npm run build-wasm
+      - name: Build
+        run: yarn build
+        env:
+          CI: true
+      - name: Generate and Diff Codegen Artifacts
+        run: |
+          SWC_PLUGIN_TEST=1 yarn examples:codegen
+          git diff --exit-code -- examples/
+      - name: Build Examples
+        run: |
+          SWC_PLUGIN_TEST=1 yarn examples:build
+      - name: End2End Test Examples
+        run: |
+          SWC_PLUGIN_TEST=1 yarn examples:test:end2end
   esm:
     name: Testing exports integrity
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           yarn run generate:examples:${{matrix.method}}
           git diff --exit-code -- dev-test/
   dev-tests:
-    name: Examples
+    name: Examples - Normal
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -71,14 +71,14 @@ jobs:
           CI: true
       - name: Generate and Diff Codegen Artifacts
         run: |
-          yarn examples:codegen
+          EXAMPLE_TYPE=normal yarn examples:codegen
           git diff --exit-code -- examples/
       - name: Build Examples
         run: |
-          yarn examples:build
+          EXAMPLE_TYPE=normal yarn examples:build
       - name: End2End Test Examples
         run: |
-          yarn examples:test:end2end
+          EXAMPLE_TYPE=normal yarn examples:test:end2end
   dev-tests-swc:
     name: Examples - SWC
     runs-on: ubuntu-latest
@@ -104,14 +104,14 @@ jobs:
           CI: true
       - name: Generate and Diff Codegen Artifacts
         run: |
-          SWC_PLUGIN_TEST=1 yarn examples:codegen
+          EXAMPLE_TYPE=swc yarn examples:codegen
           git diff --exit-code -- examples/
       - name: Build Examples
         run: |
-          SWC_PLUGIN_TEST=1 yarn examples:build
+          EXAMPLE_TYPE=swc yarn examples:build
       - name: End2End Test Examples
         run: |
-          SWC_PLUGIN_TEST=1 yarn examples:test:end2end
+          EXAMPLE_TYPE=swc yarn examples:test:end2end
   esm:
     name: Testing exports integrity
     runs-on: ubuntu-latest

--- a/scripts/print-example-ci-command.js
+++ b/scripts/print-example-ci-command.js
@@ -7,14 +7,23 @@ const packageJSON = fg.sync(['examples/**/package.json'], { ignore: ['**/node_mo
 const ignoredPackages = [];
 
 const command = process.argv[2];
+const isSwcPluginTest = !!(process.env.SWC_PLUGIN_TEST || false); // TODO: this is a hacky way to target the examples with swc plugins, but a quick way indeed.
 const currentGroup = process.env.RUN_GROUP || 1;
 const totalGroups = process.env.RUN_GROUP_TOTAL | 1;
 
 const result = packageJSON.reduce(
   (res, packageJSONPath) => {
-    const { name } = fs.readJSONSync(packageJSONPath);
+    const { name, devDependencies } = fs.readJSONSync(packageJSONPath);
 
     if (ignoredPackages.includes(name)) {
+      res.ignored.push(name);
+      return res;
+    }
+
+    if (
+      (isSwcPluginTest && !devDependencies['@graphql-codegen/client-preset-swc-plugin']) ||
+      (!isSwcPluginTest && devDependencies['@graphql-codegen/client-preset-swc-plugin'])
+    ) {
       res.ignored.push(name);
       return res;
     }


### PR DESCRIPTION
## Description

Examples test is taking ~9mins and is the longest step in the pipeline:

<img width="859" alt="Screenshot 2025-01-27 at 1 04 25 PM" src="https://github.com/user-attachments/assets/8b45722f-7db3-4dd3-92ff-32dcb76636e5" />

A quick look showed us that:
- We needed to build SWC which takes ~4mins...
- But was only used for 1 or 2 SWC tests

So, we can speed up CI by splitting the Examples tests to 2 parts: 
- "normal" packages  a.k.a packages without `@graphql-codegen/client-preset-swc-plugin` dep
- "swc" packages a.k.a. packages with `@graphql-codegen/client-preset-swc-plugin` dep

This change also keeps the default behaviour where example commands target all examples a.k.a "all" packages

Result: Testing workflow takes ~5min . Meaning **44% reduction in CI time!** (and makes me **100% happier**)

<img width="859" alt="Screenshot 2025-01-27 at 1 05 16 PM" src="https://github.com/user-attachments/assets/d228d7c1-e945-4330-96f2-5a50148a4030" />
