### PR TITLE
feat: implement sequential stages PoC for plugin output hand-off

### DIFF
--- a/packages/graphql-codegen-cli/src/codegen.ts
+++ b/packages/graphql-codegen-cli/src/codegen.ts
@@ -8,6 +8,7 @@ import { codegen } from '@graphql-codegen/core';
 import {
   CodegenPlugin,
   getCachedDocumentNodeFromSchema,
+  isSequentialStagesArray,
   normalizeConfig,
   normalizeImportExtension,
   normalizeInstanceOrArray,
@@ -84,6 +85,15 @@ export async function executeCodegen(
   let rootDocuments: Types.OperationDocument[];
   let rootExternalDocuments: Types.OperationDocument[];
   const generates: { [filename: string]: Types.ConfiguredOutput } = {};
+  /**
+   * PoC (see https://github.com/dotansimha/graphql-code-generator/issues/10943, "Option 1:
+   * Sequential Stages"): `generates` entries written as an array of `{ plugins }` stage objects
+   * are collected here instead of `generates`, and run through the dedicated sequential-stages
+   * code path below rather than the normal single-stage `ConfiguredOutput` path. Per-stage
+   * `schema`/`documents` overrides are out of scope for this PoC: stages share the root
+   * `schema`/`documents`.
+   */
+  const generatesStages: { [filename: string]: Types.SequentialStages } = {};
 
   const cache = createCache();
 
@@ -159,7 +169,14 @@ export async function executeCodegen(
     }
 
     for (const filename of generateKeys) {
-      const output = (generates[filename] = normalizeOutputParam(config.generates[filename]));
+      const rawEntry = config.generates[filename];
+
+      if (isSequentialStagesArray(rawEntry)) {
+        generatesStages[filename] = rawEntry;
+        continue;
+      }
+
+      const output = (generates[filename] = normalizeOutputParam(rawEntry));
 
       if (!output.preset && (!output.plugins || output.plugins.length === 0)) {
         throw new Error(
@@ -567,7 +584,150 @@ export async function executeCodegen(
             };
           });
 
-          return task.newListr(generateTasks, {
+          /**
+           * PoC (see https://github.com/dotansimha/graphql-code-generator/issues/10943,
+           * "Option 1: Sequential Stages"): one task per `generatesStages` entry. Unlike
+           * `generateTasks` above, each stage here runs its plugins sequentially (not in
+           * parallel) via successive calls to `codegen()`, and threads the `meta` a stage's
+           * plugins produced into the next stage via `pluginContext.previousStageMeta`.
+           */
+          const stageGenerateTasks: ListrTask<Ctx>[] = Object.keys(generatesStages).map(
+            filename => {
+              const stages = generatesStages[filename];
+              const title = `Generate to ${filename} (sequential stages)`;
+
+              return {
+                title,
+                async task(_, subTask) {
+                  let stageSchemaAst: GraphQLSchema;
+                  let stageSchema: DocumentNode;
+                  let stageDocuments: Types.DocumentFile[] = [];
+
+                  return subTask.newListr(
+                    [
+                      {
+                        title: 'Load GraphQL schemas',
+                        task: wrapTask(
+                          async () => {
+                            stageSchemaAst = await context.loadSchema(rootSchemas);
+                            stageSchema = getCachedDocumentNodeFromSchema(stageSchemaAst);
+                          },
+                          filename,
+                          `Load GraphQL schemas: ${filename}`,
+                          ctx,
+                        ),
+                      },
+                      {
+                        title: 'Load GraphQL documents',
+                        task: wrapTask(
+                          async () => {
+                            const documentPointerMap: UnnormalizedTypeDefPointer = {};
+                            for (const ptr of rootDocuments) {
+                              if (typeof ptr === 'string') {
+                                documentPointerMap[ptr] = {};
+                              } else if (typeof ptr === 'object') {
+                                Object.assign(documentPointerMap, ptr);
+                              }
+                            }
+                            stageDocuments =
+                              Object.keys(documentPointerMap).length > 0
+                                ? await context.loadDocuments(documentPointerMap, 'standard')
+                                : [];
+                          },
+                          filename,
+                          `Load GraphQL documents: ${filename}`,
+                          ctx,
+                        ),
+                      },
+                      {
+                        title: 'Generate (sequential stages)',
+                        task: wrapTask(
+                          async () => {
+                            const pluginLoader =
+                              config.pluginLoader || makeDefaultLoader(context.cwd);
+                            let content = '';
+                            // Meta handed off from the previous stage's plugins, keyed by plugin
+                            // name, so the next stage's plugins can build on top of it.
+                            let previousStageMeta: Record<string, unknown> = {};
+
+                            for (const stageConfig of stages) {
+                              const normalizedPluginsArray = normalizeConfig(
+                                stageConfig.plugins || [],
+                              );
+                              const pluginPackages = await Promise.all(
+                                normalizedPluginsArray.map(plugin =>
+                                  getPluginByName(Object.keys(plugin)[0], pluginLoader),
+                                ),
+                              );
+                              const pluginMap: { [name: string]: CodegenPlugin } =
+                                Object.fromEntries(
+                                  pluginPackages.map((pkg, i) => [
+                                    Object.keys(normalizedPluginsArray[i])[0],
+                                    pkg,
+                                  ]),
+                                );
+
+                              const mergedConfig = {
+                                ...rootConfig,
+                                emitLegacyCommonJSImports: config.emitLegacyCommonJSImports,
+                                importExtension: config.importExtension,
+                                ...stageConfig.config,
+                              };
+
+                              const stageMeta: Record<string, unknown> = {};
+
+                              const stageContent = await codegen({
+                                filename,
+                                plugins: normalizedPluginsArray,
+                                schema: stageSchema,
+                                schemaAst: stageSchemaAst,
+                                documents: stageDocuments,
+                                config: mergedConfig,
+                                pluginMap,
+                                pluginContext: { ...pluginContext, previousStageMeta },
+                                profiler: context.profiler,
+                                cache,
+                                onPluginOutput: (name, output) => {
+                                  if (
+                                    output &&
+                                    typeof output === 'object' &&
+                                    'meta' in output &&
+                                    output.meta !== undefined
+                                  ) {
+                                    stageMeta[name] = output.meta;
+                                  }
+                                },
+                              });
+
+                              content += (content ? '\n' : '') + stageContent;
+                              // Hand this stage's meta off to the next one.
+                              previousStageMeta = { ...previousStageMeta, ...stageMeta };
+                            }
+
+                            result.push({
+                              filename,
+                              content,
+                              hooks: {},
+                            });
+                          },
+                          filename,
+                          `Generate: ${filename}`,
+                          ctx,
+                        ),
+                      },
+                    ],
+                    {
+                      exitOnError: true,
+                      concurrent: false,
+                    },
+                  );
+                },
+                exitOnError: false,
+              };
+            },
+          );
+
+          return task.newListr([...generateTasks, ...stageGenerateTasks], {
             concurrent: cpus().length || 1,
           });
         },

--- a/packages/graphql-codegen-cli/tests/custom-plugins/sequential-stage-1.js
+++ b/packages/graphql-codegen-cli/tests/custom-plugins/sequential-stage-1.js
@@ -1,0 +1,16 @@
+/**
+ * PoC fixture for https://github.com/dotansimha/graphql-code-generator/issues/10943
+ * ("Option 1: Sequential Stages"). Stands in for a plugin like `typescript`: it produces
+ * `content` for the file, plus `meta` describing something a later stage's plugin might
+ * want to build on (here, the list of type names it "generated").
+ */
+module.exports = {
+  plugin(_schema, _documents, _config) {
+    return {
+      content: '// Stage 1 (typescript-like): generated types Foo, Bar\n',
+      meta: {
+        typeNames: ['Foo', 'Bar'],
+      },
+    };
+  },
+};

--- a/packages/graphql-codegen-cli/tests/custom-plugins/sequential-stage-2.js
+++ b/packages/graphql-codegen-cli/tests/custom-plugins/sequential-stage-2.js
@@ -1,0 +1,16 @@
+/**
+ * PoC fixture for https://github.com/dotansimha/graphql-code-generator/issues/10943
+ * ("Option 1: Sequential Stages"). Stands in for a plugin like `typescript-resolvers`: it
+ * reads the `meta` handed off by the previous stage's plugin (via
+ * `pluginContext.previousStageMeta`, keyed by plugin name) instead of independently
+ * re-deriving the same information.
+ */
+module.exports = {
+  plugin(_schema, _documents, _config, { pluginContext }) {
+    const previousStageMeta = pluginContext?.previousStageMeta || {};
+    const stage1Meta = previousStageMeta['./tests/custom-plugins/sequential-stage-1.js'];
+    const typeNames = stage1Meta?.typeNames || [];
+
+    return `// Stage 2 (typescript-resolvers-like): received typeNames from stage 1 -> [${typeNames.join(', ')}]\n`;
+  },
+};

--- a/packages/graphql-codegen-cli/tests/sequential-stages.spec.ts
+++ b/packages/graphql-codegen-cli/tests/sequential-stages.spec.ts
@@ -1,0 +1,65 @@
+import { executeCodegen } from '../src/index.js';
+
+/**
+ * PoC for https://github.com/dotansimha/graphql-code-generator/issues/10943
+ * ("RFC: Sequential Execution & Output Hand-off Between GraphQL Codegen Plugins/Presets"),
+ * exercising Option 1 ("Sequential Stages"): a `generates` entry can be an array of
+ * `{ plugins }` stage objects that run in order (instead of the plugins-within-a-stage
+ * parallel execution) against the same output path, with each stage's plugin(s) able to
+ * hand `meta` off to the next stage via `pluginContext.previousStageMeta`.
+ */
+const SIMPLE_TEST_SCHEMA = `type MyType { f: String } type Query { f: String }`;
+
+describe('Sequential Stages (PoC for issue #10943, Option 1)', () => {
+  it('runs stages in order and concatenates their content into one output', async () => {
+    const { result, error } = await executeCodegen({
+      schema: SIMPLE_TEST_SCHEMA,
+      generates: {
+        'out1.ts': [
+          { plugins: ['./tests/custom-plugins/sequential-stage-1.js'] },
+          { plugins: ['./tests/custom-plugins/sequential-stage-2.js'] },
+        ],
+      },
+    });
+
+    expect(error).toBeNull();
+    expect(result.length).toBe(1);
+    expect(result[0].filename).toBe('out1.ts');
+
+    const content = result[0].content;
+    expect(content).toContain('Stage 1');
+    expect(content).toContain('Stage 2');
+    // Stage 1's content comes before stage 2's - they ran in order, not in parallel.
+    expect(content.indexOf('Stage 1')).toBeLessThan(content.indexOf('Stage 2'));
+  });
+
+  it('hands off `meta` from an earlier stage to a later stage via pluginContext.previousStageMeta', async () => {
+    const { result, error } = await executeCodegen({
+      schema: SIMPLE_TEST_SCHEMA,
+      generates: {
+        'out1.ts': [
+          { plugins: ['./tests/custom-plugins/sequential-stage-1.js'] },
+          { plugins: ['./tests/custom-plugins/sequential-stage-2.js'] },
+        ],
+      },
+    });
+
+    expect(error).toBeNull();
+    // Stage 2 didn't hardcode `Foo, Bar` - it read it from stage 1's `meta`.
+    expect(result[0].content).toContain(
+      '// Stage 2 (typescript-resolvers-like): received typeNames from stage 1 -> [Foo, Bar]',
+    );
+  });
+
+  it('still runs a single-stage (non-array) `generates` entry as before', async () => {
+    const { result, error } = await executeCodegen({
+      schema: SIMPLE_TEST_SCHEMA,
+      generates: {
+        'out1.ts': { plugins: ['./tests/custom-plugins/sequential-stage-1.js'] },
+      },
+    });
+
+    expect(error).toBeNull();
+    expect(result[0].content).toContain('Stage 1');
+  });
+});

--- a/packages/graphql-codegen-core/src/codegen.ts
+++ b/packages/graphql-codegen-core/src/codegen.ts
@@ -213,6 +213,8 @@ export async function codegen(options: Types.GenerateOptions): Promise<string> {
         `Plugin ${name}`,
       );
 
+      options.onPluginOutput?.(name, result);
+
       if (typeof result === 'string') {
         return result || '';
       }

--- a/packages/utils/plugins-helpers/src/helpers.ts
+++ b/packages/utils/plugins-helpers/src/helpers.ts
@@ -25,9 +25,45 @@ export function isConfiguredOutput(type: any): type is Types.ConfiguredOutput {
   return typeof type === 'object';
 }
 
+/**
+ * PoC (see https://github.com/dotansimha/graphql-code-generator/issues/10943, "Option 1:
+ * Sequential Stages"): distinguishes the new `Types.SequentialStages` array shape (an ordered
+ * list of `{ plugins }` / `{ preset }` stage objects) from the pre-existing `ConfiguredPlugin[]`
+ * shorthand (a flat list of plugin names/configs, e.g. `['typescript', 'typescript-operations']`).
+ */
+export function isSequentialStagesArray(type: any): type is Types.SequentialStages {
+  return (
+    Array.isArray(type) &&
+    type.length > 0 &&
+    type.every(
+      item =>
+        item &&
+        typeof item === 'object' &&
+        !Array.isArray(item) &&
+        ('plugins' in item || 'preset' in item),
+    )
+  );
+}
+
 export function normalizeOutputParam(
-  config: Types.OutputConfig | Types.ConfiguredPlugin[] | Types.ConfiguredOutput,
+  config:
+    | Types.OutputConfig
+    | Types.ConfiguredPlugin[]
+    | Types.ConfiguredOutput
+    | Types.SequentialStages,
 ): Types.ConfiguredOutput {
+  // PoC (see https://github.com/dotansimha/graphql-code-generator/issues/10943, "Option 1:
+  // Sequential Stages"): callers that only care about this output's `schema`/`documents`/
+  // `watchPattern` (e.g. watch-mode pattern matching) can treat a stages array as a single
+  // `ConfiguredOutput` by merging each stage's values. This does *not* merge `plugins`/`preset`,
+  // since running the stages themselves is handled by the dedicated sequential-stages code path.
+  if (isSequentialStagesArray(config)) {
+    return {
+      documents: config.flatMap(stage => normalizeInstanceOrArray(stage.documents)),
+      schema: config.flatMap(stage => normalizeInstanceOrArray(stage.schema)),
+      watchPattern: config.flatMap(stage => normalizeInstanceOrArray(stage.watchPattern)),
+    };
+  }
   // In case of direct array with a list of plugins
   if (isOutputConfigArray(config)) {
     return {

--- a/packages/utils/plugins-helpers/src/types.ts
+++ b/packages/utils/plugins-helpers/src/types.ts
@@ -43,6 +43,13 @@ export namespace Types {
      * to decide whether the write can be skipped. See {@link Types.ContentComparison}.
      */
     contentComparison?: Types.ContentComparison;
+    /**
+     * PoC (see https://github.com/dotansimha/graphql-code-generator/issues/10943, "Option 1: Sequential Stages"):
+     * called synchronously with each plugin's raw output as it completes, so a caller
+     * (e.g. a later sequential stage) can observe the `meta` a plugin produced without
+     * changing `codegen()`'s existing `Promise<string>` return type.
+     */
+    onPluginOutput?: (pluginName: string, output: Types.PluginOutput) => void;
   }
 
   export type FileOutput = {
@@ -276,6 +283,16 @@ export namespace Types {
   export type NamedPreset = string;
   export type OutputConfig = NamedPlugin | ConfiguredPlugin;
 
+  /**
+   * PoC (see https://github.com/dotansimha/graphql-code-generator/issues/10943, "Option 1:
+   * Sequential Stages"): an ordered list of stages sharing a single output path. Stages run one
+   * after another (not in parallel like plugins within a single stage do), and a stage's `meta`
+   * (from `Types.ComplexPluginOutput['meta']`) is made available to the next stage via
+   * `pluginContext.previousStageMeta`, keyed by plugin name. Each stage's `content` is appended to
+   * the same output file, in order.
+   */
+  export type SequentialStages = ConfiguredOutput[];
+
   export type PresetNamesBase =
     | 'client'
     | 'near-operation-file'
@@ -502,9 +519,14 @@ export namespace Types {
      * @description A map where the key represents an output path for the generated code and the value represents a set of options which are relevant for that specific file.
      *
      * For more details: https://graphql-code-generator.com/docs/config-reference/codegen-config
+     *
+     * PoC (see https://github.com/dotansimha/graphql-code-generator/issues/10943, "Option 1: Sequential
+     * Stages"): the value can also be an array of `ConfiguredOutput` "stages" (each entry has a `plugins`
+     * and/or `preset` key), executed in order against the same output path. A stage's plugins can read the
+     * `meta` returned by a plugin from an earlier stage via `pluginContext.previousStageMeta`.
      */
     generates: {
-      [outputPath: string]: ConfiguredOutput | ConfiguredPlugin[];
+      [outputPath: string]: ConfiguredOutput | ConfiguredPlugin[] | Types.SequentialStages;
     };
     /**
      * @description A flag to overwrite files if they already exist when generating code (`true` by default).


### PR DESCRIPTION
## Description

This PR implements a proof-of-concept for RFC #10943 ("Sequential Execution & Output Hand-off Between GraphQL Codegen Plugins/Presets"), specifically **Option 1: Sequential Stages**.

### What Changed

The implementation allows `generates` entries to be defined as an array of stage objects (instead of just a single `ConfiguredOutput`), where:

1. **Stages execute sequentially** (not in parallel) against the same output file
2. **Meta hand-off between stages**: Each stage's plugins can produce `meta` that is passed to the next stage via `pluginContext.previousStageMeta`, keyed by plugin name
3. **Content concatenation**: Output from each stage is appended to the same file in order

### Key Modifications

- **`packages/graphql-codegen-cli/src/codegen.ts`**: Added `generatesStages` collection and sequential stage execution logic with proper schema/document loading and meta threading
- **`packages/utils/plugins-helpers/src/helpers.ts`**: Added `isSequentialStagesArray()` type guard to distinguish sequential stages from plugin arrays, and updated `normalizeOutputParam()` to handle stages
- **`packages/utils/plugins-helpers/src/types.ts`**: 
  - Added `SequentialStages` type definition
  - Added `onPluginOutput` callback to `GenerateOptions` for observing plugin output and meta
  - Updated `generates` config to accept `SequentialStages`
- **`packages/graphql-codegen-core/src/codegen.ts`**: Added `onPluginOutput` callback invocation to expose plugin output to callers

### Testing

Added comprehensive test suite (`sequential-stages.spec.ts`) with:
- Test verifying stages run in order and content is concatenated
- Test verifying meta hand-off between stages via `pluginContext.previousStageMeta`
- Test verifying backward compatibility with single-stage (non-array) `generates` entries

Added fixture plugins (`sequential-stage-1.js`, `sequential-stage-2.js`) demonstrating the meta hand-off pattern.

### Backward Compatibility

✅ Fully backward compatible - existing single-stage `generates` entries continue to work as before. The new array syntax is opt-in.

Related #10943

https://claude.ai/code/session_01Xva2iGJ4Xw5GYGAHxyCEra