### PR TITLE
fix(fragment-matcher): don't introspect a schema that declares @defer/@stream

### DIFF
--- a/.changeset/eighty-buttons-shake.md
+++ b/.changeset/eighty-buttons-shake.md
@@ -1,0 +1,7 @@
+---
+'@graphql-codegen/fragment-matcher': patch
+---
+
+Introspect a copy of the schema without `@defer` and `@stream`
+
+`graphql@17`'s `execute()` rejects any schema that declares `@defer` or `@stream`, even when the document does not use them. The plugin's introspection query never does, so the directives are now stripped before executing it. The schema is only rebuilt when one of them is declared, so output is unchanged otherwise.

--- a/packages/plugins/other/fragment-matcher/src/index.ts
+++ b/packages/plugins/other/fragment-matcher/src/index.ts
@@ -143,7 +143,18 @@ export const plugin: PluginFunction = async (
   };
 
   const apolloClientVersion = parseInt(config.apolloClientVersion as any);
-  const cleanSchema = config.federation ? removeFederation(schema) : schema;
+  const federationlessSchema = config.federation ? removeFederation(schema) : schema;
+  // graphql@17's execute() throws on any schema that declares @defer or @stream, even when the
+  // document does not use them. The introspection query below never does, so strip them first.
+  const cleanSchema =
+    federationlessSchema.getDirective('defer') || federationlessSchema.getDirective('stream')
+      ? new GraphQLSchema({
+          ...federationlessSchema.toConfig(),
+          directives: federationlessSchema
+            .getDirectives()
+            .filter(d => d.name !== 'defer' && d.name !== 'stream'),
+        })
+      : federationlessSchema;
   const { useExplicitTyping } = config;
 
   const introspection = (await execute({

--- a/packages/plugins/other/fragment-matcher/tests/plugin.spec.ts
+++ b/packages/plugins/other/fragment-matcher/tests/plugin.spec.ts
@@ -512,4 +512,41 @@ describe('Fragment Matcher Plugin', () => {
 
     expect(contentA).toEqual(contentB);
   });
+  it('should support schemas that declare @defer and @stream', async () => {
+    const incrementalSchema = buildASTSchema(gql`
+      directive @defer(if: Boolean! = true, label: String) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+      directive @stream(if: Boolean! = true, label: String, initialCount: Int = 0) on FIELD
+
+      type Character {
+        name: String
+      }
+
+      type Jedi {
+        side: String
+      }
+
+      type Droid {
+        model: String
+      }
+
+      union People = Character | Jedi | Droid
+
+      type Query {
+        allPeople: [People]
+      }
+    `);
+
+    const content = await plugin(
+      incrementalSchema,
+      [],
+      {
+        apolloClientVersion: 2,
+      },
+      {
+        outputFile: 'foo.json',
+      },
+    );
+
+    expect(content).toEqual(introspection);
+  });
 });


### PR DESCRIPTION
Fixes #10894.

graphql 17's `execute()` refuses to run against a schema that *declares* `@defer` or `@stream`, whether
or not the document uses them. The introspection query here doesn't use either, but having `@defer` in
the SDL is enough to kill codegen. We declare it so `@graphql-eslint` picks it up in operations, and
there's no config option to skip past this.

Introspect a copy without them instead:

```ts
const cleanSchema =
  federationlessSchema.getDirective('defer') || federationlessSchema.getDirective('stream')
    ? new GraphQLSchema({
        ...federationlessSchema.toConfig(),
        directives: federationlessSchema
          .getDirectives()
          .filter(d => d.name !== 'defer' && d.name !== 'stream'),
      })
    : federationlessSchema;
```

Only rebuilds when one of them is actually declared, so nothing changes otherwise.

Output is unaffected. The same schema on graphql 16 unpatched and on graphql 17 patched both give:

```json
{ "possibleTypes": { "Node": ["User", "Post"], "Content": ["User", "Post"] } }
```

Also ran it across our own codegen configs, generated output unchanged.

The test can't fail on the graphql 16 pinned here, since 16's `execute()` doesn't throw. It starts
guarding properly whenever the repo moves to 17.
