### PR TITLE
Revert Partial handling when conditional fragment and fragment masking are used

### DIFF
--- a/dev-test/general/gql-tag-operations-masking/gql/fragment-masking.ts
+++ b/dev-test/general/gql-tag-operations-masking/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/dev-test/general/gql-tag-operations-urql/gql/fragment-masking.ts
+++ b/dev-test/general/gql-tag-operations-urql/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/dev-test/general/gql-tag-operations/gql/fragment-masking.ts
+++ b/dev-test/general/gql-tag-operations/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/dev-test/general/gql-tag-operations/graphql/fragment-masking.ts
+++ b/dev-test/general/gql-tag-operations/graphql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/persisted-documents-string-mode/src/gql/fragment-masking.ts
+++ b/examples/persisted-documents-string-mode/src/gql/fragment-masking.ts
@@ -11,11 +11,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/persisted-documents/src/gql/fragment-masking.ts
+++ b/examples/persisted-documents/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/react/apollo-client-defer/src/gql/fragment-masking.ts
+++ b/examples/react/apollo-client-defer/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/react/apollo-client/src/gql/fragment-masking.ts
+++ b/examples/react/apollo-client/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/react/http-executor/src/gql/fragment-masking.ts
+++ b/examples/react/http-executor/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/react/tanstack-react-query/src/gql/fragment-masking.ts
+++ b/examples/react/tanstack-react-query/src/gql/fragment-masking.ts
@@ -11,11 +11,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/react/urql/src/gql/fragment-masking.ts
+++ b/examples/react/urql/src/gql/fragment-masking.ts
@@ -11,11 +11,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/typescript-esm/src/gql/fragment-masking.ts
+++ b/examples/typescript-esm/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/typescript-graphql-request/src/gql/fragment-masking.ts
+++ b/examples/typescript-graphql-request/src/gql/fragment-masking.ts
@@ -11,11 +11,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/vite/vite-react-cts/src/gql/fragment-masking.ts
+++ b/examples/vite/vite-react-cts/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/vite/vite-react-mts/src/gql/fragment-masking.ts
+++ b/examples/vite/vite-react-mts/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/vite/vite-react-ts/src/gql/fragment-masking.ts
+++ b/examples/vite/vite-react-ts/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/vue/apollo-composable/src/gql/fragment-masking.ts
+++ b/examples/vue/apollo-composable/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/vue/urql/src/gql/fragment-masking.ts
+++ b/examples/vue/urql/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/vue/villus/src/gql/fragment-masking.ts
+++ b/examples/vue/villus/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/examples/yoga-tests/src/gql/fragment-masking.ts
+++ b/examples/yoga-tests/src/gql/fragment-masking.ts
@@ -16,11 +16,6 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
       : never
     : never;
 
-// return partial if `fragmentType` is partial e.g. because of conditional directives
-export function useFragment<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>,
-): Partial<TType>;
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,

--- a/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
+++ b/packages/plugins/other/visitor-plugin-common/src/selection-set-to-object.ts
@@ -1023,11 +1023,12 @@ export class SelectionSetToObject<
         fields.push(
           `{ ' $fragmentRefs'?: { ${fragmentsSpreadUsages
             .map(name => {
+              // FIXME: https://github.com/dotansimha/graphql-code-generator/pull/10904/changes#r3729881814
               // A conditional (`@skip`/`@include`) masked spread may be absent,
               // so its data is wrapped in `Partial`.
-              if (options.partialTypes) {
-                return `'${name}': Partial<${name}>`;
-              }
+              // if (options.partialTypes) {
+              //   return `'${name}': Partial<${name}>`;
+              // }
               if (options.unsetTypes) {
                 return `'${name}': Incremental<${name}>`;
               }

--- a/packages/presets/client/src/fragment-masking-plugin.ts
+++ b/packages/presets/client/src/fragment-masking-plugin.ts
@@ -23,11 +23,12 @@ export function makeFragmentData<
 const defaultUnmaskFunctionName = 'useFragment';
 
 const createUnmaskFunctionTypeDefinitions = (unmaskFunctionName = defaultUnmaskFunctionName) => [
-  `// return partial if \`fragmentType\` is partial e.g. because of conditional directives
-export function ${unmaskFunctionName}<TType>(
-  _documentNode: DocumentTypeDecoration<TType, any>,
-  fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>
-): Partial<TType>;`,
+  // FIXME: https://github.com/dotansimha/graphql-code-generator/pull/10904/changes#r3729881814
+  //   `// return partial if \`fragmentType\` is partial e.g. because of conditional directives
+  // export function ${unmaskFunctionName}<TType>(
+  //   _documentNode: DocumentTypeDecoration<TType, any>,
+  //   fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>
+  // ): Partial<TType>;`,
 
   `// return non-nullable if \`fragmentType\` is non-nullable
 export function ${unmaskFunctionName}<TType>(

--- a/packages/presets/client/tests/client-preset.fragment-masking.spec.ts
+++ b/packages/presets/client/tests/client-preset.fragment-masking.spec.ts
@@ -148,100 +148,95 @@ describe('client-preset - fragment masking', () => {
     expect(result).toHaveLength(4);
     const gqlFile = result.find(file => file.filename === 'out1/fragment-masking.ts');
     expect(gqlFile.content).toMatchInlineSnapshot(`
-        "/* eslint-disable */
-        import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
-        import { FragmentDefinitionNode } from 'graphql';
-        import { Incremental } from './graphql';
+      "/* eslint-disable */
+      import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
+      import { FragmentDefinitionNode } from 'graphql';
+      import { Incremental } from './graphql';
 
 
-        export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>> = TDocumentType extends DocumentTypeDecoration<
-          infer TType,
-          any
-        >
-          ? [TType] extends [{ ' $fragmentName'?: infer TKey }]
-            ? TKey extends string
-              ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-              : never
+      export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>> = TDocumentType extends DocumentTypeDecoration<
+        infer TType,
+        any
+      >
+        ? [TType] extends [{ ' $fragmentName'?: infer TKey }]
+          ? TKey extends string
+            ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
             : never
-          : never;
+          : never
+        : never;
 
-        // return partial if \`fragmentType\` is partial e.g. because of conditional directives
-        export function iLikeTurtles<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>
-        ): Partial<TType>;
-        // return non-nullable if \`fragmentType\` is non-nullable
-        export function iLikeTurtles<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
-        ): TType;
-        // return nullable if \`fragmentType\` is undefined
-        export function iLikeTurtles<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
-        ): TType | undefined;
-        // return nullable if \`fragmentType\` is nullable
-        export function iLikeTurtles<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
-        ): TType | null;
-        // return nullable if \`fragmentType\` is nullable or undefined
-        export function iLikeTurtles<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
-        ): TType | null | undefined;
-        // return array of non-nullable if \`fragmentType\` is array of non-nullable
-        export function iLikeTurtles<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
-        ): Array<TType>;
-        // return array of nullable if \`fragmentType\` is array of nullable
-        export function iLikeTurtles<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): Array<TType> | null | undefined;
-        // return readonly array of non-nullable if \`fragmentType\` is array of non-nullable
-        export function iLikeTurtles<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
-        ): ReadonlyArray<TType>;
-        // return readonly array of nullable if \`fragmentType\` is array of nullable
-        export function iLikeTurtles<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): ReadonlyArray<TType> | null | undefined;
-        export function iLikeTurtles<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | Array<FragmentType<DocumentTypeDecoration<TType, any>>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
-          return fragmentType as any;
-        }
+      // return non-nullable if \`fragmentType\` is non-nullable
+      export function iLikeTurtles<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
+      ): TType;
+      // return nullable if \`fragmentType\` is undefined
+      export function iLikeTurtles<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
+      ): TType | undefined;
+      // return nullable if \`fragmentType\` is nullable
+      export function iLikeTurtles<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
+      ): TType | null;
+      // return nullable if \`fragmentType\` is nullable or undefined
+      export function iLikeTurtles<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
+      ): TType | null | undefined;
+      // return array of non-nullable if \`fragmentType\` is array of non-nullable
+      export function iLikeTurtles<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
+      ): Array<TType>;
+      // return array of nullable if \`fragmentType\` is array of nullable
+      export function iLikeTurtles<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): Array<TType> | null | undefined;
+      // return readonly array of non-nullable if \`fragmentType\` is array of non-nullable
+      export function iLikeTurtles<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
+      ): ReadonlyArray<TType>;
+      // return readonly array of nullable if \`fragmentType\` is array of nullable
+      export function iLikeTurtles<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): ReadonlyArray<TType> | null | undefined;
+      export function iLikeTurtles<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | Array<FragmentType<DocumentTypeDecoration<TType, any>>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
+        return fragmentType as any;
+      }
 
 
-        export function makeFragmentData<
-          F extends DocumentTypeDecoration<any, any>,
-          FT extends ResultOf<F>
-        >(data: FT, _fragment: F): FragmentType<F> {
-          return data as FragmentType<F>;
-        }
-        export function isFragmentReady<TQuery, TFrag>(
-          queryNode: DocumentTypeDecoration<TQuery, any>,
-          fragmentNode: TypedDocumentNode<TFrag>,
-          data: FragmentType<TypedDocumentNode<Incremental<TFrag>, any>> | null | undefined
-        ): data is FragmentType<typeof fragmentNode> {
-          const deferredFields = (queryNode as { __meta__?: { deferredFields: Record<string, (keyof TFrag)[]> } }).__meta__
-            ?.deferredFields;
+      export function makeFragmentData<
+        F extends DocumentTypeDecoration<any, any>,
+        FT extends ResultOf<F>
+      >(data: FT, _fragment: F): FragmentType<F> {
+        return data as FragmentType<F>;
+      }
+      export function isFragmentReady<TQuery, TFrag>(
+        queryNode: DocumentTypeDecoration<TQuery, any>,
+        fragmentNode: TypedDocumentNode<TFrag>,
+        data: FragmentType<TypedDocumentNode<Incremental<TFrag>, any>> | null | undefined
+      ): data is FragmentType<typeof fragmentNode> {
+        const deferredFields = (queryNode as { __meta__?: { deferredFields: Record<string, (keyof TFrag)[]> } }).__meta__
+          ?.deferredFields;
 
-          if (!deferredFields) return true;
+        if (!deferredFields) return true;
 
-          const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
-          const fragName = fragDef?.name?.value;
+        const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
+        const fragName = fragDef?.name?.value;
 
-          const fields = (fragName && deferredFields[fragName]) || [];
-          return fields.length > 0 && fields.every(field => data && field in data);
-        }
-        "
-      `);
+        const fields = (fragName && deferredFields[fragName]) || [];
+        return fields.length > 0 && fields.every(field => data && field in data);
+      }
+      "
+    `);
   });
 
   it('can accept null in useFragment', async () => {
@@ -273,100 +268,95 @@ describe('client-preset - fragment masking', () => {
     const fragmentFile = result.find(file => file.filename.includes('fragment-masking.ts'));
 
     expect(fragmentFile.content).toMatchInlineSnapshot(`
-        "/* eslint-disable */
-        import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
-        import { FragmentDefinitionNode } from 'graphql';
-        import { Incremental } from './graphql';
+      "/* eslint-disable */
+      import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
+      import { FragmentDefinitionNode } from 'graphql';
+      import { Incremental } from './graphql';
 
 
-        export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>> = TDocumentType extends DocumentTypeDecoration<
-          infer TType,
-          any
-        >
-          ? [TType] extends [{ ' $fragmentName'?: infer TKey }]
-            ? TKey extends string
-              ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-              : never
+      export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>> = TDocumentType extends DocumentTypeDecoration<
+        infer TType,
+        any
+      >
+        ? [TType] extends [{ ' $fragmentName'?: infer TKey }]
+          ? TKey extends string
+            ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
             : never
-          : never;
+          : never
+        : never;
 
-        // return partial if \`fragmentType\` is partial e.g. because of conditional directives
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>
-        ): Partial<TType>;
-        // return non-nullable if \`fragmentType\` is non-nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
-        ): TType;
-        // return nullable if \`fragmentType\` is undefined
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
-        ): TType | undefined;
-        // return nullable if \`fragmentType\` is nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
-        ): TType | null;
-        // return nullable if \`fragmentType\` is nullable or undefined
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
-        ): TType | null | undefined;
-        // return array of non-nullable if \`fragmentType\` is array of non-nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
-        ): Array<TType>;
-        // return array of nullable if \`fragmentType\` is array of nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): Array<TType> | null | undefined;
-        // return readonly array of non-nullable if \`fragmentType\` is array of non-nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
-        ): ReadonlyArray<TType>;
-        // return readonly array of nullable if \`fragmentType\` is array of nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): ReadonlyArray<TType> | null | undefined;
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | Array<FragmentType<DocumentTypeDecoration<TType, any>>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
-          return fragmentType as any;
-        }
+      // return non-nullable if \`fragmentType\` is non-nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
+      ): TType;
+      // return nullable if \`fragmentType\` is undefined
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
+      ): TType | undefined;
+      // return nullable if \`fragmentType\` is nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
+      ): TType | null;
+      // return nullable if \`fragmentType\` is nullable or undefined
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
+      ): TType | null | undefined;
+      // return array of non-nullable if \`fragmentType\` is array of non-nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
+      ): Array<TType>;
+      // return array of nullable if \`fragmentType\` is array of nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): Array<TType> | null | undefined;
+      // return readonly array of non-nullable if \`fragmentType\` is array of non-nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
+      ): ReadonlyArray<TType>;
+      // return readonly array of nullable if \`fragmentType\` is array of nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): ReadonlyArray<TType> | null | undefined;
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | Array<FragmentType<DocumentTypeDecoration<TType, any>>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
+        return fragmentType as any;
+      }
 
 
-        export function makeFragmentData<
-          F extends DocumentTypeDecoration<any, any>,
-          FT extends ResultOf<F>
-        >(data: FT, _fragment: F): FragmentType<F> {
-          return data as FragmentType<F>;
-        }
-        export function isFragmentReady<TQuery, TFrag>(
-          queryNode: DocumentTypeDecoration<TQuery, any>,
-          fragmentNode: TypedDocumentNode<TFrag>,
-          data: FragmentType<TypedDocumentNode<Incremental<TFrag>, any>> | null | undefined
-        ): data is FragmentType<typeof fragmentNode> {
-          const deferredFields = (queryNode as { __meta__?: { deferredFields: Record<string, (keyof TFrag)[]> } }).__meta__
-            ?.deferredFields;
+      export function makeFragmentData<
+        F extends DocumentTypeDecoration<any, any>,
+        FT extends ResultOf<F>
+      >(data: FT, _fragment: F): FragmentType<F> {
+        return data as FragmentType<F>;
+      }
+      export function isFragmentReady<TQuery, TFrag>(
+        queryNode: DocumentTypeDecoration<TQuery, any>,
+        fragmentNode: TypedDocumentNode<TFrag>,
+        data: FragmentType<TypedDocumentNode<Incremental<TFrag>, any>> | null | undefined
+      ): data is FragmentType<typeof fragmentNode> {
+        const deferredFields = (queryNode as { __meta__?: { deferredFields: Record<string, (keyof TFrag)[]> } }).__meta__
+          ?.deferredFields;
 
-          if (!deferredFields) return true;
+        if (!deferredFields) return true;
 
-          const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
-          const fragName = fragDef?.name?.value;
+        const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
+        const fragName = fragDef?.name?.value;
 
-          const fields = (fragName && deferredFields[fragName]) || [];
-          return fields.length > 0 && fields.every(field => data && field in data);
-        }
-        "
-      `);
+        const fields = (fragName && deferredFields[fragName]) || [];
+        return fields.length > 0 && fields.every(field => data && field in data);
+      }
+      "
+    `);
 
     // FIXME(pnpm-update): TypeScript errors. Maybe content shouldn't be merged?
     // const content = mergeOutputs([
@@ -411,100 +401,95 @@ describe('client-preset - fragment masking', () => {
     const fragmentFile = result.find(file => file.filename.includes('fragment-masking.ts'));
 
     expect(fragmentFile.content).toMatchInlineSnapshot(`
-        "/* eslint-disable */
-        import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
-        import { FragmentDefinitionNode } from 'graphql';
-        import { Incremental } from './graphql';
+      "/* eslint-disable */
+      import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
+      import { FragmentDefinitionNode } from 'graphql';
+      import { Incremental } from './graphql';
 
 
-        export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>> = TDocumentType extends DocumentTypeDecoration<
-          infer TType,
-          any
-        >
-          ? [TType] extends [{ ' $fragmentName'?: infer TKey }]
-            ? TKey extends string
-              ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-              : never
+      export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>> = TDocumentType extends DocumentTypeDecoration<
+        infer TType,
+        any
+      >
+        ? [TType] extends [{ ' $fragmentName'?: infer TKey }]
+          ? TKey extends string
+            ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
             : never
-          : never;
+          : never
+        : never;
 
-        // return partial if \`fragmentType\` is partial e.g. because of conditional directives
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>
-        ): Partial<TType>;
-        // return non-nullable if \`fragmentType\` is non-nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
-        ): TType;
-        // return nullable if \`fragmentType\` is undefined
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
-        ): TType | undefined;
-        // return nullable if \`fragmentType\` is nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
-        ): TType | null;
-        // return nullable if \`fragmentType\` is nullable or undefined
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
-        ): TType | null | undefined;
-        // return array of non-nullable if \`fragmentType\` is array of non-nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
-        ): Array<TType>;
-        // return array of nullable if \`fragmentType\` is array of nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): Array<TType> | null | undefined;
-        // return readonly array of non-nullable if \`fragmentType\` is array of non-nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
-        ): ReadonlyArray<TType>;
-        // return readonly array of nullable if \`fragmentType\` is array of nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): ReadonlyArray<TType> | null | undefined;
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | Array<FragmentType<DocumentTypeDecoration<TType, any>>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
-          return fragmentType as any;
-        }
+      // return non-nullable if \`fragmentType\` is non-nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
+      ): TType;
+      // return nullable if \`fragmentType\` is undefined
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
+      ): TType | undefined;
+      // return nullable if \`fragmentType\` is nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
+      ): TType | null;
+      // return nullable if \`fragmentType\` is nullable or undefined
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
+      ): TType | null | undefined;
+      // return array of non-nullable if \`fragmentType\` is array of non-nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
+      ): Array<TType>;
+      // return array of nullable if \`fragmentType\` is array of nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): Array<TType> | null | undefined;
+      // return readonly array of non-nullable if \`fragmentType\` is array of non-nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
+      ): ReadonlyArray<TType>;
+      // return readonly array of nullable if \`fragmentType\` is array of nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): ReadonlyArray<TType> | null | undefined;
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | Array<FragmentType<DocumentTypeDecoration<TType, any>>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
+        return fragmentType as any;
+      }
 
 
-        export function makeFragmentData<
-          F extends DocumentTypeDecoration<any, any>,
-          FT extends ResultOf<F>
-        >(data: FT, _fragment: F): FragmentType<F> {
-          return data as FragmentType<F>;
-        }
-        export function isFragmentReady<TQuery, TFrag>(
-          queryNode: DocumentTypeDecoration<TQuery, any>,
-          fragmentNode: TypedDocumentNode<TFrag>,
-          data: FragmentType<TypedDocumentNode<Incremental<TFrag>, any>> | null | undefined
-        ): data is FragmentType<typeof fragmentNode> {
-          const deferredFields = (queryNode as { __meta__?: { deferredFields: Record<string, (keyof TFrag)[]> } }).__meta__
-            ?.deferredFields;
+      export function makeFragmentData<
+        F extends DocumentTypeDecoration<any, any>,
+        FT extends ResultOf<F>
+      >(data: FT, _fragment: F): FragmentType<F> {
+        return data as FragmentType<F>;
+      }
+      export function isFragmentReady<TQuery, TFrag>(
+        queryNode: DocumentTypeDecoration<TQuery, any>,
+        fragmentNode: TypedDocumentNode<TFrag>,
+        data: FragmentType<TypedDocumentNode<Incremental<TFrag>, any>> | null | undefined
+      ): data is FragmentType<typeof fragmentNode> {
+        const deferredFields = (queryNode as { __meta__?: { deferredFields: Record<string, (keyof TFrag)[]> } }).__meta__
+          ?.deferredFields;
 
-          if (!deferredFields) return true;
+        if (!deferredFields) return true;
 
-          const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
-          const fragName = fragDef?.name?.value;
+        const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
+        const fragName = fragDef?.name?.value;
 
-          const fields = (fragName && deferredFields[fragName]) || [];
-          return fields.length > 0 && fields.every(field => data && field in data);
-        }
-        "
-      `);
+        const fields = (fragName && deferredFields[fragName]) || [];
+        return fields.length > 0 && fields.every(field => data && field in data);
+      }
+      "
+    `);
 
     // FIXME(pnpm-update): TypeScript errors. Maybe content shouldn't be merged?
     // const content = mergeOutputs([
@@ -549,100 +534,95 @@ describe('client-preset - fragment masking', () => {
     const fragmentFile = result.find(file => file.filename.includes('fragment-masking.ts'));
 
     expect(fragmentFile.content).toMatchInlineSnapshot(`
-        "/* eslint-disable */
-        import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
-        import { FragmentDefinitionNode } from 'graphql';
-        import { Incremental } from './graphql';
+      "/* eslint-disable */
+      import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
+      import { FragmentDefinitionNode } from 'graphql';
+      import { Incremental } from './graphql';
 
 
-        export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>> = TDocumentType extends DocumentTypeDecoration<
-          infer TType,
-          any
-        >
-          ? [TType] extends [{ ' $fragmentName'?: infer TKey }]
-            ? TKey extends string
-              ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
-              : never
+      export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>> = TDocumentType extends DocumentTypeDecoration<
+        infer TType,
+        any
+      >
+        ? [TType] extends [{ ' $fragmentName'?: infer TKey }]
+          ? TKey extends string
+            ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
             : never
-          : never;
+          : never
+        : never;
 
-        // return partial if \`fragmentType\` is partial e.g. because of conditional directives
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>
-        ): Partial<TType>;
-        // return non-nullable if \`fragmentType\` is non-nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
-        ): TType;
-        // return nullable if \`fragmentType\` is undefined
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
-        ): TType | undefined;
-        // return nullable if \`fragmentType\` is nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
-        ): TType | null;
-        // return nullable if \`fragmentType\` is nullable or undefined
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
-        ): TType | null | undefined;
-        // return array of non-nullable if \`fragmentType\` is array of non-nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
-        ): Array<TType>;
-        // return array of nullable if \`fragmentType\` is array of nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): Array<TType> | null | undefined;
-        // return readonly array of non-nullable if \`fragmentType\` is array of non-nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
-        ): ReadonlyArray<TType>;
-        // return readonly array of nullable if \`fragmentType\` is array of nullable
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): ReadonlyArray<TType> | null | undefined;
-        export function useFragment<TType>(
-          _documentNode: DocumentTypeDecoration<TType, any>,
-          fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | Array<FragmentType<DocumentTypeDecoration<TType, any>>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
-        ): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
-          return fragmentType as any;
-        }
+      // return non-nullable if \`fragmentType\` is non-nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
+      ): TType;
+      // return nullable if \`fragmentType\` is undefined
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
+      ): TType | undefined;
+      // return nullable if \`fragmentType\` is nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
+      ): TType | null;
+      // return nullable if \`fragmentType\` is nullable or undefined
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
+      ): TType | null | undefined;
+      // return array of non-nullable if \`fragmentType\` is array of non-nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
+      ): Array<TType>;
+      // return array of nullable if \`fragmentType\` is array of nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): Array<TType> | null | undefined;
+      // return readonly array of non-nullable if \`fragmentType\` is array of non-nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
+      ): ReadonlyArray<TType>;
+      // return readonly array of nullable if \`fragmentType\` is array of nullable
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): ReadonlyArray<TType> | null | undefined;
+      export function useFragment<TType>(
+        _documentNode: DocumentTypeDecoration<TType, any>,
+        fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | Array<FragmentType<DocumentTypeDecoration<TType, any>>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+      ): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
+        return fragmentType as any;
+      }
 
 
-        export function makeFragmentData<
-          F extends DocumentTypeDecoration<any, any>,
-          FT extends ResultOf<F>
-        >(data: FT, _fragment: F): FragmentType<F> {
-          return data as FragmentType<F>;
-        }
-        export function isFragmentReady<TQuery, TFrag>(
-          queryNode: DocumentTypeDecoration<TQuery, any>,
-          fragmentNode: TypedDocumentNode<TFrag>,
-          data: FragmentType<TypedDocumentNode<Incremental<TFrag>, any>> | null | undefined
-        ): data is FragmentType<typeof fragmentNode> {
-          const deferredFields = (queryNode as { __meta__?: { deferredFields: Record<string, (keyof TFrag)[]> } }).__meta__
-            ?.deferredFields;
+      export function makeFragmentData<
+        F extends DocumentTypeDecoration<any, any>,
+        FT extends ResultOf<F>
+      >(data: FT, _fragment: F): FragmentType<F> {
+        return data as FragmentType<F>;
+      }
+      export function isFragmentReady<TQuery, TFrag>(
+        queryNode: DocumentTypeDecoration<TQuery, any>,
+        fragmentNode: TypedDocumentNode<TFrag>,
+        data: FragmentType<TypedDocumentNode<Incremental<TFrag>, any>> | null | undefined
+      ): data is FragmentType<typeof fragmentNode> {
+        const deferredFields = (queryNode as { __meta__?: { deferredFields: Record<string, (keyof TFrag)[]> } }).__meta__
+          ?.deferredFields;
 
-          if (!deferredFields) return true;
+        if (!deferredFields) return true;
 
-          const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
-          const fragName = fragDef?.name?.value;
+        const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
+        const fragName = fragDef?.name?.value;
 
-          const fields = (fragName && deferredFields[fragName]) || [];
-          return fields.length > 0 && fields.every(field => data && field in data);
-        }
-        "
-      `);
+        const fields = (fragName && deferredFields[fragName]) || [];
+        return fields.length > 0 && fields.every(field => data && field in data);
+      }
+      "
+    `);
 
     // FIXME(pnpm-update): TypeScript errors. Maybe content shouldn't be merged?
     // const content = mergeOutputs([
@@ -711,7 +691,7 @@ describe('client-preset - fragment masking', () => {
       }>;
 
 
-      export type GetUserQuery = { user: { id: string } & { age?: number | null } & { ' $fragmentRefs'?: { 'UserNicknamesFragment': Partial<UserNicknamesFragment> } } | null };
+      export type GetUserQuery = { user: { id: string } & { age?: number | null } & { ' $fragmentRefs'?: { 'UserNicknamesFragment': UserNicknamesFragment } } | null };
 
       export type UserNicknamesFragment = { nicknames: Array<string> | null } & { ' $fragmentName'?: 'UserNicknamesFragment' };
 
@@ -737,11 +717,6 @@ describe('client-preset - fragment masking', () => {
           : never
         : never;
 
-      // return partial if \`fragmentType\` is partial e.g. because of conditional directives
-      export function useFragment<TType>(
-        _documentNode: DocumentTypeDecoration<TType, any>,
-        fragmentType: FragmentType<DocumentTypeDecoration<Partial<TType>, any>>
-      ): Partial<TType>;
       // return non-nullable if \`fragmentType\` is non-nullable
       export function useFragment<TType>(
         _documentNode: DocumentTypeDecoration<TType, any>,


### PR DESCRIPTION
## Description

In https://github.com/dotansimha/graphql-code-generator/pull/10904, we handled conditional directive with fragment masking but the generated types do not quite work. Main issue found: https://github.com/dotansimha/graphql-code-generator/pull/10904#discussion_r3729881814

This PR reverts the `Partial` usage, will fix it properly next

Related https://github.com/dotansimha/graphql-code-generator/pull/10904

## Type of change

- [x] Revert
