### PR TITLE
Add support for inputMaybeValue in client preset

### DIFF
--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -141,6 +141,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       onlyOperationTypes: options.config.onlyOperationTypes,
       onlyEnums: options.config.onlyEnums,
       customDirectives: options.config.customDirectives,
+      inputMaybeValue: options.config.inputMaybeValue,
     };
 
     const visitor = new ClientSideBaseVisitor(options.schemaAst, [], options.config, options.config);


### PR DESCRIPTION
## Description

This adds support for the client preset to accept the `inputValueMaybe` configuration option, addressing issue #10005.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I made this change locally and it seems to have produced the intended change in the InputMaybe type. Everything else seemed to continue working.

**Test Environment**:

- OS: MacOS
- `@graphql-codegen/...`:
- NodeJS: 22.12

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules