### PR TITLE
feat(codegen): use existing types in operations with preResolveTypes …

### DIFF
--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -142,6 +142,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       onlyOperationTypes: options.config.onlyOperationTypes,
       onlyEnums: options.config.onlyEnums,
       customDirectives: options.config.customDirectives,
+      preResolveTypes: options.config.preResolveTypes,
     };
 
     const visitor = new ClientSideBaseVisitor(options.schemaAst, [], options.config, options.config);


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

---

## Description

This merge request updates the GraphQL Codegen configuration to support using existing type definitions with the `client` preset. Specifically, it introduces the `preResolveTypes` option in `presetConfig` so that operation files reference shared types (e.g., from `@graphql-codegen/typescript`) instead of generating inline duplicates.

This change improves maintainability and reduces redundancy across the codebase.

Related #10367

---

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

---

## Screenshots/Sandbox (if appropriate/relevant):

_N/A – configuration-only change affecting generated TypeScript output._

---

## How Has This Been Tested?

- Ran `graphql-codegen` locally with the updated config.
- Verified that generated operation files reference existing types from shared output (`types.ts`) instead of creating inline ones.

**Test Environment**:

- OS: macOS/Linux/Windows
- `@graphql-codegen/...`: [insert version used]
- NodeJS: [insert version used]

---

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

## Further comments

The `client` preset produces clean modular output but always generates inline operation types. With `preResolveTypes`, we can now reuse existing types (already generated separately), reducing duplication and improving consistency.

This feature is opt-in and has no breaking changes.
