### PR TITLE
Add missing changeset

### DIFF
--- a/.changeset/afraid-wings-attend.md
+++ b/.changeset/afraid-wings-attend.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': minor
+---
+
+Add disableFederationDirectiveAndScalarInjection config to better support Federation v2


### PR DESCRIPTION
## Description

After merging https://github.com/dotansimha/graphql-code-generator/pull/10788, I realised CLI also needs a minor bump to bring in the latest `core` package. Doing this is easier for consumers to use because they don't have to pick a core version manually 

e.g. if user already installed CLI, the only way they would get core is through `resolutions` to force a newer version.