### PR TITLE
Make graphql 17 support minor instead of patch

### DIFF
--- a/.changeset/@graphql-codegen_add-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_add-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/add": patch
+"@graphql-codegen/add": minor
 ---
 dependencies updates:
   - Updated dependency [`graphql@^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` ↗︎](https://www.npmjs.com/package/graphql/v/0.8.0) (from `^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0`, in `peerDependencies`)

--- a/.changeset/@graphql-codegen_cli-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_cli-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/cli": patch
+"@graphql-codegen/cli": minor
 ---
 dependencies updates:
   - Updated dependency [`@graphql-tools/utils@^11.2.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/11.2.0) (from `^11.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_client-preset-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_client-preset-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/client-preset": patch
+"@graphql-codegen/client-preset": minor
 ---
 dependencies updates:
   - Updated dependency [`@graphql-tools/utils@^11.2.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/11.2.0) (from `^11.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_core-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_core-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/core": patch
+"@graphql-codegen/core": minor
 ---
 dependencies updates:
   - Updated dependency [`@graphql-tools/utils@^11.2.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/11.2.0) (from `^11.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_fragment-matcher-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_fragment-matcher-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/fragment-matcher": patch
+"@graphql-codegen/fragment-matcher": minor
 ---
 dependencies updates:
   - Updated dependency [`graphql@^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` ↗︎](https://www.npmjs.com/package/graphql/v/0.8.0) (from `^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0`, in `peerDependencies`)

--- a/.changeset/@graphql-codegen_gql-tag-operations-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_gql-tag-operations-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/gql-tag-operations": patch
+"@graphql-codegen/gql-tag-operations": minor
 ---
 dependencies updates:
   - Updated dependency [`@graphql-tools/utils@^11.2.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/11.2.0) (from `^11.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_graphql-modules-preset-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_graphql-modules-preset-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/graphql-modules-preset": patch
+"@graphql-codegen/graphql-modules-preset": minor
 ---
 dependencies updates:
   - Updated dependency [`@graphql-tools/utils@^11.2.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/11.2.0) (from `^11.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_introspection-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_introspection-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/introspection": patch
+"@graphql-codegen/introspection": minor
 ---
 dependencies updates:
   - Updated dependency [`graphql@^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` ↗︎](https://www.npmjs.com/package/graphql/v/0.8.0) (from `^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0`, in `peerDependencies`)

--- a/.changeset/@graphql-codegen_plugin-helpers-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_plugin-helpers-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/plugin-helpers": patch
+"@graphql-codegen/plugin-helpers": minor
 ---
 dependencies updates:
   - Updated dependency [`@graphql-tools/utils@^11.2.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/11.2.0) (from `^11.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_schema-ast-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_schema-ast-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/schema-ast": patch
+"@graphql-codegen/schema-ast": minor
 ---
 dependencies updates:
   - Updated dependency [`@graphql-tools/utils@^11.2.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/11.2.0) (from `^11.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_time-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_time-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/time": patch
+"@graphql-codegen/time": minor
 ---
 dependencies updates:
   - Updated dependency [`graphql@^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` ↗︎](https://www.npmjs.com/package/graphql/v/0.8.0) (from `^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0`, in `peerDependencies`)

--- a/.changeset/@graphql-codegen_typed-document-node-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_typed-document-node-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/typed-document-node": patch
+"@graphql-codegen/typed-document-node": minor
 ---
 dependencies updates:
   - Updated dependency [`graphql@^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` ↗︎](https://www.npmjs.com/package/graphql/v/0.8.0) (from `^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0`, in `peerDependencies`)

--- a/.changeset/@graphql-codegen_typescript-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/typescript": patch
+"@graphql-codegen/typescript": minor
 ---
 dependencies updates:
   - Updated dependency [`graphql@^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` ↗︎](https://www.npmjs.com/package/graphql/v/0.12.0) (from `^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0`, in `peerDependencies`)

--- a/.changeset/@graphql-codegen_typescript-document-nodes-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-document-nodes-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/typescript-document-nodes": patch
+"@graphql-codegen/typescript-document-nodes": minor
 ---
 dependencies updates:
   - Updated dependency [`graphql@^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` ↗︎](https://www.npmjs.com/package/graphql/v/0.8.0) (from `^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0`, in `peerDependencies`)

--- a/.changeset/@graphql-codegen_typescript-operations-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-operations-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/typescript-operations": patch
+"@graphql-codegen/typescript-operations": minor
 ---
 dependencies updates:
   - Updated dependency [`graphql@^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0` ↗︎](https://www.npmjs.com/package/graphql/v/0.8.0) (from `^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0`, in `peerDependencies`)

--- a/.changeset/@graphql-codegen_typescript-resolvers-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-resolvers-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/typescript-resolvers": patch
+"@graphql-codegen/typescript-resolvers": minor
 ---
 dependencies updates:
   - Updated dependency [`@graphql-tools/utils@^11.2.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/11.2.0) (from `^11.0.0`, in `dependencies`)

--- a/.changeset/@graphql-codegen_visitor-plugin-common-10866-dependencies.md
+++ b/.changeset/@graphql-codegen_visitor-plugin-common-10866-dependencies.md
@@ -1,5 +1,5 @@
 ---
-"@graphql-codegen/visitor-plugin-common": patch
+"@graphql-codegen/visitor-plugin-common": minor
 ---
 dependencies updates:
   - Updated dependency [`@graphql-tools/utils@^11.2.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/11.2.0) (from `^11.0.0`, in `dependencies`)


### PR DESCRIPTION
## Description

Maybe not too important, but adding support with backwards compatibility feels more like a minor version.