### PR TITLE
Implement rolling profiler output for watch mode

### DIFF
--- a/.changeset/quick-profilers-report.md
+++ b/.changeset/quick-profilers-report.md
@@ -1,0 +1,12 @@
+---
+'@graphql-codegen/plugin-helpers': patch
+'@graphql-codegen/cli': patch
+---
+
+Fix profiler output not being written to the filesystem in watch mode (`--profile --watch`)
+
+The profiler trace was only written on the non-watch code path, after the watch-mode early return, so a profiled watch session never produced a `codegen-*.json` file.
+
+The profiler now writes a fresh trace file after the initial run and after every rebuild, with each file containing only that run's events. A failed rebuild does not produce a trace and its events are discarded so they don't leak into the next successful run.
+
+The `Profiler` now owns its own trace lifecycle: a new `clear()` method starts a new trace, and a new `outputName` property provides the filename for the current trace (`null` for the noop profiler). Filename generation was removed from `CodegenContext` (the `profilerOutput` field and `rotateProfilerOutput()` no longer exist).

--- a/packages/graphql-codegen-cli/src/config.ts
+++ b/packages/graphql-codegen-cli/src/config.ts
@@ -380,7 +380,6 @@ export class CodegenContext {
   cwd: string;
   filepath: string;
   profiler: Profiler;
-  profilerOutput?: string;
   checkModeStaleFiles = [];
 
   constructor({
@@ -452,12 +451,6 @@ export class CodegenContext {
 
   useProfiler() {
     this.profiler = createProfiler();
-
-    const now = new Date(); // 2011-10-05T14:48:00.000Z
-    const datetime = now.toISOString().split('.')[0]; // 2011-10-05T14:48:00
-    const datetimeNormalized = datetime.replace(/-|:/g, ''); // 20111005T144800
-
-    this.profilerOutput = `codegen-${datetimeNormalized}.json`;
   }
 
   getPluginContext(): { [key: string]: any } {

--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -143,9 +143,22 @@ export async function generate(
     return generationResult;
   }
 
+  // Flush the collected profiler events to disk, then reset the profiler so the
+  // next run produces its own trace under a fresh filename. No-op when profiling
+  // is disabled (the noop profiler has no `outputName`).
+  async function writeProfilerOutput(): Promise<void> {
+    const { profiler } = context;
+    if (!profiler.outputName) {
+      return;
+    }
+
+    await writeFile(join(context.cwd, profiler.outputName), JSON.stringify(profiler.collect()));
+    profiler.clear();
+  }
+
   // watch mode
   if (config.watch) {
-    return createWatcher(context, writeOutput).runningWatcher;
+    return createWatcher(context, writeOutput, writeProfilerOutput).runningWatcher;
   }
 
   const { result: outputFiles, error } = await context.profiler.run(
@@ -179,12 +192,7 @@ export async function generate(
     'Lifecycle: beforeDone',
   );
 
-  if (context.profilerOutput) {
-    await writeFile(
-      join(context.cwd, context.profilerOutput),
-      JSON.stringify(context.profiler.collect()),
-    );
-  }
+  await writeProfilerOutput();
 
   return outputFiles;
 }

--- a/packages/graphql-codegen-cli/src/utils/watcher.ts
+++ b/packages/graphql-codegen-cli/src/utils/watcher.ts
@@ -29,6 +29,12 @@ function emitWatching(watchDir: string) {
 export const createWatcher = (
   initialContext: CodegenContext,
   onNext: (result: Types.FileOutput[]) => Promise<Types.FileOutput[]>,
+  /**
+   * Called after a successful run (initial build or rebuild) once `onNext` has
+   * finished. Used to flush profiler output per run; a no-op when profiling is
+   * disabled.
+   */
+  afterRun: () => Promise<void> = () => Promise.resolve(),
 ): {
   /**
    * Call this function to stop the running watch server
@@ -82,9 +88,10 @@ export const createWatcher = (
 
     const debouncedExec = debounce(() => {
       if (!isShutdown) {
-        executeCodegen(initialContext)
+        initialContext.profiler
+          .run(() => executeCodegen(initialContext), 'executeCodegen')
           .then(
-            ({ result, error }) => {
+            async ({ result, error }) => {
               // FIXME: this is a quick fix to stop `onNext` (writeOutput) from
               // removing all files when there is an error.
               //
@@ -95,9 +102,13 @@ export const createWatcher = (
               //
               // This also means we don't have config.allowPartialOutputs in watch mode
               if (error) {
+                // Discard this failed run's profiler events so they don't leak
+                // into the next successful run's trace.
+                initialContext.profiler.clear();
                 return;
               }
-              onNext(result);
+              await onNext(result);
+              await afterRun();
             },
             () => Promise.resolve(),
           )
@@ -224,15 +235,20 @@ export const createWatcher = (
    * stopWatching() was called or there was an error inside it
    */
   stopWatching.runningWatcher = new Promise<void>((resolve, reject) => {
-    executeCodegen(initialContext)
+    initialContext.profiler
+      .run(() => executeCodegen(initialContext), 'executeCodegen')
       .then(
-        ({ result, error }) => {
+        async ({ result, error }) => {
           // TODO: this is the initial run, the logic here mimics the above watcher logic.
           // We need to check whether it's ok to deviate between these two.
           if (error) {
+            // Discard this failed run's profiler events so they don't leak
+            // into the next successful run's trace.
+            initialContext.profiler.clear();
             return;
           }
-          onNext(result);
+          await onNext(result);
+          await afterRun();
         },
         () => Promise.resolve(),
       )

--- a/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
+++ b/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
 import * as path from 'path';
 import type { Mock } from 'vitest';
 import { CodegenContext } from '../src/config.js';
@@ -311,5 +319,189 @@ describe('Watch runs - overwrite.removeStaleFiles', () => {
     await stopWatching();
     await runningWatcher;
     await waitForNextEvent();
+  });
+});
+
+describe('Watch runs - profiler output', () => {
+  // The watcher matches changed paths relative to process.cwd(), so a profiled
+  // watch run resolves `context.cwd` to process.cwd() and writes its trace files
+  // there. Since that location is shared, each test tracks only the files it
+  // created (baseline delta) and cleans up just those.
+  //
+  // IMPORTANT: these tests must stay sequential (do NOT mark them
+  // `.concurrent`). They share process.cwd() for trace output, so running them
+  // at the same time would make each test see the other's files in its delta and
+  // clobber them during cleanup.
+  const listProfilerFiles = () =>
+    readdirSync(process.cwd()).filter(f => f.startsWith('codegen-') && f.endsWith('.json'));
+
+  test('writes a fresh profiler trace file after the initial run and after each rebuild', async () => {
+    const { testDir, schemaFile, documentFile } = setupTestFiles();
+    writeFileSync(
+      schemaFile.absolute,
+      /* GraphQL */ `
+        type Query {
+          me: User
+        }
+
+        type User {
+          id: ID!
+          name: String!
+        }
+      `,
+    );
+    writeFileSync(
+      documentFile.absolute,
+      /* GraphQL */ `
+        query {
+          me {
+            id
+          }
+        }
+      `,
+    );
+    await waitForNextEvent();
+
+    const context = new CodegenContext({
+      filepath: path.join(testDir, 'codegen.ts'),
+      config: {
+        schema: schemaFile.relative,
+        documents: documentFile.relative,
+        watch: true,
+        generates: {
+          [path.join(testDir, 'types.ts')]: {
+            plugins: ['typescript'],
+          },
+        },
+      },
+    });
+    context.useProfiler();
+
+    const runningWatcher = generate(context);
+    await waitForNextEvent();
+
+    const { stopWatching } = createWatcherSpy.mock.results.at(-1)!.value as ReturnType<
+      typeof watcherModule.createWatcher
+    >;
+
+    try {
+      // Initial run writes one profiler trace
+      const afterInitial = listProfilerFiles();
+      expect(afterInitial).toHaveLength(1);
+
+      // Trigger a rebuild
+      writeFileSync(
+        documentFile.absolute,
+        /* GraphQL */ `
+          query {
+            me {
+              id
+              name
+            }
+          }
+        `,
+      );
+      await waitForNextEvent();
+
+      // Rebuild writes a second, distinct profiler trace
+      const afterRebuild = listProfilerFiles();
+      expect(afterRebuild).toHaveLength(2);
+      expect(new Set(afterRebuild).size).toBe(2); // filenames are unique per run
+
+      // Each trace contains only its own run's events (profiler was cleared between runs)
+      for (const filename of afterRebuild) {
+        const events = JSON.parse(readFileSync(path.join(process.cwd(), filename), 'utf8'));
+        expect(Array.isArray(events)).toBe(true);
+        expect(events.length).toBeGreaterThan(0);
+      }
+    } finally {
+      await stopWatching();
+      await runningWatcher;
+      await waitForNextEvent();
+      for (const filename of listProfilerFiles()) {
+        unlinkSync(path.join(process.cwd(), filename));
+      }
+    }
+  });
+
+  test('does not write a trace for a failed rebuild and clears its events so the next trace stays clean', async () => {
+    const { testDir, schemaFile, documentFile } = setupTestFiles();
+    writeFileSync(
+      schemaFile.absolute,
+      /* GraphQL */ `
+        type Query {
+          me: User
+        }
+
+        type User {
+          id: ID!
+          name: String!
+        }
+      `,
+    );
+    writeFileSync(
+      documentFile.absolute,
+      /* GraphQL */ `
+        query {
+          me {
+            id
+          }
+        }
+      `,
+    );
+    await waitForNextEvent();
+
+    const context = new CodegenContext({
+      filepath: path.join(testDir, 'codegen.ts'),
+      config: {
+        schema: schemaFile.relative,
+        documents: documentFile.relative,
+        watch: true,
+        generates: {
+          [path.join(testDir, 'types.ts')]: {
+            plugins: ['typescript'],
+          },
+        },
+      },
+    });
+    context.useProfiler();
+
+    const runningWatcher = generate(context);
+    await waitForNextEvent();
+
+    const { stopWatching } = createWatcherSpy.mock.results.at(-1)!.value as ReturnType<
+      typeof watcherModule.createWatcher
+    >;
+
+    try {
+      // Initial run writes one profiler trace
+      const afterInitial = listProfilerFiles();
+      expect(afterInitial).toHaveLength(1);
+
+      // Trigger a rebuild that fails (invalid field in the document)
+      writeFileSync(
+        documentFile.absolute,
+        /* GraphQL */ `
+          query {
+            me {
+              id
+              zzzz # invalid field -> generation error
+            }
+          }
+        `,
+      );
+      await waitForNextEvent();
+
+      // No trace is written for the failed run, and its events were discarded
+      expect(listProfilerFiles()).toHaveLength(1);
+      expect(context.profiler.collect()).toHaveLength(0);
+    } finally {
+      await stopWatching();
+      await runningWatcher;
+      await waitForNextEvent();
+      for (const filename of listProfilerFiles()) {
+        unlinkSync(path.join(process.cwd(), filename));
+      }
+    }
   });
 });

--- a/packages/utils/plugins-helpers/src/profiler.ts
+++ b/packages/utils/plugins-helpers/src/profiler.ts
@@ -22,27 +22,53 @@ export interface ProfilerEvent {
 }
 
 export interface Profiler {
+  /**
+   * Filename of the current trace's collected events should be written to,
+   * or `null` when profiling is disabled.
+   * A fresh name is generated whenever {@link clear} starts a new trace.
+   */
+  readonly outputName: string | null;
   run<T>(fn: () => Promise<T>, name: string, cat?: string): Promise<T>;
   collect(): ProfilerEvent[];
+  /** Discard all collected events so the next {@link collect} starts fresh */
+  clear(): void;
 }
 
 export function createNoopProfiler(): Profiler {
   return {
+    outputName: null,
     run(fn) {
       return Promise.resolve().then(() => fn());
     },
     collect() {
       return [];
     },
+    clear() {},
   };
 }
 
 export function createProfiler(): Profiler {
+  /** Build a unique, human-readable trace filename e.g. `codegen-20111005T144800000.json` */
+  function generateOutputName(): string {
+    const datetimeNormalized = new Date()
+      .toISOString() // 2011-10-05T14:48:00.000Z
+      .replace(/[-:.Z]/g, ''); // 20111005T144800000
+    return `codegen-${datetimeNormalized}.json`;
+  }
+
   const events: ProfilerEvent[] = [];
+  let outputName = generateOutputName();
 
   return {
+    get outputName() {
+      return outputName;
+    },
     collect() {
       return events;
+    },
+    clear() {
+      events.length = 0;
+      outputName = generateOutputName();
     },
     run(fn, name, cat) {
       let startTime: [number, number];


### PR DESCRIPTION
## Description

I'm improving Server Preset watch mode behaviour but noticed the profiler is not working in watch mode. This PR fixes it by having the profiler creating a file every run in watch mode

Also related: https://github.com/dotansimha/graphql-code-generator/issues/10382

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test
- [ ] Manual test of alpha version
