### PR TITLE
Add typedDocumentStringTemplate to re-use across client plugins

### DIFF
--- a/.changeset/nice-goats-beg.md
+++ b/.changeset/nice-goats-beg.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/typed-document-node': patch
+---
+
+Use typedDocumentStringTemplate from @graphql-codegen/visitor-plugin-common instead of the inline
+version

--- a/.changeset/tricky-brooms-ring.md
+++ b/.changeset/tricky-brooms-ring.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+---
+
+Create typedDocumentStringTemplate to support TypedDocumentString usage (common in Client-side
+plugins when documentMode=string)

--- a/packages/plugins/other/visitor-plugin-common/src/index.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/index.ts
@@ -21,3 +21,4 @@ export * from './utils.js';
 export * from './variables-to-object.js';
 export * from './convert-schema-enum-to-declaration-block-string.js';
 export * from './graphql-type-utils.js';
+export { typedDocumentStringTemplate } from './typed-document-string.js';

--- a/packages/plugins/other/visitor-plugin-common/src/typed-document-string.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/typed-document-string.ts
@@ -1,0 +1,24 @@
+/**
+ * `typedDocumentStringTemplate` is a utility template required by plugins
+ * that use documentMode=string.
+ * The class acts as a wrapper of string but allows it to type the string with
+ * GraphQL Result and Variables type.
+ */
+export const typedDocumentStringTemplate = `export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}`;

--- a/packages/plugins/typescript/typed-document-node/src/index.ts
+++ b/packages/plugins/typescript/typed-document-node/src/index.ts
@@ -6,6 +6,7 @@ import {
   LoadedFragment,
   optimizeOperations,
   RawClientSideBasePluginConfig,
+  typedDocumentStringTemplate,
 } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptTypedDocumentNodesConfig } from './config.js';
 import { TypeScriptDocumentNodesVisitor } from './visitor.js';
@@ -39,27 +40,7 @@ export const plugin: PluginFunction<TypeScriptTypedDocumentNodesConfig> = (
 
   let content: string[] = [];
   if (config.documentMode === DocumentMode.string) {
-    content = [
-      `\
-export class TypedDocumentString<TResult, TVariables>
-  extends String
-  implements DocumentTypeDecoration<TResult, TVariables>
-{
-  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
-  private value: string;
-  public __meta__?: Record<string, any> | undefined;
-
-  constructor(value: string, __meta__?: Record<string, any> | undefined) {
-    super(value);
-    this.value = value;
-    this.__meta__ = __meta__;
-  }
-
-  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
-    return this.value;
-  }
-}`,
-    ];
+    content = [typedDocumentStringTemplate];
   }
 
   return {


### PR DESCRIPTION
## Description

Since `visitor-plugin-common` ~v3, we've wrapped strings in `TypedDocumentNode` to type document strings with GraphQL`Result` and `Variables`. This is useful for clients that take strings, instead of ASTs. Most relevant PR I could find [is this one](https://github.com/dotansimha/graphql-code-generator/pull/9137)

However, community packages never got these `TypedDocumentNode` implemented. So they were stuck on `visitor-plugin-common` v2.x for a long time. 

This PR extracts the `TypedDocumentNode` template to `visitor-plugin-common` so they could be shared with community plugins

Related https://github.com/dotansimha/graphql-code-generator-community/issues/1410, https://github.com/dotansimha/graphql-code-generator/issues/10759

## Type of change

- [x] New feature / refactor

## How Has This Been Tested?

- [x] No new tests since it's a refactor, existing tests should pass
