### PR TITLE
[cli] test: reproduce #6803 — codegen runs twice for `codegen` then `codegen watch` (failing)

### DIFF
--- a/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
+++ b/packages/graphql-codegen-cli/tests/watcher.run.spec.ts
@@ -10,6 +10,7 @@ import {
 import * as path from 'path';
 import type { Mock } from 'vitest';
 import type { Types } from '@graphql-codegen/plugin-helpers';
+import * as codegenModule from '../src/codegen.js';
 import { CodegenContext } from '../src/config.js';
 import { generate } from '../src/generate-and-save.js';
 import * as watcherModule from '../src/utils/watcher.js';
@@ -956,6 +957,104 @@ describe('Watch runs - profiler output', () => {
       for (const filename of listProfilerFiles()) {
         unlinkSync(path.join(process.cwd(), filename));
       }
+    }
+  });
+});
+
+describe('Watch runs - duplicate initial run (#6803)', () => {
+  // https://github.com/dotansimha/graphql-code-generator/issues/6803
+  //
+  // A typical CI/dev workflow runs `codegen` once (to fail fast on errors before
+  // compiling), then starts `codegen watch` to keep types up to date while
+  // developing. Each of those is a separate CLI invocation against the exact
+  // same schema/documents, one right after the other.
+  test('running `codegen` and then `codegen watch` runs codegen twice with nothing changed in between', async () => {
+    const { testDir, schemaFile, documentFile } = setupTestFiles();
+    writeFileSync(
+      schemaFile.absolute,
+      /* GraphQL */ `
+        type Query {
+          me: User
+        }
+
+        type User {
+          id: ID!
+          name: String!
+        }
+      `,
+    );
+    writeFileSync(
+      documentFile.absolute,
+      /* GraphQL */ `
+        query {
+          me {
+            id
+          }
+        }
+      `,
+    );
+    await waitForNextEvent();
+
+    const executeCodegenSpy = vi.spyOn(codegenModule, 'executeCodegen');
+    executeCodegenSpy.mockClear();
+
+    const outputFile = path.join(testDir, 'output.ts');
+    const config: Types.Config = {
+      schema: schemaFile.relative,
+      documents: documentFile.relative,
+      generates: {
+        // An inline preset, like the other tests in this file use, rather than
+        // a plugin looked up by name -- this test only cares how many times
+        // `executeCodegen` runs, not about exercising a real named plugin.
+        [testDir]: {
+          preset: {
+            buildGeneratesSection: options => [
+              {
+                filename: outputFile,
+                schema: options.schema,
+                schemaAst: options.schemaAst,
+                documents: [],
+                config: {},
+                pluginMap: { inline: { plugin: () => 'export const generated = true;' } },
+                plugins: [{ inline: {} }],
+              },
+            ],
+          } satisfies Types.OutputPreset,
+        },
+      },
+    };
+
+    // Step 1: `codegen` -- a plain, one-off run, e.g. run in CI to fail fast
+    // before compiling. In real life this is its own CLI invocation; here
+    // it's a `generate()` call against a fresh, non-watch context.
+    await generate(new CodegenContext({ filepath: path.join(testDir, 'codegen.ts'), config }));
+    expect(executeCodegenSpy).toHaveBeenCalledTimes(1);
+
+    // Step 2: `codegen watch` -- started right after, with nothing having
+    // changed on disk since step 1. In real life this is a second, separate
+    // CLI invocation.
+    const { stopWatching } = watcherModule.createWatcher(
+      new CodegenContext({
+        filepath: path.join(testDir, 'codegen.ts'),
+        config: { ...config, watch: true },
+      }),
+      vi.fn().mockResolvedValue([]),
+    );
+
+    try {
+      await waitForNextEvent();
+
+      // #6803: codegen was already run against this exact schema and these
+      // exact documents one step ago -- nothing has changed since. Watch mode
+      // should not need to regenerate anything before it starts watching, so
+      // the total call count should still be 1. Instead, watch mode always
+      // runs its own initial codegen pass unconditionally, so codegen ends up
+      // triggered twice for no reason.
+      expect(executeCodegenSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      await stopWatching();
+      await waitForNextEvent();
+      executeCodegenSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Description

This is a **checkpoint PR**, not a fix. It adds a failing test that proves the behavior reported in #6803 exists in the current code — it does not need to merge, or even go green, before a follow-up fix builds on top of it.

Relates to #6803

**What #6803 reports:** in the common workflow of running `codegen` once (to fail fast before compiling) and then `codegen watch` to keep types up to date while developing, `codegen watch` itself unconditionally runs a full codegen pass again before it starts watching for file changes — duplicating the run that was just done, with nothing having changed in between.

**Confirmed directly in the source**, not just from the issue text — `packages/graphql-codegen-cli/src/utils/watcher.ts`, `createWatcher()`:

```ts
stopWatching.runningWatcher = new Promise<void>((resolve, reject) => {
  initialContext.profiler
    .run(() => executeCodegen(initialContext), 'executeCodegen') // <- always runs, unconditionally
    .then(...)
    .then(() => runWatcher(abortController.signal)) // <- only *then* does watching start
    ...
```

There is no existing option to skip this initial run.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Checkpoint: failing test proving the reported behavior (see `issue-verify`/`issue-fix` workflow below)

## How Has This Been Tested?

Added a new test, `Watch runs - duplicate initial run (#6803)` in `packages/graphql-codegen-cli/tests/watcher.run.spec.ts`, that directly mirrors the reported workflow rather than any hypothetical fix API:

1. **Step 1** — a plain, non-watch `generate()` call against a schema/documents pair, standing in for the first `codegen` CLI invocation.
2. **Step 2** — a watcher started right after (`createWatcher`), against the same schema/documents with nothing changed on disk, standing in for the immediately-following `codegen watch` invocation.

It spies on `executeCodegen` and asserts the total call count across both steps is `1` (nothing changed, so a second full run is redundant).

Run: `pnpm vitest run tests/watcher.run.spec.ts -t "duplicate initial run"` inside `packages/graphql-codegen-cli`.

**Captured failure** (current behavior — codegen runs a second time regardless):

```
AssertionError: expected "executeCodegen" to be called 1 times, but got 2 times
 ❯ tests/watcher.run.spec.ts:1055:33
      expect(executeCodegenSpy).toHaveBeenCalledTimes(1);
```

This test is left failing on purpose — it's the checkpoint this PR exists to produce, not something to skip or mark pending.

**Test Environment**:

- OS: Linux
- `@graphql-codegen/cli`: workspace (unreleased)
- NodeJS: 22

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works — a failing test proving the reported gap exists (the fix itself is out of scope for this PR)
- [ ] New and existing unit tests pass locally with my changes — this one is expected to fail until a follow-up fix lands
- [x] I have performed a self-review of my own code

## Further comments

This PR is produced by an `issue-verify` pass and is meant to be picked up directly by a follow-up `issue-fix` PR, which will implement an actual mechanism for watch mode to skip its redundant initial codegen run and turn this test green. The test intentionally avoids assuming any particular fix API/config shape — it only asserts on the observable symptom (`executeCodegen` call count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qAsujZbmFpSQmLQYQiq9Z