### PR TITLE
CODEGEN-935 - Fix `extractAllFieldsToTypes=true` with `@defer` causing duplicated types to be generated

### DIFF
--- a/.changeset/beige-birds-agree.md
+++ b/.changeset/beige-birds-agree.md
@@ -1,0 +1,7 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-operations': patch
+---
+
+Fix issues when `extractAllFieldsToTypes=true` and `@defer` are used, then duplicate types may be
+generated

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -1096,7 +1096,8 @@ export class SelectionSetToObject<
     const dependentTypes = Object.keys(grouped)
       .map(typeName => {
         const relevant = grouped[typeName].filter(Boolean);
-        return relevant.map(objDefinition => {
+        const hasTypesToMerge = relevant.length > 1;
+        return relevant.map((objDefinition, index) => {
           // In extractAllFieldsToTypesCompact mode, we still need to keep the final concrete type name for union/interface types
           // to distinguish between different implementations, but we skip it for simple object types
           const hasMultipleTypes = Object.keys(grouped).length > 1;
@@ -1104,6 +1105,8 @@ export class SelectionSetToObject<
           if (fieldName) {
             if (this._config.extractAllFieldsToTypesCompact && !hasMultipleTypes) {
               name = fieldName;
+            } else if (this._config.extractAllFieldsToTypes && hasTypesToMerge) {
+              name = `${fieldName}_${typeName}_${index}`;
             } else {
               name = `${fieldName}_${typeName}`;
             }

--- a/packages/plugins/typescript/operations/tests/extract-all-types-with-defer.spec.ts
+++ b/packages/plugins/typescript/operations/tests/extract-all-types-with-defer.spec.ts
@@ -1,0 +1,61 @@
+import { buildSchema, parse } from 'graphql';
+import { mergeOutputs } from '@graphql-codegen/plugin-helpers';
+import { validateTs } from '@graphql-codegen/testing';
+import { plugin } from '../src/index.js';
+
+describe('extractAllFieldsToTypes: true with @defer', () => {
+  it('should extract types from queries', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        user(id: ID!): User
+      }
+
+      type User {
+        id: ID!
+        username: String!
+        email: String!
+      }
+    `);
+
+    const document = parse(/* GraphQL */ `
+      fragment UserEmail on User {
+        email
+      }
+
+      query user {
+        user(id: 1) {
+          id
+          username
+          ...UserEmail @defer
+        }
+      }
+    `);
+
+    const result = mergeOutputs([
+      await plugin(schema, [{ document }], { extractAllFieldsToTypes: true }, { outputFile: '' }),
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      "/** Internal type. DO NOT USE DIRECTLY. */
+      type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+      /** Internal type. DO NOT USE DIRECTLY. */
+      export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+      export type UserEmailFragment = { email: string };
+
+      export type UserQuery_user_User = { id: string, username: string };
+
+      export type UserQuery_user_User = { email: string } | { email?: never };
+
+      export type UserQuery_Query = { user: UserQuery_user_User & UserQuery_user_User | null };
+
+
+      export type UserQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+      export type UserQuery = UserQuery_Query;
+      "
+    `);
+
+    validateTs(result, undefined, undefined, undefined, undefined, true);
+  });
+});

--- a/packages/plugins/typescript/operations/tests/extract-all-types-with-defer.spec.ts
+++ b/packages/plugins/typescript/operations/tests/extract-all-types-with-defer.spec.ts
@@ -4,7 +4,7 @@ import { validateTs } from '@graphql-codegen/testing';
 import { plugin } from '../src/index.js';
 
 describe('extractAllFieldsToTypes: true with @defer', () => {
-  it('should extract types from queries', async () => {
+  it('#10867 - should extract fields to types with @defer', async () => {
     const schema = buildSchema(/* GraphQL */ `
       type Query {
         user(id: ID!): User
@@ -42,11 +42,11 @@ describe('extractAllFieldsToTypes: true with @defer', () => {
       export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
       export type UserEmailFragment = { email: string };
 
-      export type UserQuery_user_User = { id: string, username: string };
+      export type UserQuery_user_User_0 = { id: string, username: string };
 
-      export type UserQuery_user_User = { email: string } | { email?: never };
+      export type UserQuery_user_User_1 = { email: string } | { email?: never };
 
-      export type UserQuery_Query = { user: UserQuery_user_User & UserQuery_user_User | null };
+      export type UserQuery_Query = { user: UserQuery_user_User_0 & UserQuery_user_User_1 | null };
 
 
       export type UserQueryVariables = Exact<{ [key: string]: never; }>;


### PR DESCRIPTION
## Description

This PR fixes a scenario where `extractAllFieldsToTypes=true` with `@defer` are used together, it may generate duplicated types

Related https://github.com/dotansimha/graphql-code-generator/issues/10867

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
