### PR TITLE
Drop graphql tools prisma loader

### DIFF
--- a/.changeset/brave-meals-brake.md
+++ b/.changeset/brave-meals-brake.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': major
+---
+
+Drop @graphql-tools/prisma-loader

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -53,7 +53,6 @@
     "@graphql-tools/graphql-file-loader": "^8.0.0",
     "@graphql-tools/json-file-loader": "^8.0.0",
     "@graphql-tools/load": "^8.1.0",
-    "@graphql-tools/prisma-loader": "^8.0.0",
     "@graphql-tools/url-loader": "^8.0.0",
     "@graphql-tools/utils": "^10.0.0",
     "@whatwg-node/fetch": "^0.10.0",

--- a/packages/graphql-codegen-cli/src/graphql-config.ts
+++ b/packages/graphql-codegen-cli/src/graphql-config.ts
@@ -2,7 +2,6 @@ import { ApolloEngineLoader } from '@graphql-tools/apollo-engine-loader';
 import { CodeFileLoader } from '@graphql-tools/code-file-loader';
 import { GitLoader } from '@graphql-tools/git-loader';
 import { GithubLoader } from '@graphql-tools/github-loader';
-import { PrismaLoader } from '@graphql-tools/prisma-loader';
 import { GraphQLConfig, GraphQLExtensionDeclaration, loadConfig } from 'graphql-config';
 
 export const CodegenExtension: GraphQLExtensionDeclaration = (api: any) => {
@@ -17,7 +16,6 @@ export const CodegenExtension: GraphQLExtensionDeclaration = (api: any) => {
   api.loaders.schema.register(new GitLoader());
   api.loaders.schema.register(new GithubLoader());
   api.loaders.schema.register(new ApolloEngineLoader());
-  api.loaders.schema.register(new PrismaLoader());
   // Documents
   api.loaders.documents.register(
     new CodeFileLoader({

--- a/packages/graphql-codegen-cli/src/load.ts
+++ b/packages/graphql-codegen-cli/src/load.ts
@@ -12,7 +12,6 @@ import {
   NoTypeDefinitionsFound,
   UnnormalizedTypeDefPointer,
 } from '@graphql-tools/load';
-import { PrismaLoader } from '@graphql-tools/prisma-loader';
 import { UrlLoader } from '@graphql-tools/url-loader';
 import { GraphQLError, GraphQLSchema } from 'graphql';
 
@@ -41,7 +40,6 @@ export async function loadSchema(
       new JsonFileLoader(),
       new UrlLoader(),
       new ApolloEngineLoader(),
-      new PrismaLoader(),
     ];
 
     const schema = await loadSchemaToolkit(schemaPointers, {


### PR DESCRIPTION
## Description

This PR drops `@graphql-tools/prisma-loader` for next major version: it seems it's not being used by anyone.

Related # https://github.com/dotansimha/graphql-code-generator/pull/10218

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
