### PR TITLE
[visitor-plugin-common] Make ClientSideBaseVisitor fragments protected

### DIFF
--- a/.changeset/yellow-baboons-grow.md
+++ b/.changeset/yellow-baboons-grow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+---
+
+Fix \_fragments to be protected instead of private

--- a/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/client-side-base-visitor.ts
@@ -248,7 +248,7 @@ export class ClientSideBaseVisitor<
 
   private _onExecutableDocumentNode?: Unstable_OnExecutableDocumentNode;
   private _omitDefinitions?: boolean;
-  private readonly _fragments: ReadonlyMap<string, LoadedFragment>;
+  protected readonly _fragments: ReadonlyMap<string, LoadedFragment>;
   private readonly fragmentsGraph: DepGraph<LoadedFragment>;
 
   constructor(


### PR DESCRIPTION
## Description

Plugins such as [typescript-react-query](https://github.com/dotansimha/graphql-code-generator-community/blob/cb682e2a12a0a12688f6be2d27158196de75ae52/packages/plugins/typescript/react-query/src/visitor.ts#L22) may need access to the parsed and validated fragments.

For example, in the mentioned community package, we need to check if there are fragments to add certain imports.

Related https://github.com/dotansimha/graphql-code-generator-community/issues/1410#issuecomment-4731408069

https://github.com/dotansimha/graphql-code-generator-community/pull/1516

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
