### PR TITLE
Drop Node 18 support

### DIFF
--- a/.changeset/wicked-timers-eat.md
+++ b/.changeset/wicked-timers-eat.md
@@ -1,0 +1,22 @@
+---
+'@graphql-codegen/visitor-plugin-common': major
+'@graphql-codegen/typescript-resolvers': major
+'@graphql-codegen/graphql-modules-preset': major
+'@graphql-codegen/plugin-helpers': major
+'@graphql-codegen/cli': major
+'@graphql-codegen/client-preset': major
+'@graphql-codegen/core': major
+'@graphql-codegen/add': major
+'@graphql-codegen/fragment-matcher': major
+'@graphql-codegen/introspection': major
+'@graphql-codegen/schema-ast': major
+'@graphql-codegen/time': major
+'@graphql-codegen/typescript-document-nodes': major
+'@graphql-codegen/gql-tag-operations': major
+'@graphql-codegen/typescript-operations': major
+'@graphql-codegen/typed-document-node': major
+'@graphql-codegen/typescript': major
+'@graphql-codegen/testing': major
+---
+
+Drop Node 18 support

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup env
         uses: the-guild-org/shared-config/setup@main
-        with:
-          nodeVersion: 18
       - name: Prettier Check
         run: yarn prettier:check
   dev-tests-old:
@@ -46,8 +44,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup env
         uses: the-guild-org/shared-config/setup@main
-        with:
-          nodeVersion: 18
       - name: Build
         run: yarn build
         env:
@@ -64,8 +60,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup env
         uses: the-guild-org/shared-config/setup@main
-        with:
-          nodeVersion: 18
       - name: Build
         run: yarn build
         env:
@@ -88,8 +82,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup env
         uses: the-guild-org/shared-config/setup@main
-        with:
-          nodeVersion: 18
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: 1.65.0
@@ -121,8 +113,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup env
         uses: the-guild-org/shared-config/setup@main
-        with:
-          nodeVersion: 18
       - name: Build
         run: yarn build
         env:
@@ -139,10 +129,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # remove windows to speed up the tests
-        node_version: [16, 18, 20]
+        node_version: [20, 22, 24]
         graphql_version: [15, 16]
         include:
-          - node-version: 14
+          - node-version: 20
             os: windows-latest
             graphql_version: 16
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,6 @@ jobs:
     with:
       npmTag: alpha
       buildScript: build
-      nodeVersion: 18
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       npmToken: ${{ secrets.NPM_TOKEN }}
@@ -29,7 +28,6 @@ jobs:
       npmTag: rc
       restoreDeletedChangesets: true
       buildScript: build
-      nodeVersion: 18
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       npmToken: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
     uses: the-guild-org/shared-config/.github/workflows/release-stable.yml@main
     with:
       releaseScript: release
-      nodeVersion: 18
     secrets:
       # githubToken: ${{ secrets.GUILD_BOT_TOKEN }}
       githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/website-integrity.yml
+++ b/.github/workflows/website-integrity.yml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Setup env
         uses: the-guild-org/shared-config/setup@main
-        with:
-          nodeVersion: 18
 
       - name: Build Packages
         run: yarn build

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,9 +20,6 @@ jobs:
 
       - uses: the-guild-org/shared-config/setup@main
         name: setup env
-        with:
-          nodeVersion: 18
-          packageManager: yarn
 
       - uses: the-guild-org/shared-config/website-cf@main
         name: build and deploy website


### PR DESCRIPTION
Node 18 is has reached EOL so we should avoid using it or test it.



