### PR TITLE
CODEGEN-793 - Treat line endings same when using check flag

### DIFF
--- a/.changeset/weak-carrots-grin.md
+++ b/.changeset/weak-carrots-grin.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Treat windows and unix line ending the same when using --check flag

--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -167,7 +167,9 @@ function isConfiguredOutput(output: any): output is Types.ConfiguredOutput {
 
 async function hashFile(filePath: string): Promise<string | null> {
   try {
-    return hash(await readFile(filePath));
+    const fileContent = await readFile(filePath);
+    fileContent.replace(/\r\n/g, '\n');
+    return hash(fileContent);
   } catch (err) {
     if (err && err.code === 'ENOENT') {
       // return null if file does not exist


### PR DESCRIPTION
## Description

We want seamless experience for users of all OS. `--check` flag currently doesn't work for Windows users when something saves the generated file.

This PR treats line endings the same by converting them both back to Linux style when comparing for hash values.

Related https://github.com/dotansimha/graphql-code-generator/issues/10309

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit test
