### PR TITLE
[typescript-operations] Fix `config.scalars` not able to override native scalars like ID, Int, etc.

### DIFF
--- a/.changeset/blue-lines-behave.md
+++ b/.changeset/blue-lines-behave.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-operations': patch
+---
+
+Fix `typescript-operations` incosistent scalar overrides for native scalars

--- a/packages/plugins/typescript/operations/src/visitor.ts
+++ b/packages/plugins/typescript/operations/src/visitor.ts
@@ -573,8 +573,8 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
         type: 'GraphQLScalarType',
         node,
         tsType:
-          (DEFAULT_INPUT_SCALARS[node.name]?.input ||
-            this.config.scalars?.[node.name]?.input.type) ??
+          this.config.scalars?.[node.name]?.input.type ??
+          DEFAULT_INPUT_SCALARS[node.name]?.input ??
           'unknown',
         useCases: {
           variables: location === 'variables',

--- a/packages/plugins/typescript/operations/tests/ts-documents.standalone.scalars.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.standalone.scalars.spec.ts
@@ -289,6 +289,89 @@ describe('TypeScript Operations Plugin - Default Scalar types', () => {
 });
 
 describe('TypeScript Operations Plugin - Custom Scalars', () => {
+  it('uses custom inline scalars for Input, Variables and Result', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        user(input: UserInput!): User
+      }
+
+      input UserInput {
+        id: ID!
+        age: Int!
+        createdAt: DateTime!
+        metadata: JSON!
+      }
+
+      type User {
+        id: ID!
+        age: Int!
+        createdAt: DateTime!
+        metadata: JSON!
+      }
+
+      scalar DateTime
+      scalar JSON
+    `);
+    const document = parse(/* GraphQL */ `
+      query User(
+        $input: UserInput!
+        $id: ID!
+        $age: Int!
+        $createdAt: DateTime!
+        $metadata: JSON!
+      ) {
+        user(input: $input) {
+          id
+          age
+          createdAt
+          metadata
+        }
+      }
+    `);
+
+    const result = mergeOutputs([
+      await plugin(
+        schema,
+        [{ document }],
+        {
+          scalars: {
+            ID: 'string',
+            Int: 'bigint',
+            DateTime: 'Date',
+          },
+        },
+        { outputFile: '' },
+      ),
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      "/** Internal type. DO NOT USE DIRECTLY. */
+      type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+      /** Internal type. DO NOT USE DIRECTLY. */
+      export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+      export type UserInput = {
+        id: string;
+        age: bigint;
+        createdAt: Date;
+        metadata: unknown;
+      };
+
+      export type UserQueryVariables = Exact<{
+        input: UserInput;
+        id: string;
+        age: bigint;
+        createdAt: Date;
+        metadata: unknown;
+      }>;
+
+
+      export type UserQuery = { user: { id: string, age: bigint, createdAt: Date, metadata: unknown } | null };
+      "
+    `);
+
+    validateTs(result, undefined, undefined, undefined, undefined, true);
+  });
+
   it('imports external custom scalar correctly when used in Result SelectionSet', async () => {
     const schema = buildSchema(/* GraphQL */ `
       type Query {


### PR DESCRIPTION
## Description

This PR fixes the ordering of scalar override logic for `typescript-operations`.

Reported on GraphQL Discord: https://discord.com/channels/625400653321076807/1501240654670467162/1501261694029004910

Related https://github.com/dotansimha/graphql-code-generator/issues/10785

---

Previously, the order is this:

1. use the default scalar type, if available
2. otherwise, use the type provided in user config, if available
3. otherwise, fall back to the default value

Now, the order of 1. and 2. is swapped (this is also the order in `typescript` plugin):

1. use the type provided in user config, if available
2. otherwise, use the default scalar type, if available
3. otherwise, fall back to the default value


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test
