### PR TITLE
fix: Don't treat schema URLs as relative file paths for the watcher

### DIFF
--- a/.changeset/hungry-ties-press.md
+++ b/.changeset/hungry-ties-press.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Fix watcher watching project root when schema URL is used

--- a/packages/graphql-codegen-cli/src/utils/helpers.ts
+++ b/packages/graphql-codegen-cli/src/utils/helpers.ts
@@ -1,0 +1,8 @@
+export function isURL(str: string): boolean {
+  try {
+    const url = new URL(str);
+    return !!url;
+  } catch {
+    return false;
+  }
+}

--- a/packages/graphql-codegen-cli/src/utils/patterns.ts
+++ b/packages/graphql-codegen-cli/src/utils/patterns.ts
@@ -4,6 +4,7 @@ import { normalizeInstanceOrArray, Types } from '@graphql-codegen/plugin-helpers
 import isGlob from 'is-glob';
 import mm from 'micromatch';
 import { CodegenContext } from '../config.js';
+import { isURL } from './helpers.js';
 
 type NegatedPattern = `!${string}`;
 
@@ -175,7 +176,7 @@ const makePatternsFromSchemas = (schemas: Types.Schema[]): string[] => {
 
   for (const s of schemas) {
     const schema = s as string;
-    if (isGlob(schema) || isValidPath(schema)) {
+    if (!isURL(schema) && (isGlob(schema) || isValidPath(schema))) {
       patterns.push(schema);
     }
   }

--- a/packages/graphql-codegen-cli/tests/watcher.spec.ts
+++ b/packages/graphql-codegen-cli/tests/watcher.spec.ts
@@ -34,6 +34,23 @@ describe('Watch targets', () => {
     await stopWatching();
   });
 
+  test('ignores schema URLs when detecting common prefix directory', async () => {
+    const { stopWatching, watchDirectory } = await setupMockWatcher({
+      filepath: './foo/some-config.ts',
+      config: {
+        schema: 'http://localhost/graphql',
+        generates: {
+          ['./foo/some-output.ts']: {
+            documents: ['./foo/bar/*.graphql'],
+          },
+        },
+      },
+    });
+
+    expect(watchDirectory).toBe(join(process.cwd(), 'foo'));
+    await stopWatching();
+  });
+
   test('watches process.cwd() when longest common prefix directory is not accessible', async () => {
     setupMockFilesystem({
       access: async path => {


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Partial fix for #10281. This PR makes sure that schema URLs are __not__ being treated as file paths when creating a watcher for `--watch`. This allows the common watched directory to be a nested directory, which in turn dramatically increases performance of the watcher as it doesn't have to watch all the extra directories (like `node_modules`).

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Unit tests

**Test Environment**:

- OS: macOS
- `@graphql-codegen/...`: master
- NodeJS: 20.15.1

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

As I said, it's only a partial fix. This resolves the issue of schema URL being treated as a file, which forces the watcher to watch the project root. However, this still does not allow the watcher to be efficient and performant when the graphql-codegen config is located in the project root, or when watched files are in two different locations.

A proper fix would be a refactor of the `watcher.ts` - one that utilizes multiple watcher subscriptions per each watched path OR one that automatically specifies all directories except relevant as ignored. I'm not sure which solution would give better performance, and I'm not sure that this project will accept a PR making those changes. Please let me know if this refactor would be possible.
