### PR TITLE
Bump pnpm to 11.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "graphql-code-generator",
   "version": "0.0.0",
   "private": true,
-  "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a",
+  "packageManager": "pnpm@11.24.0+sha512.bd27e345e976dcb0be0b7a1228217b049a817e21b1f355c90dbe7dc46671895a8bc1e6d06c24554505ea93ea0b45f489a27ec1bfbc8de6a9659fca0f16fa0000",
   "engines": {
     "node": ">= 16.0.0"
   },


### PR DESCRIPTION
## Description

This is the latest pnpm (that is not too new) . 
I'm getting issues locally with 11.1: `[ERR_PNPM_MISSING_TIME] The metadata of typescript is missing the "time" field`
So trying to see if bumping helps

Ran using `corepack use pnpm 11.24`

