### PR TITLE
[resolvers][federation] Bring Federation reference selection set to ResolversParentTypes instead of each resolver

### DIFF
--- a/dev-test/test-schema/resolvers-federation.ts
+++ b/dev-test/test-schema/resolvers-federation.ts
@@ -154,7 +154,13 @@ export type ResolversParentTypes = {
   ID: Scalars['ID']['output'];
   Lines: Lines;
   Query: {};
-  User: User;
+  User:
+    | User
+    | ({ __typename: 'User' } & (
+        | GraphQLRecursivePick<FederationTypes['User'], { id: true }>
+        | GraphQLRecursivePick<FederationTypes['User'], { name: true }>
+      ) &
+        GraphQLRecursivePick<FederationTypes['User'], { address: { city: true; lines: { line2: true } } }>);
   Int: Scalars['Int']['output'];
   Boolean: Scalars['Boolean']['output'];
 };
@@ -200,19 +206,12 @@ export type UserResolvers<
     { __typename: 'User' } & (
       | GraphQLRecursivePick<FederationType, { id: true }>
       | GraphQLRecursivePick<FederationType, { name: true }>
-    ),
-    ContextType
-  >;
-
-  email?: Resolver<
-    ResolversTypes['String'],
-    { __typename: 'User' } & (
-      | GraphQLRecursivePick<FederationType, { id: true }>
-      | GraphQLRecursivePick<FederationType, { name: true }>
     ) &
       GraphQLRecursivePick<FederationType, { address: { city: true; lines: { line2: true } } }>,
     ContextType
   >;
+
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 };
 
 export type Resolvers<ContextType = any> = {

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -780,8 +780,8 @@ export class BaseResolversVisitor<
       onNotMappedObjectType: ({ typeName, initialType }) => {
         let result = initialType;
         const federationReferenceTypes = this._federation.printReferenceSelectionSets({
-          convertName: this.convertName,
           typeName,
+          baseFederationType: `${this.convertName('FederationTypes')}['${typeName}']`,
         });
         if (federationReferenceTypes) {
           result += ` | ${federationReferenceTypes}`;

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.interface.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.interface.spec.ts
@@ -147,8 +147,12 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - Interface', () => {
         Query: {};
         Person: ResolversInterfaceTypes<ResolversParentTypes>['Person'];
         ID: Scalars['ID']['output'];
-        User: User | ( { __typename: 'User' } & GraphQLRecursivePick<FederationTypes['User'], {"id":true}> );
-        Admin: Admin | ( { __typename: 'Admin' } & GraphQLRecursivePick<FederationTypes['Admin'], {"id":true}> );
+        User: User |
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationTypes['User'], {"id":true}> );
+        Admin: Admin |
+          ( { __typename: 'Admin' }
+          & GraphQLRecursivePick<FederationTypes['Admin'], {"id":true}> );
         Boolean: Scalars['Boolean']['output'];
         PersonName: PersonName;
         String: Scalars['String']['output'];
@@ -160,18 +164,24 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - Interface', () => {
 
       export type PersonResolvers<ContextType = any, ParentType extends ResolversParentTypes['Person'] = ResolversParentTypes['Person'], FederationType extends FederationTypes['Person'] = FederationTypes['Person']> = {
         __resolveType: TypeResolveFn<'User' | 'Admin', ParentType, ContextType>;
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Person']>, { __typename: 'Person' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Person']>,
+          ( { __typename: 'Person' }
+          & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
       };
 
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         name?: Resolver<ResolversTypes['PersonName'], ParentType, ContextType>;
         __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
 
       export type AdminResolvers<ContextType = any, ParentType extends ResolversParentTypes['Admin'] = ResolversParentTypes['Admin'], FederationType extends FederationTypes['Admin'] = FederationTypes['Admin']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Admin']>, { __typename: 'Admin' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Admin']>,
+          ( { __typename: 'Admin' }
+          & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         name?: Resolver<ResolversTypes['PersonName'], ParentType, ContextType>;
         canImpersonate?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.interface.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.interface.spec.ts
@@ -147,8 +147,8 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - Interface', () => {
         Query: {};
         Person: ResolversInterfaceTypes<ResolversParentTypes>['Person'];
         ID: Scalars['ID']['output'];
-        User: User;
-        Admin: Admin;
+        User: User | ( { __typename: 'User' } & GraphQLRecursivePick<FederationTypes['User'], {"id":true}> );
+        Admin: Admin | ( { __typename: 'Admin' } & GraphQLRecursivePick<FederationTypes['Admin'], {"id":true}> );
         Boolean: Scalars['Boolean']['output'];
         PersonName: PersonName;
         String: Scalars['String']['output'];

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.mappers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.mappers.spec.ts
@@ -144,7 +144,9 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
       };
 
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       };

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
@@ -111,7 +111,8 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // User should have __resolveReference because it has resolvable @key (by default)
     expect(content).toBeSimilarStringTo(`
     export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
+        ( { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -121,7 +122,9 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // SingleResolvable has __resolveReference because it has resolvable: true
     expect(content).toBeSimilarStringTo(`
     export type SingleResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['SingleResolvable'] = ResolversParentTypes['SingleResolvable'], FederationType extends FederationTypes['SingleResolvable'] = FederationTypes['SingleResolvable']> = {
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['SingleResolvable']>, { __typename: 'SingleResolvable' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['SingleResolvable']>,
+        ( { __typename: 'SingleResolvable' }
+        & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
     };
   `);
@@ -136,7 +139,8 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // AtLeastOneResolvable has __resolveReference because it at least one resolvable
     expect(content).toBeSimilarStringTo(`
     export type AtLeastOneResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['AtLeastOneResolvable'] = ResolversParentTypes['AtLeastOneResolvable'], FederationType extends FederationTypes['AtLeastOneResolvable'] = FederationTypes['AtLeastOneResolvable']> = {
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['AtLeastOneResolvable']>, { __typename: 'AtLeastOneResolvable' } & GraphQLRecursivePick<FederationType, {"id2":true}>, ContextType>;
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['AtLeastOneResolvable']>,
+        ( { __typename: 'AtLeastOneResolvable' } & GraphQLRecursivePick<FederationType, {"id2":true}> ), ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -146,7 +150,9 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // MixedResolvable has __resolveReference and references for resolvable keys
     expect(content).toBeSimilarStringTo(`
     export type MixedResolvableResolvers<ContextType = any, ParentType extends ResolversParentTypes['MixedResolvable'] = ResolversParentTypes['MixedResolvable'], FederationType extends FederationTypes['MixedResolvable'] = FederationTypes['MixedResolvable']> = {
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['MixedResolvable']>, { __typename: 'MixedResolvable' } & (GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"id2":true}>), ContextType>;
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['MixedResolvable']>,
+        ( { __typename: 'MixedResolvable' }
+        & ( GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"id2":true}> ) ), ContextType>;
       id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id2?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
       id3?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -196,11 +202,11 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
     // User should have it
     expect(content).toBeSimilarStringTo(`
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, ( { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
     `);
     // Foo shouldn't because it doesn't have @key
     expect(content).not.toBeSimilarStringTo(`
-      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Book']>, { __typename: 'Book' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+      __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Book']>, ( { __typename: 'Book' } & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
     `);
   });
 
@@ -237,17 +243,21 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-        name?: Resolver<Maybe<ResolversTypes['Name']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<Maybe<ResolversTypes['Name']>, ParentType, ContextType>;
       }
     `);
 
     expect(content).toBeSimilarStringTo(`
       export type NameResolvers<ContextType = any, ParentType extends ResolversParentTypes['Name'] = ResolversParentTypes['Name'], FederationType extends FederationTypes['Name'] = FederationTypes['Name']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Name']>, { __typename: 'Name' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-        first?: Resolver<ResolversTypes['String'], { __typename: 'Name' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-        last?: Resolver<ResolversTypes['String'], { __typename: 'Name' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Name']>,
+          ( { __typename: 'Name' }
+          & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
+        first?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        last?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
       }
     `);
   });
@@ -287,9 +297,12 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // User should have it
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], Parent, ContextType>;
-        username?: Resolver<Maybe<ResolversTypes['String']>, Parent, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationType, {"id":true}>
+          & GraphQLRecursivePick<FederationType, {"name":true,"age":true}> ), ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       };
     `);
   });
@@ -335,8 +348,11 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-        username?: Resolver<Maybe<ResolversTypes['String']>, Parent, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationType, {"id":true}>
+          & GraphQLRecursivePick<FederationType, {"name":true,"age":true,"address":{"street":true}}> ), ContextType>;
+        username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       };
     `);
   });
@@ -368,7 +384,9 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
       export type ResolversParentTypes = {
         Query: {};
-        User: User | ( { __typename: 'User' } & GraphQLRecursivePick<FederationTypes['User'], {"name":{"first":true,"last":true}}> );
+        User: User |
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationTypes['User'], {"name":{"first":true,"last":true}}> );
         String: Scalars['String']['output'];
         Name: Name;
         Boolean: Scalars['Boolean']['output'];
@@ -377,8 +395,10 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"name":{"first":true,"last":true}}>, ContextType>;
-        username?: Resolver<Maybe<ResolversTypes['String']>, Parent, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationType, {"name":{"first":true,"last":true}}> ), ContextType>;
+        username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       };
     `);
   });
@@ -414,7 +434,11 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
       export type ResolversParentTypes = {
         Query: {};
-        User: User | ( { __typename: 'User' } & ( GraphQLRecursivePick<FederationTypes['User'], {"id":true}> | GraphQLRecursivePick<FederationTypes['User'], {"uuid":true}> | GraphQLRecursivePick<FederationTypes['User'], {"legacyId":{"oldId1":true,"oldId2":true}}> ) & GraphQLRecursivePick<FederationTypes['User'], {"id":true,"name":true}> & GraphQLRecursivePick<FederationTypes['User'], {"legacyId":{"oldId1":true},"name":true}> );
+        User: User |
+          ( { __typename: 'User' }
+          & ( GraphQLRecursivePick<FederationTypes['User'], {"id":true}> | GraphQLRecursivePick<FederationTypes['User'], {"uuid":true}> | GraphQLRecursivePick<FederationTypes['User'], {"legacyId":{"oldId1":true,"oldId2":true}}> )
+          & GraphQLRecursivePick<FederationTypes['User'], {"id":true,"name":true}>
+          & GraphQLRecursivePick<FederationTypes['User'], {"legacyId":{"oldId1":true},"name":true}> );
         ID: Scalars['ID']['output'];
         String: Scalars['String']['output'];
         LegacyId: LegacyId;
@@ -424,11 +448,15 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & (GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"uuid":true}> | GraphQLRecursivePick<FederationType, {"legacyId":{"oldId1":true,"oldId2":true}}>), ContextType>;
-        id?: Resolver<ResolversTypes['ID'], Parent, ContextType>;
-        uuid?: Resolver<ResolversTypes['ID'], Parent, ContextType>;
-        username?: Resolver<ResolversTypes['String'], Parent, ContextType>;
-        usernameLegacy?: Resolver<ResolversTypes['String'], Parent, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
+          ( { __typename: 'User' }
+          & ( GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"uuid":true}> | GraphQLRecursivePick<FederationType, {"legacyId":{"oldId1":true,"oldId2":true}}> )
+          & GraphQLRecursivePick<FederationType, {"id":true,"name":true}>
+          & GraphQLRecursivePick<FederationType, {"legacyId":{"oldId1":true},"name":true}> ), ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        username?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        usernameLegacy?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
       };
     `);
   });
@@ -459,7 +487,9 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"name":{"first":true,"last":true}}>, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationType, {"name":{"first":true,"last":true}}> ), ContextType>;
         name?: Resolver<ResolversTypes['Name'], ParentType, ContextType>;
         username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       };
@@ -493,9 +523,11 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // UserResolver should not have a resolver function of name field
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-        id?: Resolver<ResolversTypes['ID'], { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
-        name?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'User' } & GraphQLRecursivePick<FederationType, {"id":true}>, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       };
     `);
   });
@@ -619,9 +651,11 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // User should have it
     expect(content).toBeSimilarStringTo(`
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & (GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"name":true}>), ContextType>;
-        name?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'User' } & (GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"name":true}>), ContextType>;
-        username?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'User' } & (GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"name":true}>), ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
+          ( { __typename: 'User' }
+          & ( GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"name":true}> ) ), ContextType>;
+        name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+        username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       };
     `);
   });

--- a/packages/utils/plugins-helpers/src/federation.ts
+++ b/packages/utils/plugins-helpers/src/federation.ts
@@ -490,16 +490,6 @@ function getDirectivesByName(
   return astNode?.directives?.filter(d => d.name.value === name) || [];
 }
 
-/**
- * Checks if the Object Type extends a federated type from a remote schema.
- * Based on if any of its fields contain the `@external` directive
- * @param node Type
- */
-function nodeHasTypeExtension(node: ObjectTypeDefinitionNode | GraphQLObjectType, schema: GraphQLSchema): boolean {
-  const definition = isObjectType(node) ? node.astNode || astFromObjectType(node, schema) : node;
-  return definition.fields?.some(field => getDirectivesByName('external', field).length);
-}
-
 function extractReferenceSelectionSet(directive: DirectiveNode): ReferenceSelectionSet {
   const arg = directive.arguments.find(arg => arg.name.value === 'fields');
   const { value } = arg.value as StringValueNode;
@@ -516,7 +506,7 @@ function extractReferenceSelectionSet(directive: DirectiveNode): ReferenceSelect
         return {
           name: node.name.value,
           selection: node.selectionSet || true,
-        } satisfies ReferenceSelectionSet;
+        } as ReferenceSelectionSet;
       },
       Document(node) {
         return node.definitions.find(


### PR DESCRIPTION
Ref CODEGEN-512

## Description

### Context

A Federation entity's resolvers may be triggered by one of these two paths:

1. From the same subgraph - if there's a path from the operation root to the relevant field in the query plan
2. From a different subgraph - after gateway calls `__resolveReference` to resolve the relevant field

Let's look at this example: 

```graphql
# User subgraph
type Query {
  me: User
}

type User @key(fields: 'id') {
  id: ID!
  name: String!
}

# Book subgraph
type Query {
  book: Book
}

type Book {
  id: ID!
  author: User!
}

type User @key(fields: 'id', resolvable: false) {
  id: ID!
}
```
---

The following query triggers the 1st scenario for `User.name`:
```graphql
query {
  me {
    id
    name # triggers `User.name` from within the same subgraph
  }
}
```

When the 1st scenario triggers, it behaves like a non-Federated Graph i.e. `User.name`'s `Parent` is `User`
  
---

The following query triggers the 2nd scenario for `User.name`:
```graphql
query {
  book {
    author {
      name # triggers `User.name` through `__resolveReference`
    }
  }
}
```
In this scenario:
- `__resolveReference` receives `{__typename: 'User', id: string}` as ref
- if `__resolveReference` is not declared, `{__typename: 'User', id: string}` is automatically passed on and becomes the `User.name`'s `Parent` 

### Breaking Change Proposal

Currently, `User.name`'s `Parent` type:
- is being typed inline as `{ __typename: 'User' } & GraphQLRecursivePick<ParentType, {"id":true}>` if a field is marked as `@external` (implemented in [here](https://github.com/dotansimha/graphql-code-generator/pull/4542) but I don't agree with this implementation, or my understanding of `@external` is wrong 🤔 ) ...
- OR is `User`...
... but never both at the same time.

This is not correct because there are two ways to get to `User.name` so the `Parent` should be either `User` or `{ __typename: 'User' } & GraphQLRecursivePick<ParentType, {"id":true}>`.

So, here's how I think this should be changed for a federated entity (`User` in this case):

- `ResolversParentTypes['User']` should be `User | { __typename: 'User' } & GraphQLRecursivePick<ParentType, {"id":true}>` (plus any extra possibilities from added by `@provides` - More on this in another PR)
   - (*) This means `User.name` need to know/check the parent, because we don't know which flow it comes from.
- If a `UserMapper` is used, then both paths require the previous resolver to return the `UserMapper`. i.e. `ResolversParentTypes['User']` simply becomes `UserMapper` (existing behaviour)
   - (**) This means `__resolveReference` MUST be explicitly implemented to turn ref into `UserMapper`

This solution makes it simpler to write plugin code, because we "normalise" both paths' `Parent` types. However, (*) and (**) could cause friction for users to understand and use - unless we make Server Preset to auto generate resolvers, to make sure users implement resolvers to return mappers, to avoid runtime errors for Federation use cases (which can be done)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Unit test