### PR TITLE
[resolvers] Report if an object can have `__isTypeOf` resolver to output meta

### DIFF
--- a/.changeset/tiny-avocados-applaud.md
+++ b/.changeset/tiny-avocados-applaud.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-resolvers': minor
+---
+
+Report to meta user defined objects whether they have isTypeOf resolver

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+      - federation-fixes # FIXME: Remove this line after the PR is merged
 
 env:
   NODE_OPTIONS: '--max_old_space_size=4096'

--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -94,7 +94,14 @@ export interface RootResolver {
   content: string;
   generatedResolverTypes: {
     resolversMap: { name: string };
-    userDefined: Record<string, { name: string; federation?: { hasResolveReference: boolean } }>;
+    userDefined: Record<
+      string,
+      {
+        name: string;
+        hasIsTypeOf: boolean;
+        federation?: { hasResolveReference: boolean };
+      }
+    >;
   };
 }
 
@@ -1437,6 +1444,7 @@ export class BaseResolversVisitor<
               if (resolverType.baseGeneratedTypename) {
                 userDefinedTypes[schemaTypeName] = {
                   name: resolverType.baseGeneratedTypename,
+                  hasIsTypeOf: this._parsedSchemaMeta.typesWithIsTypeOf[schemaTypeName] || false,
                 };
 
                 const federationMeta = this._federation.getMeta()[schemaTypeName];

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
@@ -950,42 +950,52 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
           },
           "userDefined": {
             "MultipleNonResolvable": {
+              "hasIsTypeOf": false,
               "name": "MultipleNonResolvableResolvers",
             },
             "MultipleResolvable": {
               "federation": {
                 "hasResolveReference": true,
               },
+              "hasIsTypeOf": false,
               "name": "MultipleResolvableResolvers",
             },
             "Node": {
+              "hasIsTypeOf": false,
               "name": "NodeResolvers",
             },
             "NotResolvable": {
+              "hasIsTypeOf": false,
               "name": "NotResolvableResolvers",
             },
             "Query": {
+              "hasIsTypeOf": false,
               "name": "QueryResolvers",
             },
             "Resolvable": {
               "federation": {
                 "hasResolveReference": true,
               },
+              "hasIsTypeOf": false,
               "name": "ResolvableResolvers",
             },
             "User": {
               "federation": {
                 "hasResolveReference": true,
               },
+              "hasIsTypeOf": false,
               "name": "UserResolvers",
             },
             "UserError": {
+              "hasIsTypeOf": true,
               "name": "UserErrorResolvers",
             },
             "UserOk": {
+              "hasIsTypeOf": true,
               "name": "UserOkResolvers",
             },
             "UserPayload": {
+              "hasIsTypeOf": false,
               "name": "UserPayloadResolvers",
             },
           },

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.meta.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.meta.spec.ts
@@ -41,6 +41,10 @@ describe('TypeScript Resolvers Plugin - Meta', () => {
           FORBIDDEN_ERROR
           INTERNAL_ERROR
         }
+
+        type TypeWithoutInterfaceOrUnion {
+          id: ID!
+        }
       `),
       [],
       {
@@ -66,6 +70,7 @@ describe('TypeScript Resolvers Plugin - Meta', () => {
         CreateUserError?: create_user_error_resolvers<ContextType>;
         CreateUserPayload?: create_user_payload_resolvers<ContextType>;
         ErrorType?: error_type_resolvers;
+        TypeWithoutInterfaceOrUnion?: type_without_interface_or_union_resolvers<ContextType>;
       };`);
     expect(result.content).toContain(`export type create_user_error_resolvers`);
     expect(result.content).toContain(`export type create_user_ok_resolvers`);
@@ -85,30 +90,43 @@ describe('TypeScript Resolvers Plugin - Meta', () => {
           },
           "userDefined": {
             "CreateUserError": {
+              "hasIsTypeOf": true,
               "name": "create_user_error_resolvers",
             },
             "CreateUserOk": {
+              "hasIsTypeOf": true,
               "name": "create_user_ok_resolvers",
             },
             "CreateUserPayload": {
+              "hasIsTypeOf": false,
               "name": "create_user_payload_resolvers",
             },
             "ErrorType": {
+              "hasIsTypeOf": false,
               "name": "error_type_resolvers",
             },
             "Mutation": {
+              "hasIsTypeOf": false,
               "name": "mutation_resolvers",
             },
             "Node": {
+              "hasIsTypeOf": false,
               "name": "node_resolvers",
             },
             "Post": {
+              "hasIsTypeOf": true,
               "name": "post_resolvers",
             },
             "Query": {
+              "hasIsTypeOf": false,
               "name": "query_resolvers",
             },
+            "TypeWithoutInterfaceOrUnion": {
+              "hasIsTypeOf": false,
+              "name": "type_without_interface_or_union_resolvers",
+            },
             "User": {
+              "hasIsTypeOf": true,
               "name": "user_resolvers",
             },
           },


### PR DESCRIPTION
## Description

This PR ensures `typescript-resolvers` plugin reports whether user defined objects have `__isTypeOf` or not.
This helps downstream plugins and presets (such as Server Preset) handle correct typing without parsing the schema again.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

