### PR TITLE
Fix CI, release-stable step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
     with:
       nodeVersion: 24
       packageManager: pnpm
-      buildScript: build
       releaseScript: release
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

We are getting errors: https://github.com/dotansimha/graphql-code-generator/actions/runs/26510692106
This is because `buildScript` is not a valid input. This is because when `release` is used, it triggers `prerelease` which  calls `build`