### PR TITLE
feat: support `erasableSyntaxOnly`

### DIFF
--- a/.changeset/unlucky-pumpkins-build.md
+++ b/.changeset/unlucky-pumpkins-build.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/typed-document-node': minor
+'@graphql-codegen/client-preset': minor
+---
+
+Update generated code to be compatible with TypeScript 5.8 `erasableSyntaxOnly` flag

--- a/examples/persisted-documents-string-mode/src/gql/graphql.ts
+++ b/examples/persisted-documents-string-mode/src/gql/graphql.ts
@@ -39,9 +39,13 @@ export class TypedDocumentString<TResult, TVariables>
   implements DocumentTypeDecoration<TResult, TVariables>
 {
   __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
 
-  constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
     super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
   }
 
   toString(): string & DocumentTypeDecoration<TResult, TVariables> {

--- a/examples/react/tanstack-react-query/src/gql/graphql.ts
+++ b/examples/react/tanstack-react-query/src/gql/graphql.ts
@@ -1303,9 +1303,13 @@ export class TypedDocumentString<TResult, TVariables>
   implements DocumentTypeDecoration<TResult, TVariables>
 {
   __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
 
-  constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
     super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
   }
 
   toString(): string & DocumentTypeDecoration<TResult, TVariables> {

--- a/examples/react/urql/src/gql/graphql.ts
+++ b/examples/react/urql/src/gql/graphql.ts
@@ -1303,9 +1303,13 @@ export class TypedDocumentString<TResult, TVariables>
   implements DocumentTypeDecoration<TResult, TVariables>
 {
   __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
 
-  constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
     super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
   }
 
   toString(): string & DocumentTypeDecoration<TResult, TVariables> {

--- a/examples/typescript-graphql-request/src/gql/graphql.ts
+++ b/examples/typescript-graphql-request/src/gql/graphql.ts
@@ -1316,9 +1316,13 @@ export class TypedDocumentString<TResult, TVariables>
   implements DocumentTypeDecoration<TResult, TVariables>
 {
   __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
 
-  constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
     super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
   }
 
   toString(): string & DocumentTypeDecoration<TResult, TVariables> {

--- a/packages/plugins/typescript/typed-document-node/src/index.ts
+++ b/packages/plugins/typescript/typed-document-node/src/index.ts
@@ -42,9 +42,13 @@ export class TypedDocumentString<TResult, TVariables>
   implements DocumentTypeDecoration<TResult, TVariables>
 {
   __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
 
-  constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
     super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
   }
 
   toString(): string & DocumentTypeDecoration<TResult, TVariables> {

--- a/packages/presets/client/tests/client-preset.spec.ts
+++ b/packages/presets/client/tests/client-preset.spec.ts
@@ -2464,9 +2464,13 @@ export * from "./gql.js";`);
           implements DocumentTypeDecoration<TResult, TVariables>
         {
           __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
+          private value: string;
+          public __meta__?: Record<string, any> | undefined;
 
-          constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
+          constructor(value: string, __meta__?: Record<string, any> | undefined) {
             super(value);
+            this.value = value;
+            this.__meta__ = __meta__;
           }
 
           toString(): string & DocumentTypeDecoration<TResult, TVariables> {
@@ -2605,9 +2609,13 @@ export * from "./gql.js";`);
           implements DocumentTypeDecoration<TResult, TVariables>
         {
           __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
+          private value: string;
+          public __meta__?: Record<string, any> | undefined;
 
-          constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
+          constructor(value: string, __meta__?: Record<string, any> | undefined) {
             super(value);
+            this.value = value;
+            this.__meta__ = __meta__;
           }
 
           toString(): string & DocumentTypeDecoration<TResult, TVariables> {
@@ -2741,9 +2749,13 @@ export * from "./gql.js";`);
           implements DocumentTypeDecoration<TResult, TVariables>
         {
           __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
+          private value: string;
+          public __meta__?: Record<string, any> | undefined;
 
-          constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
+          constructor(value: string, __meta__?: Record<string, any> | undefined) {
             super(value);
+            this.value = value;
+            this.__meta__ = __meta__;
           }
 
           toString(): string & DocumentTypeDecoration<TResult, TVariables> {
@@ -3036,9 +3048,13 @@ export * from "./gql.js";`);
           implements DocumentTypeDecoration<TResult, TVariables>
         {
           __apiType?: DocumentTypeDecoration<TResult, TVariables>['__apiType'];
+          private value: string;
+          public __meta__?: Record<string, any> | undefined;
 
-          constructor(private value: string, public __meta__?: Record<string, any> | undefined) {
+          constructor(value: string, __meta__?: Record<string, any> | undefined) {
             super(value);
+            this.value = value;
+            this.__meta__ = __meta__;
           }
 
           toString(): string & DocumentTypeDecoration<TResult, TVariables> {


### PR DESCRIPTION
Update the generated `TypedDocumentString` class to remove the usage of
class parameters in order to be compatible with `erasableSyntaxOnly`

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related # (issue)

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated unit-tests

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
