### PR TITLE
feat: add option to add `__typename` to interfaces

### DIFF
--- a/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-resolvers-visitor.ts
@@ -1071,7 +1071,9 @@ export class BaseResolversVisitor<
     relevantFields: ReturnType<typeof this.getRelevantFieldsToOmit>
   ): string {
     this._globalDeclarations.add(OMIT_TYPE);
-    return `Omit<${typeName}, ${relevantFields.map(f => `'${f.fieldName}'`).join(' | ')}> & { ${relevantFields
+    return `Omit<${typeName}, ${relevantFields
+      .map(f => `'${f.fieldName}'`)
+      .join(this.typeUnionOperator)}> & { ${relevantFields
       .map(f => `${f.fieldName}${f.addOptionalSign ? '?' : ''}: ${f.replaceWithType}`)
       .join(', ')} }`;
   }
@@ -1222,7 +1224,7 @@ export class BaseResolversVisitor<
         ? 'never'
         : members.length > 1
         ? `\n    | ${members.map(m => m.replace(/\n/g, '\n  ')).join('\n    | ')}\n  `
-        : members.join(' | ');
+        : members.join(this.typeUnionOperator);
     return result;
   }
 
@@ -1783,7 +1785,7 @@ export class BaseResolversVisitor<
 
   protected applyRequireFields(argsType: string, fields: InputValueDefinitionNode[]): string {
     this._globalDeclarations.add(REQUIRE_FIELDS_TYPE);
-    return `RequireFields<${argsType}, ${fields.map(f => `'${f.name.value}'`).join(' | ')}>`;
+    return `RequireFields<${argsType}, ${fields.map(f => `'${f.name.value}'`).join(this.typeUnionOperator)}>`;
   }
 
   protected applyOptionalFields(argsType: string, _fields: readonly InputValueDefinitionNode[]): string {
@@ -1875,7 +1877,7 @@ export class BaseResolversVisitor<
     const possibleTypes = originalNode.types
       .map(node => node.name.value)
       .map(f => `'${f}'`)
-      .join(' | ');
+      .join(this.typeUnionOperator);
 
     this._collectedResolvers[node.name.value] = {
       typename: name + '<ContextType>',
@@ -2039,7 +2041,7 @@ export class BaseResolversVisitor<
       typeName,
     });
 
-    const possibleTypes = implementingTypes.map(name => `'${name}'`).join(' | ') || 'null';
+    const possibleTypes = implementingTypes.map(name => `'${name}'`).join(this.typeUnionOperator) || 'null';
 
     // An Interface has __resolveType resolver, and no other fields.
     const blockFields: string[] = [

--- a/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts
@@ -28,6 +28,7 @@ export interface ParsedConfig {
   typesPrefix: string;
   typesSuffix: string;
   addTypename: boolean;
+  addTypenameToInterfaces: boolean;
   nonOptionalTypename: boolean;
   extractAllFieldsToTypes: boolean;
   externalFragments: LoadedFragment[];
@@ -284,6 +285,28 @@ export interface RawConfig {
    */
   skipTypename?: boolean;
   /**
+   * @description Similarly to the `addTypename` option, if true, a `__typename` field will be added to type definitions resulting from interface declarations.
+   *
+   * @exampleMarkdown
+   * ```ts filename="codegen.ts"
+   *  import type { CodegenConfig } from '@graphql-codegen/cli';
+   *
+   *  const config: CodegenConfig = {
+   *    // ...
+   *    generates: {
+   *      'path/to/file': {
+   *        // plugins...
+   *        config: {
+   *          addTypenameToInterfaces: true
+   *        },
+   *      },
+   *    },
+   *  };
+   *  export default config;
+   * ```
+   */
+  addTypenameToInterfaces?: boolean;
+  /**
    * @default false
    * @description Automatically adds `__typename` field to the generated types, even when they are not specified
    * in the selection set, and makes it non-optional
@@ -416,6 +439,7 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
       externalFragments: rawConfig.externalFragments || [],
       fragmentImports: rawConfig.fragmentImports || [],
       addTypename: !rawConfig.skipTypename,
+      addTypenameToInterfaces: !rawConfig.skipTypename && rawConfig.addTypenameToInterfaces,
       nonOptionalTypename: !!rawConfig.nonOptionalTypename,
       useTypeImports: !!rawConfig.useTypeImports,
       allowEnumStringTypes: !!rawConfig.allowEnumStringTypes,
@@ -449,6 +473,10 @@ export class BaseVisitor<TRawConfig extends RawConfig = RawConfig, TPluginConfig
 
   get config(): TPluginConfig {
     return this._parsedConfig;
+  }
+
+  get typeUnionOperator() {
+    return ' | ';
   }
 
   public convertName(node: ASTNode | string, options?: BaseVisitorConvertOptions & ConvertOptions): string {

--- a/packages/plugins/typescript/typescript/src/visitor.ts
+++ b/packages/plugins/typescript/typescript/src/visitor.ts
@@ -125,7 +125,7 @@ export class TsVisitor<
       }
 
       if (implementingTypes.length > 0) {
-        return implementingTypes.join(' | ');
+        return implementingTypes.join(this.typeUnionOperator);
       }
     }
 
@@ -255,7 +255,7 @@ export class TsVisitor<
     const possibleTypes = originalNode.types
       .map(t => (this.scalars[t.name.value] ? this._getScalar(t.name.value, 'output') : this.convertName(t)))
       .concat(...withFutureAddedValue)
-      .join(' | ');
+      .join(this.typeUnionOperator);
 
     return new DeclarationBlock(this._declarationBlockConfig)
       .export()

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -3950,6 +3950,37 @@ describe('TypeScript', () => {
     `);
   });
 
+  it('should union concrete type names in interface __typename field - issue #10522', async () => {
+    debugger;
+    const testSchema = buildSchema(/* GraphQL */ `
+      interface TopLevel {
+        topLevelField: Boolean
+      }
+
+      type OneImplementation implements TopLevel {
+        topLevelField: Boolean
+        implementationField: String
+      }
+
+      type AnotherImplementation implements TopLevel {
+        topLevelField: Boolean
+        anotherImplementationField: Int
+      }
+    `);
+    const output = await plugin(
+      testSchema,
+      [],
+      {
+        addTypenameToInterfaces: true,
+      },
+      { outputFile: 'graphql.ts' }
+    );
+
+    expect(output.content).toBeSimilarStringTo(`
+      __typename?: 'OneImplementation' | 'AnotherImplementation'
+    `);
+  });
+
   it('should use implementing types as node type - issue #5126', async () => {
     const testSchema = buildSchema(/* GraphQL */ `
       type Matrix {


### PR DESCRIPTION
The new option `addTypenameToInterfaces` adds the `__typename` field to types resulting from interfaces. The field admits a union of string values, each the name of one of the concrete types implementing the interface.

Also adds field `typeUnionOperator` to class `BaseVisitor` so we don't have the literal `' | '` in a bunch of places.

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This will allow us to treat incoming objects uniformly using their parent type, and will also allow us to type cast appropriately when the handling of the individual object begins to diverge based on their type.

Related #10522

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

A unit test is included. The remaining unit tests verify that no change occurs when the option is absent.

**Test Environment**:

- OS: OSX
- NodeJS: 20

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
