### PR TITLE
CODEGEN-859 [graphql-modules-preset] Fix __isTypeOf getting picked from from all objects

### DIFF
--- a/.changeset/lemon-insects-attend.md
+++ b/.changeset/lemon-insects-attend.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/graphql-modules-preset': patch
+---
+
+Fix \_\_isTypeOf wrongly picked on objects that are not implementing types or union members

--- a/dev-test/modules/blog/generated.ts
+++ b/dev-test/modules/blog/generated.ts
@@ -10,7 +10,7 @@ export namespace BlogModule {
   export type User = Types.User;
   export type Query = Pick<Types.Query, DefinedFields['Query']>;
 
-  export type ArticleResolvers = Pick<Types.ArticleResolvers, DefinedFields['Article'] | '__isTypeOf'>;
+  export type ArticleResolvers = Pick<Types.ArticleResolvers, DefinedFields['Article']>;
   export type QueryResolvers = Pick<Types.QueryResolvers, DefinedFields['Query']>;
 
   export interface Resolvers {

--- a/dev-test/modules/dotanions/generated.ts
+++ b/dev-test/modules/dotanions/generated.ts
@@ -23,7 +23,7 @@ export namespace DotanionsModule {
 
   export type PaypalResolvers = Pick<Types.PaypalResolvers, DefinedFields['Paypal'] | '__isTypeOf'>;
   export type CreditCardResolvers = Pick<Types.CreditCardResolvers, DefinedFields['CreditCard'] | '__isTypeOf'>;
-  export type DonationResolvers = Pick<Types.DonationResolvers, DefinedFields['Donation'] | '__isTypeOf'>;
+  export type DonationResolvers = Pick<Types.DonationResolvers, DefinedFields['Donation']>;
   export type MutationResolvers = Pick<Types.MutationResolvers, DefinedFields['Mutation']>;
   export type UserResolvers = Pick<Types.UserResolvers, DefinedFields['User']>;
 

--- a/dev-test/modules/users/generated.ts
+++ b/dev-test/modules/users/generated.ts
@@ -9,7 +9,7 @@ export namespace UsersModule {
   export type User = Pick<Types.User, DefinedFields['User']>;
   export type Query = Pick<Types.Query, DefinedFields['Query']>;
 
-  export type UserResolvers = Pick<Types.UserResolvers, DefinedFields['User'] | '__isTypeOf'>;
+  export type UserResolvers = Pick<Types.UserResolvers, DefinedFields['User']>;
   export type QueryResolvers = Pick<Types.QueryResolvers, DefinedFields['Query']>;
 
   export interface Resolvers {

--- a/packages/presets/graphql-modules/tests/__snapshots__/integration.spec.ts.snap
+++ b/packages/presets/graphql-modules/tests/__snapshots__/integration.spec.ts.snap
@@ -25,7 +25,7 @@ export type Mutation = Pick<Types.Mutation, DefinedFields['Mutation']>;
 
 export type PaypalResolvers = Pick<Types.PaypalResolvers, DefinedFields['Paypal'] | '__isTypeOf'>;
 export type CreditCardResolvers = Pick<Types.CreditCardResolvers, DefinedFields['CreditCard'] | '__isTypeOf'>;
-export type DonationResolvers = Pick<Types.DonationResolvers, DefinedFields['Donation'] | '__isTypeOf'>;
+export type DonationResolvers = Pick<Types.DonationResolvers, DefinedFields['Donation']>;
 export type MutationResolvers = Pick<Types.MutationResolvers, DefinedFields['Mutation']>;
 export type UserResolvers = Pick<Types.UserResolvers, DefinedFields['User']>;
 

--- a/packages/presets/graphql-modules/tests/integration.spec.ts
+++ b/packages/presets/graphql-modules/tests/integration.spec.ts
@@ -34,7 +34,7 @@ describe('Integration', () => {
   test('should not duplicate type even if type and extend type are in the same module', async () => {
     const { result } = await executeCodegen(options);
 
-    const userResolversStr = `export type UserResolvers = Pick<Types.UserResolvers, DefinedFields['User'] | '__isTypeOf'>;`;
+    const userResolversStr = `export type UserResolvers = Pick<Types.UserResolvers, DefinedFields['User']>;`;
     const nbOfTimeUserResolverFound = result[4].content.split(userResolversStr).length - 1;
 
     expect(nbOfTimeUserResolverFound).toBe(1);
@@ -176,7 +176,7 @@ describe('Integration', () => {
 
     // Only Query related properties should be required
     expect(usersModuleOutput.content).toBeSimilarStringTo(`
-      export type UserResolvers = Pick<Types.UserResolvers, DefinedFields['User'] | '__isTypeOf'>;
+      export type UserResolvers = Pick<Types.UserResolvers, DefinedFields['User']>;
       export type QueryResolvers = Required<Pick<Types.QueryResolvers, DefinedFields['Query']>>;
     `);
     expect(usersModuleOutput.content).toBeSimilarStringTo(`


### PR DESCRIPTION
## Description

This PR fixes `__isTypeOf` getting picked from all objects.
With https://github.com/dotansimha/graphql-code-generator/releases/tag/release-1757264511789 release, `__isTypeOf` is only generated for implementing types and union members.

This PR applies the same logic to `graphql-modules-preset` to make sure it's correctly picked.

Related https://github.com/dotansimha/graphql-code-generator/issues/10438

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test
