### PR TITLE
fix: stop mixing * with other patterns in renovate.json (#10876)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,10 @@
   },
   "packageRules": [
     {
-      "excludePackagePatterns": [
+      "excludePackageNames": [
         "@changesets/*",
         "typescript",
-        "^@theguild/",
+        "/^@theguild\\//",
         "next",
         "tailwindcss",
         "@whatwg-node/*",
@@ -22,7 +22,6 @@
         "@types/lz-string",
         "swc*"
       ],
-      "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"


### PR DESCRIPTION
## Description

This PR fixes #10876 ("Action Required: Fix Renovate Configuration") by removing the config shape that Renovate's own validator flags as invalid.

`renovate.json`'s only `packageRule` combined the deprecated `matchPackagePatterns: ["*"]` with `excludePackagePatterns`. Renovate migrates that legacy pair into a single `matchPackageNames` array (`"*"` plus a batch of negated entries), which its own validator rejects — `*` already matches everything, so mixing it with anything else is a config mistake:

```
packageRules[0].matchPackageNames: Your input contains * or ** along with other patterns.
Please remove them, as * or ** matches all patterns.
```

The fix:
- Drops the redundant `matchPackagePatterns: ["*"]` — omitting a `match*` field already means "match everything", so it was a no-op sitting next to `excludePackagePatterns`.
- Migrates `excludePackagePatterns` to the modern `excludePackageNames`. Most entries (`@changesets/*`, `@whatwg-node/*`, `swc*`, etc.) are unchanged glob-style strings; `"^@theguild/"` relied on regex anchoring, so it's kept as an explicit regex (`"/^@theguild\\//"`) to preserve its exact original matching behavior instead of silently becoming a no-op literal match.

(A previous cleanup, #10835, removed an unrelated duplicate `lockFileMaintenance` block but didn't touch this — the issue was filed over a month after that PR merged.)

Related #10876

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No test infra was added — verified directly by running the real `renovate-config-validator` CLI against `renovate.json`:

- Before this fix, it failed with the exact error Renovate's bot reported, using `renovate@43.234.0` (the release current when the issue was filed).
- After this fix, it validates cleanly with both `renovate@43.234.0` and the latest `renovate` release:
  ```
  $ npx -p renovate@<version> renovate-config-validator renovate.json
  ...
  INFO: Config validated successfully
  ```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PPx7BUyzER3NVTLHHzoSk