### PR TITLE
feat(typed-document-node): Allow importing operation types

### DIFF
--- a/packages/plugins/typescript/typed-document-node/src/config.ts
+++ b/packages/plugins/typescript/typed-document-node/src/config.ts
@@ -48,4 +48,31 @@ export interface TypeScriptTypedDocumentNodesConfig extends RawClientSideBasePlu
    * ```
    */
   addTypenameToSelectionSets?: boolean;
+
+  /**
+   * @description Allows you to import the operation types from a different file.
+   * @default ""
+   *
+   * @exampleMarkdown
+   * ```ts filename="codegen.ts"
+   *  import type { CodegenConfig } from '@graphql-codegen/cli';
+   *
+   *  const config: CodegenConfig = {
+   *    // ...
+   *    generates: {
+   *      'path/to/file.ts': {
+   *        plugins: ['typescript', 'typescript-operations']
+   *      },
+   *      'path/to/file2.ts': {
+   *        plugins: ['typed-document-node'],
+   *        config: {
+   *          importOperationTypesFrom: 'path/to/file.ts'
+   *        },
+   *      },
+   *    },
+   *  };
+   *  export default config;
+   * ```
+   */
+  importOperationTypesFrom?: string;
 }

--- a/packages/plugins/typescript/typed-document-node/src/visitor.ts
+++ b/packages/plugins/typescript/typed-document-node/src/visitor.ts
@@ -103,11 +103,15 @@ export class TypeScriptDocumentNodesVisitor extends ClientSideBaseVisitor<
       this.config.documentMode === DocumentMode.documentNodeImportFragments ||
       this.config.documentMode === DocumentMode.graphQLTag
     ) {
-      return ` as unknown as DocumentNode<${resultType}, ${variablesTypes}>`;
+      return ` as unknown as DocumentNode<${this.config.importOperationTypesFrom ? 'Types.' : ''}${resultType}, ${
+        this.config.importOperationTypesFrom ? 'Types.' : ''
+      }${variablesTypes}>`;
     }
 
     if (this.config.documentMode === DocumentMode.string) {
-      return ` as unknown as TypedDocumentString<${resultType}, ${variablesTypes}>`;
+      return ` as unknown as TypedDocumentString<${
+        this.config.importOperationTypesFrom ? 'Types.' : ''
+      }${resultType}, ${this.config.importOperationTypesFrom ? 'Types.' : ''}${variablesTypes}>`;
     }
 
     return super.getDocumentNodeSignature(resultType, variablesTypes, node);

--- a/packages/plugins/typescript/typed-document-node/tests/typed-document-node.spec.ts
+++ b/packages/plugins/typescript/typed-document-node/tests/typed-document-node.spec.ts
@@ -77,4 +77,39 @@ describe('TypedDocumentNode', () => {
       expect((res.content.match(/__typename/g) || []).length).toBe(1);
     });
   });
+
+  describe('addTypenameToSelectionSets', () => {
+    it('Should import Types from the given file', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        schema {
+          query: Query
+        }
+
+        type Query {
+          job: Job
+        }
+
+        type Job {
+          id: ID!
+        }
+      `);
+
+      const ast = parse(/* GraphQL */ `
+        query {
+          job {
+            id
+          }
+        }
+      `);
+
+      const res = (await plugin(
+        schema,
+        [{ location: '', document: ast }],
+        { importOperationTypesFrom: 'file.ts' },
+        { outputFile: '' }
+      )) as Types.ComplexPluginOutput;
+
+      expect((res.content.match(/<Types.Query, Types.QueryVariables>/g) || []).length).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Allows importing the operation types from a different file, similar to other plugins. It allows this plugin to be used with the near-operation-file preset while maintaining a single location for operation types.

Related # 8340

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Added unit test
- [x] Used `yarn link` on my large enterprise project

**Test Environment**:

- OS: Mac 26.0.1
- NodeJS: 22.10.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
