### PR TITLE
Add import util for typed-document-string helper

### DIFF
--- a/.changeset/nice-goats-beg.md
+++ b/.changeset/nice-goats-beg.md
@@ -2,5 +2,5 @@
 '@graphql-codegen/typed-document-node': patch
 ---
 
-Use typedDocumentStringTemplate from @graphql-codegen/visitor-plugin-common instead of the inline
+Use `typedDocumentString` from @graphql-codegen/visitor-plugin-common instead of the inlined
 version

--- a/.changeset/tricky-brooms-ring.md
+++ b/.changeset/tricky-brooms-ring.md
@@ -2,5 +2,4 @@
 '@graphql-codegen/visitor-plugin-common': minor
 ---
 
-Create typedDocumentStringTemplate to support TypedDocumentString usage (common in Client-side
-plugins when documentMode=string)
+Create `typedDocumentString` to support `TypedDocumentString` usage (common in Client-side plugins when documentMode=string)

--- a/packages/plugins/other/visitor-plugin-common/src/index.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/index.ts
@@ -21,4 +21,4 @@ export * from './utils.js';
 export * from './variables-to-object.js';
 export * from './convert-schema-enum-to-declaration-block-string.js';
 export * from './graphql-type-utils.js';
-export { typedDocumentStringTemplate } from './typed-document-string.js';
+export { typedDocumentString } from './typed-document-string.js';

--- a/packages/plugins/other/visitor-plugin-common/src/typed-document-string.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/typed-document-string.ts
@@ -1,10 +1,10 @@
-/**
- * `typedDocumentStringTemplate` is a utility template required by plugins
- * that use documentMode=string.
- * The class acts as a wrapper of string but allows it to type the string with
- * GraphQL Result and Variables type.
- */
-export const typedDocumentStringTemplate = `export class TypedDocumentString<TResult, TVariables>
+export const typedDocumentString = {
+  /**
+   * This is a utility template required by plugins that use `documentMode=string`
+   * The class acts as a wrapper of string, and allows typing the string with
+   * GraphQL `Result` and `Variables` types.
+   */
+  template: `export class TypedDocumentString<TResult, TVariables>
   extends String
   implements DocumentTypeDecoration<TResult, TVariables>
 {
@@ -21,4 +21,16 @@ export const typedDocumentStringTemplate = `export class TypedDocumentString<TRe
   override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
     return this.value;
   }
-}`;
+}`,
+  /**
+   * `TypedDocumentString` class above needs `DocumentTypeDecoration` from `@graphql-typed-document-node/core`
+   * This `imports` object helps when generating the import statement.
+   *
+   * This intentionally follows [ClientSideBaseVisitor#_generateImport()]({@link https://github.com/dotansimha/graphql-code-generator/blob/master/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts})
+   * to make it easier to use.
+   */
+  import: {
+    moduleName: '@graphql-typed-document-node/core',
+    propName: 'DocumentTypeDecoration',
+  },
+};

--- a/packages/plugins/typescript/typed-document-node/src/index.ts
+++ b/packages/plugins/typescript/typed-document-node/src/index.ts
@@ -6,7 +6,7 @@ import {
   LoadedFragment,
   optimizeOperations,
   RawClientSideBasePluginConfig,
-  typedDocumentStringTemplate,
+  typedDocumentString,
 } from '@graphql-codegen/visitor-plugin-common';
 import { TypeScriptTypedDocumentNodesConfig } from './config.js';
 import { TypeScriptDocumentNodesVisitor } from './visitor.js';
@@ -40,7 +40,7 @@ export const plugin: PluginFunction<TypeScriptTypedDocumentNodesConfig> = (
 
   let content: string[] = [];
   if (config.documentMode === DocumentMode.string) {
-    content = [typedDocumentStringTemplate];
+    content = [typedDocumentString.template];
   }
 
   return {

--- a/packages/plugins/typescript/typed-document-node/src/visitor.ts
+++ b/packages/plugins/typescript/typed-document-node/src/visitor.ts
@@ -7,6 +7,7 @@ import {
   DocumentMode,
   LoadedFragment,
   RawClientSideBasePluginConfig,
+  typedDocumentString,
 } from '@graphql-codegen/visitor-plugin-common';
 
 interface TypeScriptDocumentNodesVisitorPluginConfig extends RawClientSideBasePluginConfig {
@@ -50,11 +51,8 @@ export class TypeScriptDocumentNodesVisitor extends ClientSideBaseVisitor<
       this._imports.add(tagImport);
     } else if (this.config.documentMode === DocumentMode.string) {
       const tagImport = this._generateImport(
-        {
-          moduleName: '@graphql-typed-document-node/core',
-          propName: 'DocumentTypeDecoration',
-        },
-        'DocumentTypeDecoration',
+        typedDocumentString.import,
+        typedDocumentString.import.propName,
         true,
       );
       this._imports.add(tagImport);


### PR DESCRIPTION
## Description

Continuation of https://github.com/dotansimha/graphql-code-generator/pull/10863

After trying the alpha version locally, I realised client plugins would need to generate an import statement to this effect:

```ts
this._generateImport(
  {
    moduleName: '@graphql-typed-document-node/core',
    propName: 'DocumentTypeDecoration',
  },
  'DocumentTypeDecoration',
  true,
)
```

So this PR improves the utility:
- Makes `typedDocumentString` an object
- Adds `typedDocumentString.template` to replace `typedDocumentStringTemplate`
- Adds `typedDocumentString.import` to help creating import statements

