### PR TITLE
fix(visitor-plugin-common): Escape special characters when emitting template literals

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -28,6 +28,8 @@ import { parseMapper } from './mappers.js';
 import { DEFAULT_SCALARS } from './scalars.js';
 import { NormalizedScalarsMap, ParsedScalarsMap, ScalarsMap, FragmentDirectives, LoadedFragment } from './types.js';
 
+export const asTemplateLiteral = str => '`' + str.replace(/[`\\]|[$][{]/g, '\\$&') + '`';
+
 export const getConfigValue = <T = any>(value: T, defaultValue: T): T => {
   if (value === null || value === undefined) {
     return defaultValue;


### PR DESCRIPTION
## Description

In ECMAScript template literals, ``` ` ``` and `\` and `$` are special and therefore need escaping in generation of source text like ``` new TypedDocumentString(`…`) ```, while still preserving literal `${…}` as appropriate for fragment references.

Related #10480

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Existing tests _seem_ to pass, although `yarn test` ends with an error for me even before application of these changes: <details>

```console
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Error: [vitest-pool]: Worker forks emitted error.
 ❯ EventEmitter.<anonymous> node_modules/vitest/dist/chunks/cli-api.BxbUFDR6.js:6866:22
 ❯ EventEmitter.emit node:events:519:28
 ❯ ChildProcess.emitUnexpectedExit node_modules/vitest/dist/chunks/cli-api.BxbUFDR6.js:6513:22
 ❯ ChildProcess.emit node:events:519:28
 ❯ Process.ChildProcess._handle.onexit node:internal/child_process:293:12

Caused by: Error: Worker exited unexpectedly
 ❯ ChildProcess.emitUnexpectedExit node_modules/vitest/dist/chunks/cli-api.BxbUFDR6.js:6512:33
 ❯ ChildProcess.emit node:events:519:28
 ❯ Process.ChildProcess._handle.onexit node:internal/child_process:293:12

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯


 Test Files  48 passed (49)
      Tests  759 passed | 4 skipped (764)
     Errors  1 error
   Start at  17:13:14
   Duration  31.49s (transform 13.16s, setup 334ms, collect 55.99s, tests 23.56s, environment 12ms, prepare 829ms)

error during close Error: [vitest-pool-runner]: Timeout waiting for worker to respond
    at Timeout.<anonymous> (file:///host/graphql-code-generator/node_modules/vitest/dist/chunks/cli-api.BxbUFDR6.js:6525:58)
    at listOnTimeout (node:internal/timers:588:17)
    at process.processTimers (node:internal/timers:523:7)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>

I'm unfamiliar with your test framework and would appreciate suggestions/guidance on how to cover the specific scenario of #10480.

**Test Environment**:

- Base: c87b779b9b400813d733fa89dcb16724b30c6d16
- NodeJS: v22.20.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules