### PR TITLE
Fix: react-vue.mdx (--save-dev instead of --dev)

### DIFF
--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -47,7 +47,7 @@ For most GraphQL clients and frameworks (React, Vue), install the following pack
 
 ```sh npm2yarn
 npm install graphql
-npm install --dev typescript @graphql-codegen/cli @parcel/watcher
+npm install --save-dev typescript @graphql-codegen/cli @parcel/watcher
 ```
 
 <br />


### PR DESCRIPTION
## Description

`pnpm add --dev typescript @graphql-codegen/cli @parcel/watcher`

=> ERROR  Unknown option: 'dev'