### PR TITLE
Remove typescript plugin from docs for client use case

### DIFF
--- a/website/src/pages/docs/advanced/generated-files-colocation.mdx
+++ b/website/src/pages/docs/advanced/generated-files-colocation.mdx
@@ -25,7 +25,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.tsx',
   generates: {
     'graphql/generated.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-urql'],
+      plugins: ['typescript-operations', 'typescript-urql'],
       config: { withHooks: true },
     },
   },

--- a/website/src/pages/docs/advanced/how-does-it-work.mdx
+++ b/website/src/pages/docs/advanced/how-does-it-work.mdx
@@ -97,7 +97,7 @@ import { CodegenConfig } from '@graphql-codegen/cli';
 const config: CodegenConfig = {
   schema: 'http://localhost:3333',
   generates: {
-    'types-and-hooks.tsx': { plugins: ['typescript', 'typescript-operations', 'typescript-react-query'] },
+    'types-and-hooks.tsx': { plugins: ['typescript-operations', 'typescript-react-query'] },
   },
 };
 export default config;

--- a/website/src/pages/docs/config-reference/documents-field.mdx
+++ b/website/src/pages/docs/config-reference/documents-field.mdx
@@ -27,7 +27,7 @@ const config: CodegenConfig = {
   schema: 'http://localhost:3000/graphql',
   documents: 'src/**/*.graphql',
   generates: {
-    './src/types.ts': { plugins: ['typescript', 'typescript-operations'] }
+    './src/types.ts': { plugins: ['typescript-operations'] }
   }
 }
 export default config
@@ -45,7 +45,7 @@ const config: CodegenConfig = {
   generates: {
     './src/types1.ts': {
       documents: 'src/**/*.graphql',
-      plugins: ['typescript', 'typescript-operations']
+      plugins: ['typescript-operations']
     }
   }
 }

--- a/website/src/pages/docs/config-reference/schema-field.mdx
+++ b/website/src/pages/docs/config-reference/schema-field.mdx
@@ -66,7 +66,7 @@ const config: CodegenConfig = {
   generates: {
     './src/types.ts': {
       schema: './schema.graphql',
-      plugins: ['typescript', 'typescript-operations']
+      plugins: ['typescript-operations']
     }
   }
 };

--- a/website/src/pages/docs/getting-started/development-workflow.mdx
+++ b/website/src/pages/docs/getting-started/development-workflow.mdx
@@ -101,7 +101,7 @@ const config: CodegenConfig = {
   schema: 'server/src/**/*.graphql',
   documents: 'client/src/**/*.graphql',
   generates: {
-    'client/src/models.ts': ['typescript', 'typescript-operations'],
+    'client/src/models.ts': ['typescript-operations'],
     'server/src/models.ts': ['typescript', 'typescript-resolver']
   }
 }

--- a/website/src/pages/docs/guides/angular.mdx
+++ b/website/src/pages/docs/guides/angular.mdx
@@ -118,7 +118,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.ts',
   generates: {
     './graphql/generated.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-apollo-angular']
+      plugins: ['typescript-operations', 'typescript-apollo-angular']
     }
   }
 }

--- a/website/src/pages/docs/guides/svelte.mdx
+++ b/website/src/pages/docs/guides/svelte.mdx
@@ -93,7 +93,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.gql',
   generates: {
     './graphql/generated.ts': {
-      plugins: ['typescript', 'typescript-operations', 'graphql-codegen-svelte-apollo']
+      plugins: ['typescript-operations', 'graphql-codegen-svelte-apollo']
     }
   }
 }

--- a/website/src/pages/docs/integrations/create-react-app.mdx
+++ b/website/src/pages/docs/integrations/create-react-app.mdx
@@ -15,7 +15,7 @@ const config: CodegenConfig = {
   documents: 'src/**/*.graphql',
   generates: {
     'components.tsx': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo']
+      plugins: ['typescript-operations', 'typescript-react-apollo']
     }
   }
 }

--- a/website/src/pages/plugins/typescript/named-operations-object.mdx
+++ b/website/src/pages/plugins/typescript/named-operations-object.mdx
@@ -44,7 +44,7 @@ const config: CodegenConfig = {
   documents: 'YOUR_OPERATIONS',
   generates: {
     './types.ts': {
-      plugins: ['typescript', 'typescript-operations', 'named-operations-object']
+      plugins: ['typescript-operations', 'named-operations-object']
     }
   }
 }

--- a/website/src/pages/plugins/typescript/relay-operation-optimizer.mdx
+++ b/website/src/pages/plugins/typescript/relay-operation-optimizer.mdx
@@ -50,7 +50,7 @@ const config: CodegenConfig = {
         skipDocumentsValidation: true,
         flattenGeneratedTypes: true
       },
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo']
+      plugins: ['typescript-operations', 'typescript-react-apollo']
     }
   }
 }

--- a/website/src/pages/plugins/typescript/typed-document-node.mdx
+++ b/website/src/pages/plugins/typescript/typed-document-node.mdx
@@ -50,7 +50,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.graphql',
   generates: {
     './src/graphql-operations.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typed-document-node']
+      plugins: ['typescript-operations', 'typed-document-node']
     }
   }
 }

--- a/website/src/pages/plugins/typescript/typescript-apollo-angular.mdx
+++ b/website/src/pages/plugins/typescript/typescript-apollo-angular.mdx
@@ -39,7 +39,7 @@ const config: CodegenConfig = {
   // ...
   generates: {
     'path/to/output.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-apollo-angular']
+      plugins: ['typescript-operations', 'typescript-apollo-angular']
     }
   }
 }

--- a/website/src/pages/plugins/typescript/typescript-apollo-next.mdx
+++ b/website/src/pages/plugins/typescript/typescript-apollo-next.mdx
@@ -74,7 +74,7 @@ const config: CodegenConfig = {
   // ...
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      plugins: ['typescript-operations', 'typescript-react-apollo'],
       config: {
         reactApolloVersion: 3
       }
@@ -99,7 +99,7 @@ const config: CodegenConfig = {
   // ...
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      plugins: ['typescript-operations', 'typescript-react-apollo'],
       config: {
         withHOC: 'I'
       }
@@ -124,7 +124,7 @@ const config: CodegenConfig = {
   // ...
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      plugins: ['typescript-operations', 'typescript-react-apollo'],
       config: {
         withHooks: 'I'
       }
@@ -182,7 +182,7 @@ const config: CodegenConfig = {
   // ...
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      plugins: ['typescript-operations', 'typescript-react-apollo'],
       config: {
         gqlImport: 'graphql.macro#gql'
       }
@@ -201,7 +201,7 @@ const config: CodegenConfig = {
   // ...
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      plugins: ['typescript-operations', 'typescript-react-apollo'],
       config: {
         gqlImport: 'gatsby#graphql'
       }
@@ -473,7 +473,7 @@ const config: CodegenConfig = {
   // ...
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      plugins: ['typescript-operations', 'typescript-react-apollo'],
       config: {
         typesPrefix: 'I'
       }
@@ -498,7 +498,7 @@ const config: CodegenConfig = {
   // ...
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      plugins: ['typescript-operations', 'typescript-react-apollo'],
       config: {
         skipTypename: true
       }
@@ -524,7 +524,7 @@ const config: CodegenConfig = {
   // ...
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      plugins: ['typescript-operations', 'typescript-react-apollo'],
       config: {
         nonOptionalTypename: true
       }

--- a/website/src/pages/plugins/typescript/typescript-react-apollo.mdx
+++ b/website/src/pages/plugins/typescript/typescript-react-apollo.mdx
@@ -66,7 +66,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.graphql',
   generates: {
     './generated-types.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo']
+      plugins: ['typescript-operations', 'typescript-react-apollo']
     }
   }
 }
@@ -102,7 +102,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.graphql',
   generates: {
     './generated-types.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      plugins: ['typescript-operations', 'typescript-react-apollo'],
       config: {
         withComponent: true
       }
@@ -125,7 +125,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.graphql',
   generates: {
     './generated-types.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      plugins: ['typescript-operations', 'typescript-react-apollo'],
       config: {
         withHOC: true
       }

--- a/website/src/pages/plugins/typescript/typescript-react-query.mdx
+++ b/website/src/pages/plugins/typescript/typescript-react-query.mdx
@@ -45,7 +45,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.graphql',
   generates: {
     './generates.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-query'],
+      plugins: ['typescript-operations', 'typescript-react-query'],
       config: {
         fetcher: 'fetch'
       }
@@ -85,7 +85,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.graphql',
   generates: {
     './generates.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-query'],
+      plugins: ['typescript-operations', 'typescript-react-query'],
       config: {
         fetcher: {
           endpoint: 'http://localhost:3000/graphql',
@@ -113,7 +113,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.graphql',
   generates: {
     './generates.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-query'],
+      plugins: ['typescript-operations', 'typescript-react-query'],
       config: {
         fetcher: {
           endpoint: 'process.env.ENDPOINT'
@@ -181,7 +181,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.graphql',
   generates: {
     './generates.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-query'],
+      plugins: ['typescript-operations', 'typescript-react-query'],
       config: {
         fetcher: 'graphql-request'
       }
@@ -215,7 +215,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.graphql',
   generates: {
     './generates.ts': {
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-query'],
+      plugins: ['typescript-operations', 'typescript-react-query'],
       config: {
         fetcher: {
           func: './my-file#myFetcher',

--- a/website/src/pages/plugins/typescript/typescript-svelte-apollo.mdx
+++ b/website/src/pages/plugins/typescript/typescript-svelte-apollo.mdx
@@ -37,7 +37,7 @@ import type { CodegenConfig } from '@graphql-codegen/cli'
 const config: CodegenConfig = {
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'graphql-codegen-svelte-apollo'],
+      plugins: ['typescript-operations', 'graphql-codegen-svelte-apollo'],
       config: {
         clientPath: 'PATH_TO_APOLLO_CLIENT'
       }
@@ -62,7 +62,7 @@ import type { CodegenConfig } from '@graphql-codegen/cli'
 const config: CodegenConfig = {
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'graphql-codegen-svelte-apollo'],
+      plugins: ['typescript-operations', 'graphql-codegen-svelte-apollo'],
       config: {
         clientPath: 'PATH_TO_APOLLO_CLIENT',
         asyncQuery: true
@@ -108,7 +108,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.graphql',
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'graphql-codegen-svelte-apollo'],
+      plugins: ['typescript-operations', 'graphql-codegen-svelte-apollo'],
       config: {
         clientPath: 'PATH_TO_APOLLO_CLIENT'
       }
@@ -177,7 +177,7 @@ const config: CodegenConfig = {
   documents: './src/**/*.graphql',
   generates: {
     'path/to/file.ts': {
-      plugins: ['typescript', 'typescript-operations', 'graphql-codegen-svelte-apollo'],
+      plugins: ['typescript-operations', 'graphql-codegen-svelte-apollo'],
       config: {
         clientPath: 'PATH_TO_APOLLO_CLIENT',
         asyncQuery: true


### PR DESCRIPTION
## Description

This PR removes references to `typescript` plugin in Client docs

Related https://github.com/dotansimha/graphql-code-generator/issues/10884

## Type of change

- [x] Documentation update
