### PR TITLE
Add `contentComparison` to allow plugins and presets to configure whether to use cache or disk for file comparison

### DIFF
--- a/.changeset/content-comparison-disk.md
+++ b/.changeset/content-comparison-disk.md
@@ -1,0 +1,27 @@
+---
+'@graphql-codegen/cli': minor
+'@graphql-codegen/plugin-helpers': minor
+---
+
+Add `contentComparison?: 'cache-first' | 'disk'` to control disk-vs-cache write
+comparison in watch mode.
+
+In watch mode the CLI caches the hash of the content it last wrote per file and
+compares new output against that cached hash to skip redundant writes. This
+assumes generated output is a pure function of the codegen inputs. An output whose
+content depends on the file's existing content (e.g. a preset that reads the file
+and rewrites part of it) breaks that assumption: if the file is changed on disk and
+codegen regenerates content identical to a previous run, the cached hash still
+matches and the write is skipped, so the on-disk change is never corrected.
+
+`contentComparison: 'disk'` opts an output into comparing the generated content
+against the file on disk instead of the in-memory record of what codegen last
+wrote, so the file is rewritten when it was changed externally. It can be set:
+
+- by a preset, on the `GenerateOptions` it returns from `buildGeneratesSection`, or
+- on the output config (`generates[output].contentComparison`) for any output,
+  including plain plugin outputs without a preset.
+
+When both are present, the preset's value takes precedence. The default,
+`'cache-first'`, keeps the existing in-memory-cache behaviour for outputs that are
+a pure function of their inputs.

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -522,6 +522,10 @@ export async function executeCodegen(
                               filename: outputArgs.filename,
                               content: output,
                               hooks: outputConfig.hooks || {},
+                              // A preset sets `outputArgs` per output via `buildGeneratesSection`.
+                              // Fall back to `outputConfig` so plugin outputs can opt in too.
+                              contentComparison:
+                                outputArgs.contentComparison ?? outputConfig.contentComparison,
                             });
                           };
 

--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -51,6 +51,10 @@ export async function generate(
     previouslyGeneratedFilenames = filenames;
   }
 
+  // Records the hash of the content codegen last wrote per file. This is always
+  // kept up to date; `FileOutput.contentComparison` only decides whether the
+  // skip-check trusts this record ('cache-first') or re-reads the file from disk
+  // ('disk'), for outputs whose content depends on the file's existing content.
   const recentOutputHash = new Map<string, string>();
 
   async function writeOutput(generationResult: Types.FileOutput[]): Promise<Types.FileOutput[]> {
@@ -69,12 +73,28 @@ export async function generate(
     await context.profiler.run(
       () =>
         Promise.all(
-          generationResult.map(async (result: Types.FileOutput) => {
-            const previousHash =
-              recentOutputHash.get(result.filename) || (await hashFile(result.filename));
+          generationResult.map(async result => {
+            // The "previous" hash the skip-check compares against:
+            // - 'cache-first' trusts the in-memory record of what codegen last wrote
+            // (falling back to disk when there's no entry).
+            // - 'disk' always re-reads the file, because the output's content
+            // depends on the file's existing content
+            // (e.g. a preset that reads the file and rewrites part of it), so the
+            // in-memory record could wrongly skip a write when the file was changed
+            // on disk but the regenerated content matches a previous run.
+            const previousHash = await (async function getPreviousHash(): Promise<string | null> {
+              const { contentComparison = 'cache-first' } = result;
+
+              if (contentComparison === 'disk') {
+                return await hashFile(result.filename);
+              }
+
+              return recentOutputHash.get(result.filename) || (await hashFile(result.filename));
+            })();
             const exists = previousHash !== null;
 
-            // Store previous hash to avoid reading from disk again
+            // Always update the cache, regardless of `cache-first` or `disk` option,
+            // so subsequent runs have consistent entry to compare against
             if (previousHash) {
               recentOutputHash.set(result.filename, previousHash);
             }

--- a/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
+++ b/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
@@ -9,6 +9,7 @@ import {
 } from 'fs';
 import * as path from 'path';
 import type { Mock } from 'vitest';
+import * as addPlugin from '@graphql-codegen/add';
 import { CodegenContext } from '../src/config.js';
 import { generate } from '../src/generate-and-save.js';
 import * as watcherModule from '../src/utils/watcher.js';
@@ -315,6 +316,251 @@ describe('Watch runs - overwrite.removeStaleFiles', () => {
     expect(existsSync(keptOutputFile)).toBe(true);
     // removeStaleFiles=false means the stale file is left on disk
     expect(existsSync(staleOutputFile)).toBe(true);
+
+    await stopWatching();
+    await runningWatcher;
+    await waitForNextEvent();
+  });
+});
+
+describe('Watch runs - externally modified output files', () => {
+  const runWatchAndGetStopWatching = async (
+    codegenContext: ConstructorParameters<typeof CodegenContext>[0],
+  ) => {
+    const context = new CodegenContext(codegenContext);
+    const runningWatcher = generate(context);
+    await waitForNextEvent();
+
+    const { stopWatching } = createWatcherSpy.mock.results.at(-1)!.value as ReturnType<
+      typeof watcherModule.createWatcher
+    >;
+
+    return { context, runningWatcher, stopWatching };
+  };
+
+  const setupSchemaAndDocument = () => {
+    const files = setupTestFiles();
+    writeFileSync(
+      files.schemaFile.absolute,
+      /* GraphQL */ `
+        type Query {
+          me: User
+        }
+
+        type User {
+          id: ID!
+          name: String!
+        }
+      `,
+    );
+    writeFileSync(
+      files.documentFile.absolute,
+      /* GraphQL */ `
+        query {
+          me {
+            id
+          }
+        }
+      `,
+    );
+    return files;
+  };
+
+  // The `typescript` plugin output depends only on the schema, so editing the
+  // document triggers a rebuild that regenerates identical content -- exercising
+  // the "identical hash -> skip write" path where the on-disk change would
+  // otherwise be lost.
+  const triggerRebuild = (documentFile: { absolute: string }) => {
+    writeFileSync(
+      documentFile.absolute,
+      /* GraphQL */ `
+        query {
+          me {
+            id
+            name
+          }
+        }
+      `,
+    );
+  };
+
+  test('preset - compares output content against content on disk when contentComparison=disk', async () => {
+    const { testDir, schemaFile, documentFile } = setupSchemaAndDocument();
+    await waitForNextEvent();
+
+    const { runningWatcher, stopWatching } = await runWatchAndGetStopWatching({
+      filepath: path.join(testDir, 'codegen.ts'),
+      config: {
+        schema: schemaFile.relative,
+        documents: documentFile.relative,
+        watch: true,
+        generates: {
+          [testDir]: {
+            preset: {
+              buildGeneratesSection: options => [
+                {
+                  filename: path.join(options.baseOutputDir, 'output.ts'),
+                  schema: options.schema,
+                  schemaAst: options.schemaAst,
+                  documents: [],
+                  config: {},
+                  pluginMap: { add: addPlugin },
+                  plugins: [{ add: { content: 'Default Content' } }],
+                  contentComparison: 'disk',
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const outputFile = path.join(testDir, 'output.ts');
+
+    // Initial run generates the file.
+    expect(existsSync(outputFile)).toBe(true);
+    const generatedContent = readFileSync(outputFile, 'utf8');
+    expect(generatedContent.length).toBeGreaterThan(0);
+
+    // Simulate the file being changed on disk after codegen wrote it. The watcher
+    // ignores output files, so this write does not itself trigger a rebuild.
+    writeFileSync(outputFile, '// tampered on disk\n');
+
+    triggerRebuild(documentFile);
+    await waitForNextEvent();
+
+    // contentComparison:'disk' forces a disk comparison, so the tampered file is
+    // restored to the generated content.
+    expect(readFileSync(outputFile, 'utf8')).toBe(generatedContent);
+
+    await stopWatching();
+    await runningWatcher;
+    await waitForNextEvent();
+  });
+
+  test('preset - compares output content against content in the cache when contentComparison=cache-first (default)', async () => {
+    const { testDir, schemaFile, documentFile } = setupSchemaAndDocument();
+    await waitForNextEvent();
+
+    const { runningWatcher, stopWatching } = await runWatchAndGetStopWatching({
+      filepath: path.join(testDir, 'codegen.ts'),
+      config: {
+        schema: schemaFile.relative,
+        documents: documentFile.relative,
+        watch: true,
+        generates: {
+          [testDir]: {
+            preset: {
+              buildGeneratesSection: options => [
+                {
+                  filename: path.join(options.baseOutputDir, 'output.ts'),
+                  schema: options.schema,
+                  schemaAst: options.schemaAst,
+                  documents: [],
+                  config: {},
+                  pluginMap: { add: addPlugin },
+                  plugins: [{ add: { content: 'Default Content' } }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const outputFile = path.join(testDir, 'output.ts');
+
+    // Initial run generates the file.
+    expect(existsSync(outputFile)).toBe(true);
+    const generatedContent = readFileSync(outputFile, 'utf8');
+    expect(generatedContent.length).toBeGreaterThan(0);
+
+    // Simulate the file being changed on disk after codegen wrote it. The watcher
+    // ignores output files, so this write does not itself trigger a rebuild.
+    const tampered = '// tampered on disk\n';
+    writeFileSync(outputFile, tampered);
+
+    triggerRebuild(documentFile);
+    await waitForNextEvent();
+
+    // The regenerated content is identical to the cached hash, so the write is
+    // skipped and the on-disk change is left untouched -- the existing
+    // performance optimization for pure outputs.
+    expect(readFileSync(outputFile, 'utf8')).toBe(tampered);
+
+    await stopWatching();
+    await runningWatcher;
+    await waitForNextEvent();
+  });
+
+  test('plugin - compares output content against content on disk when contentComparison=disk', async () => {
+    const { testDir, schemaFile, documentFile } = setupSchemaAndDocument();
+    await waitForNextEvent();
+
+    const outputFile = path.join(testDir, 'types.ts');
+
+    const { runningWatcher, stopWatching } = await runWatchAndGetStopWatching({
+      filepath: path.join(testDir, 'codegen.ts'),
+      config: {
+        schema: schemaFile.relative,
+        documents: documentFile.relative,
+        watch: true,
+        generates: {
+          // No preset: the flag is set directly on the output config, which the CLI
+          // forwards to the resulting FileOutput.
+          [outputFile]: { plugins: ['typescript'], contentComparison: 'disk' },
+        },
+      },
+    });
+
+    expect(existsSync(outputFile)).toBe(true);
+    const generatedContent = readFileSync(outputFile, 'utf8');
+    expect(generatedContent.length).toBeGreaterThan(0);
+
+    writeFileSync(outputFile, '// tampered on disk\n');
+
+    triggerRebuild(documentFile);
+    await waitForNextEvent();
+
+    expect(readFileSync(outputFile, 'utf8')).toBe(generatedContent);
+
+    await stopWatching();
+    await runningWatcher;
+    await waitForNextEvent();
+  });
+
+  test('plugin - compares output content against content in the cache when contentComparison=cache-first (default)', async () => {
+    const { testDir, schemaFile, documentFile } = setupSchemaAndDocument();
+    await waitForNextEvent();
+
+    const outputFile = path.join(testDir, 'types.ts');
+
+    const { runningWatcher, stopWatching } = await runWatchAndGetStopWatching({
+      filepath: path.join(testDir, 'codegen.ts'),
+      config: {
+        schema: schemaFile.relative,
+        documents: documentFile.relative,
+        watch: true,
+        generates: {
+          // Default contentComparison ('cache-first'): output is treated as a pure
+          // function of the schema, so the CLI trusts its in-memory hash and skips
+          // re-reading the file.
+          [outputFile]: { plugins: ['typescript'] },
+        },
+      },
+    });
+
+    expect(existsSync(outputFile)).toBe(true);
+    const tampered = '// tampered on disk\n';
+    writeFileSync(outputFile, tampered);
+
+    triggerRebuild(documentFile);
+    await waitForNextEvent();
+
+    // The regenerated content is identical to the cached hash, so the write is
+    // skipped and the on-disk change is left untouched -- the existing
+    // performance optimization for pure outputs.
+    expect(readFileSync(outputFile, 'utf8')).toBe(tampered);
 
     await stopWatching();
     await runningWatcher;

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -4,6 +4,22 @@ import { Source } from '@graphql-tools/utils';
 import type { Profiler } from './profiler.js';
 
 export namespace Types {
+  /**
+   * @description Controls how the CLI decides whether the generated content already
+   * matches the output file so the write can be skipped:
+   *
+   * - `'cache-first'` (default): compare against the in-memory hash of what codegen
+   *   last wrote, falling back to reading the file from disk when there is no cached
+   *   entry. Assumes the output is a pure function of the codegen inputs.
+   * - `'disk'`: always compare against the file on disk. Use this when the output
+   *   depends on the file's existing content (e.g. a preset that reads the file and
+   *   rewrites part of it), so a file that was changed on disk is not wrongly skipped
+   *   in watch mode.
+   *
+   * @default 'cache-first'
+   */
+  export type ContentComparison = 'cache-first' | 'disk';
+
   export interface GenerateOptions {
     filename: string;
     plugins: Types.ConfiguredPlugin[];
@@ -22,6 +38,11 @@ export namespace Types {
     documentTransforms?: ConfiguredDocumentTransform[];
     emitLegacyCommonJSImports?: boolean;
     importExtension?: '' | `.${string}`;
+    /**
+     * @description How the CLI compares generated content against the output file
+     * to decide whether the write can be skipped. See {@link Types.ContentComparison}.
+     */
+    contentComparison?: Types.ContentComparison;
   }
 
   export type FileOutput = {
@@ -31,6 +52,11 @@ export namespace Types {
       beforeOneFileWrite?: LifecycleHooksDefinition['beforeOneFileWrite'];
       afterOneFileWrite?: LifecycleHooksDefinition['afterOneFileWrite'];
     };
+    /**
+     * @description How the CLI compares generated content against the output file
+     * to decide whether the write can be skipped. See {@link Types.ContentComparison}.
+     */
+    contentComparison?: Types.ContentComparison;
   };
 
   export interface DocumentFile extends Source {
@@ -289,6 +315,14 @@ export namespace Types {
      * For more details: https://graphql-code-generator.com/docs/config-reference/codegen-config
      */
     overwrite?: boolean | Partial<NormalizedOverwriteOption>;
+    /**
+     * @description How the CLI compares generated content against the output file
+     * to decide whether the write can be skipped. See {@link Types.ContentComparison}.
+     *
+     * A preset can also set this per output from `buildGeneratesSection`; the value
+     * returned there takes precedence over this one.
+     */
+    contentComparison?: Types.ContentComparison;
     /**
      * @description A pointer(s) to your GraphQL documents: query, mutation, subscription and fragment. These documents will be loaded into for all your output files.
      * You can use one of the following:

--- a/website/src/pages/docs/config-reference/codegen-config.mdx
+++ b/website/src/pages/docs/config-reference/codegen-config.mdx
@@ -83,6 +83,16 @@ Here are the supported options that you can define in the config file (see
   - **`generates.overwrite`** - Same as root `overwrite`, but applies only for the specific output
     file. When set, it takes precedence over the root `overwrite` option for this output file
 
+  - **`generates.contentComparison`** - Controls how Codegen decides whether a generated file needs
+    to be rewritten in [watch mode](/docs/getting-started/development-workflow#watch-mode)
+    (`'cache-first'` by default). In watch mode the CLI remembers the hash of the content it last
+    wrote for each file and skips the write when the newly generated content matches, which assumes
+    the output is a pure function of its inputs. If an output's content instead depends on the
+    file's existing content on disk (for example a preset that reads the file and rewrites part of
+    it), set this to `'disk'` so the comparison is made against the file on disk, ensuring the file
+    is rewritten when it was changed externally. A preset can also set this on the outputs it
+    returns from `buildGeneratesSection`; when both are set, the preset's value takes precedence
+
 - [**`require`**](./require-field) - A path to a file which defines custom Node.JS `require()`
   handlers for custom file extensions. This option is essential if the code generator has to go
   through files that require other files in an unsupported format

--- a/website/src/pages/docs/getting-started/development-workflow.mdx
+++ b/website/src/pages/docs/getting-started/development-workflow.mdx
@@ -85,6 +85,37 @@ const config: CodegenConfig = {
 export default config
 ```
 
+### Skipping unchanged writes
+
+To avoid redundant writes on every rebuild, watch mode remembers the hash of the content it last
+wrote for each output and skips the write when the newly generated content is identical. This
+assumes each output is a pure function of its inputs (schema and documents), which is true for
+regular plugin outputs.
+
+If an output's content instead depends on the file's existing content on disk — for example a preset
+that reads the current file and rewrites only part of it — that assumption breaks: if the file is
+changed externally and codegen regenerates content matching an earlier run, the cached hash still
+matches and the change on disk is never corrected. Set
+[`contentComparison`](/docs/config-reference/codegen-config) to `'disk'` on that output to compare
+against the file on disk instead:
+
+```ts {8}
+import { CodegenConfig } from '@graphql-codegen/cli'
+
+const config: CodegenConfig = {
+  schema: 'http://localhost:4000/graphql',
+  watch: true,
+  generates: {
+    './src/generated.ts': {
+      contentComparison: 'disk',
+      plugins: ['typescript']
+    }
+  }
+}
+
+export default config
+```
+
 ## Monorepo and pnpm Workspaces
 
 If you are using a monorepo structure, with tools such as


### PR DESCRIPTION
## Description

Codegen maintains an in-memory cache that caches the content of a generated files.
When plugins and presets send output to be written to disk, Codegen checks the cache before checking the file on disk to see if it should write to disk.

This is an optimisation approach:
1. To avoid writing to disk given the same content
2. To avoid reading from disk if data exists in cache.

However, in the edge case where content of a file in the cache vs disk are not in sync e.g. file is updated by user or Server Preset, then it may get to a scenario where Codegen incorrectly skips writing generated content.

Here's a quick example:

1. First run, output file has content `abcd` (value is `abcd` in both cache and disk)
2. Output file content is updated to `zzzz` manually (value is `abcd` in cache, `zzzz` in disk )
3. Second run, plugin sends `abcd` again to be written to disk. Since `abcd` is in cache, writing is skipped. So the `zzzz` content in disk is never updated back to `abcd`!

---

This PR adds a config option `contentComparison: 'cache-first' | 'disk'` for plugins and presets to declare which content comparison approach to use:

- `cache-first` (default): the existing behaviour. Majority of Codegen use case assumes generated files are not updated manually i.e. cache and disk do not go out of sync. So the existing optimisation is valid.
- `disk`: this behaviour forces Codegen to check for the generated file content on disk instead of cache. This is useful for plugins/presets where generated types are manually updated or codemoded e.g. resolver files of Server Preset
     - Note: To keep it consistent, also update cache after every run.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit test 
- [x] Alpha version test

