### PR TITLE
Add callout for Apollo Client 4.0 compatibility with the `typescript-react-apollo` plugin

### DIFF
--- a/website/src/pages/plugins/typescript/typescript-react-apollo.mdx
+++ b/website/src/pages/plugins/typescript/typescript-react-apollo.mdx
@@ -16,6 +16,12 @@ We now recommend using the `client-preset` package for a **better developer expe
 
 </Callout>
 
+<Callout type="warning">
+
+The generated hooks created by this package are no longer compatible with Apollo Client 4.0. We provide a codemod that automates the the migration to the `client` preset. See the [tutorial video](https://youtu.be/GGmt0hvnQNU?si=4DQEyqc24pfiih9J) to learn how to use the codemod to migrate your codebase.
+
+</Callout>
+
 <PluginHeader />
 <PluginApiDocs />
 


### PR DESCRIPTION
We (the Apollo Client team) have seen some feedback a couple places ([example](https://www.reddit.com/r/graphql/comments/1n7p2j7/apollo_client_40_a_leaner_and_cleaner_graphql/)) now where migrating to Apollo Client 4.0 breaks type usage in codebases that generate hooks using this plugin due to the change in where the old deprecated types are generated and with the new type structure. We now provide [guidance](https://www.apollographql.com/docs/react/migrating/apollo-client-4-migration#recommended-avoid-using-generated-hooks) in our migration guide to move away from them and I know a codemod was created to help modify this.

I'm proposing that we add this callout in the docs in addition to Apollo's docs so that we ensure this guidance can be seen as many places as possible.

## Type of change

Please delete options that are not relevant.

- [x] Documentation update
