### PR TITLE
Add `futureProofUnions` config to client preset

### DIFF
--- a/.changeset/fruity-comics-argue.md
+++ b/.changeset/fruity-comics-argue.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/client-preset': minor
+---
+
+The client preset now allows the use of the `futureProofUnions` config option

--- a/packages/presets/client/src/index.ts
+++ b/packages/presets/client/src/index.ts
@@ -134,6 +134,7 @@ export const preset: Types.OutputPreset<ClientPresetConfig> = {
       enumsAsConst: options.config.enumsAsConst,
       enumValues: options.config.enumValues,
       futureProofEnums: options.config.futureProofEnums,
+      futureProofUnions: options.config.futureProofUnions,
       nonOptionalTypename: options.config.nonOptionalTypename,
       avoidOptionals: options.config.avoidOptionals,
       documentMode: options.config.documentMode,

--- a/website/src/pages/plugins/presets/preset-client.mdx
+++ b/website/src/pages/plugins/presets/preset-client.mdx
@@ -56,6 +56,7 @@ The `client` preset allows the following `config` options:
 - [`enumsAsConst`](/plugins/typescript/typescript#enumsasconst): Generates enum as TypeScript const assertions instead of enum. This can even be used to enable enum-like patterns in plain JavaScript code if you choose not to use TypeScript’s enum construct.
 - [`enumValues`](/plugins/typescript/typescript#enumvalues): Overrides the default value of enum values declared in your GraphQL schema. You can also map the entire enum to an external type by providing a string that of module#type.
 - [`futureProofEnums`](/plugins/typescript/typescript#futureproofenums): Adds a catch-all entry to enum type definitions for values that may be added in the future.
+- [`futureProofUnions`](/plugins/typescript/typescript#futureproofunions): Adds a catch-all entry to union type definitions for values that may be added in the future.
 - [`nonOptionalTypename`](/plugins/typescript/typescript#nonoptionaltypename): Automatically adds `__typename` field to the generated types, even when they are not specified in the selection set, and makes it non-optional.
 - [`avoidOptionals`](/plugins/typescript/typescript#avoidoptionals): This will cause the generator to avoid using TypeScript optionals (`?`) on types.
 - [`documentMode`](#documentmode): Allows you to control how the documents are generated.


### PR DESCRIPTION
- Related to: #8562
- Related to: #9683

## Description

Hooks the `futureProofUnions` config option from the `typescript` plugin to the client preset, which was already done in #9683 for `futureProofEnums`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

The change was tested locally.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules