### PR TITLE
CODEGEN-940 Fix conditional directive (`@skip` and `@include`) incorrectly drop fields in Result when used  on Inline Fragment / Fragment Spread

### DIFF
--- a/.changeset/petite-sides-change.md
+++ b/.changeset/petite-sides-change.md
@@ -1,0 +1,7 @@
+---
+'@graphql-codegen/visitor-plugin-common': patch
+'@graphql-codegen/typescript-operations': patch
+---
+
+Fix conditional directive (`@skip` and `@include`) incorrectly drop fields in Result when used on
+Inline Fragment / Fragment Spread

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -872,6 +872,9 @@ export class SelectionSetToObject<
         );
       }
 
+      // #region Recursively find all fields and nested fields of the SelectionSet
+      // And by pushing the fields to `selectionNodes`
+      // The for loop continues to build SelectionSet & nested SelectionSet exhaustively
       if (
         parentSchemaType.name === selectionNode.onType ||
         parentSchemaType
@@ -881,17 +884,32 @@ export class SelectionSetToObject<
           fragmentType.getTypes().find(objectType => objectType.name === parentSchemaType.name))
       ) {
         // also process fields from fragment that apply for this parentType
-        const { selectionNodesByTypeName } = this.flattenSelectionSet(
-          selectionNode.selectionNodes,
-          parentSchemaType,
-        );
+        const { selectionNodesByTypeName, selectionNodesByTypeNameConditional } =
+          this.flattenSelectionSet(selectionNode.selectionNodes, parentSchemaType);
+
         const typeNodes = selectionNodesByTypeName.get(parentSchemaType.name) ?? [];
         selectionNodes.push(...typeNodes);
         for (const iinterface of parentSchemaType.getInterfaces()) {
           const typeNodes = selectionNodesByTypeName.get(iinterface.name) ?? [];
           selectionNodes.push(...typeNodes);
         }
+
+        for (const conditionalNodes of selectionNodesByTypeNameConditional) {
+          const _selectionNodes = (conditionalNodes.get(parentSchemaType.name) || []).filter(
+            (node): node is EnrichedFieldNode | FragmentSpreadUsage => 'fragmentDirectives' in node,
+          );
+          for (const selectionNode of _selectionNodes) {
+            if ('kind' in selectionNode) {
+              // Inline fragments are inline as `EnrichedFieldNode` i.e. a field
+              selectionNodes.push(selectionNode);
+            } else {
+              // `FragmentSpreadUsage` contains `selectionNodes` i.e. an array of fields
+              selectionNodes.push(...selectionNode.selectionNodes);
+            }
+          }
+        }
       }
+      // #endregion
     }
 
     const linkFields: LinkField[] = [];

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -64,7 +64,7 @@ type FragmentSpreadUsage = {
 /**
  * @description EnrichedFieldNode are field nodes enriched with Codegen metadata for subsequent processing
  */
-type EnrichedFieldNode = FieldNode & {
+export type EnrichedFieldNode = FieldNode & {
   /**
    * A field node may implicitly inherit fragment directives from parents
    * For example, if the field's parent is marked with `@skip`, the field is implicitly marked with `@skip` as well
@@ -174,9 +174,12 @@ export class SelectionSetToObject<
         // that can be associated back to the fields in the fragment, to
         // support things like making those fields optional when deferring a
         // fragment (using @defer).
-        const fieldsWithFragmentDirectives: EnrichedFieldNode[] = fields.map(field => ({
+        const fieldsWithFragmentDirectives = fields.map(field => ({
           ...field,
-          fragmentDirectives: directives,
+          // A field may already carry `fragmentDirectives` from an enclosing
+          // conditional fragment spread; keep those in addition to the
+          // directives on this inline fragment, instead of overwriting them.
+          fragmentDirectives: [...(field.fragmentDirectives || []), ...(directives || [])],
         }));
 
         if (isObjectType(typeOnSchema)) {
@@ -899,13 +902,7 @@ export class SelectionSetToObject<
             (node): node is EnrichedFieldNode | FragmentSpreadUsage => 'fragmentDirectives' in node,
           );
           for (const selectionNode of _selectionNodes) {
-            if ('kind' in selectionNode) {
-              // Inline fragments are inline as `EnrichedFieldNode` i.e. a field
-              selectionNodes.push(selectionNode);
-            } else {
-              // `FragmentSpreadUsage` contains `selectionNodes` i.e. an array of fields
-              selectionNodes.push(...selectionNode.selectionNodes);
-            }
+            selectionNodes.push(selectionNode);
           }
         }
       }

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -782,7 +782,7 @@ export class SelectionSetToObject<
     selectionNodes = [...selectionNodes];
     let inlineFragmentConditional = false;
     for (const selectionNode of selectionNodes) {
-      // 1. Handle Field or Directtives selection nodes
+      // 1. Handle Field or Directives selection nodes
       if ('kind' in selectionNode) {
         if (selectionNode.kind === Kind.FIELD) {
           if (selectionNode.selectionSet) {
@@ -934,36 +934,46 @@ export class SelectionSetToObject<
       requireTypename,
       this._config.skipTypeNameForRoot,
     );
-    const transformed: ProcessResult = [
-      // Only add the typename field if we're not merging fragment
-      // types. If we are merging, we need to wait until we know all
-      // the involved typenames.
-      ...(typeInfoField &&
+
+    // Only add the typename field if we're not merging fragment
+    // types. If we are merging, we need to wait until we know all
+    // the involved typenames.
+    const transformedTypenameFields =
+      typeInfoField &&
       (!this._config.mergeFragmentTypes || this._config.inlineFragmentTypes === 'mask')
         ? this._processor.transformTypenameField(typeInfoField.type, typeInfoField.name)
-        : []),
-      ...this._processor.transformPrimitiveFields(
-        parentSchemaType,
-        Array.from(primitiveFields.values()).map(field => ({
-          isConditional:
-            hasConditionalDirectives(field.directives) ||
-            hasConditionalDirectives(field.fragmentDirectives),
-          fieldName: field.name.value,
-        })),
-        options.unsetTypes,
-      ),
-      ...this._processor.transformAliasesPrimitiveFields(
-        parentSchemaType,
-        Array.from(primitiveAliasFields.values()).map(field => ({
-          alias: field.alias.value,
-          fieldName: field.name.value,
-          isConditional:
-            hasConditionalDirectives(field.directives) ||
-            hasConditionalDirectives(field.fragmentDirectives),
-        })),
-        options.unsetTypes,
-      ),
-      ...this._processor.transformLinkFields(linkFields, options.unsetTypes),
+        : [];
+    const transformedPrimitiveFields = this._processor.transformPrimitiveFields(
+      parentSchemaType,
+      Array.from(primitiveFields.values()).map(field => ({
+        isConditional:
+          hasConditionalDirectives(field.directives) ||
+          hasConditionalDirectives(field.fragmentDirectives),
+        fieldName: field.name.value,
+      })),
+      options.unsetTypes,
+    );
+    const transformedAliasesPrimitiveFields = this._processor.transformAliasesPrimitiveFields(
+      parentSchemaType,
+      Array.from(primitiveAliasFields.values()).map(field => ({
+        alias: field.alias.value,
+        fieldName: field.name.value,
+        isConditional:
+          hasConditionalDirectives(field.directives) ||
+          hasConditionalDirectives(field.fragmentDirectives),
+      })),
+      options.unsetTypes,
+    );
+    const transformedLinkFields = this._processor.transformLinkFields(
+      linkFields,
+      options.unsetTypes,
+    );
+
+    const transformed: ProcessResult = [
+      ...transformedTypenameFields,
+      ...transformedPrimitiveFields,
+      ...transformedAliasesPrimitiveFields,
+      ...transformedLinkFields,
     ].filter(Boolean);
 
     const allStrings: string[] = transformed.filter(t => typeof t === 'string') as string[];

--- a/packages/plugins/other/visitor-plugin-common/src/utils.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/utils.ts
@@ -26,10 +26,16 @@ import {
   StringValueNode,
   TypeNode,
 } from 'graphql';
-import { RawConfig } from './base-visitor.js';
+import type { RawConfig } from './base-visitor.js';
 import { parseMapper } from './mappers.js';
 import { DEFAULT_SCALARS } from './scalars.js';
-import { LoadedFragment, NormalizedScalarsMap, ParsedScalarsMap, ScalarsMap } from './types.js';
+import type { EnrichedFieldNode } from './selection-set-to-object.js';
+import type {
+  LoadedFragment,
+  NormalizedScalarsMap,
+  ParsedScalarsMap,
+  ScalarsMap,
+} from './types.js';
 
 export const getConfigValue = <T = any>(value: T, defaultValue: T): T => {
   if (value === null || value === undefined) {
@@ -487,12 +493,12 @@ export const getFieldNodeNameValue = (node: FieldNode): string => {
 };
 
 export function separateSelectionSet(selections: ReadonlyArray<SelectionNode>): {
-  fields: FieldNode[];
+  fields: EnrichedFieldNode[];
   spreads: FragmentSpreadNode[];
   inlines: InlineFragmentNode[];
 } {
   return {
-    fields: selections.filter(s => s.kind === Kind.FIELD) as FieldNode[],
+    fields: selections.filter(s => s.kind === Kind.FIELD) as EnrichedFieldNode[],
     inlines: selections.filter(s => s.kind === Kind.INLINE_FRAGMENT) as InlineFragmentNode[],
     spreads: selections.filter(s => s.kind === Kind.FRAGMENT_SPREAD) as FragmentSpreadNode[],
   };

--- a/packages/plugins/typescript/operations/tests/ts-documents.skip-include-directives.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.skip-include-directives.spec.ts
@@ -1210,7 +1210,7 @@ describe('TypeScript Operations Plugin - @skip directive', () => {
 });
 
 describe('TypeScript Operations Plugin - @include and @skip with @defer', () => {
-  it('generates conditional object with defer fields when @skip and @include are used with defer', async () => {
+  it('generates conditional object with defer fields when @skip and @include are used with @defer', async () => {
     const schema = buildSchema(/* GraphQL */ `
       type Query {
         user: User
@@ -1221,7 +1221,7 @@ describe('TypeScript Operations Plugin - @include and @skip with @defer', () => 
         id: ID!
         name: String!
         nickName: String!
-        age: Int!
+        age: Int
         createdAt: String!
       }
     `);
@@ -1265,16 +1265,16 @@ describe('TypeScript Operations Plugin - @include and @skip with @defer', () => 
       "export type UserSkipQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-      export type UserSkipQuery = { user: { id: string } & { name?: string, niName?: string } & { age?: number, createdAt?: string } & ({ age: number, createdAt: string } | { age?: never, createdAt?: never }) | null };
+      export type UserSkipQuery = { user: { id: string } & { name?: string, niName?: string } & { age?: number | null, createdAt?: string } & ({ age?: number | null, createdAt?: string } | { age?: never, createdAt?: never }) | null };
 
       export type UserIncludeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-      export type UserIncludeQuery = { user: { id: string } & { name?: string, niName?: string } & { age?: number, createdAt?: string } & ({ age: number, createdAt: string } | { age?: never, createdAt?: never }) | null };
+      export type UserIncludeQuery = { user: { id: string } & { name?: string, niName?: string } & { age?: number | null, createdAt?: string } & ({ age?: number | null, createdAt?: string } | { age?: never, createdAt?: never }) | null };
 
       export type User_NameFragment = { name: string, niName: string };
 
-      export type User_AgeFragment = { age: number, createdAt: string };
+      export type User_AgeFragment = { age: number | null, createdAt: string };
       "
     `);
   });

--- a/packages/plugins/typescript/operations/tests/ts-documents.skip-include-directives.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.skip-include-directives.spec.ts
@@ -1,4 +1,6 @@
 import { buildSchema, parse, versionInfo } from 'graphql';
+import { mergeOutputs } from '@graphql-codegen/plugin-helpers';
+import { validateTs } from '@graphql-codegen/testing';
 import { plugin } from '../src/index.js';
 import { schema } from './shared/schema.js';
 
@@ -771,6 +773,65 @@ describe('TypeScript Operations Plugin - @include directives', () => {
       "
     `);
   });
+
+  it('#10881 - nested @include fragments (inline and spread) must be added correctly to the operation Result', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        user: User
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        bio: String!
+        email: String!
+      }
+    `);
+
+    const document = parse(/* GraphQL */ `
+      fragment EmailFields on User {
+        email
+      }
+
+      fragment UserFields on User {
+        id
+        bio @include(if: $withBio)
+        ...EmailFields @include(if: $withEmail)
+        ... on User @include(if: $withName) {
+          name
+        }
+      }
+
+      query GetUser($withBio: Boolean!, $withEmail: Boolean!, $withName: Boolean!) {
+        user {
+          ...UserFields
+        }
+      }
+    `);
+
+    const result = mergeOutputs([await plugin(schema, [{ document }], {}, { outputFile: '' })]);
+
+    expect(result).toMatchInlineSnapshot(`
+      "/** Internal type. DO NOT USE DIRECTLY. */
+      type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+      /** Internal type. DO NOT USE DIRECTLY. */
+      export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+      export type EmailFieldsFragment = { email: string };
+
+      export type UserFieldsFragment = { id: string, bio?: string } & { name?: string } & { email?: string };
+
+      export type GetUserQueryVariables = Exact<{
+        withBio: boolean;
+        withEmail: boolean;
+        withName: boolean;
+      }>;
+
+
+      export type GetUserQuery = { user: { id: string, bio?: string, name?: string, email?: string } | null };
+      "
+    `);
+    validateTs(result, undefined, undefined, undefined, undefined, true);
+  });
 });
 
 describe('TypeScript Operations Plugin - @skip directive', () => {
@@ -1050,6 +1111,65 @@ describe('TypeScript Operations Plugin - @skip directive', () => {
       export type User_CreatedAtFragment = { createdAt: string };
       "
     `);
+  });
+
+  it('#10881 - nested @skip fragments (inline and spread) must be added correctly to the operation Result', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        user: User
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        bio: String!
+        email: String!
+      }
+    `);
+
+    const document = parse(/* GraphQL */ `
+      fragment EmailFields on User {
+        email
+      }
+
+      fragment UserFields on User {
+        id
+        bio @skip(if: $noBio)
+        ...EmailFields @skip(if: $noEmail)
+        ... on User @skip(if: $noName) {
+          name
+        }
+      }
+
+      query GetUser($noBio: Boolean!, $noEmail: Boolean!, $noName: Boolean!) {
+        user {
+          ...UserFields
+        }
+      }
+    `);
+
+    const result = mergeOutputs([await plugin(schema, [{ document }], {}, { outputFile: '' })]);
+
+    expect(result).toMatchInlineSnapshot(`
+      "/** Internal type. DO NOT USE DIRECTLY. */
+      type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+      /** Internal type. DO NOT USE DIRECTLY. */
+      export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+      export type EmailFieldsFragment = { email: string };
+
+      export type UserFieldsFragment = { id: string, bio?: string } & { name?: string } & { email?: string };
+
+      export type GetUserQueryVariables = Exact<{
+        noBio: boolean;
+        noEmail: boolean;
+        noName: boolean;
+      }>;
+
+
+      export type GetUserQuery = { user: { id: string, bio?: string, name?: string, email?: string } | null };
+      "
+    `);
+    validateTs(result, undefined, undefined, undefined, undefined, true);
   });
 });
 

--- a/packages/plugins/typescript/operations/tests/ts-documents.skip-include-directives.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.skip-include-directives.spec.ts
@@ -785,12 +785,22 @@ describe('TypeScript Operations Plugin - @include directives', () => {
         name: String!
         bio: String!
         email: String!
+        emailLocalPart: String!
+        emailDomainPart: String!
       }
     `);
 
     const document = parse(/* GraphQL */ `
+      fragment EmailLocalPartFields on User {
+        emailLocalPart
+      }
+
       fragment EmailFields on User {
         email
+        ...EmailLocalPartFields @include(if: $withEmailParts)
+        ... on User @include(if: $withEmailParts) {
+          emailDomainPart
+        }
       }
 
       fragment UserFields on User {
@@ -802,7 +812,12 @@ describe('TypeScript Operations Plugin - @include directives', () => {
         }
       }
 
-      query GetUser($withBio: Boolean!, $withEmail: Boolean!, $withName: Boolean!) {
+      query GetUser(
+        $withBio: Boolean!
+        $withEmail: Boolean!
+        $withName: Boolean!
+        $withEmailParts: Boolean!
+      ) {
         user {
           ...UserFields
         }
@@ -816,7 +831,9 @@ describe('TypeScript Operations Plugin - @include directives', () => {
       type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
       /** Internal type. DO NOT USE DIRECTLY. */
       export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
-      export type EmailFieldsFragment = { email: string };
+      export type EmailLocalPartFieldsFragment = { emailLocalPart: string };
+
+      export type EmailFieldsFragment = { email: string } & { emailDomainPart?: string } & { emailLocalPart?: string };
 
       export type UserFieldsFragment = { id: string, bio?: string } & { name?: string } & { email?: string };
 
@@ -824,10 +841,11 @@ describe('TypeScript Operations Plugin - @include directives', () => {
         withBio: boolean;
         withEmail: boolean;
         withName: boolean;
+        withEmailParts: boolean;
       }>;
 
 
-      export type GetUserQuery = { user: { id: string, bio?: string, name?: string, email?: string } | null };
+      export type GetUserQuery = { user: { id: string, bio?: string, name?: string, email?: string, emailDomainPart?: string, emailLocalPart?: string } | null };
       "
     `);
     validateTs(result, undefined, undefined, undefined, undefined, true);

--- a/packages/plugins/typescript/operations/tests/ts-documents.skip-include-directives.spec.ts
+++ b/packages/plugins/typescript/operations/tests/ts-documents.skip-include-directives.spec.ts
@@ -1142,12 +1142,22 @@ describe('TypeScript Operations Plugin - @skip directive', () => {
         name: String!
         bio: String!
         email: String!
+        emailLocalPart: String!
+        emailDomainPart: String!
       }
     `);
 
     const document = parse(/* GraphQL */ `
+      fragment EmailLocalPartFields on User {
+        emailLocalPart
+      }
+
       fragment EmailFields on User {
         email
+        ...EmailLocalPartFields @skip(if: $noEmailParts)
+        ... on User @skip(if: $noEmailParts) {
+          emailDomainPart
+        }
       }
 
       fragment UserFields on User {
@@ -1159,7 +1169,12 @@ describe('TypeScript Operations Plugin - @skip directive', () => {
         }
       }
 
-      query GetUser($noBio: Boolean!, $noEmail: Boolean!, $noName: Boolean!) {
+      query GetUser(
+        $noBio: Boolean!
+        $noEmail: Boolean!
+        $noName: Boolean!
+        $noEmailParts: Boolean!
+      ) {
         user {
           ...UserFields
         }
@@ -1173,7 +1188,9 @@ describe('TypeScript Operations Plugin - @skip directive', () => {
       type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
       /** Internal type. DO NOT USE DIRECTLY. */
       export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
-      export type EmailFieldsFragment = { email: string };
+      export type EmailLocalPartFieldsFragment = { emailLocalPart: string };
+
+      export type EmailFieldsFragment = { email: string } & { emailDomainPart?: string } & { emailLocalPart?: string };
 
       export type UserFieldsFragment = { id: string, bio?: string } & { name?: string } & { email?: string };
 
@@ -1181,10 +1198,11 @@ describe('TypeScript Operations Plugin - @skip directive', () => {
         noBio: boolean;
         noEmail: boolean;
         noName: boolean;
+        noEmailParts: boolean;
       }>;
 
 
-      export type GetUserQuery = { user: { id: string, bio?: string, name?: string, email?: string } | null };
+      export type GetUserQuery = { user: { id: string, bio?: string, name?: string, email?: string, emailDomainPart?: string, emailLocalPart?: string } | null };
       "
     `);
     validateTs(result, undefined, undefined, undefined, undefined, true);


### PR DESCRIPTION
## Description

This PR fixes an issue where conditional directives (`@skip` and `@include`) are ignored in the Result field.
This happened because conditional directives were split [here](selectionNodesByTypeNameConditional) and weren't handle consistently

Related https://github.com/dotansimha/graphql-code-generator/issues/10881

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test