### PR TITLE
fix(visitor-plugin-common): add parent interfaces to interface type

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -40,6 +40,7 @@ export interface ParsedConfig {
   importExtension: '' | `.${string}`;
   printFieldsOnNewLines: boolean;
   includeExternalFragments: boolean;
+  useImplementingTypes: boolean;
 }
 
 export interface RawConfig {

--- a/packages/plugins/typescript/typescript/src/config.ts
+++ b/packages/plugins/typescript/typescript/src/config.ts
@@ -412,31 +412,6 @@ export interface TypeScriptPluginConfig extends RawTypesConfig {
    */
   disableDescriptions?: boolean;
   /**
-   * @description When a GraphQL interface is used for a field, this flag will use the implementing types, instead of the interface itself.
-   * @default false
-   *
-   * @exampleMarkdown
-   * ## Override all definition types
-   *
-   * ```ts filename="codegen.ts"
-   * import type { CodegenConfig } from '@graphql-codegen/cli'
-   *
-   * const config: CodegenConfig = {
-   *   // ...
-   *   generates: {
-   *     'path/to/file.ts': {
-   *       plugins: ['typescript'],
-   *       config: {
-   *         useImplementingTypes: true
-   *       }
-   *     }
-   *   }
-   * }
-   * export default config
-   * ```
-   */
-  useImplementingTypes?: boolean;
-  /**
    * @name wrapEntireFieldDefinitions
    * @type boolean
    * @description Set to `true` in order to wrap field definitions with `EntireFieldWrapper`.

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -3950,6 +3950,31 @@ describe('TypeScript', () => {
     `);
   });
 
+  it('should list parent interface on an intermediate interface - issue #10515', async () => {
+    const testSchema = buildSchema(/* GraphQL */ `
+      interface TopLevel {
+        topLevelField: Boolean
+      }
+
+      interface MidLevel implements TopLevel {
+        topLevelField: Boolean
+        midLevelField: Int
+      }
+
+      type BottomLevel implements MidLevel & TopLevel {
+        topLevelField: Boolean
+        midLevelField: Int
+        bottomLevelField: String
+      }
+    `);
+
+    const output = (await plugin(testSchema, [], {} as any, { outputFile: 'graphql.ts' })) as Types.ComplexPluginOutput;
+
+    expect(output.content).toBeSimilarStringTo(`
+      type MidLevel = TopLevel & {
+    `);
+  });
+
   it('should use implementing types as node type - issue #5126', async () => {
     const testSchema = buildSchema(/* GraphQL */ `
       type Matrix {


### PR DESCRIPTION
Much like an `ObjectTypeDefinition`, an `InterfaceTypeDefinition` can also have parent interface types. With this change, the output reflects that.

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related #10515.

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] unit test is included. Also manually added `{ useImplementingTypes: true }` to the new unit test and it fails.


**Test Environment**:

- OS: OSX
- `@graphql-codegen/...`:
- NodeJS: 20

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Further comments

We have some downstream code that becomes unnecessarily complex because we don't have proper type chaining in the case of multiple levels of interfaces.