### PR TITLE
[typescript-operations] Add generatesOperationTypes config option

### DIFF
--- a/.changeset/proud-jobs-decide.md
+++ b/.changeset/proud-jobs-decide.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+'@graphql-codegen/typescript-operations': minor
+---
+
+Add generatesOperationTypes to typescript-operations to allow omitting operation types such as Variables, Query/Mutation/Subscription selection set, and Fragment types

--- a/packages/plugins/typescript/operations/src/index.ts
+++ b/packages/plugins/typescript/operations/src/index.ts
@@ -65,7 +65,7 @@ export const plugin: PluginFunction<TypeScriptDocumentsPluginConfig, Types.Compl
       ...visitor.getImports(),
       ...visitor.getEnumsImports(),
       ...visitor.getGlobalDeclarations(visitor.config.noExport),
-      'type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };',
+      visitor.getExactUtilityType(),
     ],
     content: content.join('\n'),
   };

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -254,4 +254,12 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
       useTypeImports: this.config.useTypeImports,
     });
   }
+
+  getExactUtilityType(): string | null {
+    if (!this.config.generatesOperationTypes) {
+      return null;
+    }
+
+    return 'type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };';
+  }
 }


### PR DESCRIPTION
## Description

This PR adds `generatesOperationTypes` config option (default `true` ) to let user chooses whether to generate types or not.

In some use cases such as `near-operation-files`, users may choose to import types from a shared file. `generatesOperationTypes` allows `typescript-operations` to generate said shared file.

This config option was original named `sharedTypesOnly` or `sharedSchemaTypesOnly` but it's easier to think about it from the lens of whether we want to generate something rather than the negation of that action.

Related https://github.com/dotansimha/graphql-code-generator/pull/10496

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit test
