### PR TITLE
Remove deprecated config options for next major version

### DIFF
--- a/.changeset/brave-days-heal.md
+++ b/.changeset/brave-days-heal.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/plugin-helpers': major
+---
+
+Remove deprecated option `watchConfig`

--- a/.changeset/kind-donkeys-retire.md
+++ b/.changeset/kind-donkeys-retire.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': major
+---
+
+Remove deprecated config option `dedupeFragments`

--- a/.changeset/tame-lizards-speak.md
+++ b/.changeset/tame-lizards-speak.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/client-preset': major
+---
+
+Stop passing through the deprecated config option `dedupeFragments`

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -33,7 +33,6 @@ export interface ParsedConfig {
   fragmentImports: ImportDeclaration<FragmentImport>[];
   immutableTypes: boolean;
   useTypeImports: boolean;
-  dedupeFragments: boolean;
   allowEnumStringTypes: boolean;
   inlineFragmentTypes: InlineFragmentTypeOptions;
   emitLegacyCommonJSImports: boolean;
@@ -347,15 +346,6 @@ export interface RawConfig {
    */
   globalNamespace?: boolean;
   /**
-   * @description  Removes fragment duplicates for reducing data transfer.
-   * It is done by removing sub-fragments imports from fragment definition
-   * Instead - all of them are imported to the Operation node.
-   * @type boolean
-   * @default false
-   * @deprecated This option is no longer needed. It will be removed in the next major version.
-   */
-  dedupeFragments?: boolean;
-  /**
    * @ignore
    */
   allowEnumStringTypes?: boolean;
@@ -416,7 +406,6 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
       addTypename: !rawConfig.skipTypename,
       nonOptionalTypename: !!rawConfig.nonOptionalTypename,
       useTypeImports: !!rawConfig.useTypeImports,
-      dedupeFragments: !!rawConfig.dedupeFragments,
       allowEnumStringTypes: !!rawConfig.allowEnumStringTypes,
       inlineFragmentTypes: rawConfig.inlineFragmentTypes ?? 'inline',
       emitLegacyCommonJSImports:

--- a/packages/plugins/typescript/document-nodes/tests/graphql-document-nodes.spec.ts
+++ b/packages/plugins/typescript/document-nodes/tests/graphql-document-nodes.spec.ts
@@ -297,29 +297,6 @@ describe('graphql-codegen typescript-graphql-document-nodes', () => {
     validateTs(mergeOutputs([result]));
   });
 
-  it('Should generate simple module without graphql-tag', async () => {
-    const result = plugin(
-      null,
-      [
-        {
-          location: 'some/file/my-query.graphql',
-          document: parse(/* GraphQL */ `
-            query MyQuery {
-              field
-            }
-          `),
-        },
-      ],
-      { noGraphQLTag: true },
-      { outputFile: '' }
-    ) as Types.ComplexPluginOutput;
-
-    expect(result.content).toBeSimilarStringTo(`
-    export const MyQuery = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MyQuery"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"field"}}]}}]} as unknown as DocumentNode;
-    `);
-    validateTs(mergeOutputs([result]));
-  });
-
   it('should contain fragment definitions', async () => {
     const result = plugin(
       null,

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -134,7 +134,6 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       enumsAsConst: options.config.enumsAsConst,
       enumValues: options.config.enumValues,
       futureProofEnums: options.config.futureProofEnums,
-      dedupeFragments: options.config.dedupeFragments,
       nonOptionalTypename: options.config.nonOptionalTypename,
       avoidOptionals: options.config.avoidOptionals,
       documentMode: options.config.documentMode,

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -465,19 +465,6 @@ export namespace Types {
      */
     watch?: boolean | string | string[];
     /**
-     * @deprecated this is not necessary since we are using `@parcel/watcher` instead of `chockidar`.
-     *
-     * @description Allows overriding the behavior of watch to use stat polling over native file watching support.
-     *
-     * Config fields have the same defaults and sematics as the identically named ones for chokidar.
-     *
-     * For more details: https://graphql-code-generator.com/docs/getting-started/development-workflow#watch-mode
-     */
-    watchConfig?: {
-      usePolling: boolean;
-      interval?: number;
-    };
-    /**
      * @description A flag to suppress non-zero exit code when there are no documents to generate.
      */
     ignoreNoDocuments?: boolean;

--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -510,7 +510,6 @@ The `client` preset allows the following `config` options:
 - [`enumsAsTypes`](/plugins/typescript/typescript#enumsastypes): Generates enum as TypeScript string union `type` instead of an `enum`. Useful if you wish to generate `.d.ts` declaration file instead of `.ts`, or if you want to avoid using TypeScript enums due to bundle size concerns.
 - [`enumsAsConst`](/plugins/typescript/typescript#enumsasconst): Generates enum as TypeScript const assertions instead of enum. This can even be used to enable enum-like patterns in plain JavaScript code if you choose not to use TypeScript’s enum construct.
 - [`enumValues`](/plugins/typescript/typescript#enumvalues): Overrides the default value of enum values declared in your GraphQL schema. You can also map the entire enum to an external type by providing a string that of module#type.
-- [`dedupeFragments`](/plugins/typescript/typescript#dedupefragments): Removes fragment duplicates for reducing data transfer. It is done by removing sub-fragments imports from fragment definition.
 - [`nonOptionalTypename`](/plugins/typescript/typescript#nonoptionaltypename): Automatically adds `__typename` field to the generated types, even when they are not specified in the selection set, and makes it non-optional.
 - [`avoidOptionals`](/plugins/typescript/typescript#avoidoptionals): This will cause the generator to avoid using TypeScript optionals (`?`) on types.
 

--- a/website/src/pages/plugins/presets/preset-client.mdx
+++ b/website/src/pages/plugins/presets/preset-client.mdx
@@ -55,7 +55,6 @@ The `client` preset allows the following `config` options:
 - [`enumsAsConst`](/plugins/typescript/typescript#enumsasconst): Generates enum as TypeScript const assertions instead of enum. This can even be used to enable enum-like patterns in plain JavaScript code if you choose not to use TypeScript’s enum construct.
 - [`enumValues`](/plugins/typescript/typescript#enumvalues): Overrides the default value of enum values declared in your GraphQL schema. You can also map the entire enum to an external type by providing a string that of module#type.
 - [`futureProofEnums`](/plugins/typescript/typescript#futureproofenums): Adds a catch-all entry to enum type definitions for values that may be added in the future.
-- [`dedupeFragments`](/plugins/typescript/typescript#dedupefragments): Removes fragment duplicates for reducing data transfer. It is done by removing sub-fragments imports from fragment definition.
 - [`nonOptionalTypename`](/plugins/typescript/typescript#nonoptionaltypename): Automatically adds `__typename` field to the generated types, even when they are not specified in the selection set, and makes it non-optional.
 - [`avoidOptionals`](/plugins/typescript/typescript#avoidoptionals): This will cause the generator to avoid using TypeScript optionals (`?`) on types.
 - [`documentMode`](#documentmode): Allows you to control how the documents are generated.


### PR DESCRIPTION
## Description

Related https://github.com/dotansimha/graphql-code-generator/pull/10218

Dropped config options marked as deprecated across packages:

- `watchConfig`
- `dedupeFragments`
- `noGraphQLTag`