### PR TITLE
[resolvers] CODEGEN-500 Support semantic non null

### DIFF
--- a/.changeset/old-gorillas-taste.md
+++ b/.changeset/old-gorillas-taste.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-resolvers': minor
+---
+
+Implement semanticNonNull custom directive

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1628,7 +1628,7 @@ export class BaseResolversVisitor<
   }
 
   /**
-   * Function that takes in a TypeScript type and apply extra transformation to it based on config options
+   * Function to apply extra transformation to a FieldDefinitionNode's TypeScript type based on config options
    * e.g. takes `Maybe<ResolversTypes['String']>`, and returns the type without the `Maybe<>` wrapper.
    */
   protected modifyFieldDefinitionNodeTransformedType({

--- a/packages/plugins/typescript/resolvers/src/visitor.ts
+++ b/packages/plugins/typescript/resolvers/src/visitor.ts
@@ -80,14 +80,6 @@ export class TypeScriptResolversVisitor extends BaseResolversVisitor<
     return `${schemaTypeName}${avoidOptionals ? '' : '?'}: ${resolverType}${this.getPunctuation(declarationKind)}`;
   }
 
-  private clearOptional(str: string): string {
-    if (str.startsWith('Maybe')) {
-      return str.replace(/Maybe<(.*?)>$/, '$1');
-    }
-
-    return str;
-  }
-
   ListType(node: ListTypeNode): string {
     return `Maybe<${super.ListType(node)}>`;
   }

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.config.customDirectives.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.config.customDirectives.spec.ts
@@ -1,0 +1,41 @@
+import { buildSchema } from 'graphql';
+import '@graphql-codegen/testing';
+import { plugin } from '../src/index.js';
+
+describe('customDirectives.sematicNonNull', () => {
+  it('allowSemanticNonNull - should build strict type if annotated by @semanticNonNull directive', async () => {
+    const testingSchema = buildSchema(/* GraphQL */ `
+      directive @semanticNonNull(levels: [Int] = [0]) on FIELD_DEFINITION
+
+      type TestingType {
+        nonNullableField: String! @semanticNonNull
+        nonNullableList: [String]! @semanticNonNull
+        nullableField: String
+        nullableList: [String]
+        semanticNonNullField: String @semanticNonNull
+        semanticNonNullList: [String] @semanticNonNull
+      }
+    `);
+
+    const result = await plugin(
+      testingSchema,
+      [],
+      {
+        customDirectives: { semanticNonNull: true },
+      },
+      { outputFile: '' }
+    );
+
+    expect(result.content).toBeSimilarStringTo(`
+      export type TestingTypeResolvers<ContextType = any, ParentType extends ResolversParentTypes['TestingType'] = ResolversParentTypes['TestingType']> = {
+        nonNullableField?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        nonNullableList?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
+        nullableField?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+        nullableList?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+        semanticNonNullField?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        semanticNonNullList?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
+        __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+      };
+    `);
+  });
+});


### PR DESCRIPTION
## Description

Based on https://github.com/dotansimha/graphql-code-generator/pull/10159
Related to https://github.com/dotansimha/graphql-code-generator/issues/10151

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit test
