### PR TITLE
Revert "fix(deps): update dependency debounce to v3"

### DIFF
--- a/.changeset/@graphql-codegen_cli-10680-dependencies.md
+++ b/.changeset/@graphql-codegen_cli-10680-dependencies.md
@@ -1,5 +1,0 @@
----
-"@graphql-codegen/cli": patch
----
-dependencies updates:
-  - Updated dependency [`debounce@^3.0.0` ↗︎](https://www.npmjs.com/package/debounce/v/3.0.0) (from `^2.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_cli-10712-dependencies.md
+++ b/.changeset/@graphql-codegen_cli-10712-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/cli": patch
+---
+dependencies updates:
+  - Updated dependency [`debounce@^2.0.0` ↗︎](https://www.npmjs.com/package/debounce/v/2.0.0) (from `^3.0.0`, in `dependencies`)

--- a/packages/graphql-codegen-cli/package.json
+++ b/packages/graphql-codegen-cli/package.json
@@ -93,7 +93,7 @@
     "@whatwg-node/fetch": "^0.10.0",
     "chalk": "^4.1.0",
     "cosmiconfig": "^9.0.0",
-    "debounce": "^3.0.0",
+    "debounce": "^2.0.0",
     "detect-indent": "^6.0.0",
     "graphql-config": "^5.1.6",
     "is-glob": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7303,10 +7303,10 @@ debounce@^1.2.1:
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
-debounce@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-3.0.0.tgz#7633adff3bcd92cdfe13370c2f46e87bdb946a1b"
-  integrity sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==
+debounce@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-2.2.0.tgz#f895fa2fbdb579a0f0d3dcf5dde19657e50eaad5"
+  integrity sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==
 
 debug@2.6.9:
   version "2.6.9"


### PR DESCRIPTION
Reverts dotansimha/graphql-code-generator#10680

This is done in the next major release: https://github.com/dotansimha/graphql-code-generator/pull/10650