### PR TITLE
Ensure `__isTypeof` is only generated for implementing types (of Interfaces) or Union members

### DIFF
--- a/.changeset/angry-lamps-notice.md
+++ b/.changeset/angry-lamps-notice.md
@@ -1,0 +1,7 @@
+---
+'@graphql-codegen/visitor-plugin-common': major
+'@graphql-codegen/typescript-resolvers': major
+'@graphql-codegen/plugin-helpers': major
+---
+
+BREAKING CHANGES: Do not generate \_\_isTypeOf for non-implementing types or non-union members

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -35,8 +35,6 @@ import {
   ConvertOptions,
   DeclarationKind,
   EnumValuesMap,
-  type NormalizedGenerateInternalResolversIfNeededConfig,
-  type GenerateInternalResolversIfNeededConfig,
   NormalizedAvoidOptionalsConfig,
   NormalizedScalarsMap,
   ParsedEnumValuesMap,
@@ -79,7 +77,6 @@ export interface ParsedResolversConfig extends ParsedConfig {
   resolverTypeSuffix: string;
   allResolversTypeName: string;
   internalResolversPrefix: string;
-  generateInternalResolversIfNeeded: NormalizedGenerateInternalResolversIfNeededConfig;
   directiveResolverMappings: Record<string, string>;
   resolversNonOptionalTypename: ResolversNonOptionalTypenameConfig;
   avoidCheckingAbstractTypesRecursively: boolean;
@@ -587,15 +584,6 @@ export interface RawResolversConfig extends RawConfig {
    */
   internalResolversPrefix?: string;
   /**
-   * @type object
-   * @default {}
-   * @description If relevant internal resolvers are set to `true`, the resolver type will only be generated if the right conditions are met.
-   * Enabling this allows a more correct type generation for the resolvers.
-   * For example:
-   * - `__isTypeOf` is generated for implementing types and union members
-   */
-  generateInternalResolversIfNeeded?: GenerateInternalResolversIfNeededConfig;
-  /**
    * @description Makes `__typename` of resolver mappings non-optional without affecting the base types.
    * @default false
    *
@@ -706,7 +694,6 @@ export class BaseResolversVisitor<
   protected _hasReferencedResolversUnionTypes = false;
   protected _hasReferencedResolversInterfaceTypes = false;
   protected _resolversUnionTypes: Record<string, string> = {};
-  protected _resolversUnionParentTypes: Record<string, string> = {};
   protected _resolversInterfaceTypes: Record<string, string> = {};
   protected _rootTypeNames = new Set<string>();
   protected _globalDeclarations = new Set<string>();

--- a/packages/plugins/other/visitor-plugin-common/src/types.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/types.ts
@@ -138,6 +138,3 @@ export interface CustomDirectivesConfig {
    */
   apolloUnmask?: boolean;
 }
-
-export interface GenerateInternalResolversIfNeededConfig {}
-export type NormalizedGenerateInternalResolversIfNeededConfig = Required<GenerateInternalResolversIfNeededConfig>;

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.interface.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.interface.spec.ts
@@ -181,7 +181,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - Interface', () => {
       export type PersonNameResolvers<ContextType = any, ParentType extends ResolversParentTypes['PersonName'] = ResolversParentTypes['PersonName']> = {
         first?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         last?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
 
       export type Resolvers<ContextType = any> = {

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.mappers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.mappers.spec.ts
@@ -147,13 +147,11 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
 
       export type UserProfileResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserProfile'] = ResolversParentTypes['UserProfile']> = {
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         user?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
-        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
 
       export type Resolvers<ContextType = any> = {

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
@@ -90,7 +90,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     };
   `);
 
@@ -99,7 +98,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     export type SingleResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['SingleResolvable'] = ResolversParentTypes['SingleResolvable'], FederationType extends FederationTypes['SingleResolvable'] = FederationTypes['SingleResolvable']> = {
       __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['SingleResolvable']>, { __typename: 'SingleResolvable' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     };
   `);
 
@@ -107,7 +105,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
     export type SingleNonResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['SingleNonResolvable'] = ResolversParentTypes['SingleNonResolvable']> = {
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     };
   `);
 
@@ -118,7 +115,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     };
   `);
 
@@ -129,7 +125,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     };
   `);
 
@@ -139,7 +134,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     };
   `);
 
@@ -147,7 +141,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
     export type BookResolvers<ContextType = any, ParentType extends ResolversParentTypes['Book'] = ResolversParentTypes['Book']> = {
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-      __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
     };
   `);
   });
@@ -222,7 +215,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
         id?: Resolver<ResolversTypes['ID'], { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
         name?: Resolver<Maybe<ResolversTypes['Name']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       }
     `);
 
@@ -231,7 +223,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Name']>, { __typename: 'Name' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
         first?: Resolver<ResolversTypes['String'], { __typename: 'Name' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
         last?: Resolver<ResolversTypes['String'], { __typename: 'Name' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       }
     `);
   });
@@ -263,7 +254,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
         id?: Resolver<ResolversTypes['ID'], { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
         username?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}> & GraphQLRecursivePick<FederationType, {"name":true,"age":true}>, ContextType>;
-        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
     `);
   });
@@ -299,7 +289,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
         username?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}> & GraphQLRecursivePick<FederationType, {"name":true,"age":true,"address":{"street":true}}>, ContextType>;
-        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
     `);
   });
@@ -332,7 +321,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"name":{"first":true,"last":true}}>, ContextType>;
         username?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"name":{"first":true,"last":true}}>, ContextType>;
-        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
     `);
   });
@@ -366,7 +354,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"name":{"first":true,"last":true}}>, ContextType>;
         name?: Resolver<ResolversTypes['Name'], ParentType, ContextType>;
         username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
     `);
   });
@@ -401,7 +388,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
         id?: Resolver<ResolversTypes['ID'], { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
         name?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
     `);
   });
@@ -528,7 +514,6 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & (GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"name":true}>), ContextType>;
         name?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'User' } & (GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"name":true}>), ContextType>;
         username?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'User' } & (GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"name":true}>), ContextType>;
-        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
     `);
   });

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.interface.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.interface.spec.ts
@@ -460,4 +460,53 @@ describe('TypeScript Resolvers Plugin - Interfaces', () => {
       };
     `);
   });
+
+  it('generates __isTypeOf for only implementing object types', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      interface Node {
+        id: ID!
+      }
+      type Cat implements Node {
+        id: ID!
+        name: String!
+      }
+      type Dog implements Node {
+        id: ID!
+        isGoodBoy: Boolean!
+      }
+      type Human {
+        _id: ID!
+      }
+    `);
+
+    const result = await plugin(
+      schema,
+      [],
+      { generateInternalResolversIfNeeded: { __isTypeOf: true } },
+      { outputFile: '' }
+    );
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type CatResolvers<ContextType = any, ParentType extends ResolversParentTypes['Cat'] = ResolversParentTypes['Cat']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      }
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type DogResolvers<ContextType = any, ParentType extends ResolversParentTypes['Dog'] = ResolversParentTypes['Dog']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        isGoodBoy?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+
+    // Human does not implement Node, so it does not have __isTypeOf
+    expect(result.content).toBeSimilarStringTo(`
+      export type HumanResolvers<ContextType = any, ParentType extends ResolversParentTypes['Human'] = ResolversParentTypes['Human']> = {
+        _id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+      };
+    `);
+  });
 });

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.union.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.union.spec.ts
@@ -236,4 +236,61 @@ describe('TypeScript Resolvers Plugin - Union', () => {
       };
     `);
   });
+
+  it('generates __isTypeOf for only union members', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type MemberOne {
+        id: ID!
+      }
+      type MemberTwo {
+        id: ID!
+        name: String!
+      }
+      type MemberThree {
+        id: ID!
+        isMember: Boolean!
+      }
+      union Union = MemberOne | MemberTwo | MemberThree
+      type Normal {
+        id: ID!
+      }
+    `);
+
+    const result = await plugin(
+      schema,
+      [],
+      { generateInternalResolversIfNeeded: { __isTypeOf: true } },
+      { outputFile: '' }
+    );
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MemberOneResolvers<ContextType = any, ParentType extends ResolversParentTypes['MemberOne'] = ResolversParentTypes['MemberOne']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      }
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MemberTwoResolvers<ContextType = any, ParentType extends ResolversParentTypes['MemberTwo'] = ResolversParentTypes['MemberTwo']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type MemberThreeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MemberThree'] = ResolversParentTypes['MemberThree']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        isMember?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+
+    // Normal type is not a union member, so it does not have __isTypeOf
+    expect(result.content).toBeSimilarStringTo(`
+      export type NormalResolvers<ContextType = any, ParentType extends ResolversParentTypes['Normal'] = ResolversParentTypes['Normal']> = {
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+      };
+    `);
+  });
 });


### PR DESCRIPTION
## Description

Only implementing types (of Interfaces) or Union members need `__isTypeOf` to help pick the right type name for the responses. This PR implements this behaviour by only generating `__isTypeOf` for said object types.

This PR also introduces `_parsedSchemaMeta` to hold metadata about the schema. This can help with performance and reduces complexity because we only parse through the schema _once_ to collect meta about the types, and use the collected meta for subsequent generation.


---

Note: This is an re-implementation for https://github.com/dotansimha/graphql-code-generator/pull/10138, because this will be released as a breaking change instead of a new config.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Unit Test
