### PR TITLE
CODEGEN-787 - Improve handling of missing @parcel/watcher scenario

### DIFF
--- a/.changeset/tidy-cows-knock.md
+++ b/.changeset/tidy-cows-knock.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Remove extraneous error stacktrace if fails to load `@parcel/watcher`

--- a/packages/graphql-codegen-cli/src/utils/watcher.ts
+++ b/packages/graphql-codegen-cli/src/utils/watcher.ts
@@ -64,9 +64,9 @@ export const createWatcher = (
     let parcelWatcher: typeof import('@parcel/watcher');
     try {
       parcelWatcher = await import('@parcel/watcher');
-    } catch (err) {
+    } catch {
       log(
-        `Failed to import @parcel/watcher due to the following error (to use watch mode, install https://www.npmjs.com/package/@parcel/watcher):\n${err}`
+        'Failed to import @parcel/watcher due to the following error (to use watch mode, install https://www.npmjs.com/package/@parcel/watcher)'
       );
       return;
     }

--- a/packages/graphql-codegen-cli/src/utils/watcher.ts
+++ b/packages/graphql-codegen-cli/src/utils/watcher.ts
@@ -23,6 +23,11 @@ function log(msg: string) {
   getLogger().info(`  ${msg}`);
 }
 
+function warn(msg: string) {
+  // double spaces to inline the message with Listr
+  getLogger().warn(`  ${msg}`);
+}
+
 function emitWatching(watchDir: string) {
   log(`${logSymbols.info} Watching for changes in ${watchDir}...`);
 }
@@ -65,7 +70,7 @@ export const createWatcher = (
     try {
       parcelWatcher = await import('@parcel/watcher');
     } catch {
-      log(
+      warn(
         'Failed to import @parcel/watcher due to the following error (to use watch mode, install https://www.npmjs.com/package/@parcel/watcher)'
       );
       return;

--- a/packages/graphql-codegen-cli/src/utils/watcher.ts
+++ b/packages/graphql-codegen-cli/src/utils/watcher.ts
@@ -23,11 +23,6 @@ function log(msg: string) {
   getLogger().info(`  ${msg}`);
 }
 
-function warn(msg: string) {
-  // double spaces to inline the message with Listr
-  getLogger().warn(`  ${msg}`);
-}
-
 function emitWatching(watchDir: string) {
   log(`${logSymbols.info} Watching for changes in ${watchDir}...`);
 }
@@ -70,8 +65,8 @@ export const createWatcher = (
     try {
       parcelWatcher = await import('@parcel/watcher');
     } catch {
-      warn(
-        'Failed to import @parcel/watcher due to the following error (to use watch mode, install https://www.npmjs.com/package/@parcel/watcher)'
+      log(
+        'Failed to import @parcel/watcher.\n  To use watch mode, install https://www.npmjs.com/package/@parcel/watcher.'
       );
       return;
     }


### PR DESCRIPTION
## Description

When running `--watch` with missing `@parcel/watcher`, the error message can be noisy.
This PR improves the messaging and logging.

Related to https://github.com/dotansimha/graphql-code-generator/issues/10305

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Result

<img width="707" alt="Screenshot 2025-05-28 at 11 30 34 pm" src="https://github.com/user-attachments/assets/5f2e11cf-e06f-4add-9c02-7aec12c66d87" />

