### PR TITLE
Remove alpha version notes in migration posts

### DIFF
--- a/website/src/pages/docs/migration/apollo-tooling.mdx
+++ b/website/src/pages/docs/migration/apollo-tooling.mdx
@@ -16,11 +16,6 @@ This guide explains how to replace it with
 [GraphQL Code Generator](https://the-guild.dev/graphql/codegen), which is actively maintained, more
 flexible, and supports a broader range of use cases.
 
-<Callout>
-  This setup is available in the next major version of `graphql-code-generator` and
-  `graphql-code-generator-community`.
-</Callout>
-
 ## Installation
 
 Remove Apollo Tooling and install GraphQL Code Generator:

--- a/website/src/pages/docs/migration/operations-and-client-preset-from-5-0.mdx
+++ b/website/src/pages/docs/migration/operations-and-client-preset-from-5-0.mdx
@@ -16,11 +16,6 @@ import { Callout } from '@theguild/components'
 
 # Migrating to `typescript-operations` and `client-preset` v6.0
 
-<Callout type="default">
-  This major version has not been released yet. You can find upcoming changes and alpha releases in
-  the [feature branch](https://github.com/dotansimha/graphql-code-generator/pull/10496).
-</Callout>
-
 ## What's new?
 
 `typescript-operations` and `client-preset` v6.0 come with a major overhaul of type generation and

--- a/website/src/pages/docs/migration/operations-and-client-preset-from-5-0.mdx
+++ b/website/src/pages/docs/migration/operations-and-client-preset-from-5-0.mdx
@@ -27,7 +27,8 @@ config to improve developer experience.
 
 For the most important changes, read the [Breaking changes](#breaking-changes) section.
 
-For a full list of changes, see the CHANGELOG.
+For a full list of changes, see the
+[release notes](https://github.com/dotansimha/graphql-code-generator/releases/tag/release-1777556900878).
 
 ## Installation
 


### PR DESCRIPTION
## Description

This PR removes notice about alpha versions in blog posts.
Released here: https://github.com/dotansimha/graphql-code-generator/releases/tag/release-1777556900878
