### PR TITLE
[resolvers][federation] Fix federation @requires type

### DIFF
--- a/.changeset/small-fans-cross.md
+++ b/.changeset/small-fans-cross.md
@@ -1,0 +1,7 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-resolvers': patch
+'@graphql-codegen/plugin-helpers': patch
+---
+
+Update @requires type

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - master
-      - federation-fixes
 
 jobs:
   # dependencies:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - federation-fixes
 
 jobs:
   # dependencies:

--- a/dev-test/test-schema/resolvers-federation.ts
+++ b/dev-test/test-schema/resolvers-federation.ts
@@ -133,6 +133,15 @@ export type FederationTypes = {
   User: User;
 };
 
+/** Mapping of federation reference types */
+export type FederationReferenceTypes = {
+  User: { __typename: 'User' } & (
+    | GraphQLRecursivePick<FederationTypes['User'], { id: true }>
+    | GraphQLRecursivePick<FederationTypes['User'], { name: true }>
+  ) &
+    ({} | GraphQLRecursivePick<FederationTypes['User'], { address: { city: true; lines: { line2: true } } }>);
+};
+
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   Address: ResolverTypeWrapper<Address>;
@@ -154,13 +163,7 @@ export type ResolversParentTypes = {
   ID: Scalars['ID']['output'];
   Lines: Lines;
   Query: {};
-  User:
-    | User
-    | ({ __typename: 'User' } & (
-        | GraphQLRecursivePick<FederationTypes['User'], { id: true }>
-        | GraphQLRecursivePick<FederationTypes['User'], { name: true }>
-      ) &
-        GraphQLRecursivePick<FederationTypes['User'], { address: { city: true; lines: { line2: true } } }>);
+  User: User | FederationReferenceTypes['User'];
   Int: Scalars['Int']['output'];
   Boolean: Scalars['Boolean']['output'];
 };
@@ -199,15 +202,11 @@ export type QueryResolvers<
 export type UserResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'],
-  FederationType extends FederationTypes['User'] = FederationTypes['User']
+  FederationReferenceType extends FederationReferenceTypes['User'] = FederationReferenceTypes['User']
 > = {
   __resolveReference?: ReferenceResolver<
-    Maybe<ResolversTypes['User']>,
-    { __typename: 'User' } & (
-      | GraphQLRecursivePick<FederationType, { id: true }>
-      | GraphQLRecursivePick<FederationType, { name: true }>
-    ) &
-      GraphQLRecursivePick<FederationType, { address: { city: true; lines: { line2: true } } }>,
+    Maybe<ResolversTypes['User']> | FederationReferenceType,
+    FederationReferenceType,
     ContextType
   >;
   email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -818,12 +818,8 @@ export class BaseResolversVisitor<
       shouldInclude: namedType => !isEnumType(namedType),
       onNotMappedObjectType: ({ typeName, initialType }) => {
         let result = initialType;
-        const federationReferenceTypes = this._federation.printReferenceSelectionSets({
-          typeName,
-          baseFederationType: `${this.convertName('FederationTypes')}['${typeName}']`,
-        });
-        if (federationReferenceTypes) {
-          result += ` | ${federationReferenceTypes}`;
+        if (this._federation.getMeta()[typeName]?.referenceSelectionSetsString) {
+          result += ` | ${this.convertName('FederationReferenceTypes')}['${typeName}']`;
         }
         return result;
       },
@@ -1306,6 +1302,33 @@ export class BaseResolversVisitor<
       ).string;
   }
 
+  public buildFederationReferenceTypes(): string {
+    const federationMeta = this._federation.getMeta();
+
+    if (Object.keys(federationMeta).length === 0) {
+      return '';
+    }
+
+    const declarationKind = 'type';
+    return new DeclarationBlock(this._declarationBlockConfig)
+      .export()
+      .asKind(declarationKind)
+      .withName(this.convertName('FederationReferenceTypes'))
+      .withComment('Mapping of federation reference types')
+      .withBlock(
+        Object.entries(federationMeta)
+          .map(([typeName, { referenceSelectionSetsString }]) => {
+            if (!referenceSelectionSetsString) {
+              return undefined;
+            }
+
+            return indent(`${typeName}: ${referenceSelectionSetsString}${this.getPunctuation(declarationKind)}`);
+          })
+          .filter(v => v)
+          .join('\n')
+      ).string;
+  }
+
   public get schema(): GraphQLSchema {
     return this._schema;
   }
@@ -1586,13 +1609,6 @@ export class BaseResolversVisitor<
           }
         }
 
-        const parentTypeSignature = this._federation.transformFieldParentType({
-          fieldNode: original,
-          parentType,
-          parentTypeSignature: this.getParentTypeForSignature(node),
-          federationTypeSignature: 'FederationType',
-        });
-
         const { mappedTypeKey, resolverType } = ((): { mappedTypeKey: string; resolverType: string } => {
           const baseType = getBaseTypeNode(original.type);
           const realType = baseType.name.value;
@@ -1637,15 +1653,18 @@ export class BaseResolversVisitor<
           name: typeName,
           modifier: avoidResolverOptionals ? '' : '?',
           type: resolverType,
-          genericTypes: [mappedTypeKey, parentTypeSignature, contextType, argsType].filter(f => f),
+          genericTypes: [mappedTypeKey, this.getParentTypeForSignature(node), contextType, argsType].filter(f => f),
         };
 
         if (this._federation.isResolveReferenceField(node)) {
           if (!this._federation.getMeta()[parentType.name].hasResolveReference) {
             return { value: '', meta };
           }
+          const resultType = `${mappedTypeKey} | FederationReferenceType`;
+          const referenceType = 'FederationReferenceType';
+
           signature.type = 'ReferenceResolver';
-          signature.genericTypes = [mappedTypeKey, parentTypeSignature, contextType];
+          signature.genericTypes = [resultType, referenceType, contextType];
           meta.federation = { isResolveReference: true };
         }
 
@@ -1788,7 +1807,7 @@ export class BaseResolversVisitor<
     ];
     this._federation.addFederationTypeGenericIfApplicable({
       genericTypes,
-      federationTypesType: this.convertName('FederationTypes'),
+      federationTypesType: this.convertName('FederationReferenceTypes'),
       typeName,
     });
 
@@ -1975,7 +1994,7 @@ export class BaseResolversVisitor<
     ];
     this._federation.addFederationTypeGenericIfApplicable({
       genericTypes,
-      federationTypesType: this.convertName('FederationTypes'),
+      federationTypesType: this.convertName('FederationReferenceTypes'),
       typeName,
     });
 

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -250,6 +250,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 `;
 
   const federationTypes = visitor.buildFederationTypes();
+  const federationReferenceTypes = visitor.buildFederationReferenceTypes();
   const resolversTypeMapping = visitor.buildResolversTypes();
   const resolversParentTypeMapping = visitor.buildResolversParentTypes();
   const resolversUnionTypesMapping = visitor.buildResolversUnionTypes();
@@ -294,6 +295,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
     content: [
       header,
       federationTypes,
+      federationReferenceTypes,
       resolversUnionTypesMapping,
       resolversInterfaceTypesMapping,
       resolversTypeMapping,

--- a/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
+++ b/packages/plugins/typescript/resolvers/tests/__snapshots__/ts-resolvers.spec.ts.snap
@@ -167,6 +167,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 ) => TResult | Promise<TResult>;
 
 
+
 /** Mapping of union types */
 export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
   ChildUnion:
@@ -431,6 +432,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   context: TContext,
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
+
 
 
 /** Mapping of union types */
@@ -783,6 +785,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   context: TContext,
   info?: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
+
 
 
 /** Mapping of union types */

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.interface.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.interface.spec.ts
@@ -124,6 +124,19 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - Interface', () => {
         Admin: Admin;
       };
 
+      /** Mapping of federation reference types */
+      export type FederationReferenceTypes = {
+        Person:
+          ( { __typename: 'Person' }
+          & GraphQLRecursivePick<FederationTypes['Person'], {"id":true}> );
+        User:
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationTypes['User'], {"id":true}> );
+        Admin:
+          ( { __typename: 'Admin' }
+          & GraphQLRecursivePick<FederationTypes['Admin'], {"id":true}> );
+      };
+
 
       /** Mapping of interface types */
       export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
@@ -150,12 +163,8 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - Interface', () => {
         Query: {};
         Person: ResolversInterfaceTypes<ResolversParentTypes>['Person'];
         ID: Scalars['ID']['output'];
-        User: User |
-          ( { __typename: 'User' }
-          & GraphQLRecursivePick<FederationTypes['User'], {"id":true}> );
-        Admin: Admin |
-          ( { __typename: 'Admin' }
-          & GraphQLRecursivePick<FederationTypes['Admin'], {"id":true}> );
+        User: User | FederationReferenceTypes['User'];
+        Admin: Admin | FederationReferenceTypes['Admin'];
         Boolean: Scalars['Boolean']['output'];
         PersonName: PersonName;
         String: Scalars['String']['output'];
@@ -165,26 +174,20 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - Interface', () => {
         me?: Resolver<Maybe<ResolversTypes['Person']>, ParentType, ContextType>;
       };
 
-      export type PersonResolvers<ContextType = any, ParentType extends ResolversParentTypes['Person'] = ResolversParentTypes['Person'], FederationType extends FederationTypes['Person'] = FederationTypes['Person']> = {
+      export type PersonResolvers<ContextType = any, ParentType extends ResolversParentTypes['Person'] = ResolversParentTypes['Person'], FederationReferenceType extends FederationReferenceTypes['Person'] = FederationReferenceTypes['Person']> = {
         __resolveType: TypeResolveFn<'User' | 'Admin', ParentType, ContextType>;
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Person']>,
-          ( { __typename: 'Person' }
-          & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Person']> | FederationReferenceType, FederationReferenceType, ContextType>;
       };
 
-      export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
-          ( { __typename: 'User' }
-          & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
+      export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationReferenceType extends FederationReferenceTypes['User'] = FederationReferenceTypes['User']> = {
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']> | FederationReferenceType, FederationReferenceType, ContextType>;
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         name?: Resolver<ResolversTypes['PersonName'], ParentType, ContextType>;
         __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
       };
 
-      export type AdminResolvers<ContextType = any, ParentType extends ResolversParentTypes['Admin'] = ResolversParentTypes['Admin'], FederationType extends FederationTypes['Admin'] = FederationTypes['Admin']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Admin']>,
-          ( { __typename: 'Admin' }
-          & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
+      export type AdminResolvers<ContextType = any, ParentType extends ResolversParentTypes['Admin'] = ResolversParentTypes['Admin'], FederationReferenceType extends FederationReferenceTypes['Admin'] = FederationReferenceTypes['Admin']> = {
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Admin']> | FederationReferenceType, FederationReferenceType, ContextType>;
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         name?: Resolver<ResolversTypes['PersonName'], ParentType, ContextType>;
         canImpersonate?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.mappers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.mappers.spec.ts
@@ -17,6 +17,12 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
         id: ID!
         user: User!
       }
+
+      type Account @key(fields: "id") {
+        id: ID!
+        name: String! @external
+        displayName: String! @requires(fields: "name")
+      }
     `;
 
     const content = await generate({
@@ -25,6 +31,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
         federation: true,
         mappers: {
           User: './mappers#UserMapper',
+          Account: './mappers#AccountMapper',
         },
       },
     });
@@ -32,7 +39,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
     // User should have it
     expect(content).toMatchInlineSnapshot(`
       "import { GraphQLResolveInfo } from 'graphql';
-      import { UserMapper } from './mappers';
+      import { UserMapper, AccountMapper } from './mappers';
       export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 
@@ -115,6 +122,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
       /** Mapping of federation types */
       export type FederationTypes = {
         User: User;
+        Account: Account;
       };
 
       /** Mapping of federation reference types */
@@ -122,6 +130,11 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
         User:
           ( { __typename: 'User' }
           & GraphQLRecursivePick<FederationTypes['User'], {"id":true}> );
+        Account:
+          ( { __typename: 'Account' }
+          & GraphQLRecursivePick<FederationTypes['Account'], {"id":true}>
+          & ( {}
+              | GraphQLRecursivePick<FederationTypes['Account'], {"name":true}> ) );
       };
 
 
@@ -133,6 +146,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
         ID: ResolverTypeWrapper<Scalars['ID']['output']>;
         String: ResolverTypeWrapper<Scalars['String']['output']>;
         UserProfile: ResolverTypeWrapper<Omit<UserProfile, 'user'> & { user: ResolversTypes['User'] }>;
+        Account: ResolverTypeWrapper<AccountMapper>;
         Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
       };
 
@@ -143,6 +157,7 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
         ID: Scalars['ID']['output'];
         String: Scalars['String']['output'];
         UserProfile: Omit<UserProfile, 'user'> & { user: ResolversParentTypes['User'] };
+        Account: AccountMapper;
         Boolean: Scalars['Boolean']['output'];
       };
 
@@ -161,10 +176,17 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
         user?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
       };
 
+      export type AccountResolvers<ContextType = any, ParentType extends ResolversParentTypes['Account'] = ResolversParentTypes['Account'], FederationReferenceType extends FederationReferenceTypes['Account'] = FederationReferenceTypes['Account']> = {
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Account']> | FederationReferenceType, FederationReferenceType, ContextType>;
+        id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+        displayName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+      };
+
       export type Resolvers<ContextType = any> = {
         Query?: QueryResolvers<ContextType>;
         User?: UserResolvers<ContextType>;
         UserProfile?: UserProfileResolvers<ContextType>;
+        Account?: AccountResolvers<ContextType>;
       };
 
       "

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.mappers.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.mappers.spec.ts
@@ -117,6 +117,13 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
         User: User;
       };
 
+      /** Mapping of federation reference types */
+      export type FederationReferenceTypes = {
+        User:
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationTypes['User'], {"id":true}> );
+      };
+
 
 
       /** Mapping between all available schema types and the resolvers types */
@@ -143,10 +150,8 @@ describe('TypeScript Resolvers Plugin + Apollo Federation - mappers', () => {
         me?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
       };
 
-      export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
-          ( { __typename: 'User' }
-          & GraphQLRecursivePick<FederationType, {"id":true}> ), ContextType>;
+      export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationReferenceType extends FederationReferenceTypes['User'] = FederationReferenceTypes['User']> = {
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']> | FederationReferenceType, FederationReferenceType, ContextType>;
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       };

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
@@ -270,9 +270,17 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
       type User @key(fields: "id") {
         id: ID!
+
         name: String @external
         age: Int! @external
         username: String @requires(fields: "name age")
+
+        publicName: String! @requires(fields: "name")
+
+        birthDay: String! @external
+        birthMonth: String! @external
+        birthYear: String! @external
+        birthDate: String! @requires(fields: "birthDay birthMonth birthYear")
       }
     `;
 
@@ -286,7 +294,16 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
       export type ResolversParentTypes = {
         Query: {};
-        User: User | ( { __typename: 'User' } & GraphQLRecursivePick<FederationTypes['User'], {"id":true}> & GraphQLRecursivePick<FederationTypes['User'], {"name":true,"age":true}> );
+        User: User |
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<FederationTypes['User'], {"id":true}>
+          & ( {}
+              | GraphQLRecursivePick<FederationTypes['User'], {"name":true,"age":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"name":true,"age":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"name":true,"age":true,"birthDay":true,"birthMonth":true,"birthYear":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"name":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"name":true,"birthDay":true,"birthMonth":true,"birthYear":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"birthDay":true,"birthMonth":true,"birthYear":true}> ) );
         ID: Scalars['ID']['output'];
         String: Scalars['String']['output'];
         Int: Scalars['Int']['output'];
@@ -300,9 +317,17 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
           ( { __typename: 'User' }
           & GraphQLRecursivePick<FederationType, {"id":true}>
-          & GraphQLRecursivePick<FederationType, {"name":true,"age":true}> ), ContextType>;
+          & ( {}
+              | GraphQLRecursivePick<FederationType, {"name":true,"age":true}>
+              | GraphQLRecursivePick<FederationType, {"name":true,"age":true}>
+              | GraphQLRecursivePick<FederationType, {"name":true,"age":true,"birthDay":true,"birthMonth":true,"birthYear":true}>
+              | GraphQLRecursivePick<FederationType, {"name":true}>
+              | GraphQLRecursivePick<FederationType, {"name":true,"birthDay":true,"birthMonth":true,"birthYear":true}>
+              | GraphQLRecursivePick<FederationType, {"birthDay":true,"birthMonth":true,"birthYear":true}> ) ), ContextType>;
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+        publicName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        birthDate?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
       };
     `);
   });
@@ -315,6 +340,10 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
 
       extend type User @key(fields: "id") {
         id: ID! @external
+
+        favouriteColor: String! @external
+        favouriteColorHex: String! @requires(fields: "favouriteColor")
+
         name: String @external
         age: Int! @external
         address: Address! @external
@@ -337,7 +366,13 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
       export type ResolversParentTypes = {
         Query: {};
-        User: User | ( { __typename: 'User' } & GraphQLRecursivePick<FederationTypes['User'], {"id":true}> & GraphQLRecursivePick<FederationTypes['User'], {"name":true,"age":true,"address":{"street":true}}> );
+        User: User |
+          ( { __typename: 'User' }
+            & GraphQLRecursivePick<FederationTypes['User'], {"id":true}>
+            & ( {}
+                | GraphQLRecursivePick<FederationTypes['User'], {"favouriteColor":true}>
+                | GraphQLRecursivePick<FederationTypes['User'], {"favouriteColor":true,"name":true,"age":true,"address":{"street":true}}>
+                | GraphQLRecursivePick<FederationTypes['User'], {"name":true,"age":true,"address":{"street":true}}> ) );
         ID: Scalars['ID']['output'];
         String: Scalars['String']['output'];
         Int: Scalars['Int']['output'];
@@ -350,8 +385,12 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
           ( { __typename: 'User' }
-          & GraphQLRecursivePick<FederationType, {"id":true}>
-          & GraphQLRecursivePick<FederationType, {"name":true,"age":true,"address":{"street":true}}> ), ContextType>;
+            & GraphQLRecursivePick<FederationType, {"id":true}>
+            & ( {}
+                | GraphQLRecursivePick<FederationType, {"favouriteColor":true}>
+                | GraphQLRecursivePick<FederationType, {"favouriteColor":true,"name":true,"age":true,"address":{"street":true}}>
+                | GraphQLRecursivePick<FederationType, {"name":true,"age":true,"address":{"street":true}}> ) ), ContextType>;
+        favouriteColorHex?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
         username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
       };
     `);

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
@@ -300,12 +300,20 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
       export type ResolversParentTypes = {
         Query: {};
-        Account: Account |
-          ( { __typename: 'Account' }
-          & GraphQLRecursivePick<FederationTypes['Account'], {"id":true}> );
+        Account: Account | FederationReferenceTypes['Account'];
         ID: Scalars['ID']['output'];
         String: Scalars['String']['output'];
-        User: User |
+        User: User | FederationReferenceTypes['User'];
+        Boolean: Scalars['Boolean']['output'];
+      };
+    `);
+
+    expect(content).toBeSimilarStringTo(`
+      export type FederationReferenceTypes = {
+        Account:
+          ( { __typename: 'Account' }
+          & GraphQLRecursivePick<FederationTypes['Account'], {"id":true}> );
+        User:
           ( { __typename: 'User' }
           & GraphQLRecursivePick<FederationTypes['User'], {"id":true}>
           & ( {}
@@ -323,31 +331,13 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
               | GraphQLRecursivePick<FederationTypes['User'], {"c":true}>
               | GraphQLRecursivePick<FederationTypes['User'], {"c":true,"d":true}>
               | GraphQLRecursivePick<FederationTypes['User'], {"d":true}> ) );
-        Boolean: Scalars['Boolean']['output'];
       };
     `);
 
     // User should have it
     expect(content).toBeSimilarStringTo(`
-      export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
-        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
-          ( { __typename: 'User' }
-          & GraphQLRecursivePick<FederationType, {"id":true}>
-          & ( {}
-              | GraphQLRecursivePick<FederationType, {"a":true}>
-              | GraphQLRecursivePick<FederationType, {"a":true,"b":true}>
-              | GraphQLRecursivePick<FederationType, {"a":true,"c":true}>
-              | GraphQLRecursivePick<FederationType, {"a":true,"d":true}>
-              | GraphQLRecursivePick<FederationType, {"a":true,"b":true,"c":true}>
-              | GraphQLRecursivePick<FederationType, {"a":true,"b":true,"d":true}>
-              | GraphQLRecursivePick<FederationType, {"a":true,"b":true,"c":true,"d":true}>
-              | GraphQLRecursivePick<FederationType, {"b":true}>
-              | GraphQLRecursivePick<FederationType, {"b":true,"c":true}>
-              | GraphQLRecursivePick<FederationType, {"b":true,"d":true}>
-              | GraphQLRecursivePick<FederationType, {"b":true,"c":true,"d":true}>
-              | GraphQLRecursivePick<FederationType, {"c":true}>
-              | GraphQLRecursivePick<FederationType, {"c":true,"d":true}>
-              | GraphQLRecursivePick<FederationType, {"d":true}> ) ), ContextType>;
+      export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationReferenceType extends FederationReferenceTypes['User'] = FederationReferenceTypes['User']> = {
+        __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']> | FederationReferenceType, FederationReferenceType, ContextType>;
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         aRequires?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
         bRequires?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
@@ -268,19 +268,25 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         users: [User]
       }
 
+      type Account @key(fields: "id") {
+        id: ID!
+        key: String!
+      }
+
       type User @key(fields: "id") {
         id: ID!
 
-        name: String @external
-        age: Int! @external
-        username: String @requires(fields: "name age")
+        a: String @external
+        aRequires: String @requires(fields: "a")
 
-        publicName: String! @requires(fields: "name")
+        b: String! @external
+        bRequires: String! @requires(fields: "b")
 
-        birthDay: String! @external
-        birthMonth: String! @external
-        birthYear: String! @external
-        birthDate: String! @requires(fields: "birthDay birthMonth birthYear")
+        c: String! @external
+        cRequires: String! @requires(fields: "c")
+
+        d: String! @external
+        dRequires: String! @requires(fields: "d")
       }
     `;
 
@@ -294,19 +300,29 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     expect(content).toBeSimilarStringTo(`
       export type ResolversParentTypes = {
         Query: {};
+        Account: Account |
+          ( { __typename: 'Account' }
+          & GraphQLRecursivePick<FederationTypes['Account'], {"id":true}> );
+        ID: Scalars['ID']['output'];
+        String: Scalars['String']['output'];
         User: User |
           ( { __typename: 'User' }
           & GraphQLRecursivePick<FederationTypes['User'], {"id":true}>
           & ( {}
-              | GraphQLRecursivePick<FederationTypes['User'], {"name":true,"age":true}>
-              | GraphQLRecursivePick<FederationTypes['User'], {"name":true,"age":true}>
-              | GraphQLRecursivePick<FederationTypes['User'], {"name":true,"age":true,"birthDay":true,"birthMonth":true,"birthYear":true}>
-              | GraphQLRecursivePick<FederationTypes['User'], {"name":true}>
-              | GraphQLRecursivePick<FederationTypes['User'], {"name":true,"birthDay":true,"birthMonth":true,"birthYear":true}>
-              | GraphQLRecursivePick<FederationTypes['User'], {"birthDay":true,"birthMonth":true,"birthYear":true}> ) );
-        ID: Scalars['ID']['output'];
-        String: Scalars['String']['output'];
-        Int: Scalars['Int']['output'];
+              | GraphQLRecursivePick<FederationTypes['User'], {"a":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"a":true,"b":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"a":true,"c":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"a":true,"d":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"a":true,"b":true,"c":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"a":true,"b":true,"d":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"a":true,"b":true,"c":true,"d":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"b":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"b":true,"c":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"b":true,"d":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"b":true,"c":true,"d":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"c":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"c":true,"d":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"d":true}> ) );
         Boolean: Scalars['Boolean']['output'];
       };
     `);
@@ -318,16 +334,25 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
           ( { __typename: 'User' }
           & GraphQLRecursivePick<FederationType, {"id":true}>
           & ( {}
-              | GraphQLRecursivePick<FederationType, {"name":true,"age":true}>
-              | GraphQLRecursivePick<FederationType, {"name":true,"age":true}>
-              | GraphQLRecursivePick<FederationType, {"name":true,"age":true,"birthDay":true,"birthMonth":true,"birthYear":true}>
-              | GraphQLRecursivePick<FederationType, {"name":true}>
-              | GraphQLRecursivePick<FederationType, {"name":true,"birthDay":true,"birthMonth":true,"birthYear":true}>
-              | GraphQLRecursivePick<FederationType, {"birthDay":true,"birthMonth":true,"birthYear":true}> ) ), ContextType>;
+              | GraphQLRecursivePick<FederationType, {"a":true}>
+              | GraphQLRecursivePick<FederationType, {"a":true,"b":true}>
+              | GraphQLRecursivePick<FederationType, {"a":true,"c":true}>
+              | GraphQLRecursivePick<FederationType, {"a":true,"d":true}>
+              | GraphQLRecursivePick<FederationType, {"a":true,"b":true,"c":true}>
+              | GraphQLRecursivePick<FederationType, {"a":true,"b":true,"d":true}>
+              | GraphQLRecursivePick<FederationType, {"a":true,"b":true,"c":true,"d":true}>
+              | GraphQLRecursivePick<FederationType, {"b":true}>
+              | GraphQLRecursivePick<FederationType, {"b":true,"c":true}>
+              | GraphQLRecursivePick<FederationType, {"b":true,"d":true}>
+              | GraphQLRecursivePick<FederationType, {"b":true,"c":true,"d":true}>
+              | GraphQLRecursivePick<FederationType, {"c":true}>
+              | GraphQLRecursivePick<FederationType, {"c":true,"d":true}>
+              | GraphQLRecursivePick<FederationType, {"d":true}> ) ), ContextType>;
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-        username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-        publicName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-        birthDate?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        aRequires?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+        bRequires?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        cRequires?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+        dRequires?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
       };
     `);
   });
@@ -475,9 +500,13 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
         Query: {};
         User: User |
           ( { __typename: 'User' }
-          & ( GraphQLRecursivePick<FederationTypes['User'], {"id":true}> | GraphQLRecursivePick<FederationTypes['User'], {"uuid":true}> | GraphQLRecursivePick<FederationTypes['User'], {"legacyId":{"oldId1":true,"oldId2":true}}> )
-          & GraphQLRecursivePick<FederationTypes['User'], {"id":true,"name":true}>
-          & GraphQLRecursivePick<FederationTypes['User'], {"legacyId":{"oldId1":true},"name":true}> );
+            & ( GraphQLRecursivePick<FederationTypes['User'], {"id":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"uuid":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"legacyId":{"oldId1":true,"oldId2":true}}> )
+            & ( {}
+              | GraphQLRecursivePick<FederationTypes['User'], {"id":true,"name":true}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"id":true,"name":true,"legacyId":{"oldId1":true}}>
+              | GraphQLRecursivePick<FederationTypes['User'], {"legacyId":{"oldId1":true},"name":true}> ) );
         ID: Scalars['ID']['output'];
         String: Scalars['String']['output'];
         LegacyId: LegacyId;
@@ -489,9 +518,13 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
       export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'], FederationType extends FederationTypes['User'] = FederationTypes['User']> = {
         __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>,
           ( { __typename: 'User' }
-          & ( GraphQLRecursivePick<FederationType, {"id":true}> | GraphQLRecursivePick<FederationType, {"uuid":true}> | GraphQLRecursivePick<FederationType, {"legacyId":{"oldId1":true,"oldId2":true}}> )
-          & GraphQLRecursivePick<FederationType, {"id":true,"name":true}>
-          & GraphQLRecursivePick<FederationType, {"legacyId":{"oldId1":true},"name":true}> ), ContextType>;
+            & ( GraphQLRecursivePick<FederationType, {"id":true}>
+              | GraphQLRecursivePick<FederationType, {"uuid":true}>
+              | GraphQLRecursivePick<FederationType, {"legacyId":{"oldId1":true,"oldId2":true}}> )
+            & ( {}
+              | GraphQLRecursivePick<FederationType, {"id":true,"name":true}>
+              | GraphQLRecursivePick<FederationType, {"id":true,"name":true,"legacyId":{"oldId1":true}}>
+              | GraphQLRecursivePick<FederationType, {"legacyId":{"oldId1":true},"name":true}> ) ), ContextType>;
         id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
         username?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/utils/plugins-helpers/src/federation.ts
+++ b/packages/utils/plugins-helpers/src/federation.ts
@@ -6,7 +6,6 @@ import {
   FieldDefinitionNode,
   GraphQLFieldConfigMap,
   GraphQLInterfaceType,
-  GraphQLNamedType,
   GraphQLObjectType,
   GraphQLSchema,
   InterfaceTypeDefinitionNode,
@@ -60,6 +59,7 @@ interface TypeMeta {
    * - [[A, B], [C, D], [E]] -> (A | B) & (C | D) & E
    */
   referenceSelectionSets: { directive: '@key' | '@requires'; selectionSets: ReferenceSelectionSet[] }[];
+  referenceSelectionSetsString: string;
 }
 
 export type FederationMeta = { [typeName: string]: TypeMeta };
@@ -90,6 +90,7 @@ export function addFederationReferencesToSchema(schema: GraphQLSchema): {
           hasResolveReference: false,
           resolvableKeyDirectives: [],
           referenceSelectionSets: [],
+          referenceSelectionSetsString: '',
         } satisfies TypeMeta)),
       ...update,
     };
@@ -123,6 +124,117 @@ export function addFederationReferencesToSchema(schema: GraphQLSchema): {
     return referenceSelectionSets;
   };
 
+  /**
+   * Function to find all combinations of selection sets and push them into the `result`
+   * This is used for `@requires` directive because depending on the operation selection set, different
+   * combination of fields are sent from the router.
+   *
+   * @example
+   * Input: [
+   *   { a: true },
+   *   { b: true },
+   *   { c: true },
+   *   { d: true},
+   * ]
+   * Output: [
+   *   { a: true },
+   *   { a: true, b: true },
+   *   { a: true, c: true },
+   *   { a: true, d: true },
+   *   { a: true, b: true, c: true },
+   *   { a: true, b: true, d: true },
+   *   { a: true, c: true, d: true },
+   *   { a: true, b: true, c: true, d: true }
+   *
+   *   { b: true },
+   *   { b: true, c: true },
+   *   { b: true, d: true },
+   *   { b: true, c: true, d: true }
+   *
+   *   { c: true },
+   *   { c: true, d: true },
+   *
+   *   { d: true },
+   * ]
+   * ```
+   */
+  function findAllSelectionSetCombinations(
+    selectionSets: ReferenceSelectionSet[],
+    result: ReferenceSelectionSet[]
+  ): void {
+    if (selectionSets.length === 0) {
+      return;
+    }
+
+    for (let baseIndex = 0; baseIndex < selectionSets.length; baseIndex++) {
+      const base = selectionSets.slice(0, baseIndex + 1);
+      const rest = selectionSets.slice(baseIndex + 1, selectionSets.length);
+
+      const currentSelectionSet = base.reduce((acc, selectionSet) => {
+        acc = { ...acc, ...selectionSet };
+        return acc;
+      }, {});
+
+      if (baseIndex === 0) {
+        result.push(currentSelectionSet);
+      }
+
+      for (const selectionSet of rest) {
+        result.push({ ...currentSelectionSet, ...selectionSet });
+      }
+    }
+
+    const next = selectionSets.slice(1, selectionSets.length);
+
+    if (next.length > 0) {
+      findAllSelectionSetCombinations(next, result);
+    }
+  }
+
+  const printReferenceSelectionSets = ({
+    typeName,
+    baseFederationType,
+    referenceSelectionSets,
+  }: {
+    typeName: string;
+    baseFederationType: string;
+    referenceSelectionSets: TypeMeta['referenceSelectionSets'];
+  }): string => {
+    const referenceSelectionSetStrings = referenceSelectionSets.reduce<string[]>(
+      (acc, { directive, selectionSets: originalSelectionSets }) => {
+        const result: string[] = [];
+
+        let selectionSets = originalSelectionSets;
+        if (directive === '@requires') {
+          selectionSets = [];
+          findAllSelectionSetCombinations(originalSelectionSets, selectionSets);
+          if (selectionSets.length > 0) {
+            result.push('{}');
+          }
+        }
+
+        for (const referenceSelectionSet of selectionSets) {
+          result.push(`GraphQLRecursivePick<${baseFederationType}, ${JSON.stringify(referenceSelectionSet)}>`);
+        }
+
+        if (result.length === 0) {
+          return acc;
+        }
+
+        if (result.length === 1) {
+          acc.push(result.join(' | '));
+          return acc;
+        }
+
+        acc.push(`( ${result.join('\n        | ')} )`);
+        return acc;
+      },
+      []
+    );
+
+    return `\n    ( { __typename: '${typeName}' }\n    & ${referenceSelectionSetStrings.join('\n    & ')} )`;
+  };
+
   const federationMeta: FederationMeta = {};
 
   const transformedSchema = mapSchema(schema, {
@@ -142,6 +254,12 @@ export function addFederationReferencesToSchema(schema: GraphQLSchema): {
           fields: typeConfig.fields,
         });
 
+        const referenceSelectionSetsString = printReferenceSelectionSets({
+          typeName: type.name,
+          baseFederationType: `FederationTypes['${type.name}']`, // FIXME: run convertName on FederationTypes
+          referenceSelectionSets,
+        });
+
         setFederationMeta({
           meta: federationMeta,
           typeName: type.name,
@@ -149,6 +267,7 @@ export function addFederationReferencesToSchema(schema: GraphQLSchema): {
             hasResolveReference: true,
             resolvableKeyDirectives: federationDetails.resolvableKeyDirectives,
             referenceSelectionSets,
+            referenceSelectionSetsString,
           },
         });
 
@@ -174,6 +293,12 @@ export function addFederationReferencesToSchema(schema: GraphQLSchema): {
           ...typeConfig.fields,
         };
 
+        const referenceSelectionSetsString = printReferenceSelectionSets({
+          typeName: type.name,
+          baseFederationType: `FederationTypes['${type.name}']`, // FIXME: run convertName on FederationTypes
+          referenceSelectionSets,
+        });
+
         setFederationMeta({
           meta: federationMeta,
           typeName: type.name,
@@ -181,6 +306,7 @@ export function addFederationReferencesToSchema(schema: GraphQLSchema): {
             hasResolveReference: true,
             resolvableKeyDirectives: federationDetails.resolvableKeyDirectives,
             referenceSelectionSets,
+            referenceSelectionSetsString,
           },
         });
 
@@ -344,44 +470,6 @@ export class ApolloFederation {
     return this.enabled && name === resolveReferenceFieldName;
   }
 
-  /**
-   * Transforms a field's ParentType signature in ObjectTypes or InterfaceTypes involved in Federation
-   */
-  transformFieldParentType({
-    fieldNode,
-    parentType,
-    parentTypeSignature,
-    federationTypeSignature,
-  }: {
-    fieldNode: FieldDefinitionNode;
-    parentType: GraphQLNamedType;
-    parentTypeSignature: string;
-    federationTypeSignature: string;
-  }): string {
-    if (!this.enabled) {
-      return parentTypeSignature;
-    }
-
-    const result = this.printReferenceSelectionSets({
-      typeName: parentType.name,
-      baseFederationType: federationTypeSignature,
-    });
-
-    // When `!result`, it means this is not a Federation entity, so we just return the parentTypeSignature
-    if (!result) {
-      return parentTypeSignature;
-    }
-
-    const isEntityResolveReferenceField =
-      (isObjectType(parentType) || isInterfaceType(parentType)) && fieldNode.name.value === resolveReferenceFieldName;
-
-    if (!isEntityResolveReferenceField) {
-      return parentTypeSignature;
-    }
-
-    return result;
-  }
-
   addFederationTypeGenericIfApplicable({
     genericTypes,
     typeName,
@@ -396,7 +484,7 @@ export class ApolloFederation {
     }
 
     const typeRef = `${federationTypesType}['${typeName}']`;
-    genericTypes.push(`FederationType extends ${typeRef} = ${typeRef}`);
+    genericTypes.push(`FederationReferenceType extends ${typeRef} = ${typeRef}`);
   }
 
   getMeta() {
@@ -415,69 +503,6 @@ export class ApolloFederation {
     }
 
     return false;
-  }
-
-  printReferenceSelectionSet({
-    typeName,
-    referenceSelectionSet,
-  }: {
-    typeName: string;
-    referenceSelectionSet: ReferenceSelectionSet;
-  }): string {
-    return `GraphQLRecursivePick<${typeName}, ${JSON.stringify(referenceSelectionSet)}>`;
-  }
-
-  printReferenceSelectionSets({
-    typeName,
-    baseFederationType,
-  }: {
-    typeName: string;
-    baseFederationType: string;
-  }): string | false {
-    const federationMeta = this.getMeta()[typeName];
-
-    if (!federationMeta?.hasResolveReference) {
-      return false;
-    }
-
-    const referenceSelectionSetStrings = federationMeta.referenceSelectionSets.reduce<string[]>(
-      (acc, { directive, selectionSets: originalSelectionSets }) => {
-        const result: string[] = [];
-
-        let selectionSets = originalSelectionSets;
-        if (directive === '@requires') {
-          selectionSets = [];
-          findAllSelectionSetCombinations(originalSelectionSets, selectionSets);
-          if (selectionSets.length > 0) {
-            result.push('{}');
-          }
-        }
-
-        for (const referenceSelectionSet of selectionSets) {
-          result.push(
-            this.printReferenceSelectionSet({
-              referenceSelectionSet,
-              typeName: baseFederationType,
-            })
-          );
-        }
-
-        if (result.length === 0) {
-          return acc;
-        }
-
-        if (result.length === 1) {
-          acc.push(result.join(' | '));
-          return acc;
-        }
-
-        acc.push(`( ${result.join('\n        | ')} )`);
-        return acc;
-      },
-      []
-    );
-
-    return `\n    ( { __typename: '${typeName}' }\n    & ${referenceSelectionSetStrings.join('\n    & ')} )`;
   }
 
   private createMapOfProvides() {
@@ -597,71 +622,4 @@ function extractReferenceSelectionSet(directive: DirectiveNode): ReferenceSelect
       },
     },
   });
-}
-
-/**
- * Function to find all combinations of selection sets and push them into the `result`
- * This is used for `@requires` directive because depending on the operation selection set, different
- * combination of fields are sent from the router.
- *
- * @example
- * Input: [
- *   { a: true },
- *   { b: true },
- *   { c: true },
- *   { d: true},
- * ]
- * Output: [
- *   { a: true },
- *   { a: true, b: true },
- *   { a: true, c: true },
- *   { a: true, d: true },
- *   { a: true, b: true, c: true },
- *   { a: true, b: true, d: true },
- *   { a: true, c: true, d: true },
- *   { a: true, b: true, c: true, d: true }
- *
- *   { b: true },
- *   { b: true, c: true },
- *   { b: true, d: true },
- *   { b: true, c: true, d: true }
- *
- *   { c: true },
- *   { c: true, d: true },
- *
- *   { d: true },
- * ]
- * ```
- */
-function findAllSelectionSetCombinations(
-  selectionSets: ReferenceSelectionSet[],
-  result: ReferenceSelectionSet[]
-): void {
-  if (selectionSets.length === 0) {
-    return;
-  }
-
-  for (let baseIndex = 0; baseIndex < selectionSets.length; baseIndex++) {
-    const base = selectionSets.slice(0, baseIndex + 1);
-    const rest = selectionSets.slice(baseIndex + 1, selectionSets.length);
-
-    const currentSelectionSet = base.reduce((acc, selectionSet) => {
-      acc = { ...acc, ...selectionSet };
-      return acc;
-    }, {});
-
-    if (baseIndex === 0) {
-      result.push(currentSelectionSet);
-    }
-
-    for (const selectionSet of rest) {
-      result.push({ ...currentSelectionSet, ...selectionSet });
-    }
-  }
-
-  const next = selectionSets.slice(1, selectionSets.length);
-
-  if (next.length > 0) {
-    findAllSelectionSetCombinations(next, result);
-  }
 }


### PR DESCRIPTION
## Description
- Creates `FederationReferenceTypes` to declare the type of references of each object. This is used by all generated types, and can be used in mappers. [More details in comment](https://github.com/dotansimha/graphql-code-generator/pull/10366#discussion_r2135735298)
- Correctly finds all combinations of selection sets declared by `@requires` in different fields and put them in `FederationReferenceTypes`. [More details in comment](https://github.com/dotansimha/graphql-code-generator/pull/10366#discussion_r2142881641)

Related https://github.com/dotansimha/graphql-code-generator/issues/10206

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test
