### PR TITLE
Fix: installation.mdx (No comment behind npm install)

### DIFF
--- a/website/src/pages/docs/getting-started/installation.mdx
+++ b/website/src/pages/docs/getting-started/installation.mdx
@@ -45,8 +45,10 @@ Once installed, GraphQL Code Generator CLI can help you configure your project b
 npx graphql-code-generator init
 ```
 
+Install the chosen packages:
+
 ```sh npm2yarn
-npm install # install the chosen packages
+npm install
 ```
 
 Question by question, it will guide you through the whole process of setting up a schema, selecting and installing plugins, picking a destination to where your files are generated, and a lot more.


### PR DESCRIPTION
## Description

`pnpm add`

=> ERR_PNPM_MISSING_PACKAGE_NAME  `pnpm add` requires the package name