### PR TITLE
feat(visitor-plugin-common): support object form for the codegenScalarType extension

### DIFF
--- a/.changeset/codegenscalartype-input-output.md
+++ b/.changeset/codegenscalartype-input-output.md
@@ -1,0 +1,7 @@
+---
+'@graphql-codegen/visitor-plugin-common': minor
+---
+
+Support an object form for the `codegenScalarType` scalar extension.
+
+A scalar's `extensions.codegenScalarType` can now be either a string (applied to both the `input` and `output` types, as before) or `{ input, output }` to map the two positions independently — matching what the `scalars` config option already accepts. This lets schema-first scalar libraries declare a stricter parsed/input type than the accepted resolver-return/output type directly from the schema, instead of collapsing both into one type.

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -366,14 +366,17 @@ export function buildScalars(
             };
           }
         } else if (scalarType.extensions?.codegenScalarType) {
+          const normalizedScalar = normalizeScalarType(
+            scalarType.extensions.codegenScalarType as string | { input: string; output: string },
+          );
           result[name] = {
             input: {
               isExternal: false,
-              type: scalarType.extensions.codegenScalarType as string,
+              type: normalizedScalar.input,
             },
             output: {
               isExternal: false,
-              type: scalarType.extensions.codegenScalarType as string,
+              type: normalizedScalar.output,
             },
           };
         } else if (!defaultScalarsMapping[name]) {

--- a/packages/plugins/typescript/typescript/tests/typescript.spec.ts
+++ b/packages/plugins/typescript/typescript/tests/typescript.spec.ts
@@ -1,4 +1,11 @@
-import { buildSchema, GraphQLEnumType, GraphQLObjectType, GraphQLSchema, parse } from 'graphql';
+import {
+  buildSchema,
+  GraphQLEnumType,
+  GraphQLObjectType,
+  GraphQLScalarType,
+  GraphQLSchema,
+  parse,
+} from 'graphql';
 import { mergeOutputs, Types } from '@graphql-codegen/plugin-helpers';
 import { validateTs } from '@graphql-codegen/testing';
 import { plugin } from '../src/index.js';
@@ -10,6 +17,32 @@ describe('TypeScript', () => {
     `);
     const result = await plugin(schema, [], {}, { outputFile: '' });
     expect(result.prepend).toBeSimilarStringTo('export type Maybe<T> =');
+  });
+
+  describe('codegenScalarType extension', () => {
+    const schemaWithScalarExtension = (codegenScalarType: unknown) =>
+      new GraphQLSchema({
+        query: new GraphQLObjectType({
+          name: 'Query',
+          fields: {
+            a: {
+              type: new GraphQLScalarType({ name: 'MyScalar', extensions: { codegenScalarType } }),
+            },
+          },
+        }),
+      });
+
+    it('maps a string codegenScalarType to both input and output', async () => {
+      const schema = schemaWithScalarExtension('MyType');
+      const result = await plugin(schema, [], {}, { outputFile: '' });
+      expect(result.content).toBeSimilarStringTo(`MyScalar: { input: MyType; output: MyType; }`);
+    });
+
+    it('maps an object codegenScalarType to distinct input and output', async () => {
+      const schema = schemaWithScalarExtension({ input: 'MyInput', output: 'MyOutput' });
+      const result = await plugin(schema, [], {}, { outputFile: '' });
+      expect(result.content).toBeSimilarStringTo(`MyScalar: { input: MyInput; output: MyOutput; }`);
+    });
   });
 
   describe('description to comment', () => {


### PR DESCRIPTION
## Description

The `codegenScalarType` scalar extension is read as a single string and copied into **both** the `input` and `output` slots of the generated `Scalars` map:

```ts
} else if (scalarType.extensions?.codegenScalarType) {
  result[name] = {
    input:  { isExternal: false, type: scalarType.extensions.codegenScalarType as string },
    output: { isExternal: false, type: scalarType.extensions.codegenScalarType as string },
  };
}
```

So a schema-first scalar (one that ships `codegenScalarType` in its type extensions) can't declare a stricter parsed/**input** type than its wider resolver-return/**output** type — the two positions the generated `Scalars` map already distinguishes.

The `scalars` **config** option already supports this, via the `normalizeScalarType` helper that accepts `string | { input, output }`. This PR routes the extension through that same helper, giving the extension parity:

- `codegenScalarType: 'Foo'` → `{ input: Foo; output: Foo }` — unchanged
- `codegenScalarType: { input: 'A', output: 'B' }` → `{ input: A; output: B }`

## Motivation

Scalar libraries such as [`graphql-scalars`](https://github.com/graphql-hive/graphql-scalars) ship one `codegenScalarType` string per scalar, which can only ever describe one of the two positions. This closes that gap for every schema-first scalar — e.g. `DateTime` can declare `{ input: 'Date', output: 'Date | string | number' }` (parsed value is a `Date`; a resolver may return a `Date`, an ISO string, or a timestamp).

## Notes

- **Backward compatible** — a string extension behaves exactly as before.
- The `codegenScalarType` extension previously had **no test coverage**; two tests are added (string form + object form).
- Changeset included (`@graphql-codegen/visitor-plugin-common`, minor).
