### PR TITLE
Fix `overwrite` being ignored for preset-based `generates` outputs

### DIFF
--- a/.changeset/overwrite-preset-outputs.md
+++ b/.changeset/overwrite-preset-outputs.md
@@ -1,0 +1,21 @@
+---
+'@graphql-codegen/cli': patch
+'@graphql-codegen/plugin-helpers': patch
+---
+
+Fix `overwrite` being ignored for preset-based `generates` outputs.
+
+A `generates` entry that used a preset and set `overwrite` (e.g.
+`overwrite: { removeStaleFiles: false }`) had that setting silently ignored, so in
+watch mode its generated files could still be deleted as stale.
+
+The CLI resolved `overwrite` per generated file by looking the file's path up in
+`config.generates`. That fails for a preset: its `generates` entry is keyed by the
+preset's `baseOutputDir`, not by any generated file's path (and a preset can emit
+files outside that directory), and the lookup additionally required a `plugins` key
+that preset entries don't have. Both cases fell through to the global `config.overwrite`
+(default `true`).
+
+The entry's `overwrite` is now carried on each `FileOutput` (alongside `hooks` and
+`contentComparison`) when outputs are built, and honored per file — including for
+files a preset emits outside its `baseOutputDir`.

--- a/.changeset/overwrite-preset-outputs.md
+++ b/.changeset/overwrite-preset-outputs.md
@@ -15,7 +15,3 @@ preset's `baseOutputDir`, not by any generated file's path (and a preset can emi
 files outside that directory), and the lookup additionally required a `plugins` key
 that preset entries don't have. Both cases fell through to the global `config.overwrite`
 (default `true`).
-
-The entry's `overwrite` is now carried on each `FileOutput` (alongside `hooks` and
-`contentComparison`) when outputs are built, and honored per file — including for
-files a preset emits outside its `baseOutputDir`.

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -526,6 +526,11 @@ export async function executeCodegen(
                               // Fall back to `outputConfig` so plugin outputs can opt in too.
                               contentComparison:
                                 outputArgs.contentComparison ?? outputConfig.contentComparison,
+                              // Carry the entry's `overwrite` onto the file so the CLI can honor it
+                              // per file. Unlike `contentComparison`, this is intentionally not
+                              // `outputArgs.overwrite ?? outputConfig.overwrite`: presets should not
+                              // be able to set `overwrite` per file (a capability this doesn't need).
+                              overwrite: outputConfig.overwrite,
                             });
                           };
 

--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -526,10 +526,12 @@ export async function executeCodegen(
                               // Fall back to `outputConfig` so plugin outputs can opt in too.
                               contentComparison:
                                 outputArgs.contentComparison ?? outputConfig.contentComparison,
-                              // Carry the entry's `overwrite` onto the file so the CLI can honor it
-                              // per file. Unlike `contentComparison`, this is intentionally not
+
+                              // Carry the entry's `overwrite` onto the file so the CLI can honor it per file.
+                              // Unlike `contentComparison`, this is intentionally not
                               // `outputArgs.overwrite ?? outputConfig.overwrite`: presets should not
-                              // be able to set `overwrite` per file (a capability this doesn't need).
+                              // be able to set `overwrite` per file from buildGeneratesSection
+                              // (a capability this doesn't need).
                               overwrite: outputConfig.overwrite,
                             });
                           };

--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -30,16 +30,18 @@ export async function generate(
     'Lifecycle: afterStart',
   );
 
-  let previouslyGeneratedFilenames: string[] = [];
+  // Store only the projection (`filename` + `overwrite`) rather than full results, so a
+  // file that disappears is still judged by the `overwrite` of the entry that produced it.
+  let previouslyGeneratedFiles: Pick<Types.FileOutput, 'filename' | 'overwrite'>[] = [];
 
   function removeStaleFiles(config: Types.Config, generationResult: Types.FileOutput[]) {
     const filenames = generationResult.map(o => o.filename);
     // find stale files from previous build which are not present in current build
-    const staleFilenames = previouslyGeneratedFilenames.filter(f => !filenames.includes(f));
-    for (const filename of staleFilenames) {
-      if (normalizeOverwriteConfig(config, filename).removeStaleFiles) {
-        unlinkFile(filename, err => {
-          const prettyFilename = filename.replace(`${input.cwd || process.cwd()}/`, '');
+    const staleFiles = previouslyGeneratedFiles.filter(f => !filenames.includes(f.filename));
+    for (const staleFile of staleFiles) {
+      if (normalizeOverwriteConfig(config, staleFile).removeStaleFiles) {
+        unlinkFile(staleFile.filename, err => {
+          const prettyFilename = staleFile.filename.replace(`${input.cwd || process.cwd()}/`, '');
           if (err) {
             debugLog(`Cannot remove stale file: ${prettyFilename}\n${err}`);
           } else {
@@ -48,7 +50,10 @@ export async function generate(
         });
       }
     }
-    previouslyGeneratedFilenames = filenames;
+    previouslyGeneratedFiles = generationResult.map(o => ({
+      filename: o.filename,
+      overwrite: o.overwrite,
+    }));
   }
 
   // Records the hash of the content codegen last wrote per file. This is always
@@ -99,7 +104,7 @@ export async function generate(
               recentOutputHash.set(result.filename, previousHash);
             }
 
-            if (!normalizeOverwriteConfig(config, result.filename).updateExistingFiles && exists) {
+            if (!normalizeOverwriteConfig(config, result).updateExistingFiles && exists) {
               return;
             }
 
@@ -219,22 +224,10 @@ export async function generate(
 
 function normalizeOverwriteConfig(
   config: Types.Config,
-  outputPath: string,
+  fileOutput: Pick<Types.FileOutput, 'filename' | 'overwrite'>,
 ): Types.NormalizedOverwriteOption {
-  const overwrite = (function getOverwriteOption(): Types.Config['overwrite'] {
-    const { overwrite: result = true } = config;
-    const outputConfig = config.generates[outputPath];
-
-    if (!outputConfig) {
-      debugLog(`Couldn't find a config of ${outputPath}`);
-      return result;
-    }
-    if (isConfiguredOutput(outputConfig) && outputConfig.overwrite !== undefined) {
-      return outputConfig.overwrite;
-    }
-
-    return result;
-  })();
+  // `??` (not `||`) is load-bearing: `overwrite: false` is meaningful and must survive.
+  const overwrite = fileOutput.overwrite ?? config.overwrite ?? true;
 
   if (overwrite === true) {
     return {
@@ -253,10 +246,6 @@ function normalizeOverwriteConfig(
   const { removeStaleFiles = true, updateExistingFiles = true } = overwrite;
 
   return { removeStaleFiles, updateExistingFiles };
-}
-
-function isConfiguredOutput(output: any): output is Types.ConfiguredOutput {
-  return typeof output.plugins !== 'undefined';
 }
 
 async function hashFile(filePath: string): Promise<string | null> {

--- a/packages/graphql-codegen-cli/src/generate-and-save.ts
+++ b/packages/graphql-codegen-cli/src/generate-and-save.ts
@@ -39,7 +39,7 @@ export async function generate(
     // find stale files from previous build which are not present in current build
     const staleFiles = previouslyGeneratedFiles.filter(f => !filenames.includes(f.filename));
     for (const staleFile of staleFiles) {
-      if (normalizeOverwriteConfig(config, staleFile).removeStaleFiles) {
+      if (normalizeOverwriteConfig(config.overwrite, staleFile.overwrite).removeStaleFiles) {
         unlinkFile(staleFile.filename, err => {
           const prettyFilename = staleFile.filename.replace(`${input.cwd || process.cwd()}/`, '');
           if (err) {
@@ -50,9 +50,9 @@ export async function generate(
         });
       }
     }
-    previouslyGeneratedFiles = generationResult.map(o => ({
-      filename: o.filename,
-      overwrite: o.overwrite,
+    previouslyGeneratedFiles = generationResult.map(res => ({
+      filename: res.filename,
+      overwrite: res.overwrite,
     }));
   }
 
@@ -104,7 +104,10 @@ export async function generate(
               recentOutputHash.set(result.filename, previousHash);
             }
 
-            if (!normalizeOverwriteConfig(config, result).updateExistingFiles && exists) {
+            if (
+              !normalizeOverwriteConfig(config.overwrite, result.overwrite).updateExistingFiles &&
+              exists
+            ) {
               return;
             }
 
@@ -223,11 +226,10 @@ export async function generate(
 }
 
 function normalizeOverwriteConfig(
-  config: Types.Config,
-  fileOutput: Pick<Types.FileOutput, 'filename' | 'overwrite'>,
+  configOverwrite: Types.Config['overwrite'],
+  fileOverwrite: Types.FileOutput['overwrite'],
 ): Types.NormalizedOverwriteOption {
-  // `??` (not `||`) is load-bearing: `overwrite: false` is meaningful and must survive.
-  const overwrite = fileOutput.overwrite ?? config.overwrite ?? true;
+  const overwrite = fileOverwrite ?? configOverwrite ?? true;
 
   if (overwrite === true) {
     return {

--- a/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
+++ b/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
@@ -9,7 +9,6 @@ import {
 } from 'fs';
 import * as path from 'path';
 import type { Mock } from 'vitest';
-import * as addPlugin from '@graphql-codegen/add';
 import type { Types } from '@graphql-codegen/plugin-helpers';
 import { CodegenContext } from '../src/config.js';
 import { generate } from '../src/generate-and-save.js';
@@ -613,8 +612,8 @@ describe('Watch runs - externally modified output files', () => {
                   schemaAst: options.schemaAst,
                   documents: [],
                   config: {},
-                  pluginMap: { add: addPlugin },
-                  plugins: [{ add: { content: 'Default Content' } }],
+                  pluginMap: { inline: { plugin: () => 'Default Content' } },
+                  plugins: [{ inline: {} }],
                   contentComparison: 'disk',
                 },
               ],
@@ -667,8 +666,8 @@ describe('Watch runs - externally modified output files', () => {
                   schemaAst: options.schemaAst,
                   documents: [],
                   config: {},
-                  pluginMap: { add: addPlugin },
-                  plugins: [{ add: { content: 'Default Content' } }],
+                  pluginMap: { inline: { plugin: () => 'Default Content' } },
+                  plugins: [{ inline: {} }],
                 },
               ],
             },

--- a/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
+++ b/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
@@ -323,7 +323,7 @@ describe('Watch runs - overwrite.removeStaleFiles', () => {
     await waitForNextEvent();
   });
 
-  test('honors overwrite.removeStaleFiles=false set on a preset-based `generates` entry', async () => {
+  test('preset - does not remove stale files when overwrite.removeStaleFiles=false', async () => {
     const { testDir, schemaFile, documentFile } = setupTestFiles();
     writeFileSync(
       schemaFile.absolute,
@@ -360,25 +360,8 @@ describe('Watch runs - overwrite.removeStaleFiles', () => {
     // path-prefix match on the directory key would not cover this one either.
     const fileOutsideDir = path.join(testDir, 'outside.ts');
 
-    // A minimal stub preset that emits one file per name in `presetConfig.filenames`,
-    // with an inline plugin so the content is non-empty and the files land on disk.
-    const stubPreset: Types.OutputPreset = {
-      buildGeneratesSection: options =>
-        (options.presetConfig.filenames as string[]).map(filename => ({
-          filename,
-          plugins: [{ inline: {} }],
-          pluginMap: { inline: { plugin: () => 'export const generated = true;' } },
-          schema: options.schema,
-          schemaAst: options.schemaAst,
-          documents: options.documents,
-          config: options.config,
-          pluginContext: options.pluginContext,
-          profiler: options.profiler,
-          documentTransforms: options.documentTransforms,
-        })),
-    };
-
-    const { context, runningWatcher, stopWatching } = await runWatchAndGetStopWatching({
+    let run = 0;
+    const { runningWatcher, stopWatching } = await runWatchAndGetStopWatching({
       filepath: path.join(testDir, 'codegen.ts'),
       config: {
         schema: schemaFile.relative,
@@ -388,8 +371,28 @@ describe('Watch runs - overwrite.removeStaleFiles', () => {
         // stale files would be deleted unless the entry's setting is honored.
         generates: {
           [baseOutputDir]: {
-            preset: stubPreset,
-            presetConfig: { filenames: [fileUnderDirA, fileUnderDirB, fileOutsideDir] },
+            preset: {
+              buildGeneratesSection: options => {
+                const runFiles: string[][] = [
+                  [fileUnderDirA, fileUnderDirB, fileOutsideDir],
+                  [fileUnderDirA],
+                ];
+
+                const result = runFiles[run].map((filename: string) => ({
+                  filename,
+                  plugins: [{ inline: {} }],
+                  pluginMap: { inline: { plugin: () => 'export const generated = true;' } },
+                  schema: options.schema,
+                  schemaAst: options.schemaAst,
+                  documents: [],
+                  config: {},
+                }));
+
+                run++;
+
+                return result;
+              },
+            } satisfies Types.OutputPreset,
             overwrite: { removeStaleFiles: false },
           },
         },
@@ -402,15 +405,6 @@ describe('Watch runs - overwrite.removeStaleFiles', () => {
     expect(existsSync(fileOutsideDir)).toBe(true);
 
     // Second run: the preset now emits only one file, so the other two become stale
-    context.updateConfig({
-      generates: {
-        [baseOutputDir]: {
-          preset: stubPreset,
-          presetConfig: { filenames: [fileUnderDirA] },
-          overwrite: { removeStaleFiles: false },
-        },
-      },
-    });
     writeFileSync(
       documentFile.absolute,
       /* GraphQL */ `

--- a/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
+++ b/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
@@ -10,6 +10,7 @@ import {
 import * as path from 'path';
 import type { Mock } from 'vitest';
 import * as addPlugin from '@graphql-codegen/add';
+import type { Types } from '@graphql-codegen/plugin-helpers';
 import { CodegenContext } from '../src/config.js';
 import { generate } from '../src/generate-and-save.js';
 import * as watcherModule from '../src/utils/watcher.js';
@@ -316,6 +317,118 @@ describe('Watch runs - overwrite.removeStaleFiles', () => {
     expect(existsSync(keptOutputFile)).toBe(true);
     // removeStaleFiles=false means the stale file is left on disk
     expect(existsSync(staleOutputFile)).toBe(true);
+
+    await stopWatching();
+    await runningWatcher;
+    await waitForNextEvent();
+  });
+
+  test('honors overwrite.removeStaleFiles=false set on a preset-based `generates` entry', async () => {
+    const { testDir, schemaFile, documentFile } = setupTestFiles();
+    writeFileSync(
+      schemaFile.absolute,
+      /* GraphQL */ `
+        type Query {
+          me: User
+        }
+
+        type User {
+          id: ID!
+          name: String!
+        }
+      `,
+    );
+    writeFileSync(
+      documentFile.absolute,
+      /* GraphQL */ `
+        query {
+          me {
+            id
+          }
+        }
+      `,
+    );
+    await waitForNextEvent();
+
+    // The `generates` entry is keyed by a directory (`baseOutputDir`), not a file path,
+    // and has no `plugins` key — the preset supplies plugins itself. Both facts used to
+    // defeat the per-file `overwrite` lookup, so the entry's setting was silently ignored.
+    const baseOutputDir = path.join(testDir, 'generated');
+    const fileUnderDirA = path.join(baseOutputDir, 'a.ts');
+    const fileUnderDirB = path.join(baseOutputDir, 'b.ts');
+    // Deliberately outside `baseOutputDir` — a preset may emit files anywhere, so a
+    // path-prefix match on the directory key would not cover this one either.
+    const fileOutsideDir = path.join(testDir, 'outside.ts');
+
+    // A minimal stub preset that emits one file per name in `presetConfig.filenames`,
+    // with an inline plugin so the content is non-empty and the files land on disk.
+    const stubPreset: Types.OutputPreset = {
+      buildGeneratesSection: options =>
+        (options.presetConfig.filenames as string[]).map(filename => ({
+          filename,
+          plugins: [{ inline: {} }],
+          pluginMap: { inline: { plugin: () => 'export const generated = true;' } },
+          schema: options.schema,
+          schemaAst: options.schemaAst,
+          documents: options.documents,
+          config: options.config,
+          pluginContext: options.pluginContext,
+          profiler: options.profiler,
+          documentTransforms: options.documentTransforms,
+        })),
+    };
+
+    const { context, runningWatcher, stopWatching } = await runWatchAndGetStopWatching({
+      filepath: path.join(testDir, 'codegen.ts'),
+      config: {
+        schema: schemaFile.relative,
+        documents: documentFile.relative,
+        watch: true,
+        // Global `overwrite` is left at its default (`removeStaleFiles: true`), so the
+        // stale files would be deleted unless the entry's setting is honored.
+        generates: {
+          [baseOutputDir]: {
+            preset: stubPreset,
+            presetConfig: { filenames: [fileUnderDirA, fileUnderDirB, fileOutsideDir] },
+            overwrite: { removeStaleFiles: false },
+          },
+        },
+      },
+    });
+
+    // Initial run: all three outputs are generated
+    expect(existsSync(fileUnderDirA)).toBe(true);
+    expect(existsSync(fileUnderDirB)).toBe(true);
+    expect(existsSync(fileOutsideDir)).toBe(true);
+
+    // Second run: the preset now emits only one file, so the other two become stale
+    context.updateConfig({
+      generates: {
+        [baseOutputDir]: {
+          preset: stubPreset,
+          presetConfig: { filenames: [fileUnderDirA] },
+          overwrite: { removeStaleFiles: false },
+        },
+      },
+    });
+    writeFileSync(
+      documentFile.absolute,
+      /* GraphQL */ `
+        query {
+          me {
+            id
+            name
+          }
+        }
+      `,
+    );
+    await waitForNextEvent();
+
+    expect(existsSync(fileUnderDirA)).toBe(true);
+    // removeStaleFiles=false on the preset entry means both stale files are left on disk,
+    // whether they were under `baseOutputDir` or outside it.
+    expect(existsSync(fileUnderDirB)).toBe(true);
+    expect(existsSync(fileOutsideDir)).toBe(true);
 
     await stopWatching();
     await runningWatcher;

--- a/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
+++ b/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
@@ -428,6 +428,108 @@ describe('Watch runs - overwrite.removeStaleFiles', () => {
     await runningWatcher;
     await waitForNextEvent();
   });
+
+  test('preset - removes stale files when overwrite.removeStaleFiles=true', async () => {
+    const { testDir, schemaFile, documentFile } = setupTestFiles();
+    writeFileSync(
+      schemaFile.absolute,
+      /* GraphQL */ `
+        type Query {
+          me: User
+        }
+
+        type User {
+          id: ID!
+          name: String!
+        }
+      `,
+    );
+    writeFileSync(
+      documentFile.absolute,
+      /* GraphQL */ `
+        query {
+          me {
+            id
+          }
+        }
+      `,
+    );
+    await waitForNextEvent();
+
+    const baseOutputDir = path.join(testDir, 'generated');
+    const fileUnderDirA = path.join(baseOutputDir, 'a.ts');
+    const fileUnderDirB = path.join(baseOutputDir, 'b.ts');
+    const fileOutsideDir = path.join(testDir, 'outside.ts');
+
+    let run = 0;
+    const { runningWatcher, stopWatching } = await runWatchAndGetStopWatching({
+      filepath: path.join(testDir, 'codegen.ts'),
+      config: {
+        schema: schemaFile.relative,
+        documents: documentFile.relative,
+        watch: true,
+        // Global `overwrite` disables stale removal, so the stale files would be kept
+        // unless the entry's `removeStaleFiles: true` is honored and overrides it.
+        overwrite: { removeStaleFiles: false },
+        generates: {
+          [baseOutputDir]: {
+            preset: {
+              buildGeneratesSection: options => {
+                const runFiles: string[][] = [
+                  [fileUnderDirA, fileUnderDirB, fileOutsideDir],
+                  [fileUnderDirA],
+                ];
+
+                const result = runFiles[run].map((filename: string) => ({
+                  filename,
+                  plugins: [{ inline: {} }],
+                  pluginMap: { inline: { plugin: () => 'export const generated = true;' } },
+                  schema: options.schema,
+                  schemaAst: options.schemaAst,
+                  documents: [],
+                  config: {},
+                }));
+
+                run++;
+
+                return result;
+              },
+            } satisfies Types.OutputPreset,
+            overwrite: { removeStaleFiles: true },
+          },
+        },
+      },
+    });
+
+    // Initial run: all three outputs are generated
+    expect(existsSync(fileUnderDirA)).toBe(true);
+    expect(existsSync(fileUnderDirB)).toBe(true);
+    expect(existsSync(fileOutsideDir)).toBe(true);
+
+    // Second run: the preset now emits only one file, so the other two become stale
+    writeFileSync(
+      documentFile.absolute,
+      /* GraphQL */ `
+        query {
+          me {
+            id
+            name
+          }
+        }
+      `,
+    );
+    await waitForNextEvent();
+
+    expect(existsSync(fileUnderDirA)).toBe(true);
+    // removeStaleFiles=true on the preset entry means both stale files are removed,
+    // whether they were under `baseOutputDir` or outside it.
+    expect(existsSync(fileUnderDirB)).toBe(false);
+    expect(existsSync(fileOutsideDir)).toBe(false);
+
+    await stopWatching();
+    await runningWatcher;
+    await waitForNextEvent();
+  });
 });
 
 describe('Watch runs - externally modified output files', () => {

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -57,6 +57,12 @@ export namespace Types {
      * to decide whether the write can be skipped. See {@link Types.ContentComparison}.
      */
     contentComparison?: Types.ContentComparison;
+    /**
+     * @description Carries the `overwrite` setting from the `generates` entry that
+     * produced this file, so the CLI can honor it per file (e.g. a preset keyed by a
+     * directory, which can't be looked up by a generated file's path).
+     */
+    overwrite?: boolean | Partial<NormalizedOverwriteOption>;
   };
 
   export interface DocumentFile extends Source {


### PR DESCRIPTION
## Description

Fixes `overwrite` being silently ignored for **preset-based** `generates` outputs.

A `generates` entry that uses a preset and sets `overwrite` — e.g.
`overwrite: { removeStaleFiles: false }` — had that setting dropped entirely. In watch
mode its generated files were still deleted as "stale". This was originally hit via
`@eddeee888/gcg-typescript-resolver-files` (the server preset), which hard-codes
`overwrite.removeStaleFiles: false` specifically to stop watch mode deleting resolver files.
(`updateExistingFiles` was dropped identically; it just happened to coincide with the
fallback default, so only `removeStaleFiles` was observable.)

### Root cause

`normalizeOverwriteConfig` in `generate-and-save.ts` resolved `overwrite` per generated
file by looking the file's path up in `config.generates`. Two independent assumptions
break for a preset output:

1. **Wrong lookup key.** A preset's `generates` entry is keyed by its `baseOutputDir`, not
   by any generated file's path — so the lookup never matches. (Presets can also emit files
   outside that dir, so path-prefix matching wouldn't be a valid fix either.)
2. **`isConfiguredOutput` required a `plugins` key**, which preset entries don't have — the
   preset supplies plugins itself.

Both cases fell through to the global `config.overwrite` (default `true` → `removeStaleFiles: true`).

### Fix

Don't look it up by path — carry it on the file, exactly as the codebase already does for
`hooks` and `contentComparison`:

- `Types.FileOutput` gains `overwrite?: boolean | Partial<NormalizedOverwriteOption>`.
- `codegen.ts` sets `overwrite: outputConfig.overwrite` on each pushed file. Intentionally
  **not** `outputArgs.overwrite ?? outputConfig.overwrite` (unlike `contentComparison`) —
  that would grant presets a new per-file capability from `buildGeneratesSection` that this
  bug doesn't need.
- `normalizeOverwriteConfig` now takes the two `overwrite` values directly
  (`configOverwrite`, `fileOverwrite`) and resolves `fileOverwrite ?? configOverwrite ?? true`
  (`??`, not `||`, is load-bearing — an explicit `overwrite: false` must survive). The
  now-unused `isConfiguredOutput` is removed.
- Stale-file tracking stores the `{ filename, overwrite }` projection so a file that
  disappears is still judged by the `overwrite` of the entry that produced it — including
  after its `generates` entry has been removed from config.

This keeps plain-plugin `overwrite` working exactly as before (the same value is now carried
on the file instead of re-looked-up by path), and additionally honors it for preset outputs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test
- [x] Alpha version test

## Other changes

Drive-by: the pre-existing `contentComparison` watch tests were switched from `@graphql-codegen/add` to the same inline-plugin stub the new tests use, 