### PR TITLE
Add missing @graphql-typed-document-node/core in doc

### DIFF
--- a/website/src/pages/docs/guides/react-vue.mdx
+++ b/website/src/pages/docs/guides/react-vue.mdx
@@ -51,7 +51,7 @@ All the below code examples are available in our
 For most GraphQL clients and frameworks (React, Vue), install the following packages:
 
 ```sh npm2yarn
-npm install graphql
+npm install graphql @graphql-typed-document-node/core
 npm install --save-dev typescript @graphql-codegen/cli @parcel/watcher
 ```
 


### PR DESCRIPTION
## Description

Add back `@graphql-typed-document-node/core` in guide for Client Preset

Related https://github.com/dotansimha/graphql-code-generator/issues/10883

## Type of change

- [x] Documentation update
