### PR TITLE
CODEGEN-953 - [typescript-operations] Fix operations plugin unncessarily visiting schema

### DIFF
--- a/.changeset/tricky-boats-watch.md
+++ b/.changeset/tricky-boats-watch.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/typescript-operations': patch
+---
+
+Fix performance issue when config.importSchemaTypesFrom is set, and the provided schema is still
+unnecessarily visited

--- a/packages/plugins/typescript/operations/src/index.ts
+++ b/packages/plugins/typescript/operations/src/index.ts
@@ -81,8 +81,16 @@ export const plugin: PluginFunction<
   // #region generateSchemaTypes
   // When Input and Enum appear in Result selection sets, we need to
   // generate those types so they can be referred to correctly
-  const schemaTypes = oldVisit(transformSchemaAST(schema, config).ast, { leave: visitor });
-  const schemaTypesDefinitions = findTransformedDefinitions(schemaTypes);
+  //
+  // Note: we don't run visitor on the schema when i.e. `!config.importSchemaTypesFrom`
+  // because the schema types are supposedly already generated elsewhere.
+  // In such cases, running the visitor on the schema will do unncessary work
+  let schemaTypesDefinitions: string[] = [];
+  if (!config.importSchemaTypesFrom) {
+    const schemaTypes = oldVisit(transformSchemaAST(schema, config).ast, { leave: visitor });
+    schemaTypesDefinitions = findTransformedDefinitions(schemaTypes);
+  }
+
   // #endregion
 
   // #region generateIntrospectionTypesDefinitions


### PR DESCRIPTION
## Description

This PR fixes `typescript-operations` perf when `config.importSchemaTypesFrom` is used.
Now, when said config option is used, the plugin no longer visits the schema, which would save a lot of processing time especially when the schema is big

Related https://github.com/dotansimha/graphql-code-generator/issues/10906, https://github.com/dotansimha/graphql-code-generator/issues/10895

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
