### PR TITLE
Fixes https://github.com/the-guild-org/website/issues/1465

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -98,6 +98,7 @@ export default withGuildDocs({
       '/typescript/typescript-resolvers': '/plugins/typescript/typescript-resolvers',
       '/docs/guides/graphql-cli': '/docs/migration/graphql-cli',
       '/plugins/presets/gql-tag-operations-preset': '/plugins/presets/preset-client',
+      '/plugins/gql-tag-operations-preset': '/plugins/presets/preset-client',
     })
       .concat(PLUGINS_REDIRECTS)
       .map(([from, to]) => ({


### PR DESCRIPTION
Adds redirect for old style URL. Broken link reported

Issue filed in The Guild website repo: https://github.com/the-guild-org/website/issues/1465

This PR resovles that issue.

Tested locally.