### PR TITLE
Fix CI, release-stable step (2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,7 @@ jobs:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
 
   release-stable:
-    if:
-      github.event_name == 'push' && github.event.pull_request.head.repo.full_name ==
-      github.repository
+    if: github.event_name == 'push'
     uses: the-guild-org/shared-config/.github/workflows/release-stable.yml@f4eea983237a44bb0ca19c3348dacbfdfcdbec23 # main
     permissions:
       id-token: write # allows OIDC publishing


### PR DESCRIPTION
## Description

Currently `release-stable` is always skipped because `github.event.pull_request.head.repo.full_name` is not available on pushes to `master`. This removes this problematic condition