### PR TITLE
Fix ESM issue for CLI `require` flag on Windows

### DIFF
--- a/.changeset/true-rocks-float.md
+++ b/.changeset/true-rocks-float.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/cli': patch
+---
+
+Fix ESM issue in native Windows

--- a/.changeset/true-rocks-float.md
+++ b/.changeset/true-rocks-float.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/cli': patch
 ---
 
-Fix ESM issue in native Windows
+Fix CLI's `require` flag when resolving module issue in ESM in native Windows

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -18,16 +18,10 @@ import { NoTypeDefinitionsFound, type UnnormalizedTypeDefPointer } from '@graphq
 import { mergeTypeDefs } from '@graphql-tools/merge';
 import { CodegenContext, ensureContext } from './config.js';
 import { getDocumentTransform } from './documentTransforms.js';
+import { isESMModule } from './isESMModule.js';
 import { getPluginByName } from './plugins.js';
 import { getPresetByName } from './presets.js';
 import { debugLog, printLogs } from './utils/debugging.js';
-
-/**
- * Poor mans ESM detection.
- * Looking at this and you have a better method?
- * Send a PR.
- */
-const isESMModule = (typeof __dirname === 'string') === false;
 
 const makeDefaultLoader = (from: string) => {
   if (fs.statSync(from).isDirectory()) {

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -1,6 +1,7 @@
 import { BinaryToTextEncoding, createHash } from 'crypto';
 import { promises } from 'fs';
 import { createRequire } from 'module';
+import * as url from 'node:url';
 import { resolve } from 'path';
 import { cosmiconfig, defaultLoaders } from 'cosmiconfig';
 import { GraphQLSchema, GraphQLSchemaExtensions, print } from 'graphql';
@@ -293,13 +294,12 @@ export async function createContext(
   if (cliFlags.require && cliFlags.require.length > 0) {
     const relativeRequire = createRequire(process.cwd());
     await Promise.all(
-      cliFlags.require.map(
-        mod =>
-          import(
-            relativeRequire.resolve(mod, {
-              paths: [process.cwd()],
-            })
-          ),
+      cliFlags.require.map(mod =>
+        safeDynamicImport(
+          relativeRequire.resolve(mod, {
+            paths: [process.cwd()],
+          }),
+        ),
       ),
     );
   }
@@ -544,3 +544,14 @@ async function addMetadataToSources(
     }),
   );
 }
+
+/**
+ * `safeDynamicImport` is a wrapper of dynamic `import()` to work across MacOS and Windows
+ * On native Windows (i.e. no WSL or CI), a filename may look like this: `C:\\Users\\path\\to\\file.ts`
+ * If used directly with `import()`, we'll see `ERR_UNSUPPORTED_ESM_URL_SCHEME` error because C: is not a valid protocol
+ * `url.pathToFileURL` turns the filename to `fil:///C:/Users/path/to/file.ts`, which is import-able
+ */
+const safeDynamicImport = (absoluteFilename: string) => {
+  const { href: fileUrl } = url.pathToFileURL(absoluteFilename);
+  return import(fileUrl);
+};

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -19,6 +19,7 @@ import {
 } from '@graphql-codegen/plugin-helpers';
 import type { UnnormalizedTypeDefPointer } from '@graphql-tools/load';
 import { findAndLoadGraphQLConfig } from './graphql-config.js';
+import { isESMModule } from './isESMModule.js';
 import {
   defaultDocumentsLoadOptions,
   defaultSchemaLoadOptions,
@@ -546,12 +547,22 @@ async function addMetadataToSources(
 }
 
 /**
- * `safeDynamicImport` is a wrapper of dynamic `import()` to work across MacOS and Windows
- * On native Windows (i.e. no WSL or CI), a filename may look like this: `C:\\Users\\path\\to\\file.ts`
- * If used directly with `import()`, we'll see `ERR_UNSUPPORTED_ESM_URL_SCHEME` error because C: is not a valid protocol
- * `url.pathToFileURL` turns the filename to `fil:///C:/Users/path/to/file.ts`, which is import-able
+ * `safeDynamicImport` is a wrapper of dynamic `import()`
+ * to work across Linux and Windows
+ *
+ * CJS:
+ * `import()` seems to work well in CJS when given resolved filename
+ *
+ * ESM:
+ * On native Windows (i.e. no WSL or CI), filename may look like this: `C:\\Users\\path\\to\\file.ts`
+ * If used directly with `import()`, we'll see `ERR_UNSUPPORTED_ESM_URL_SCHEME` error because `c:` is not a valid protocol
+ * `url.pathToFileURL` turns the filename to `file:///C:/Users/path/to/file.ts`, which is import-able
  */
-const safeDynamicImport = (absoluteFilename: string) => {
-  const { href: fileUrl } = url.pathToFileURL(absoluteFilename);
-  return import(fileUrl);
+const safeDynamicImport = (absoluteFilename: string): Promise<any> => {
+  if (isESMModule) {
+    const { href: fileUrl } = url.pathToFileURL(absoluteFilename);
+    return import(fileUrl);
+  }
+
+  return import(absoluteFilename);
 };

--- a/packages/graphql-codegen-cli/src/isESMModule.ts
+++ b/packages/graphql-codegen-cli/src/isESMModule.ts
@@ -1,0 +1,6 @@
+/**
+ * Poor mans ESM detection.
+ * Looking at this and you have a better method?
+ * Send a PR.
+ */
+export const isESMModule = (typeof __dirname === 'string') === false;


### PR DESCRIPTION
## Description

This PR fixes importing modules from CLI `require` flag for ESM on native Windows.
When the `require` flag is used, a module is resolved with native path e.g. `C:\\Users\\path\\to\\file.ts`. This is not usable in `import()` (dynamic import) in ESM. 

To solve this for ESM, we need to use `url.pathToFileURL` on the filename, which converts the value with the correct protocol `file:///` and path `C:/Users/path/to/file.ts`.
CJS works fine with `import()`

Related https://github.com/dotansimha/graphql-code-generator/issues/10842

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `dev-test` (integration)
