### PR TITLE
Fix: add file extenstions to import for ESM modules

### DIFF
--- a/.changeset/stale-swans-serve.md
+++ b/.changeset/stale-swans-serve.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/graphql-modules-preset': patch
+---
+
+Fix generated imports for graphql-modules-preset: .js extension is used.

--- a/packages/presets/graphql-modules/src/index.ts
+++ b/packages/presets/graphql-modules/src/index.ts
@@ -72,7 +72,11 @@ export const preset: Types.OutputPreset<ModulesConfig> = {
       documentTransforms: options.documentTransforms,
     };
 
-    const baseTypesFilename = baseTypesPath.replace(/\.(js|ts|d.ts)$/, '');
+    const baseTypesFilename = baseTypesPath.replace(
+      /\.(js|ts|d.ts)$/,
+      // we need extension if ESM modules are used
+      options.config.emitLegacyCommonJSImports ? '' : '.js'
+    );
     const baseTypesDir = stripFilename(baseOutput.filename);
 
     // One file per each module

--- a/packages/presets/graphql-modules/tests/integration.spec.ts
+++ b/packages/presets/graphql-modules/tests/integration.spec.ts
@@ -198,4 +198,19 @@ describe('Integration', () => {
       };
     `);
   });
+
+  test('import paths for ESM should have correct extension', async () => {
+    const emitLegacyCommonJSImports = {
+      emitLegacyCommonJSImports: false,
+      ...options,
+    };
+    const output = await executeCodegen(emitLegacyCommonJSImports);
+    const esmImportStatement = `import * as Types from "../global-types.js";`;
+
+    expect(output.length).toBe(5);
+    expect(output[1].content).toMatch(esmImportStatement);
+    expect(output[2].content).toMatch(esmImportStatement);
+    expect(output[3].content).toMatch(esmImportStatement);
+    expect(output[4].content).toMatch(esmImportStatement);
+  });
 });


### PR DESCRIPTION
## Description

If start codegen with `emitLegacyCommonJSImports: false` for `graphql-modules` preset imports with `.js`  extension should be generated.

Related # (issue)
[#8806](https://github.com/dotansimha/graphql-code-generator/issues/8806)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Wrote new test and checked that each module types contain correct import with `.js` extension.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
