### PR TITLE
chore(cli): generate profiler output file on process exit event

### DIFF
--- a/packages/graphql-codegen-cli/src/utils/file-system.ts
+++ b/packages/graphql-codegen-cli/src/utils/file-system.ts
@@ -1,4 +1,4 @@
-import { promises, unlink as fsUnlink } from 'fs';
+import { promises, unlink as fsUnlink, writeFileSync as fsWriteFileSync } from 'fs';
 
 const { access: fsAccess, writeFile: fsWriteFile, readFile: fsReadFile, mkdir } = promises;
 
@@ -8,6 +8,10 @@ export function access(...args: Parameters<typeof fsAccess>) {
 
 export function writeFile(filepath: string, content: string) {
   return fsWriteFile(filepath, content);
+}
+
+export function writeFileSync(filepath: string, content: string) {
+  return fsWriteFileSync(filepath, content);
 }
 
 export function readFile(filepath: string) {


### PR DESCRIPTION
## Description

This PR moves writing the profiler output to the `exit` process event. This is to ensure both single-pass and watch mode consistently write the profiler file as the event will be fired on explicit `process.exit()` or any unhandled exceptions

Related #10382 

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I had explored using the `shutdown` method of the watcher but I was unable to reliably trigger that method as the `SIGINT` and `SIGTERM` event listeners weren't being called when stopping the watcher with `CTRL + C` or an explicit `SIGINT` signal with `kill`. I plan to further explore this in the future but this was why I opted to use the `exit` event