### PR TITLE
fix `onlyEnums` passthrough in client-preset

### DIFF
--- a/.changeset/weak-lions-occur.md
+++ b/.changeset/weak-lions-occur.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/client-preset': patch
+---
+
+fix `onlyEnums` passthrough in client-preset

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -135,7 +135,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       documentMode: options.config.documentMode,
       skipTypeNameForRoot: options.config.skipTypeNameForRoot,
       onlyOperationTypes: options.config.onlyOperationTypes,
-      onlyEnumTypes: options.config.onlyEnumTypes,
+      onlyEnums: options.config.onlyEnums,
       customDirectives: options.config.customDirectives,
     };
 


### PR DESCRIPTION
## Description

Correct the name of the config to:
https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#onlyenums

Related #10155 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
