### PR TITLE
feat(cli): use `ESM` by default

### DIFF
--- a/.changeset/wacky-books-post.md
+++ b/.changeset/wacky-books-post.md
@@ -1,0 +1,14 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Use ESM for CLI instead of CJS;
+
+For backwards compatibility; `graphql-codegen-esm` is reserved, and also `graphql-codegen-cjs` is added for users who want to use CJS.
+
+So the commands are;
+- `graphql-codegen` - ESM version, default
+- `graphql-codegen-esm` - ESM version, same as above, but reserved for backwards compatibility
+- `graphql-codegen-cjs` - CJS version, for users who want to use CJS, but not recommended for new users. Will be removed in the future.
+- `gql-gen` - ESM version, same as `graphql-codegen`
+- `graphql-code-generator` - ESM version, same as `graphql-codegen` and `gql-gen`

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -20,7 +20,7 @@
     "gql-gen": "dist/esm/bin.js",
     "graphql-codegen": "dist/esm/bin.js",
     "graphql-code-generator": "dist/esm/bin.js",
-    "graphql-codegen-esm": "dist/cjs/bin.js",
+    "graphql-codegen-esm": "dist/esm/bin.js",
     "graphql-codegen-cjs": "dist/cjs/bin.js"
   },
   "main": "dist/cjs/index.js",

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -17,10 +17,11 @@
     "node": ">=16"
   },
   "bin": {
-    "gql-gen": "dist/cjs/bin.js",
-    "graphql-codegen": "dist/cjs/bin.js",
-    "graphql-code-generator": "dist/cjs/bin.js",
-    "graphql-codegen-esm": "dist/esm/bin.js"
+    "gql-gen": "dist/esm/bin.js",
+    "graphql-codegen": "dist/esm/bin.js",
+    "graphql-code-generator": "dist/esm/bin.js",
+    "graphql-codegen-esm": "dist/cjs/bin.js",
+    "graphql-codegen-cjs": "dist/cjs/bin.js"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Use ESM for CLI instead of CJS;

For backwards compatibility; `graphql-codegen-esm` is reserved, and also `graphql-codegen-cjs` is added for users who want to use CJS.

So the commands are;
- `graphql-codegen` - ESM version, default
- `graphql-codegen-esm` - ESM version, same as above, but reserved for backwards compatibility
- `graphql-codegen-cjs` - CJS version, for users who want to use CJS, but not recommended for new users. Will be removed in the future.
- `gql-gen` - ESM version, same as `graphql-codegen`
- `graphql-code-generator` - ESM version, same as `graphql-codegen` and `gql-gen`