### PR TITLE
Notify the unified website when docs content changes

### DIFF
--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -1,0 +1,49 @@
+name: docs-preview
+
+# Asks the-guild-org/website (which builds and serves these docs at
+# the-guild.dev/graphql/codegen) to deploy a preview built with this PR's
+# content. Same-repo PRs only: the dispatch needs a secret, which fork PRs
+# don't receive — a maintainer can trigger the website repo's
+# codegen-docs-preview workflow manually for those.
+
+on:
+  pull_request:
+    paths:
+      - website/src/pages/**
+      - website/src/components/java-installation.mdx
+      - website/src/lib/plugins/**
+      - website/src/category-to-packages.mjs
+      - website/public/assets/**
+      - website/public/config.schema.json
+
+jobs:
+  request-preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: request preview build
+        env:
+          TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+        run: |
+          curl --fail-with-body -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/the-guild-org/website/dispatches \
+            -d "{\"event_type\":\"codegen-docs-preview\",\"client_payload\":{\"pr\":\"${{ github.event.pull_request.number }}\"}}"
+
+      - name: comment preview link
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          url="https://codegen-pr-${PR}.guild-dev-website.pages.dev/graphql/codegen"
+          marker="<!-- docs-preview-link -->"
+          body="${marker}
+          📖 Docs preview (rebuilds on every push, ready ~10 min after each): ${url}"
+          existing=$(gh api "repos/${{ github.repository }}/issues/${PR}/comments" \
+            --jq ".[] | select(.body | startswith(\"${marker}\")) | .id" | head -1)
+          if [ -z "$existing" ]; then
+            gh api "repos/${{ github.repository }}/issues/${PR}/comments" -f body="$body" >/dev/null
+          fi

--- a/.github/workflows/notify-website.yaml
+++ b/.github/workflows/notify-website.yaml
@@ -1,0 +1,32 @@
+name: notify-website
+
+# The docs at the-guild.dev/graphql/codegen are built by
+# the-guild-org/website, which fetches this repo's website/src/pages content
+# at build time. Tell it to redeploy whenever that content changes.
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - website/src/pages/**
+      - website/src/components/java-installation.mdx
+      - website/src/lib/plugins/**
+      - website/src/category-to-packages.mjs
+      - website/public/assets/**
+      - website/public/config.schema.json
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger website rebuild
+        env:
+          # Fine-grained PAT for the-guild-org/website with contents:write
+          # (repository_dispatch permission).
+          TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+        run: |
+          curl --fail-with-body -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/the-guild-org/website/dispatches \
+            -d '{"event_type":"codegen-content-update"}'


### PR DESCRIPTION
The Codegen docs are moving into the unified the-guild.dev website (the-guild-org/website), which fetches this repo's `website/src/pages` content at build time and serves it at `the-guild.dev/graphql/codegen`.

Two workflows:

1. **notify-website** — on content pushes to master, fires a `repository_dispatch` (`codegen-content-update`) so the website redeploys with fresh content.
2. **docs-preview** — on same-repo PRs touching content, asks the website repo to build the site with this PR's content (`refs/pull/<n>/head`) and deploy it to `https://codegen-pr-<n>.guild-dev-website.pages.dev/graphql/codegen`, and drops a sticky comment with the link. Fork PRs can't carry the secret; a maintainer can trigger the website repo's `codegen-docs-preview` workflow manually with the PR number.

**Setup needed before merge:** add a `WEBSITE_DISPATCH_TOKEN` repo secret — a fine-grained PAT scoped to `the-guild-org/website` with `contents: write` permission.

Companion PR on the website side: the-guild-org/website#1939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)