### PR TITLE
CODEGEN-907 [typescript-resolvers] Fix Federation types not apply prefix and suffix

### DIFF
--- a/.changeset/tangy-terms-dance.md
+++ b/.changeset/tangy-terms-dance.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/typescript-resolvers': patch
+'@graphql-codegen/plugin-helpers': patch
+---
+
+Fix FederationTypes not having typesPrefix and typesSuffix applied

--- a/packages/plugins/typescript/resolvers/src/index.ts
+++ b/packages/plugins/typescript/resolvers/src/index.ts
@@ -6,7 +6,12 @@ import {
   PluginFunction,
   Types,
 } from '@graphql-codegen/plugin-helpers';
-import { parseMapper, type RootResolver } from '@graphql-codegen/visitor-plugin-common';
+import {
+  convertFactory,
+  convertName as convertNameUtil,
+  parseMapper,
+  type RootResolver,
+} from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptResolversPluginConfig } from './config.js';
 import { TypeScriptResolversVisitor } from './visitor.js';
 
@@ -88,7 +93,19 @@ export type Resolver${capitalizedDirectiveName}WithResolve<TResult, TParent, TCo
   }
 
   let { transformedSchema, federationMeta } = config.federation
-    ? addFederationReferencesToSchema(schema)
+    ? (() => {
+        const baseConvert = convertFactory(config);
+        return addFederationReferencesToSchema(schema, {
+          convertName: name =>
+            convertNameUtil({
+              convert: () => baseConvert(name),
+              options: {
+                typesPrefix: config.typesPrefix || '',
+                typesSuffix: config.typesSuffix || '',
+              },
+            }),
+        });
+      })()
     : { transformedSchema: schema, federationMeta: {} };
 
   transformedSchema = config.customDirectives?.semanticNonNull

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
@@ -1009,3 +1009,177 @@ describe('TypeScript Resolvers Plugin & Federation - meta', () => {
       `);
   });
 });
+
+describe('TypeScript Resolvers Plugin & Federation - config', () => {
+  it('generates FederationTypes with correct typesPrefix and typesSuffix applied', async () => {
+    const federatedSchema = /* GraphQL */ `
+      scalar _FieldSet
+      directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+
+      type Query {
+        all: [Person]
+      }
+
+      interface Person @key(fields: "id") {
+        id: ID!
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        name: String
+      }
+    `;
+
+    const result = await plugin(
+      buildSchema(federatedSchema),
+      [],
+      { federation: true, typesPrefix: '$', typesSuffix: '__' },
+      { outputFile: '' },
+    );
+
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+
+      export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+      export type ReferenceResolver<TResult, TReference, TContext> = (
+            reference: TReference,
+            context: TContext,
+            info: GraphQLResolveInfo
+          ) => Promise<TResult> | TResult;
+
+            type ScalarCheck<T, S> = S extends true ? T : NullableCheck<T, S>;
+            type NullableCheck<T, S> = Maybe<T> extends T ? Maybe<ListCheck<NonNullable<T>, S>> : ListCheck<T, S>;
+            type ListCheck<T, S> = T extends (infer U)[] ? NullableCheck<U, S>[] : GraphQLRecursivePick<T, S>;
+            export type GraphQLRecursivePick<T, S> = { [K in keyof T & keyof S]: ScalarCheck<T[K], S[K]> };
+          
+
+      export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+        resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+      };
+      export type Resolver<TResult, TParent = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>, TArgs = Record<PropertyKey, never>> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+      export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+        parent: TParent,
+        args: TArgs,
+        context: TContext,
+        info: GraphQLResolveInfo
+      ) => Promise<TResult> | TResult;
+
+      export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+        parent: TParent,
+        args: TArgs,
+        context: TContext,
+        info: GraphQLResolveInfo
+      ) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+      export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+        parent: TParent,
+        args: TArgs,
+        context: TContext,
+        info: GraphQLResolveInfo
+      ) => TResult | Promise<TResult>;
+
+      export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+        subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+        resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+      }
+
+      export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+        subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+        resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+      }
+
+      export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+        | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+        | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+      export type SubscriptionResolver<TResult, TKey extends string, TParent = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>, TArgs = Record<PropertyKey, never>> =
+        | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+        | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+      export type TypeResolveFn<TTypes, TParent = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>> = (
+        parent: TParent,
+        context: TContext,
+        info: GraphQLResolveInfo
+      ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+      export type IsTypeOfResolverFn<T = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+
+      export type NextResolverFn<T> = () => Promise<T>;
+
+      export type DirectiveResolverFn<TResult = Record<PropertyKey, never>, TParent = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>, TArgs = Record<PropertyKey, never>> = (
+        next: NextResolverFn<TResult>,
+        parent: TParent,
+        args: TArgs,
+        context: TContext,
+        info: GraphQLResolveInfo
+      ) => TResult | Promise<TResult>;
+
+      /** Mapping of federation types */
+      export type $FederationTypes__ = {
+        Person: $Person__;
+        User: $User__;
+      };
+
+      /** Mapping of federation reference types */
+      export type $FederationReferenceTypes__ = {
+        Person:
+          ( { __typename: 'Person' }
+          & GraphQLRecursivePick<$FederationTypes__['Person'], {"id":true}> );
+        User:
+          ( { __typename: 'User' }
+          & GraphQLRecursivePick<$FederationTypes__['User'], {"id":true}> );
+      };
+
+
+      /** Mapping of interface types */
+      export type $ResolversInterfaceTypes__<_RefType extends Record<string, unknown>> = {
+        Person: never;
+      };
+
+      /** Mapping between all available schema types and the resolvers types */
+      export type $ResolversTypes__ = {
+        Query: ResolverTypeWrapper<Record<PropertyKey, never>>;
+        Person: ResolverTypeWrapper<$ResolversInterfaceTypes__<$ResolversTypes__>['Person']>;
+        ID: ResolverTypeWrapper<Scalars['ID']['output']>;
+        User: ResolverTypeWrapper<$User__>;
+        String: ResolverTypeWrapper<Scalars['String']['output']>;
+        Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+      };
+
+      /** Mapping between all available schema types and the resolvers parents */
+      export type $ResolversParentTypes__ = {
+        Query: Record<PropertyKey, never>;
+        Person: $ResolversInterfaceTypes__<$ResolversParentTypes__>['Person'];
+        ID: Scalars['ID']['output'];
+        User: $User__ | $FederationReferenceTypes__['User'];
+        String: Scalars['String']['output'];
+        Boolean: Scalars['Boolean']['output'];
+      };
+
+      export type $QueryResolvers__<ContextType = any, ParentType extends $ResolversParentTypes__['Query'] = $ResolversParentTypes__['Query']> = {
+        all?: Resolver<Maybe<Array<Maybe<$ResolversTypes__['Person']>>>, ParentType, ContextType>;
+      };
+
+      export type $PersonResolvers__<ContextType = any, ParentType extends $ResolversParentTypes__['Person'] = $ResolversParentTypes__['Person'], FederationReferenceType extends $FederationReferenceTypes__['Person'] = $FederationReferenceTypes__['Person']> = {
+        __resolveType: TypeResolveFn<null, ParentType, ContextType>;
+        __resolveReference?: ReferenceResolver<Maybe<$ResolversTypes__['Person']> | FederationReferenceType, FederationReferenceType, ContextType>;
+      };
+
+      export type $UserResolvers__<ContextType = any, ParentType extends $ResolversParentTypes__['User'] = $ResolversParentTypes__['User'], FederationReferenceType extends $FederationReferenceTypes__['User'] = $FederationReferenceTypes__['User']> = {
+        __resolveReference?: ReferenceResolver<Maybe<$ResolversTypes__['User']> | FederationReferenceType, FederationReferenceType, ContextType>;
+        id?: Resolver<$ResolversTypes__['ID'], ParentType, ContextType>;
+        name?: Resolver<Maybe<$ResolversTypes__['String']>, ParentType, ContextType>;
+      };
+
+      export type $Resolvers__<ContextType = any> = {
+        Query?: $QueryResolvers__<ContextType>;
+        Person?: $PersonResolvers__<ContextType>;
+        User?: $UserResolvers__<ContextType>;
+      };
+
+      "
+    `);
+  });
+});

--- a/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
+++ b/packages/plugins/typescript/resolvers/tests/ts-resolvers.federation.spec.ts
@@ -23,7 +23,7 @@ function generate({ schema, config }: { schema: string; config: TypeScriptResolv
   });
 }
 
-describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
+describe('TypeScript Resolvers Plugin & Federation', () => {
   it('generates __resolveReference for object types with resolvable @key', async () => {
     const federatedSchema = /* GraphQL */ `
       type Query {
@@ -879,76 +879,77 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
     // no GraphQLScalarType
     expect(content).not.toContain('GraphQLScalarType');
   });
+});
 
-  describe('meta', () => {
-    it('generates federation meta correctly', async () => {
-      const federatedSchema = /* GraphQL */ `
-        scalar _FieldSet
-        directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+describe('TypeScript Resolvers Plugin & Federation - meta', () => {
+  it('generates federation meta correctly', async () => {
+    const federatedSchema = /* GraphQL */ `
+      scalar _FieldSet
+      directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
 
-        type Query {
-          user: UserPayload!
-          allUsers: [User]
-        }
+      type Query {
+        user: UserPayload!
+        allUsers: [User]
+      }
 
-        type User @key(fields: "id") {
-          id: ID!
-          name: String
-          username: String
-        }
+      type User @key(fields: "id") {
+        id: ID!
+        name: String
+        username: String
+      }
 
-        interface Node {
-          id: ID!
-        }
+      interface Node {
+        id: ID!
+      }
 
-        type UserOk {
-          id: ID!
-        }
-        type UserError {
-          message: String!
-        }
-        union UserPayload = UserOk | UserError
+      type UserOk {
+        id: ID!
+      }
+      type UserError {
+        message: String!
+      }
+      union UserPayload = UserOk | UserError
 
-        enum Country {
-          FR
-          US
-        }
+      enum Country {
+        FR
+        US
+      }
 
-        type NotResolvable @key(fields: "id", resolvable: false) {
-          id: ID!
-        }
+      type NotResolvable @key(fields: "id", resolvable: false) {
+        id: ID!
+      }
 
-        type Resolvable @key(fields: "id", resolvable: true) {
-          id: ID!
-        }
+      type Resolvable @key(fields: "id", resolvable: true) {
+        id: ID!
+      }
 
-        type MultipleResolvable
-          @key(fields: "id")
-          @key(fields: "id2", resolvable: true)
-          @key(fields: "id3", resolvable: false) {
-          id: ID!
-          id2: ID!
-          id3: ID!
-        }
+      type MultipleResolvable
+        @key(fields: "id")
+        @key(fields: "id2", resolvable: true)
+        @key(fields: "id3", resolvable: false) {
+        id: ID!
+        id2: ID!
+        id3: ID!
+      }
 
-        type MultipleNonResolvable
-          @key(fields: "id", resolvable: false)
-          @key(fields: "id2", resolvable: false)
-          @key(fields: "id3", resolvable: false) {
-          id: ID!
-          id2: ID!
-          id3: ID!
-        }
-      `;
+      type MultipleNonResolvable
+        @key(fields: "id", resolvable: false)
+        @key(fields: "id2", resolvable: false)
+        @key(fields: "id3", resolvable: false) {
+        id: ID!
+        id2: ID!
+        id3: ID!
+      }
+    `;
 
-      const result = await plugin(
-        buildSchema(federatedSchema),
-        [],
-        { federation: true },
-        { outputFile: '' },
-      );
+    const result = await plugin(
+      buildSchema(federatedSchema),
+      [],
+      { federation: true },
+      { outputFile: '' },
+    );
 
-      expect(result.meta?.generatedResolverTypes).toMatchInlineSnapshot(`
+    expect(result.meta?.generatedResolverTypes).toMatchInlineSnapshot(`
         {
           "resolversMap": {
             "name": "Resolvers",
@@ -1006,6 +1007,5 @@ describe('TypeScript Resolvers Plugin + Apollo Federation', () => {
           },
         }
       `);
-    });
   });
 });

--- a/packages/utils/plugins-helpers/src/federation.ts
+++ b/packages/utils/plugins-helpers/src/federation.ts
@@ -79,7 +79,12 @@ export type FederationMeta = { [typeName: string]: TypeMeta };
  * - return type
  * @param schema
  */
-export function addFederationReferencesToSchema(schema: GraphQLSchema): {
+export function addFederationReferencesToSchema(
+  schema: GraphQLSchema,
+  config: {
+    convertName: (type: string) => string;
+  },
+): {
   transformedSchema: GraphQLSchema;
   federationMeta: FederationMeta;
 } {
@@ -275,7 +280,7 @@ export function addFederationReferencesToSchema(schema: GraphQLSchema): {
 
         const referenceSelectionSetsString = printReferenceSelectionSets({
           typeName: type.name,
-          baseFederationType: `FederationTypes['${type.name}']`, // FIXME: run convertName on FederationTypes
+          baseFederationType: `${config.convertName('FederationTypes')}['${type.name}']`,
           referenceSelectionSets,
         });
 
@@ -315,7 +320,7 @@ export function addFederationReferencesToSchema(schema: GraphQLSchema): {
 
         const referenceSelectionSetsString = printReferenceSelectionSets({
           typeName: type.name,
-          baseFederationType: `FederationTypes['${type.name}']`, // FIXME: run convertName on FederationTypes
+          baseFederationType: `${config.convertName('FederationTypes')}['${type.name}']`,
           referenceSelectionSets,
         });
 


### PR DESCRIPTION
## Description

Previously, `FederationTypes` did not apply `typesPrefix` and `typesSuffix` correctly, mostly due to where the generation of this type happens (outside of the Visitor). 

Now, copy the `convertName` functionality for the federation type generation as well. Note that we are still duplicating the `convertName` functionality in two places, meaning the logic may drift in the future. However, convert logic hasn't changed for awhile, so we can do this to fix the issue, and think about the ideal state later.

Related https://github.com/dotansimha/graphql-code-generator/issues/10587

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] Unit test

