### PR TITLE
Add missing forwarded options for client preset

### DIFF
--- a/website/src/pages/plugins/presets/preset-client.mdx
+++ b/website/src/pages/plugins/presets/preset-client.mdx
@@ -59,7 +59,7 @@ The `client` preset allows the following `config` options:
 - [`nonOptionalTypename`](/plugins/typescript/typescript#nonoptionaltypename): Automatically adds `__typename` field to the generated types, even when they are not specified in the selection set, and makes it non-optional.
 - [`avoidOptionals`](/plugins/typescript/typescript#avoidoptionals): This will cause the generator to avoid using TypeScript optionals (`?`) on types.
 - [`documentMode`](#documentmode): Allows you to control how the documents are generated.
-- [`skipTypeNameForRoot`](/plugins/typescript/typescript-operations#skiptypenameforroot): Avoid adding __typename for root types. This is ignored when a selection explicitly specifies `__typename`.
+- [`skipTypeNameForRoot`](/plugins/typescript/typescript-operations#skiptypenameforroot): Avoid adding `__typename` for root types. This is ignored when a selection explicitly specifies `__typename`.
 - [`onlyOperationTypes`](/plugins/typescript/typescript#onlyoperationtypes): This will cause the generator to emit types required for operations only i.e. only enums and scalars.
 - [`onlyEnums`](/plugins/typescript/typescript#onlyenums): This will cause the generator to emit types for enums only.
 - [`customDirectives`](/plugins/typescript/typescript-operations#customdirectives): Configures behavior for use with custom directives from various GraphQL libraries, such as Apollo Client's [@unmask](https://www.apollographql.com/docs/react/data/directives#unmask).


### PR DESCRIPTION
## Description

This PR adds missing Client Preset  forwarded options in the doc:

- `skipTypeNameForRoot`
- `onlyOperationTypes`
- `onlyEnums`
- `customDirectives`