### PR TITLE
Revert "fix(deps): update dependency ts-log to v3"

### DIFF
--- a/.changeset/@graphql-codegen_cli-10686-dependencies.md
+++ b/.changeset/@graphql-codegen_cli-10686-dependencies.md
@@ -1,5 +1,0 @@
----
-"@graphql-codegen/cli": patch
----
-dependencies updates:
-  - Updated dependency [`ts-log@^3.0.0` ↗︎](https://www.npmjs.com/package/ts-log/v/3.0.0) (from `^2.2.3`, in `dependencies`)

--- a/.changeset/@graphql-codegen_cli-10710-dependencies.md
+++ b/.changeset/@graphql-codegen_cli-10710-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/cli": patch
+---
+dependencies updates:
+  - Updated dependency [`ts-log@^2.2.3` ↗︎](https://www.npmjs.com/package/ts-log/v/2.2.3) (from `^3.0.0`, in `dependencies`)

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -104,7 +104,7 @@
     "micromatch": "^4.0.5",
     "shell-quote": "^1.7.3",
     "string-env-interpolation": "^1.0.1",
-    "ts-log": "^3.0.0",
+    "ts-log": "^2.2.3",
     "tslib": "^2.4.0",
     "yaml": "^2.3.1",
     "yargs": "^17.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14488,10 +14488,10 @@ ts-invariant@^0.10.3:
   dependencies:
     tslib "^2.1.0"
 
-ts-log@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-3.0.0.tgz#74a84ca54ebeea02d6a6d052d21a8c47889c119a"
-  integrity sha512-dOh2B+XwtPsIt+bOy0krUiGGO9fbqUCrR4nkNNir/EObVmEJYd4q6KkfF2Ni8/QG1Lji3JwX8TrTa7LHftPWsA==
+ts-log@^2.2.3:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.7.tgz#4f4512144898b77c9984e91587076fcb8518688e"
+  integrity sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==
 
 ts-node@10.9.2, ts-node@^10.9.1:
   version "10.9.2"


### PR DESCRIPTION
Reverts dotansimha/graphql-code-generator#10686

This is done in the next major release: https://github.com/dotansimha/graphql-code-generator/pull/10650