### PR TITLE
[operations] CODEGEN-784 - Fix Apollo @unmask fragmentRefs

### DIFF
--- a/.changeset/funny-monkeys-hide.md
+++ b/.changeset/funny-monkeys-hide.md
@@ -1,0 +1,7 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-operations': patch
+'@graphql-codegen/client-preset': patch
+---
+
+Fix Apollo unmask directive incorrectly generating fragmentRefs

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -599,9 +599,14 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
         continue;
       }
 
-      // 2. Handle Fragment selection nodes
-      // 2a. If `inlineFragmentTypes` is 'combine' or 'mask', the fragment is masked i.e. do not generate inline types
-      // In some cases like Apollo `@unmask`, the fragment would be generated inline.
+      // 2. Handle Fragment Spread nodes
+      // A Fragment Spread can be:
+      // - masked: the fields declared in the Fragment do not appear in the operation types
+      // - inline: the fields declared in the Fragment appear in the operation types
+
+      // 2a. If `inlineFragmentTypes` is 'combine' or 'mask', the Fragment Spread is masked by default
+      // In some cases, a masked node could be unmasked (i.e. treated as inline):
+      // - Fragment spread node is marked with Apollo `@unmask`, e.g. `...User @unmask`
       if (this._config.inlineFragmentTypes === 'combine' || this._config.inlineFragmentTypes === 'mask') {
         let isMasked = true;
 
@@ -618,7 +623,7 @@ export class SelectionSetToObject<Config extends ParsedDocumentsConfig = ParsedD
         }
       }
 
-      // 2b. If the Fragment is not masked, handle Fragment Spreads by generating inline types.
+      // 2b. If the Fragment Spread is not masked, generate inline types.
       const fragmentType = this._schema.getType(selectionNode.onType);
 
       if (fragmentType == null) {

--- a/packages/plugins/typescript/operations/tests/ts-documents.apolloUnmask.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.apolloUnmask.spec.ts
@@ -27,7 +27,6 @@ describe('TypeScript Operations Plugin - apolloUnmask', () => {
 
       export type Unnamed_1_Query = { __typename?: 'Query', me?: (
           { __typename?: 'User', id: string }
-          & { ' $fragmentRefs'?: { 'UserFragmentFragment': UserFragmentFragment } }
         ) | null };
 
       export type UserFragmentFragment = { __typename?: 'User', id: string } & { ' $fragmentName'?: 'UserFragmentFragment' };
@@ -58,7 +57,6 @@ describe('TypeScript Operations Plugin - apolloUnmask', () => {
 
       export type Unnamed_1_Query = { __typename?: 'Query', me?: (
           { __typename?: 'User' }
-          & { ' $fragmentRefs'?: { 'UserFragmentFragment': UserFragmentFragment } }
         ) | null };
 
       export type UserFragmentFragment = { __typename?: 'User', id: string } & { ' $fragmentName'?: 'UserFragmentFragment' };
@@ -89,7 +87,6 @@ describe('TypeScript Operations Plugin - apolloUnmask', () => {
 
       export type Unnamed_1_Query = { __typename?: 'Query', me?: (
           { __typename?: 'User' }
-          & { ' $fragmentRefs'?: { 'UserFragmentFragment': UserFragmentFragment } }
         ) | null };
 
       export type UserFragmentFragment = { __typename?: 'User', id: string } & { ' $fragmentName'?: 'UserFragmentFragment' };
@@ -125,7 +122,7 @@ describe('TypeScript Operations Plugin - apolloUnmask', () => {
 
       export type Unnamed_1_Query = { __typename?: 'Query', me?: (
           { __typename?: 'User', id: string }
-          & { ' $fragmentRefs'?: { 'UserFragmentFragment': UserFragmentFragment;'UserFragment2Fragment': UserFragment2Fragment } }
+          & { ' $fragmentRefs'?: { 'UserFragment2Fragment': UserFragment2Fragment } }
         ) | null };
 
       export type UserFragmentFragment = { __typename?: 'User', id: string } & { ' $fragmentName'?: 'UserFragmentFragment' };
@@ -164,7 +161,7 @@ describe('TypeScript Operations Plugin - apolloUnmask', () => {
 
       export type Unnamed_1_Query = { __typename?: 'Query', me?: (
           { __typename?: 'User', id: string, email: string }
-          & { ' $fragmentRefs'?: { 'UserFragmentFragment': UserFragmentFragment;'UserFragment2Fragment': UserFragment2Fragment } }
+          & { ' $fragmentRefs'?: { 'UserFragment2Fragment': UserFragment2Fragment } }
         ) | null };
 
       export type UserFragmentFragment = { __typename?: 'User', id: string, email: string } & { ' $fragmentName'?: 'UserFragmentFragment' };

--- a/packages/plugins/typescript/operations/tests/ts-documents.apolloUnmask.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.apolloUnmask.spec.ts
@@ -25,9 +25,7 @@ describe('TypeScript Operations Plugin - apolloUnmask', () => {
       "export type Unnamed_1_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-      export type Unnamed_1_Query = { __typename?: 'Query', me?: (
-          { __typename?: 'User', id: string }
-        ) | null };
+      export type Unnamed_1_Query = { __typename?: 'Query', me?: { __typename?: 'User', id: string } | null };
 
       export type UserFragmentFragment = { __typename?: 'User', id: string } & { ' $fragmentName'?: 'UserFragmentFragment' };
       "
@@ -57,6 +55,7 @@ describe('TypeScript Operations Plugin - apolloUnmask', () => {
 
       export type Unnamed_1_Query = { __typename?: 'Query', me?: (
           { __typename?: 'User' }
+          & { ' $fragmentRefs'?: { 'UserFragmentFragment': UserFragmentFragment } }
         ) | null };
 
       export type UserFragmentFragment = { __typename?: 'User', id: string } & { ' $fragmentName'?: 'UserFragmentFragment' };
@@ -87,6 +86,7 @@ describe('TypeScript Operations Plugin - apolloUnmask', () => {
 
       export type Unnamed_1_Query = { __typename?: 'Query', me?: (
           { __typename?: 'User' }
+          & { ' $fragmentRefs'?: { 'UserFragmentFragment': UserFragmentFragment } }
         ) | null };
 
       export type UserFragmentFragment = { __typename?: 'User', id: string } & { ' $fragmentName'?: 'UserFragmentFragment' };

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -619,10 +619,7 @@ export * from "./gql";`);
       export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-      export type MeQuery = { __typename?: 'Query', unmasked?: (
-          { __typename?: 'User', id: string, name: string, age: number }
-          & { ' $fragmentRefs'?: { 'User_MeFragment': User_MeFragment } }
-        ) | null, masked?: (
+      export type MeQuery = { __typename?: 'Query', unmasked?: { __typename?: 'User', id: string, name: string, age: number } | null, masked?: (
           { __typename?: 'User', id: string }
           & { ' $fragmentRefs'?: { 'User_MeFragment': User_MeFragment } }
         ) | null };


### PR DESCRIPTION
## Description

When using Apollo masking features, an `@unmask` fragment is the same as inlined i.e.
- should not have `$fragmentRefs`
- selection node fields are inlined

Reference: https://github.com/dotansimha/graphql-code-generator/issues/10299

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test
