### PR TITLE
Fix `const` enum type prefix/suffix misconfiguration

### DIFF
--- a/.changeset/sunny-shoes-glow.md
+++ b/.changeset/sunny-shoes-glow.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-operations': patch
+---
+
+Fix `const` enum applying `typesPrefix` and `typesSuffix` incorrectly

--- a/packages/plugins/other/visitor-plugin-common/src/convert-schema-enum-to-declaration-block-string.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/convert-schema-enum-to-declaration-block-string.ts
@@ -136,7 +136,7 @@ export const convertSchemaEnumToDeclarationBlockString = ({
               convertName({
                 options: {
                   typesPrefix: naming.options.typesPrefix,
-                  typesSuffix: naming.options.typesPrefix,
+                  typesSuffix: naming.options.typesSuffix,
                 },
                 convert: () =>
                   naming.convert(enumOption, {

--- a/packages/plugins/typescript/operations/tests/ts-documents.standalone.enum.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.standalone.enum.spec.ts
@@ -164,6 +164,72 @@ describe('TypeScript Operations Plugin - Enum', () => {
     validateTs(result, undefined, undefined, undefined, undefined, true);
   });
 
+  it('handles `const` enum with prefix and suffix', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        me: User
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        role: UserRole!
+        createdAt: DateTime!
+      }
+
+      enum UserRole {
+        A_B_C
+        X_Y_Z
+        _TEST
+        My_Value
+        _123
+      }
+
+      scalar DateTime
+    `);
+    const document = parse(/* GraphQL */ `
+      query Me($role: UserRole!) {
+        me {
+          id
+        }
+      }
+    `);
+
+    const result = mergeOutputs([
+      await plugin(
+        schema,
+        [{ document }],
+        { enumType: 'const', typesPrefix: 'AA_', typesSuffix: '_ZZ' },
+        { outputFile: '' },
+      ),
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      "/** Internal type. DO NOT USE DIRECTLY. */
+      type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+      /** Internal type. DO NOT USE DIRECTLY. */
+      export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+      export const AA_UserRole_ZZ = {
+        AA_ABC_ZZ: 'A_B_C',
+        AA_XYZ_ZZ: 'X_Y_Z',
+        AA_Test_ZZ: '_TEST',
+        AA_MyValue_ZZ: 'My_Value',
+        AA_123_ZZ: '_123'
+      } as const;
+
+      export type AA_UserRole_ZZ = typeof AA_UserRole_ZZ[keyof typeof AA_UserRole_ZZ];
+      export type AA_MeQueryVariables_ZZ = Exact<{
+        role: AA_UserRole_ZZ;
+      }>;
+
+
+      export type AA_MeQuery_ZZ = { me: { id: string } | null };
+      "
+    `);
+
+    validateTs(result, undefined, undefined, undefined, undefined, true);
+  });
+
   it('handles `native-const` enum', async () => {
     const schema = buildSchema(/* GraphQL */ `
       type Query {

--- a/packages/plugins/typescript/operations/tests/ts-documents.standalone.enum.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.standalone.enum.spec.ts
@@ -49,7 +49,7 @@ describe('TypeScript Operations Plugin - Enum', () => {
     validateTs(result, undefined, undefined, undefined, undefined, true);
   });
 
-  it('handles `native-numeric`', async () => {
+  it('handles `native-numeric` enum', async () => {
     const schema = buildSchema(/* GraphQL */ `
       type Query {
         me: User

--- a/packages/plugins/typescript/operations/tests/ts-documents.standalone.enum.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.standalone.enum.spec.ts
@@ -49,7 +49,7 @@ describe('TypeScript Operations Plugin - Enum', () => {
     validateTs(result, undefined, undefined, undefined, undefined, true);
   });
 
-  it('handles `native-numeric` enum', async () => {
+  it('handles `native-numeric`', async () => {
     const schema = buildSchema(/* GraphQL */ `
       type Query {
         me: User
@@ -97,6 +97,65 @@ describe('TypeScript Operations Plugin - Enum', () => {
 
 
       export type MeQuery = { me: { id: string } | null };
+      "
+    `);
+
+    validateTs(result, undefined, undefined, undefined, undefined, true);
+  });
+
+  it('handles `native-numeric` enum with types prefix and suffix', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        me: User
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        role: UserRole!
+        createdAt: DateTime!
+      }
+
+      enum UserRole {
+        ADMIN
+        CUSTOMER
+      }
+
+      scalar DateTime
+    `);
+    const document = parse(/* GraphQL */ `
+      query Me($role: UserRole!) {
+        me {
+          id
+        }
+      }
+    `);
+
+    const result = mergeOutputs([
+      await plugin(
+        schema,
+        [{ document }],
+        { enumType: 'native-numeric', typesPrefix: 'AA_', typesSuffix: '_ZZ' },
+        { outputFile: '' },
+      ),
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      "/** Internal type. DO NOT USE DIRECTLY. */
+      type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+      /** Internal type. DO NOT USE DIRECTLY. */
+      export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+      export enum AA_UserRole_ZZ {
+        Admin_ZZ = 0,
+        Customer_ZZ = 1
+      }
+
+      export type AA_MeQueryVariables_ZZ = Exact<{
+        role: AA_UserRole_ZZ;
+      }>;
+
+
+      export type AA_MeQuery_ZZ = { me: { id: string } | null };
       "
     `);
 
@@ -164,7 +223,7 @@ describe('TypeScript Operations Plugin - Enum', () => {
     validateTs(result, undefined, undefined, undefined, undefined, true);
   });
 
-  it('handles `const` enum with prefix and suffix', async () => {
+  it('handles `const` enum with types prefix and suffix', async () => {
     const schema = buildSchema(/* GraphQL */ `
       type Query {
         me: User


### PR DESCRIPTION
## Description

This is a bug that happened during the refactoring enum prefix/suffix when `typesPrefix` and `typesSuffix` is used with `enumType=const` specifically. In this case, `typesPrefix` is accidentally used in the `typesSuffix` slot. 

This PR fixes the issue and add tests for relevant cases.

Related https://github.com/dotansimha/graphql-code-generator/issues/10776

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)