### PR TITLE
Remove revert changesets

### DIFF
--- a/.changeset/@graphql-codegen_cli-10707-dependencies.md
+++ b/.changeset/@graphql-codegen_cli-10707-dependencies.md
@@ -1,5 +1,0 @@
----
-"@graphql-codegen/cli": patch
----
-dependencies updates:
-  - Updated dependency [`yargs@^17.0.0` ↗︎](https://www.npmjs.com/package/yargs/v/17.0.0) (from `^18.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_cli-10708-dependencies.md
+++ b/.changeset/@graphql-codegen_cli-10708-dependencies.md
@@ -1,5 +1,0 @@
----
-"@graphql-codegen/cli": patch
----
-dependencies updates:
-  - Updated dependency [`listr2@^9.0.0` ↗︎](https://www.npmjs.com/package/listr2/v/9.0.0) (from `^10.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_cli-10710-dependencies.md
+++ b/.changeset/@graphql-codegen_cli-10710-dependencies.md
@@ -1,5 +1,0 @@
----
-"@graphql-codegen/cli": patch
----
-dependencies updates:
-  - Updated dependency [`ts-log@^2.2.3` ↗︎](https://www.npmjs.com/package/ts-log/v/2.2.3) (from `^3.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_cli-10712-dependencies.md
+++ b/.changeset/@graphql-codegen_cli-10712-dependencies.md
@@ -1,5 +1,0 @@
----
-"@graphql-codegen/cli": patch
----
-dependencies updates:
-  - Updated dependency [`debounce@^2.0.0` ↗︎](https://www.npmjs.com/package/debounce/v/2.0.0) (from `^3.0.0`, in `dependencies`)


### PR DESCRIPTION
These changesets were created automatically by revert PRs:

- https://github.com/dotansimha/graphql-code-generator/pull/10712
- https://github.com/dotansimha/graphql-code-generator/pull/10710
- https://github.com/dotansimha/graphql-code-generator/pull/10708
- https://github.com/dotansimha/graphql-code-generator/pull/10707

We don't need these, since they create a misleading CHANGELOG message: saying these versions were reverted, but they were never bumped in the first place (because the release PR wasn't merged)