### PR TITLE
Deduplicate external fragments in typescript-operations

### DIFF
--- a/packages/plugins/typescript/operations/src/index.ts
+++ b/packages/plugins/typescript/operations/src/index.ts
@@ -57,6 +57,7 @@ export const plugin: PluginFunction<
   // For Fragment types to resolve correctly, we must get read all docs (`standard` and `external`)
   // Fragment types are usually (but not always) in `external` files in certain setup, like a monorepo.
   const allDocumentsAST = concatAST(parsedDocuments.all.documentNodes);
+  const fragmentNames = new Set<string>();
   const allFragments: LoadedFragment[] = [
     ...(
       allDocumentsAST.definitions.filter(
@@ -69,7 +70,14 @@ export const plugin: PluginFunction<
       isExternal: false,
     })),
     ...(config.externalFragments || []),
-  ];
+  ].filter(fragment => {
+    if (fragmentNames.has(fragment.name)) {
+      return false;
+    }
+
+    fragmentNames.add(fragment.name);
+    return true;
+  });
 
   const visitor = new TypeScriptDocumentsVisitor(schema, config, allFragments);
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.externalFragments.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.externalFragments.spec.ts
@@ -1,0 +1,79 @@
+import { buildSchema, parse } from 'graphql';
+import { beforeEach, vi } from 'vitest';
+
+const { visitorSpy } = vi.hoisted(() => ({
+  visitorSpy: [] as unknown[][],
+}));
+
+vi.mock('../src/visitor.js', () => ({
+  TypeScriptDocumentsVisitor: class MockTypeScriptDocumentsVisitor {
+    config = { noExport: false };
+
+    constructor(...args: unknown[]) {
+      visitorSpy.push(args);
+    }
+
+    getImports() {
+      return [];
+    }
+
+    getGlobalDeclarations() {
+      return [];
+    }
+  },
+}));
+
+describe('TypeScript Operations Plugin - externalFragments', () => {
+  beforeEach(() => {
+    visitorSpy.length = 0;
+  });
+
+  it('dedupes repeated external fragments before visiting documents', async () => {
+    const { plugin } = await import('../src/index.js');
+
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        user: User
+      }
+
+      type User {
+        id: ID!
+        name: String!
+      }
+    `);
+
+    const query = parse(/* GraphQL */ `
+      query User {
+        user {
+          ...UserFragment
+        }
+      }
+    `);
+
+    const externalFragment = {
+      node: parse(/* GraphQL */ `
+        fragment UserFragment on User {
+          id
+          name
+        }
+      `).definitions[0],
+      name: 'UserFragment',
+      onType: 'User',
+      isExternal: true,
+    };
+
+    await plugin(
+      schema,
+      [{ location: '', document: query }],
+      {
+        externalFragments: [externalFragment, externalFragment],
+      },
+      { outputFile: '' },
+    );
+
+    const fragments = visitorSpy[0][2];
+
+    expect(fragments).toHaveLength(1);
+    expect(fragments[0].name).toBe('UserFragment');
+  });
+});


### PR DESCRIPTION
This deduplicates `externalFragments` by name in `@graphql-codegen/typescript-operations` before they are passed to `TypeScriptDocumentsVisitor`.

Why:
- `near-operation-file` can supply repeated nested `externalFragments`
- `typescript-operations` currently forwards them as-is
- this can cause severe blow-ups when repeated fragment spreads are nested

This is related to dotansimha/graphql-code-generator-community#752.

Validation:
- added a regression test that asserts repeated `externalFragments` are deduped before visiting documents
- `yarn workspace @graphql-codegen/typescript-operations vitest run tests/ts-documents.externalFragments.spec.ts tests/ts-documents.externalDocuments.spec.ts`

Local benchmark from a downstream repo using `near-operation-file` + `typescript-operations`:
- before: ~248s
- after dedupe: ~2s
