### PR TITLE
chore(deps): bump dev graphql to 17.0.2, add v17 to test-watcher CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,7 +232,7 @@ jobs:
       matrix:
         os: [ubuntu-latest] # remove windows to speed up the tests
         node_version: [20]
-        graphql_version: [15, 16]
+        graphql_version: [15, 16, 17]
         include:
           - node_version: 20
             os: windows-latest

--- a/examples/programmatic-typescript/package.json
+++ b/examples/programmatic-typescript/package.json
@@ -19,7 +19,7 @@
     "@graphql-tools/graphql-file-loader": "8.1.12",
     "@graphql-tools/load": "8.1.10",
     "@graphql-tools/schema": "10.0.33",
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "graphql-tag": "2.12.6",
     "prettier": "3.8.3"
   },

--- a/examples/react/apollo-client-defer/package.json
+++ b/examples/react/apollo-client-defer/package.json
@@ -15,7 +15,7 @@
     "@apollo/client": "3.14.1",
     "@graphql-typed-document-node/core": "3.2.0",
     "@graphql-yoga/plugin-defer-stream": "3.21.0",
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "graphql-yoga": "5.21.0",
     "react": "19.2.6",
     "react-dom": "19.2.6"

--- a/examples/react/apollo-client/package.json
+++ b/examples/react/apollo-client/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.14.1",
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "react": "19.2.6",
     "react-dom": "19.2.6"
   },

--- a/examples/typescript-esm/package.json
+++ b/examples/typescript-esm/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@graphql-typed-document-node/core": "3.2.0",
-    "graphql": "16.14.0"
+    "graphql": "17.0.2"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "workspace:*",

--- a/examples/typescript-graphql-request/package.json
+++ b/examples/typescript-graphql-request/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@graphql-typed-document-node/core": "3.2.0",
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "graphql-request": "7.4.0",
     "graphql-yoga": "5.21.0"
   },

--- a/examples/typescript-resolvers/package.json
+++ b/examples/typescript-resolvers/package.json
@@ -11,7 +11,7 @@
     "test:end2end": "exit 0"
   },
   "dependencies": {
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "graphql-yoga": "5.21.0"
   },
   "devDependencies": {

--- a/examples/vite/vite-react-cts/package.json
+++ b/examples/vite/vite-react-cts/package.json
@@ -15,7 +15,7 @@
     "@apollo/client": "3.14.1",
     "@graphql-typed-document-node/core": "3.2.0",
     "@vitejs/plugin-react-swc": "4.3.1",
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "vite": "8.0.13"

--- a/examples/vite/vite-react-mts/package.json
+++ b/examples/vite/vite-react-mts/package.json
@@ -15,7 +15,7 @@
     "@apollo/client": "3.14.1",
     "@graphql-typed-document-node/core": "3.2.0",
     "@vitejs/plugin-react-swc": "4.3.1",
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "vite": "8.0.13"

--- a/examples/vite/vite-react-ts/package.json
+++ b/examples/vite/vite-react-ts/package.json
@@ -15,7 +15,7 @@
     "@apollo/client": "3.14.1",
     "@graphql-typed-document-node/core": "3.2.0",
     "@vitejs/plugin-react-swc": "4.3.1",
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "vite": "8.0.13"

--- a/examples/vue/apollo-composable/package.json
+++ b/examples/vue/apollo-composable/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@apollo/client": "3.14.1",
     "@vue/apollo-composable": "4.2.2",
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "vue": "3.5.34"
   },
   "devDependencies": {

--- a/examples/vue/urql/package.json
+++ b/examples/vue/urql/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@urql/vue": "2.1.0",
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "vue": "3.5.34"
   },
   "devDependencies": {

--- a/examples/vue/villus/package.json
+++ b/examples/vue/villus/package.json
@@ -11,7 +11,7 @@
     "test:end2end": "start-server-and-test start http://localhost:3000 test"
   },
   "dependencies": {
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "villus": "3.5.2",
     "vue": "3.5.34"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-unicorn": "64.0.0",
     "fast-glob": "3.3.3",
     "fs-extra": "11.3.5",
-    "graphql": "16.14.0",
+    "graphql": "17.0.2",
     "husky": "9.1.7",
     "jest-diff": "30.4.1",
     "js-yaml": "4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  graphql: 17.0.2
   '@rushstack/eslint-patch': 1.16.1
   '@typescript-eslint/eslint-plugin': 8.59.3
   '@typescript-eslint/parser': 8.59.3
@@ -17,7 +18,9 @@ overrides:
   jiti: 2.7.0
 
 patchedDependencies:
-  bob-the-bundler@7.0.1: ae094f164c44292465775b71c129fc3305c94d7ad5df4dfb5a00ed7d23181369
+  bob-the-bundler@7.0.1:
+    hash: ae094f164c44292465775b71c129fc3305c94d7ad5df4dfb5a00ed7d23181369
+    path: patches/bob-the-bundler@7.0.1.patch
 
 importers:
 
@@ -25,13 +28,13 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: 7.29.0
-        version: 7.29.0(supports-color@10.2.2)
+        version: 7.29.0
       '@babel/preset-env':
         specifier: 7.29.5
-        version: 7.29.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.29.5(@babel/core@7.29.0)
       '@babel/preset-typescript':
         specifier: 7.28.5
-        version: 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.28.5(@babel/core@7.29.0)
       '@changesets/changelog-github':
         specifier: 0.7.0
         version: 0.7.0
@@ -40,19 +43,19 @@ importers:
         version: 2.31.0(@types/node@24.12.4)
       '@eslint/eslintrc':
         specifier: 3.3.5
-        version: 3.3.5(supports-color@10.2.2)
+        version: 3.3.5
       '@eslint/js':
         specifier: 10.0.1
-        version: 10.0.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+        version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
       '@ianvs/prettier-plugin-sort-imports':
         specifier: 4.7.1
-        version: 4.7.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)(supports-color@10.2.2)
+        version: 4.7.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)
       '@theguild/eslint-config':
         specifier: 0.13.4
-        version: 0.13.4(bluebird@3.7.2)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(is-bun-module@2.0.0)(supports-color@10.2.2)(typescript@6.0.3)
+        version: 0.13.4(eslint@10.4.0(jiti@2.7.0))(is-bun-module@2.0.0)(typescript@6.0.3)
       '@theguild/prettier-config':
         specifier: 3.0.1
-        version: 3.0.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)(supports-color@10.2.2)
+        version: 3.0.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)
       '@types/node':
         specifier: 24.12.4
         version: 24.12.4
@@ -64,16 +67,16 @@ importers:
         version: 17.4.2
       eslint:
         specifier: 10.4.0
-        version: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+        version: 10.4.0(jiti@2.7.0)
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0))
       eslint-plugin-tailwindcss:
         specifier: npm:@hasparus/eslint-plugin-tailwindcss@3.17.5
         version: '@hasparus/eslint-plugin-tailwindcss@3.17.5(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))'
       eslint-plugin-unicorn:
         specifier: 64.0.0
-        version: 64.0.0(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+        version: 64.0.0(eslint@10.4.0(jiti@2.7.0))
       fast-glob:
         specifier: 3.3.3
         version: 3.3.3
@@ -81,8 +84,8 @@ importers:
         specifier: 11.3.5
         version: 11.3.5
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -109,7 +112,7 @@ importers:
         version: 3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3))
       prettier-plugin-tailwindcss:
         specifier: 0.8.0
-        version: 0.8.0(@ianvs/prettier-plugin-sort-imports@4.7.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)(supports-color@10.2.2))(prettier-plugin-svelte@3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(prettier@3.8.3)
+        version: 0.8.0(@ianvs/prettier-plugin-sort-imports@4.7.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3))(prettier-plugin-svelte@3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(prettier@3.8.3)
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -130,7 +133,7 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.14.1
-        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@graphql-codegen/cli':
         specifier: workspace:*
         version: link:../packages/graphql-codegen-cli/dist
@@ -170,10 +173,10 @@ importers:
         version: link:../../packages/graphql-codegen-cli/dist
       '@graphql-codegen/flow':
         specifier: 3.0.1
-        version: 3.0.1(graphql@16.14.0)(supports-color@10.2.2)
+        version: 3.0.1(graphql@17.0.2)
       '@graphql-codegen/flow-resolvers':
         specifier: 3.0.1
-        version: 3.0.1(graphql@16.14.0)(supports-color@10.2.2)
+        version: 3.0.1(graphql@17.0.2)
       '@graphql-codegen/graphql-modules-preset':
         specifier: workspace:*
         version: link:../../packages/presets/graphql-modules/dist
@@ -185,7 +188,7 @@ importers:
         version: link:../../packages/plugins/typescript/typescript/dist
       '@graphql-codegen/typescript-graphql-files-modules':
         specifier: 4.0.1
-        version: 4.0.1(graphql@16.14.0)
+        version: 4.0.1(graphql@17.0.2)
       '@graphql-codegen/typescript-operations':
         specifier: workspace:*
         version: link:../../packages/plugins/typescript/operations/dist
@@ -206,20 +209,20 @@ importers:
     dependencies:
       '@graphql-yoga/plugin-persisted-operations':
         specifier: 3.21.0
-        version: 3.21.0(graphql-yoga@5.21.0(graphql@16.14.0))(graphql@16.14.0)
+        version: 3.21.0(graphql-yoga@5.21.0(graphql@17.0.2))(graphql@17.0.2)
       graphql-yoga:
         specifier: 5.21.0
-        version: 5.21.0(graphql@16.14.0)
+        version: 5.21.0(graphql@17.0.2)
     devDependencies:
       '@babel/core':
         specifier: 7.29.0
-        version: 7.29.0(supports-color@10.2.2)
+        version: 7.29.0
       '@babel/preset-env':
         specifier: 7.29.5
-        version: 7.29.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.29.5(@babel/core@7.29.0)
       '@babel/preset-typescript':
         specifier: 7.28.5
-        version: 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.28.5(@babel/core@7.29.0)
       '@graphql-codegen/cli':
         specifier: workspace:*
         version: link:../../packages/graphql-codegen-cli/dist
@@ -228,26 +231,26 @@ importers:
         version: link:../../packages/presets/client/dist
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
-        version: 3.2.0(graphql@16.14.0)
+        version: 3.2.0(graphql@17.0.2)
 
   examples/persisted-documents-string-mode:
     dependencies:
       '@graphql-yoga/plugin-persisted-operations':
         specifier: 3.21.0
-        version: 3.21.0(graphql-yoga@5.21.0(graphql@16.14.0))(graphql@16.14.0)
+        version: 3.21.0(graphql-yoga@5.21.0(graphql@17.0.2))(graphql@17.0.2)
       graphql-yoga:
         specifier: 5.21.0
-        version: 5.21.0(graphql@16.14.0)
+        version: 5.21.0(graphql@17.0.2)
     devDependencies:
       '@babel/core':
         specifier: 7.29.0
-        version: 7.29.0(supports-color@10.2.2)
+        version: 7.29.0
       '@babel/preset-env':
         specifier: 7.29.5
-        version: 7.29.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.29.5(@babel/core@7.29.0)
       '@babel/preset-typescript':
         specifier: 7.28.5
-        version: 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.28.5(@babel/core@7.29.0)
       '@graphql-codegen/cli':
         specifier: workspace:*
         version: link:../../packages/graphql-codegen-cli/dist
@@ -256,7 +259,7 @@ importers:
         version: link:../../packages/presets/client/dist
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
-        version: 3.2.0(graphql@16.14.0)
+        version: 3.2.0(graphql@17.0.2)
 
   examples/programmatic-typescript:
     dependencies:
@@ -280,19 +283,19 @@ importers:
         version: link:../../packages/plugins/typescript/resolvers/dist
       '@graphql-tools/graphql-file-loader':
         specifier: 8.1.12
-        version: 8.1.12(graphql@16.14.0)
+        version: 8.1.12(graphql@17.0.2)
       '@graphql-tools/load':
         specifier: 8.1.10
-        version: 8.1.10(graphql@16.14.0)
+        version: 8.1.10(graphql@17.0.2)
       '@graphql-tools/schema':
         specifier: 10.0.33
-        version: 10.0.33(graphql@16.14.0)
+        version: 10.0.33(graphql@17.0.2)
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       graphql-tag:
         specifier: 2.12.6
-        version: 2.12.6(graphql@16.14.0)
+        version: 2.12.6(graphql@17.0.2)
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -302,16 +305,16 @@ importers:
         version: 24.12.4
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(@swc/core@1.15.33)(jiti@2.7.0)(postcss@8.5.14)(supports-color@10.2.2)(tsx@4.22.0)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(@swc/core@1.15.33)(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.0)(typescript@6.0.3)(yaml@2.9.0)
 
   examples/react/apollo-client:
     dependencies:
       '@apollo/client':
         specifier: 3.14.1
-        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -342,10 +345,10 @@ importers:
         version: 15.15.0
       serve:
         specifier: 14.2.6
-        version: 14.2.6(supports-color@8.1.1)
+        version: 14.2.6
       start-server-and-test:
         specifier: 3.0.5
-        version: 3.0.5(supports-color@8.1.1)
+        version: 3.0.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -357,19 +360,19 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.14.1
-        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
-        version: 3.2.0(graphql@16.14.0)
+        version: 3.2.0(graphql@17.0.2)
       '@graphql-yoga/plugin-defer-stream':
         specifier: 3.21.0
-        version: 3.21.0(graphql-yoga@5.21.0(graphql@16.14.0))(graphql@16.14.0)
+        version: 3.21.0(graphql-yoga@5.21.0(graphql@17.0.2))(graphql@17.0.2)
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       graphql-yoga:
         specifier: 5.21.0
-        version: 5.21.0(graphql@16.14.0)
+        version: 5.21.0(graphql@17.0.2)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -400,10 +403,10 @@ importers:
         version: 15.15.0
       serve:
         specifier: 14.2.6
-        version: 14.2.6(supports-color@10.2.2)
+        version: 14.2.6
       start-server-and-test:
         specifier: 3.0.5
-        version: 3.0.5(supports-color@10.2.2)
+        version: 3.0.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -415,7 +418,7 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.14.1
-        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -449,7 +452,7 @@ importers:
     dependencies:
       '@graphql-tools/executor-http':
         specifier: 3.3.0
-        version: 3.3.0(@types/node@24.12.4)(graphql@16.14.0)
+        version: 3.3.0(@types/node@24.12.4)(graphql@17.0.2)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -480,10 +483,10 @@ importers:
         version: 15.15.0
       serve:
         specifier: 14.2.6
-        version: 14.2.6(supports-color@10.2.2)
+        version: 14.2.6
       start-server-and-test:
         specifier: 3.0.5
-        version: 3.0.5(supports-color@10.2.2)
+        version: 3.0.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -495,10 +498,10 @@ importers:
     dependencies:
       '@graphql-tools/executor-http':
         specifier: 3.3.0
-        version: 3.3.0(@types/node@24.12.4)(graphql@16.14.0)
+        version: 3.3.0(@types/node@24.12.4)(graphql@17.0.2)
       next:
         specifier: 15.5.18
-        version: 15.5.18(@babel/core@7.29.0(supports-color@10.2.2))(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 15.5.18(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -529,10 +532,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       eslint:
         specifier: 10.4.0
-        version: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+        version: 10.4.0(jiti@2.7.0)
       eslint-config-next:
         specifier: 13.5.1
-        version: 13.5.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+        version: 13.5.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -572,10 +575,10 @@ importers:
         version: 15.15.0
       serve:
         specifier: 14.2.6
-        version: 14.2.6(supports-color@10.2.2)
+        version: 14.2.6
       start-server-and-test:
         specifier: 3.0.5
-        version: 3.0.5(supports-color@10.2.2)
+        version: 3.0.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -593,7 +596,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       urql:
         specifier: 3.0.4
-        version: 3.0.4(graphql@16.14.0)(react@19.2.6)
+        version: 3.0.4(graphql@17.0.2)(react@19.2.6)
     devDependencies:
       '@graphql-codegen/cli':
         specifier: workspace:*
@@ -615,10 +618,10 @@ importers:
         version: 15.15.0
       serve:
         specifier: 14.2.6
-        version: 14.2.6(supports-color@10.2.2)
+        version: 14.2.6
       start-server-and-test:
         specifier: 3.0.5
-        version: 3.0.5(supports-color@10.2.2)
+        version: 3.0.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -630,10 +633,10 @@ importers:
     dependencies:
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
-        version: 3.2.0(graphql@16.14.0)
+        version: 3.2.0(graphql@17.0.2)
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
     devDependencies:
       '@graphql-codegen/cli':
         specifier: workspace:*
@@ -646,16 +649,16 @@ importers:
     dependencies:
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
-        version: 3.2.0(graphql@16.14.0)
+        version: 3.2.0(graphql@17.0.2)
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       graphql-request:
         specifier: 7.4.0
-        version: 7.4.0(graphql@16.14.0)
+        version: 7.4.0(graphql@17.0.2)
       graphql-yoga:
         specifier: 5.21.0
-        version: 5.21.0(graphql@16.14.0)
+        version: 5.21.0(graphql@17.0.2)
     devDependencies:
       '@graphql-codegen/cli':
         specifier: workspace:*
@@ -670,11 +673,11 @@ importers:
   examples/typescript-resolvers:
     dependencies:
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       graphql-yoga:
         specifier: 5.21.0
-        version: 5.21.0(graphql@16.14.0)
+        version: 5.21.0(graphql@17.0.2)
     devDependencies:
       '@graphql-codegen/cli':
         specifier: workspace:*
@@ -693,16 +696,16 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.14.1
-        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
-        version: 3.2.0(graphql@16.14.0)
+        version: 3.2.0(graphql@17.0.2)
       '@vitejs/plugin-react-swc':
         specifier: 4.3.1
         version: 4.3.1(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -730,7 +733,7 @@ importers:
         version: 15.15.0
       start-server-and-test:
         specifier: 3.0.5
-        version: 3.0.5(supports-color@10.2.2)
+        version: 3.0.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -739,16 +742,16 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.14.1
-        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
-        version: 3.2.0(graphql@16.14.0)
+        version: 3.2.0(graphql@17.0.2)
       '@vitejs/plugin-react-swc':
         specifier: 4.3.1
         version: 4.3.1(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -776,7 +779,7 @@ importers:
         version: 15.15.0
       start-server-and-test:
         specifier: 3.0.5
-        version: 3.0.5(supports-color@10.2.2)
+        version: 3.0.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -785,16 +788,16 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.14.1
-        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
-        version: 3.2.0(graphql@16.14.0)
+        version: 3.2.0(graphql@17.0.2)
       '@vitejs/plugin-react-swc':
         specifier: 4.3.1
         version: 4.3.1(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -822,7 +825,7 @@ importers:
         version: 15.15.0
       start-server-and-test:
         specifier: 3.0.5
-        version: 3.0.5(supports-color@10.2.2)
+        version: 3.0.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -831,13 +834,13 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.14.1
-        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@vue/apollo-composable':
         specifier: 4.2.2
-        version: 4.2.2(@apollo/client@3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(graphql@16.14.0)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))
+        version: 4.2.2(@apollo/client@3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(graphql@17.0.2)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       vue:
         specifier: 3.5.34
         version: 3.5.34(typescript@6.0.3)
@@ -856,10 +859,10 @@ importers:
         version: 15.15.0
       serve:
         specifier: 14.2.6
-        version: 14.2.6(supports-color@10.2.2)
+        version: 14.2.6
       start-server-and-test:
         specifier: 3.0.5
-        version: 3.0.5(supports-color@10.2.2)
+        version: 3.0.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -874,10 +877,10 @@ importers:
     dependencies:
       '@urql/vue':
         specifier: 2.1.0
-        version: 2.1.0(@urql/core@6.0.3(graphql@16.14.0))(vue@3.5.34(typescript@6.0.3))
+        version: 2.1.0(@urql/core@6.0.3(graphql@17.0.2))(vue@3.5.34(typescript@6.0.3))
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       vue:
         specifier: 3.5.34
         version: 3.5.34(typescript@6.0.3)
@@ -896,10 +899,10 @@ importers:
         version: 15.15.0
       serve:
         specifier: 14.2.6
-        version: 14.2.6(supports-color@10.2.2)
+        version: 14.2.6
       start-server-and-test:
         specifier: 3.0.5
-        version: 3.0.5(supports-color@10.2.2)
+        version: 3.0.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -913,11 +916,11 @@ importers:
   examples/vue/villus:
     dependencies:
       graphql:
-        specifier: 16.14.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       villus:
         specifier: 3.5.2
-        version: 3.5.2(graphql@16.14.0)(vue@3.5.34(typescript@6.0.3))
+        version: 3.5.2(graphql@17.0.2)(vue@3.5.34(typescript@6.0.3))
       vue:
         specifier: 3.5.34
         version: 3.5.34(typescript@6.0.3)
@@ -936,10 +939,10 @@ importers:
         version: 15.15.0
       serve:
         specifier: 14.2.6
-        version: 14.2.6(supports-color@10.2.2)
+        version: 14.2.6
       start-server-and-test:
         specifier: 3.0.5
-        version: 3.0.5(supports-color@10.2.2)
+        version: 3.0.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -954,17 +957,17 @@ importers:
     dependencies:
       graphql-yoga:
         specifier: 5.21.0
-        version: 5.21.0(graphql@16.14.0)
+        version: 5.21.0(graphql@17.0.2)
     devDependencies:
       '@babel/core':
         specifier: 7.29.0
-        version: 7.29.0(supports-color@10.2.2)
+        version: 7.29.0
       '@babel/preset-env':
         specifier: 7.29.5
-        version: 7.29.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.29.5(@babel/core@7.29.0)
       '@babel/preset-typescript':
         specifier: 7.28.5
-        version: 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.28.5(@babel/core@7.29.0)
       '@graphql-codegen/cli':
         specifier: workspace:*
         version: link:../../packages/graphql-codegen-cli/dist
@@ -973,7 +976,7 @@ importers:
         version: link:../../packages/presets/client/dist
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
-        version: 3.2.0(graphql@16.14.0)
+        version: 3.2.0(graphql@17.0.2)
 
   packages/graphql-codegen-cli:
     dependencies:
@@ -997,34 +1000,34 @@ importers:
         version: link:../utils/plugins-helpers/dist
       '@graphql-tools/apollo-engine-loader':
         specifier: ^8.0.28
-        version: 8.0.30(graphql@16.14.0)
+        version: 8.0.30(graphql@17.0.2)
       '@graphql-tools/code-file-loader':
         specifier: ^8.1.39
-        version: 8.1.39(graphql@16.14.0)(supports-color@10.2.2)
+        version: 8.1.39(graphql@17.0.2)
       '@graphql-tools/git-loader':
         specifier: ^8.0.32
-        version: 8.0.36(graphql@16.14.0)(supports-color@10.2.2)
+        version: 8.0.36(graphql@17.0.2)
       '@graphql-tools/github-loader':
         specifier: ^9.0.6
-        version: 9.1.2(@types/node@24.12.4)(graphql@16.14.0)(supports-color@10.2.2)
+        version: 9.1.2(@types/node@24.12.4)(graphql@17.0.2)
       '@graphql-tools/graphql-file-loader':
         specifier: ^8.1.11
-        version: 8.1.12(graphql@16.14.0)
+        version: 8.1.12(graphql@17.0.2)
       '@graphql-tools/json-file-loader':
         specifier: ^8.0.26
-        version: 8.0.28(graphql@16.14.0)
+        version: 8.0.28(graphql@17.0.2)
       '@graphql-tools/load':
         specifier: ^8.1.8
-        version: 8.1.10(graphql@16.14.0)
+        version: 8.1.10(graphql@17.0.2)
       '@graphql-tools/merge':
         specifier: ^9.2.4
-        version: 9.2.4(graphql@16.14.0)
+        version: 9.2.4(graphql@17.0.2)
       '@graphql-tools/url-loader':
         specifier: ^9.0.6
-        version: 9.1.2(@types/node@24.12.4)(graphql@16.14.0)
+        version: 9.1.2(@types/node@24.12.4)(graphql@17.0.2)
       '@graphql-tools/utils':
         specifier: ^11.2.0
-        version: 11.2.0(graphql@16.14.0)
+        version: 11.2.0(graphql@17.0.2)
       '@inquirer/prompts':
         specifier: ^8.3.2
         version: 8.4.3(@types/node@24.12.4)
@@ -1044,11 +1047,11 @@ importers:
         specifier: ^7.0.0
         version: 7.0.2
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       graphql-config:
         specifier: ^5.1.6
-        version: 5.1.6(@types/node@24.12.4)(graphql@16.14.0)(typescript@6.0.3)
+        version: 5.1.6(@types/node@24.12.4)(graphql@17.0.2)(typescript@6.0.3)
       is-glob:
         specifier: ^4.0.1
         version: 4.0.3
@@ -1091,10 +1094,10 @@ importers:
         version: link:../plugins/other/add/dist
       '@graphql-codegen/flow':
         specifier: 3.0.1
-        version: 3.0.1(graphql@16.14.0)(supports-color@10.2.2)
+        version: 3.0.1(graphql@17.0.2)
       '@graphql-codegen/flow-resolvers':
         specifier: 3.0.1
-        version: 3.0.1(graphql@16.14.0)(supports-color@10.2.2)
+        version: 3.0.1(graphql@17.0.2)
       '@graphql-codegen/graphql-modules-preset':
         specifier: workspace:*
         version: link:../presets/graphql-modules/dist
@@ -1106,7 +1109,7 @@ importers:
         version: link:../plugins/typescript/typescript/dist
       '@graphql-codegen/typescript-graphql-files-modules':
         specifier: 4.0.1
-        version: 4.0.1(graphql@16.14.0)
+        version: 4.0.1(graphql@17.0.2)
       '@graphql-codegen/typescript-operations':
         specifier: workspace:*
         version: link:../plugins/typescript/operations/dist
@@ -1155,13 +1158,13 @@ importers:
         version: link:../utils/plugins-helpers/dist
       '@graphql-tools/schema':
         specifier: ^10.0.0
-        version: 10.0.33(graphql@16.14.0)
+        version: 10.0.33(graphql@17.0.2)
       '@graphql-tools/utils':
         specifier: ^11.2.0
-        version: 11.2.0(graphql@16.14.0)
+        version: 11.2.0(graphql@17.0.2)
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
@@ -1173,8 +1176,8 @@ importers:
         specifier: workspace:^
         version: link:../../../utils/plugins-helpers/dist
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
@@ -1186,15 +1189,15 @@ importers:
         specifier: workspace:^
         version: link:../../../utils/plugins-helpers/dist
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
     devDependencies:
       graphql-tag:
         specifier: 2.12.6
-        version: 2.12.6(graphql@16.14.0)
+        version: 2.12.6(graphql@17.0.2)
     publishDirectory: dist
 
   packages/plugins/other/introspection:
@@ -1206,8 +1209,8 @@ importers:
         specifier: workspace:^
         version: link:../visitor-plugin-common/dist
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
@@ -1220,10 +1223,10 @@ importers:
         version: link:../../../utils/plugins-helpers/dist
       '@graphql-tools/utils':
         specifier: ^11.2.0
-        version: 11.2.0(graphql@16.14.0)
+        version: 11.2.0(graphql@17.0.2)
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
@@ -1235,8 +1238,8 @@ importers:
         specifier: workspace:^
         version: link:../../../utils/plugins-helpers/dist
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       moment:
         specifier: ~2.30.0
         version: 2.30.1
@@ -1249,13 +1252,13 @@ importers:
         version: link:../../../utils/plugins-helpers/dist
       '@graphql-tools/optimize':
         specifier: ^2.0.0
-        version: 2.0.0(graphql@16.14.0)
+        version: 2.0.0(graphql@17.0.2)
       '@graphql-tools/relay-operation-optimizer':
         specifier: ^7.1.1
-        version: 7.1.4(graphql@16.14.0)
+        version: 7.1.4(graphql@17.0.2)
       '@graphql-tools/utils':
         specifier: ^11.2.0
-        version: 11.2.0(graphql@16.14.0)
+        version: 11.2.0(graphql@17.0.2)
       auto-bind:
         specifier: ^5.0.0
         version: 5.0.1
@@ -1266,11 +1269,11 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       graphql-tag:
         specifier: ^2.11.0
-        version: 2.12.6(graphql@16.14.0)
+        version: 2.12.6(graphql@17.0.2)
       parse-filepath:
         specifier: ^1.0.2
         version: 1.0.2
@@ -1295,8 +1298,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.1
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
@@ -1312,13 +1315,13 @@ importers:
         version: link:../../other/visitor-plugin-common/dist
       '@graphql-tools/utils':
         specifier: ^11.2.0
-        version: 11.2.0(graphql@16.14.0)
+        version: 11.2.0(graphql@17.0.2)
       auto-bind:
         specifier: ^5.0.0
         version: 5.0.1
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
@@ -1339,15 +1342,15 @@ importers:
         specifier: ^5.0.0
         version: 5.0.1
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
     devDependencies:
       graphql-sock:
         specifier: 1.0.1
-        version: 1.0.1(graphql@16.14.0)
+        version: 1.0.1(graphql@17.0.2)
     publishDirectory: dist
 
   packages/plugins/typescript/resolvers:
@@ -1363,23 +1366,23 @@ importers:
         version: link:../../other/visitor-plugin-common/dist
       '@graphql-tools/utils':
         specifier: ^11.2.0
-        version: 11.2.0(graphql@16.14.0)
+        version: 11.2.0(graphql@17.0.2)
       auto-bind:
         specifier: ^5.0.0
         version: 5.0.1
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
     devDependencies:
       graphql-sock:
         specifier: 1.0.1
-        version: 1.0.1(graphql@16.14.0)
+        version: 1.0.1(graphql@17.0.2)
       graphql-subscriptions:
         specifier: 3.0.0
-        version: 3.0.0(graphql@16.14.0)
+        version: 3.0.0(graphql@17.0.2)
     publishDirectory: dist
 
   packages/plugins/typescript/typed-document-node:
@@ -1397,8 +1400,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
@@ -1419,8 +1422,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.1
       graphql:
-        specifier: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ~2.8.0
         version: 2.8.1
@@ -1457,23 +1460,23 @@ importers:
         version: link:../../plugins/other/visitor-plugin-common/dist
       '@graphql-tools/documents':
         specifier: ^1.0.0
-        version: 1.0.1(graphql@16.14.0)
+        version: 1.0.1(graphql@17.0.2)
       '@graphql-tools/utils':
         specifier: ^11.2.0
-        version: 11.2.0(graphql@16.14.0)
+        version: 11.2.0(graphql@17.0.2)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
-        version: 3.2.0(graphql@16.14.0)
+        version: 3.2.0(graphql@17.0.2)
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
     devDependencies:
       '@babel/traverse':
         specifier: 7.29.0
-        version: 7.29.0(supports-color@10.2.2)
+        version: 7.29.0
       '@babel/types':
         specifier: 7.29.0
         version: 7.29.0
@@ -1488,7 +1491,7 @@ importers:
         version: 7.4.4
       graphql-sock:
         specifier: 1.0.1
-        version: 1.0.1(graphql@16.14.0)
+        version: 1.0.1(graphql@17.0.2)
       jiti:
         specifier: 2.7.0
         version: 2.7.0
@@ -1504,13 +1507,13 @@ importers:
         version: link:../../plugins/other/visitor-plugin-common/dist
       '@graphql-tools/utils':
         specifier: ^11.2.0
-        version: 11.2.0(graphql@16.14.0)
+        version: 11.2.0(graphql@17.0.2)
       change-case-all:
         specifier: ^2.1.0
         version: 2.1.0
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       parse-filepath:
         specifier: ^1.0.2
         version: 1.0.2
@@ -1535,7 +1538,7 @@ importers:
         version: 1.8.2
       graphql-helix:
         specifier: 1.13.0
-        version: 1.13.0(graphql@16.14.0)
+        version: 1.13.0(graphql@17.0.2)
       jest-diff:
         specifier: ^23.0.0 || ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0 || ^30.0.0
         version: 30.4.1
@@ -1561,7 +1564,7 @@ importers:
     dependencies:
       '@graphql-tools/utils':
         specifier: ^11.2.0
-        version: 11.2.0(graphql@16.14.0)
+        version: 11.2.0(graphql@17.0.2)
       change-case-all:
         specifier: ^2.1.0
         version: 2.1.0
@@ -1569,8 +1572,8 @@ importers:
         specifier: 1.8.2
         version: 1.8.2
       graphql:
-        specifier: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-        version: 16.14.0
+        specifier: 17.0.2
+        version: 17.0.2
       import-from:
         specifier: 4.0.0
         version: 4.0.0
@@ -1580,107 +1583,107 @@ importers:
     devDependencies:
       '@graphql-tools/apollo-engine-loader':
         specifier: 8.0.30
-        version: 8.0.30(graphql@16.14.0)
+        version: 8.0.30(graphql@17.0.2)
     publishDirectory: dist
 
   website:
     dependencies:
       '@graphql-codegen/c-sharp':
         specifier: 6.0.1
-        version: 6.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+        version: 6.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       '@graphql-codegen/c-sharp-operations':
         specifier: 4.0.1
-        version: 4.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+        version: 4.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       '@graphql-codegen/flow':
         specifier: 3.0.1
-        version: 3.0.1(graphql@16.14.0)(supports-color@10.2.2)
+        version: 3.0.1(graphql@17.0.2)
       '@graphql-codegen/flow-operations':
         specifier: 3.0.2
-        version: 3.0.2(graphql@16.14.0)(supports-color@10.2.2)
+        version: 3.0.2(graphql@17.0.2)
       '@graphql-codegen/flow-resolvers':
         specifier: 3.0.2
-        version: 3.0.2(graphql@16.14.0)(supports-color@10.2.2)
+        version: 3.0.2(graphql@17.0.2)
       '@graphql-codegen/flutter-freezed':
         specifier: 5.0.1
-        version: 5.0.1(graphql@16.14.0)
+        version: 5.0.1(graphql@17.0.2)
       '@graphql-codegen/hasura-allow-list':
         specifier: 4.0.1
-        version: 4.0.1(graphql@16.14.0)
+        version: 4.0.1(graphql@17.0.2)
       '@graphql-codegen/import-types-preset':
         specifier: 4.0.1
-        version: 4.0.1(graphql@16.14.0)
+        version: 4.0.1(graphql@17.0.2)
       '@graphql-codegen/java':
         specifier: 5.0.1
-        version: 5.0.1(graphql@16.14.0)
+        version: 5.0.1(graphql@17.0.2)
       '@graphql-codegen/java-apollo-android':
         specifier: 4.0.1
-        version: 4.0.1(graphql@16.14.0)
+        version: 4.0.1(graphql@17.0.2)
       '@graphql-codegen/java-resolvers':
         specifier: 4.0.1
-        version: 4.0.1(graphql@16.14.0)
+        version: 4.0.1(graphql@17.0.2)
       '@graphql-codegen/kotlin':
         specifier: 4.0.1
-        version: 4.0.1(graphql@16.14.0)
+        version: 4.0.1(graphql@17.0.2)
       '@graphql-codegen/named-operations-object':
         specifier: 4.0.1
-        version: 4.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+        version: 4.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       '@graphql-codegen/near-operation-file-preset':
         specifier: 5.2.1
-        version: 5.2.1(graphql@16.14.0)
+        version: 5.2.1(graphql@17.0.2)
       '@graphql-codegen/typescript-apollo-angular':
         specifier: 5.0.1
-        version: 5.0.1(graphql@16.14.0)
+        version: 5.0.1(graphql@17.0.2)
       '@graphql-codegen/typescript-apollo-client-helpers':
         specifier: 4.0.1
-        version: 4.0.1(graphql@16.14.0)
+        version: 4.0.1(graphql@17.0.2)
       '@graphql-codegen/typescript-generic-sdk':
         specifier: 5.0.1
-        version: 5.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+        version: 5.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       '@graphql-codegen/typescript-graphql-files-modules':
         specifier: 4.0.1
-        version: 4.0.1(graphql@16.14.0)
+        version: 4.0.1(graphql@17.0.2)
       '@graphql-codegen/typescript-graphql-request':
         specifier: 7.0.1
-        version: 7.0.1(graphql-request@6.1.0(graphql@16.14.0))(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+        version: 7.0.1(graphql-request@7.4.0(graphql@17.0.2))(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       '@graphql-codegen/typescript-mongodb':
         specifier: 4.0.2
-        version: 4.0.2(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+        version: 4.0.2(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       '@graphql-codegen/typescript-msw':
         specifier: 4.0.1
-        version: 4.0.1(graphql@16.14.0)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))
+        version: 4.0.1(graphql@17.0.2)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))
       '@graphql-codegen/typescript-nhost':
         specifier: 1.0.1
-        version: 1.0.1(graphql@16.14.0)
+        version: 1.0.1(graphql@17.0.2)
       '@graphql-codegen/typescript-react-apollo':
         specifier: 4.4.2
-        version: 4.4.2(graphql@16.14.0)
+        version: 4.4.2(graphql@17.0.2)
       '@graphql-codegen/typescript-react-query':
         specifier: 4.1.0
-        version: 4.1.0(graphql@16.14.0)(supports-color@10.2.2)
+        version: 4.1.0(graphql@17.0.2)
       '@graphql-codegen/typescript-rtk-query':
         specifier: 4.0.1
-        version: 4.0.1(@reduxjs/toolkit@2.12.0(react@19.2.6))(graphql-request@6.1.0(graphql@16.14.0))(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+        version: 4.0.1(@reduxjs/toolkit@2.12.0(react@19.2.6))(graphql-request@7.4.0(graphql@17.0.2))(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       '@graphql-codegen/typescript-stencil-apollo':
         specifier: 4.0.1
-        version: 4.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)(stencil-apollo@0.1.6(apollo-client@2.6.10(graphql@16.14.0))(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0))
+        version: 4.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)(stencil-apollo@0.1.6(apollo-client@2.6.10(graphql@17.0.2))(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2))
       '@graphql-codegen/typescript-type-graphql':
         specifier: 3.0.1
-        version: 3.0.1(graphql@16.14.0)(supports-color@10.2.2)
+        version: 3.0.1(graphql@17.0.2)
       '@graphql-codegen/typescript-urql':
         specifier: 5.0.1
-        version: 5.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+        version: 5.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       '@graphql-codegen/typescript-vue-apollo':
         specifier: 5.0.1
-        version: 5.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+        version: 5.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       '@graphql-codegen/typescript-vue-apollo-smart-ops':
         specifier: 4.0.1
-        version: 4.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+        version: 4.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       '@graphql-codegen/typescript-vue-urql':
         specifier: 4.0.1
-        version: 4.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+        version: 4.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       '@graphql-codegen/urql-introspection':
         specifier: 4.0.1
-        version: 4.0.1(graphql@16.14.0)
+        version: 4.0.1(graphql@17.0.2)
     devDependencies:
       '@graphql-codegen/add':
         specifier: workspace:*
@@ -1739,7 +1742,7 @@ packages:
   '@0no-co/graphql.web@1.3.4':
     resolution: {integrity: sha512-imSwulOeDQodRy/olQmVEo2PiY6ntjkZ9eiGdw6lMYylh/tay9b7MusyJBmEnkL8GiKRKr6ltr+D42mY5bd8Bg==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
     peerDependenciesMeta:
       graphql:
         optional: true
@@ -1751,7 +1754,7 @@ packages:
   '@apollo/client@3.14.1':
     resolution: {integrity: sha512-SgGX6E23JsZhUdG2anxiyHvEvvN6CUaI4ZfMsndZFeuHPXL3H0IsaiNAhLITSISbeyeYd+CBd9oERXQDdjXWZw==}
     peerDependencies:
-      graphql: ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-ws: ^5.5.5 || ^6.0.3
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
@@ -1770,12 +1773,12 @@ packages:
     resolution: {integrity: sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==}
     hasBin: true
     peerDependencies:
-      graphql: '*'
+      graphql: 17.0.2
 
   '@ardatan/relay-compiler@13.0.1':
     resolution: {integrity: sha512-afG3YPwuSA0E5foouZusz5GlXKs74dObv4cuWyLyfKsYFj2r7oGRNB28v18HvwuLSQtQFCi+DpIe0TZkgQDYyg==}
     peerDependencies:
-      graphql: '*'
+      graphql: 17.0.2
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -3020,182 +3023,182 @@ packages:
     resolution: {integrity: sha512-MSylSekjpVWbOBw2A/2ssk1fPY54sYb6Qk2C4AX5u7s2R+2pMQ9ws7DTXo8VU9qwTgWwVp6vGfdQ0AMpAn4Iug==}
     engines: {node: '>=16'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/add@7.0.0':
     resolution: {integrity: sha512-fQGlUQd0BpoevCTOKi3b7M+kuXCI13udXmJrIh1QMtTCLXUTYGgsubNVcPLr0cVjVwyBK/ZRgwtxdCmkVXqTwQ==}
     engines: {node: '>=16'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/c-sharp-common@2.0.1':
     resolution: {integrity: sha512-4acV9IDAp9aO0IacDs6HR6J5DTqI1DUnrtvO/1JktXuq+0a/QXdXWKf/sN//+I68j06W4JTTbxby+YexFlknow==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-tag: 2.12.6
 
   '@graphql-codegen/c-sharp-operations@4.0.1':
     resolution: {integrity: sha512-qIXCb0q4R5f+1x/8Jv0cDd3Cs7ZMxZzH0oOMItSFAv6/4ztprpE6al6Ytb5fF33FKmZdpmFSwsuuDhCrGA5stw==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-tag: 2.12.6
 
   '@graphql-codegen/c-sharp@6.0.1':
     resolution: {integrity: sha512-KezdUcrWzUAIhYk0GEDeX+tCKApVKDeXNYIiCUBZoiMmTRu4WYR4wx9PphwoHwVuOruF0UA/kJef4u4JKz6VmA==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/flow-operations@3.0.2':
     resolution: {integrity: sha512-4GYZ3ZVGIF4kI6D6XwXifch2/k8SF1j7e4aoJTkaR74i1P1Ldc/92CM9/LpRF4X9tU2io/J1N5Hz9DRR0qHl5w==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/flow-resolvers@3.0.1':
     resolution: {integrity: sha512-3Ea2vdZh7nbdlntAvd/rgOSZV/XVpO6824mA0MUg8leWI3BI893oY/+O9Rq7HgAxszUThbQfTci7qN5Xd9yYVA==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/flow-resolvers@3.0.2':
     resolution: {integrity: sha512-+tPU+ye4MQWAmppicYSwc7xJ8mONc1ItO4jskpF/dSeLjfymBdNDsXuzzaNMJ7FrJp0PGi/CFWcrLXJQp/odnQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/flow@3.0.1':
     resolution: {integrity: sha512-b+7uU89kPMl8j9mnTWFIm2+fa1/PU7tYuHtGMAbXDkKTkqH9rR6LTOnI9MvnavfUhq2VipYKJPeec3xC7yBlEQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/flutter-freezed@5.0.1':
     resolution: {integrity: sha512-EYgaM8OeLaDmmbWJfG8zUnlr/zsTKvsgrpSzxaqLezLZUvmaxtObpA+rN/9gxRbum3pWBLuCC3oTb3idAKUV3g==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/hasura-allow-list@4.0.1':
     resolution: {integrity: sha512-+/C764nTNS6BgYUxC5Lrnj8T7veFJ40ZXrbWdvecu5yJbeK5BoZAG7FCeWhd0cegbdBN8tbZY0RX6pDuY/Cg9A==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/import-types-preset@4.0.1':
     resolution: {integrity: sha512-0qN9ptrRdg4St6636RZIpEidizXFDh73LZ+Bebmss2vYW5+Bu2T/ZJ+WXduMzeRkPFFzF7adaZNRFy2ejuzmzQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/java-apollo-android@4.0.1':
     resolution: {integrity: sha512-YPKdj0om/gug6vjedU/jGVywPmJRBWfQjEdTWkeCKxxK072uvt/X2h1X7iglo/xxNw7S8IGM/zuXT++OmvBxLw==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/java-common@4.0.1':
     resolution: {integrity: sha512-5N+ccnLmLwiDnfnjcUxf3fEb3GgPV3w+xo8LZ+XC2OTN0JBFD6gcHGYqfPufKDQ7Zn+RlWTs4FjWCsM5EecnkQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/java-resolvers@4.0.1':
     resolution: {integrity: sha512-hX+KzPa8o7WMsdcGxgutbs4BPMDfHYI0TUEVbJZu9FW/pT37m0vjAvhO/1SuGFM6dH62yZrh1my67fvVjGl/Qw==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/java@5.0.1':
     resolution: {integrity: sha512-c0oydoImnsrJh9gAgl2XCsBqDcyBFXvi42xLZzLLx29/AJvUEGZsFtZirJy4cjBvjf3rqHtRO0qoecn79aZSsQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/kotlin@4.0.1':
     resolution: {integrity: sha512-SmPHN6Fp8mHoEhh0JpKxYdNHA3ZeiC0P/9z4C87p7+MW9aNSwMKOuli4dsuHUdVmU7whyber8yxyiSIzPXjuTA==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/named-operations-object@4.0.1':
     resolution: {integrity: sha512-f+3zfq56WSfkNFVikUhuD0PmzOskfYXB8kQNQWnO/DQ9hWqROd0GEGgtXwE0ucMnTNpyuy/YEnqOMnZOZsdfDQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-tag: ^2.0.0
 
   '@graphql-codegen/near-operation-file-preset@5.2.1':
     resolution: {integrity: sha512-F+9gln4QboYozcMfsXwOxsPDdqUmMBOQoGZww+9qegvpWNvQVcZXm1LbYibi1iWOfuM0TTXVtMsDDjMeyNJcHA==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/plugin-helpers@2.7.2':
     resolution: {integrity: sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/plugin-helpers@3.1.2':
     resolution: {integrity: sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/plugin-helpers@6.3.0':
     resolution: {integrity: sha512-Auc+/B7okDx9+pVgLVliZtZLYh6iltWXlnzzM+bRE+zh1T4r3hKbnr8xAmtT937ArfSgk5GHcQHr8LfPYnrRBg==}
     engines: {node: '>=16'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/plugin-helpers@7.0.1':
     resolution: {integrity: sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==}
     engines: {node: '>=16'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/schema-ast@2.6.1':
     resolution: {integrity: sha512-5TNW3b1IHJjCh07D2yQNGDQzUpUl2AD+GVe1Dzjqyx/d2Fn0TPMxLsHsKPS4Plg4saO8FK/QO70wLsP7fdbQ1w==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/schema-ast@5.0.2':
     resolution: {integrity: sha512-jl1F/9IjRkJisEb9B0ayG4QGqYlPldLRy8ojDdmL9NE1NsdB5ROfxQnSqyC3g+wuvBhWX7kZgMRQYn3RU1I5bA==}
     engines: {node: '>=16'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/typescript-apollo-angular@5.0.1':
     resolution: {integrity: sha512-gXHPLmBKtJHcvDwxzL4M9FKTNpYTy5hCdBHrA+fNTvA+bpnWW8wBtNVAQVe/lfpaTfXj82AV6LbJpgeXyl9mEQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/typescript-apollo-client-helpers@4.0.1':
     resolution: {integrity: sha512-qYIuhDtcn5FBPr6IjSfP+PhgOEGYgNFj0C7MaNX+V9ri2FdY8C/m1vZp86TmHKt3X+ppjeOLgUDRYlKFaap83A==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/typescript-generic-sdk@5.0.1':
     resolution: {integrity: sha512-xnx51KjC76quF/9GzV9xu3J2Rt/43onH9yPIrx9GVNfQ9M2M3eigkzxPDJHHPvbUdbWCPTebQvp2kNkrKI0+BQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-tag: ^2.0.0
 
   '@graphql-codegen/typescript-graphql-files-modules@4.0.1':
     resolution: {integrity: sha512-xY1nq+/jdYYx23uiaJkMb1HGS+M0GzkC378hbPD6WXQNagGavtMyTt2IZRnJXL488NYlTZkBsM8Xp4h7EyqGVg==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/typescript-graphql-request@7.0.1':
     resolution: {integrity: sha512-nL4tsD7FYT1+1gPKb+6l/HwmRTqJuNvNaE1hOBU/e5y+am2k2VcR0ATuiXBbviNemE/rUOcidtmRjo/j4v5M+A==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-request: ^6.0.0 || ^7.0.0
       graphql-tag: ^2.0.0
 
@@ -3203,39 +3206,39 @@ packages:
     resolution: {integrity: sha512-VrB+frfaZqzFAm+byvMcPjwGlpzZmNctNWzGCi21R6rHF9zYKVCEJHeSJgVjGmlx3pPrHRmh5/ihUgFyCsRQ9g==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-tag: ^2.0.0
 
   '@graphql-codegen/typescript-msw@4.0.1':
     resolution: {integrity: sha512-NA4J6B8ErWjQiDD513Z5ewHo0u2m8lQ5fIzLGTBCL5N1SXVlEAUEbtRadEfo3/DPE92iBgAvb9dTkEOS65fTsQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       msw: ^2.0.0
 
   '@graphql-codegen/typescript-nhost@1.0.1':
     resolution: {integrity: sha512-SykAUuqnnBqStia9tGwUI9PnXgrx1ps4woAtxAGMxWQckHiJzndz4Hl5pKnhhGMnpBEIlYYkIiqXlLbPr7sPPg==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/typescript-react-apollo@4.4.2':
     resolution: {integrity: sha512-S/VQeLWMNzo/WnUpvCQELqh2qgAK4H9kkWyC8JrrrPHaV3w/BmOwzeHpcwlHKcuSYWRH6u61XPRQ5+eCjj00AQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/typescript-react-query@4.1.0':
     resolution: {integrity: sha512-+3Hk+ws6HfCAZl7+5Q4LBkFh3y+2ISuahMYRHIqzqpwNnrthftg8xNx11VH5sabqqjqEmjY3UaP8glP93itPWQ==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/typescript-rtk-query@4.0.1':
     resolution: {integrity: sha512-Ucm0AYBW1UARnzqzaRfldm+qlCPJ+gYzjCyT9wo9LlwGGww0FZcPA05VwqRavPTl1Xa7AyL+sJjfVoUMxgpGyA==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       '@reduxjs/toolkit': ^1.6.0 || ^2.0.0
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-request: ^3.4.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
       graphql-tag: ^2.0.0
     peerDependenciesMeta:
@@ -3246,7 +3249,7 @@ packages:
     resolution: {integrity: sha512-szpDg7YFwDHutsbGEALGVYK/YgHY3SVZXwIojdY+3PtJbqHu80+C6G4xgcqKBSvqG2jHFEeST5EYfrKz7iewYw==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-tag: ^2.0.0
       stencil-apollo: ^0.1.3
 
@@ -3254,74 +3257,74 @@ packages:
     resolution: {integrity: sha512-ndVTy1ifP1i9slntQbvYjpHEGqmQiMs+DojFBAwJNlH9/S0qa9HFG52yFwRvWYlwBRbJJUk3dB1Tm5M1jCK+kg==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/typescript-urql@5.0.1':
     resolution: {integrity: sha512-kRxsZtkGMt2EC3itsqCwVXIgCfSnN+hDy/wSsFEi31WrbZgMVPn89Bqcv3Pel+zRxEwS5Osc9Pnl9pbVZND1fg==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-tag: ^2.0.0
 
   '@graphql-codegen/typescript-vue-apollo-smart-ops@4.0.1':
     resolution: {integrity: sha512-y4cvPGXKCKTPLwqO8xIMK+asDgYneYUR8w9R9mkPMG62qqXxyFNYSj0TBhX5FIdJWuFzddrx1qhCTBbe9rBa2w==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-tag: ^2.0.0
 
   '@graphql-codegen/typescript-vue-apollo@5.0.1':
     resolution: {integrity: sha512-+0NxqP4cD9OXapsb7AxUP7gLz+iaeD0PGx8sHxouXNcgcUba0JaCUu8NFIAe5pArayKsCMYTTe+s7N1e1Gnu7g==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-tag: ^2.0.0
 
   '@graphql-codegen/typescript-vue-urql@4.0.1':
     resolution: {integrity: sha512-1Ab3Kk/ADqJh/f0YYXnWG7Yk6HQevclwFmzbAlEIZMcM2j01qa2bm81GV6vTc1yhI52+bsjO7YJG+b3AoEoBHA==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-tag: ^2.0.0
 
   '@graphql-codegen/typescript@2.8.8':
     resolution: {integrity: sha512-A0oUi3Oy6+DormOlrTC4orxT9OBZkIglhbJBcDmk34jAKKUgesukXRd4yOhmTrnbchpXz2T8IAOFB3FWIaK4Rw==}
     peerDependencies:
-      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/typescript@5.0.10':
     resolution: {integrity: sha512-Pa8OFmL9TdhEYnLYJLYA9EhP8eEeivP/YDYq4Nb8LQaL7GXm4TGX8zELYaCM9Fu8M3iZb7iQGMt7qc+1lXz8XQ==}
     engines: {node: '>=16'}
     peerDependencies:
-      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/urql-introspection@4.0.1':
     resolution: {integrity: sha512-nDfNojYqgrKHpGeeC+3Qq/nUCgfoHD8lpjfp4ce/e55v8Go1fzuwET5glERAeUu9hvVX5pzmMlCweL07o833Qg==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/visitor-plugin-common@2.13.1':
     resolution: {integrity: sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/visitor-plugin-common@2.13.8':
     resolution: {integrity: sha512-IQWu99YV4wt8hGxIbBQPtqRuaWZhkQRG2IZKbMoSvh0vGeWb3dB0n0hSgKaOOxDY+tljtOf9MTcUYvJslQucMQ==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/visitor-plugin-common@6.3.0':
     resolution: {integrity: sha512-vGBoE+4huzZyNhyGSAhXAkdROHlwKxxuziZm4XtP1mxe7nuI+VgyOmXebafLijbmuDsptPXQN0C/htL54O8hrg==}
     engines: {node: '>=16'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-codegen/visitor-plugin-common@7.0.2':
     resolution: {integrity: sha512-3v1dPjkSiAIsqwZ/6btSZ6BCYlYYpr3FdLhsBZ/JoPP2hYgN6AlGKdUyhYm5FsgDKU04L7al3+rfnTOCxqM0gw==}
     engines: {node: '>=16'}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@graphql-hive/signal@2.0.0':
     resolution: {integrity: sha512-Pz8wB3K0iU6ae9S1fWfsmJX24CcGeTo6hE7T44ucmV/ALKRj+bxClmqrYcDT7v3f0d12Rh4FAXBb6gon+WkDpQ==}
@@ -3331,188 +3334,188 @@ packages:
     resolution: {integrity: sha512-hUydKGGECrWloERMmfoMzHZi12X99AM9geCGF5XVsv4iMRl/Iyuet24th4kC9bZ8MlAdCwAwtUsCyv9uRfYwSA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/batch-execute@10.0.8':
     resolution: {integrity: sha512-Kobt37qrVTFhX4HUK5/vPgMXFw/5f97AzmAlfmDBSRh/GnoAmLKCb48FrEI3gdeIwZB2fEhVHJyDqsojldnLQA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/code-file-loader@8.1.39':
     resolution: {integrity: sha512-9hPTdcF1qEkS7C6DJmrSM25G5BiY0yLajTfrtVW7VQppDHqIU8Uyi8DPVwtDDmOZ2o9fYQKwd5tIL1csrjmyBA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/delegate@12.0.16':
     resolution: {integrity: sha512-WEJaFwWG82a0VzhfE4sRsaOPjxgCVfn4fOe3ho+r3uIbPYpc7qHpFdu1PLg6meikq6fuW9NJ1J88fEgnWuXDVg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/documents@1.0.1':
     resolution: {integrity: sha512-aweoMH15wNJ8g7b2r4C4WRuJxZ0ca8HtNO54rkye/3duxTkW4fGBEutCx03jCIr5+a1l+4vFJNP859QnAVBVCA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/executor-common@1.0.6':
     resolution: {integrity: sha512-23/K5C+LSlHDI0mj2SwCJ33RcELCcyDUgABm1Z8St7u/4Z5+95i925H/NAjUyggRjiaY8vYtNiMOPE49aPX1sg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/executor-graphql-ws@3.1.5':
     resolution: {integrity: sha512-WXRsfwu9AkrORD9nShrd61OwwxeQ5+eXYcABRR3XPONFIS8pWQfDJGGqxql9/227o/s0DV5SIfkBURb5Knzv+A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/executor-http@3.3.0':
     resolution: {integrity: sha512-IkKXIjSg9U8MNsQUBVJAXE4+LSxaQ0cs7p5JTALLGDABY1o17vPDRwWALsX81AXD5dY27ihi/+OhGMueW/Fopg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/executor-legacy-ws@1.1.28':
     resolution: {integrity: sha512-O4uj93GG9iUb3s32eyhUohvyfA8mLhN8FvGzEdK628hFQPhZN75yurtVFrR08DHex71mQ3wYCCFkErpwdJbDDQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/executor@1.5.3':
     resolution: {integrity: sha512-mgBFC0bsrZPZLu9EnydpMnAuQ8Iiq0CEbUcsmvXsm2/iYektGHDN/+bmb7hicA6dWZtdPfklYJmr21WD0GnOfA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/git-loader@8.0.36':
     resolution: {integrity: sha512-PDDakesRu8FJYHJLf9/gkTweh8M19Bymz9i+vOlk9OTs9XmNcCqKM+1S610KX2AodvuBFz/xbesjTtTJIppLPg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/github-loader@9.1.2':
     resolution: {integrity: sha512-jhRJncj9Wkr1Cd8Mo3QI2oG6fTw5ILr1/OXcHIqx744NBj8pPwQBXmQzZqh7MXxbekl2EAcum7SJIjq1HpYcPA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/graphql-file-loader@8.1.12':
     resolution: {integrity: sha512-Nma7gBgJoUbqXWTmdHjouo36tjzewA8MptVcHoH7widzkciaUVzBhriHzqICFB/dVxig//g9MX8s1XawZo7UAg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/graphql-tag-pluck@8.3.31':
     resolution: {integrity: sha512-ema2RRPZGj8TKruNElyDBHVCNFMxioGIVfLBuiA+GdfmRGt95b/i7Uksnj4EwItA6MCmhxokxZoa/fl6mJt3tw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/graphql-tag-pluck@8.3.37':
     resolution: {integrity: sha512-pTKex/pmHH+MjNEtzFAKhksM8S6qL+60kssc2/DurcaQmQn6Tkt/yRHe90JNAJsRHNXxhlqZRl8iAI8bIAMuXQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/import@7.1.14':
     resolution: {integrity: sha512-aqLcu04aEidszbXM6M0PWWL8bP17eX9sxXwjYWpglLvIRd4NFqb3C9QzBY8pleqXNMtWqXktlm9BQjevgSrirQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/json-file-loader@8.0.28':
     resolution: {integrity: sha512-qgCsSkPArnjlNkcYpgGKiXxCTNkrAT9E+l1LhR+Por2jTlKBBeZ8stortkQ/PNDDjuL0WPrLQmHKhNPHabnB3A==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/load@8.1.10':
     resolution: {integrity: sha512-hjcvfEFtwtc8vGi46wtpmGWadNzfEhzbjqinyFIZuIZPlR4aYdWQtqWtY/RMM4Ew4t1USkMNm6xrqC2TH1vCSA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/merge@9.2.4':
     resolution: {integrity: sha512-vV+8uWNWn0+OsqT0r22lZuoT0cTe6fBqBtpLHre2rriLjI/ZTrsOHmabLPTUOyzgFnRrS2PzFSYGL3zKL1Wj4Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/optimize@1.4.0':
     resolution: {integrity: sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/optimize@2.0.0':
     resolution: {integrity: sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/relay-operation-optimizer@6.5.18':
     resolution: {integrity: sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/relay-operation-optimizer@7.1.4':
     resolution: {integrity: sha512-cwOD/GEo/R//1uGCP0/urIxsMFoUgzkJVyMt9BDM2HhQhU6rSgH5l6lFukAFTJyPJVdyeOdYm2i0Jj5vYWbHTw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/schema@10.0.33':
     resolution: {integrity: sha512-O6P3RIftO0jafnSsFAqpjurUuUxJ43s/AdPVLQsBkI6y4Ic/tKm4C1Qm1KKQsCDTOxXPJClh/v3g7k7yLKCFBQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/url-loader@9.1.2':
     resolution: {integrity: sha512-pVSiPrfWQKb3jq23Pl7EjbB2uv3tgZLnWo/axkmg4itAEZ5s/vV/jKa8P1HZzUnSVUTR+8tcEZVeNsUbzFCbkg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/utils@10.11.0':
     resolution: {integrity: sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/utils@11.2.0':
     resolution: {integrity: sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/utils@12.0.1':
     resolution: {integrity: sha512-8YC6jn4xYDS6YTY6xDAgQAs/nGgvzRaIGHS8GeSfVItQzNK7Ms24CQtE3EJY+amvR+tBnhRSX0N83aGj+V/RIg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/utils@8.13.1':
     resolution: {integrity: sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/utils@9.2.1':
     resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-tools/wrap@11.1.15':
     resolution: {integrity: sha512-GCMx6l0MPwHVaBMHf29oG8eIrsJ8PBXq9y5DNX9/r9oCpCBfqxfWzcejx4CpO4chA3+yylGOKcAyEbOUgxfI1Q==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@graphql-yoga/logger@2.0.1':
     resolution: {integrity: sha512-Nv0BoDGLMg9QBKy9cIswQ3/6aKaKjlTh87x3GiBg2Z4RrjyrM48DvOOK0pJh1C1At+b0mUIM67cwZcFTDLN4sA==}
@@ -3522,14 +3525,14 @@ packages:
     resolution: {integrity: sha512-zWhbsl9ceyR8PwRnJCwKpE7KtakaaIi0Fsit4K+LkQu7XIGuVmLlAB9Cr6Esi0AjDmjAnviLYotknythNcEyGA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      graphql: ^15.2.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-yoga: ^5.21.0
 
   '@graphql-yoga/plugin-persisted-operations@3.21.0':
     resolution: {integrity: sha512-JzzaHzqFXiMgTHA9Qsl1r/Ll9t2WA1Lg3R2+MZcKodaBFS0XSaJSHrQigaxe8hrN4EohNlrx3P8w7Z03J3k/iw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      graphql: ^15.2.0 || ^16.0.0
+      graphql: 17.0.2
       graphql-yoga: ^5.21.0
 
   '@graphql-yoga/subscription@5.0.5':
@@ -4872,9 +4875,6 @@ packages:
   '@types/parse-filepath@1.0.2':
     resolution: {integrity: sha512-CcyaQuvlpejsJR57RWxUR++E7zTKvbDDotZyiKaJsZdlbV8JfHgRYj4aZszEGKVLhiX0pbD8QeAuzEFUol4mRA==}
 
-  '@types/parse-json@4.0.2':
-    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
-
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -5168,7 +5168,7 @@ packages:
   '@urql/core@3.2.2':
     resolution: {integrity: sha512-i046Cz8cZ4xIzGMTyHZrbdgzcFMcKD7+yhCAH5FwWBRjcKrc+RjEOuR9X5AMuBvr8c6IAaE92xAqa4wmlGfWTQ==}
     peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@urql/core@6.0.3':
     resolution: {integrity: sha512-0F39XWR21+IVLJfsqBvLShvoSzxT6h6wWXwrDhN8j9J+IEVOpQIUNHwpgjsp+2ePzn9aCH+rpDonn3HOAUnn9A==}
@@ -5176,12 +5176,12 @@ packages:
   '@urql/introspection@0.3.3':
     resolution: {integrity: sha512-tekSLLqWnusfV6V7xaEnLJQSdXOD/lWy7f8JYQwrX+88Md+voGSCSx5WJXI7KLBN3Tat2OV08tAr8UROykls4Q==}
     peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   '@urql/introspection@1.2.1':
     resolution: {integrity: sha512-U9FTSISz69EEK3bHWDsqux9JqOeiLzr3eDFBQ5DmHuTLaBsd5mjPdtLRzzzmb9nW1Ygd6IR8YcuM7zeNqQ5lCQ==}
     peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: 17.0.2
 
   '@urql/vue@2.1.0':
     resolution: {integrity: sha512-fRsMOSJze7d9y2NUd31ekZMUWDoc+HYv/jFcO9iPpRFCFlqcuqto5r0v54jDB6C7MEo+xLsqRQGuxe0NM0J8YA==}
@@ -5252,18 +5252,13 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@vue/apollo-composable@4.2.2':
     resolution: {integrity: sha512-5j+Jl07Gemz5vmuS8u/FfWtYgr04Rh0rjQ5HBv6DZDP7d+pvQfsCIRgX5adJoZJcznJLsQ0JupO/mZmRCBWGaQ==}
     peerDependencies:
       '@apollo/client': ^3.4.13
       '@vue/composition-api': ^1.0.0
-      graphql: '>=15'
+      graphql: 17.0.2
       vue: ^2.6.0 || ^3.1.0
     peerDependenciesMeta:
       '@vue/composition-api':
@@ -5422,22 +5417,22 @@ packages:
   apollo-cache@1.3.5:
     resolution: {integrity: sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==}
     peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+      graphql: 17.0.2
 
   apollo-client@2.6.10:
     resolution: {integrity: sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==}
     peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+      graphql: 17.0.2
 
   apollo-link@1.2.14:
     resolution: {integrity: sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==}
     peerDependencies:
-      graphql: ^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0
+      graphql: 17.0.2
 
   apollo-utilities@1.3.4:
     resolution: {integrity: sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==}
     peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+      graphql: 17.0.2
 
   arch@2.2.0:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
@@ -5554,10 +5549,6 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
-
-  babel-plugin-macros@3.1.0:
-    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
-    engines: {node: '>=10', npm: '>=6'}
 
   babel-plugin-polyfill-corejs2@0.4.17:
     resolution: {integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==}
@@ -5922,10 +5913,6 @@ packages:
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
-
-  cosmiconfig@7.1.0:
-    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
-    engines: {node: '>=10'}
 
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
@@ -6835,7 +6822,7 @@ packages:
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       cosmiconfig-toml-loader: ^1.0.0
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
     peerDependenciesMeta:
       cosmiconfig-toml-loader:
         optional: true
@@ -6843,34 +6830,29 @@ packages:
   graphql-helix@1.13.0:
     resolution: {integrity: sha512-cqDKMoRywKjnL0ZWCTB0GOiBgsH6d3nU4JGDF6RuzAyd35tmalzKpSxkx3NNp4H5RvnKWnrukWzR51wUq277ng==}
     peerDependencies:
-      graphql: ^15.3.0 || ^16.0.0
-
-  graphql-request@6.1.0:
-    resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
-    peerDependencies:
-      graphql: 14 - 16
+      graphql: 17.0.2
 
   graphql-request@7.4.0:
     resolution: {integrity: sha512-xfr+zFb/QYbs4l4ty0dltqiXIp07U6sl+tOKAb0t50/EnQek6CVVBLjETXi+FghElytvgaAWtIOt3EV7zLzIAQ==}
     peerDependencies:
-      graphql: 14 - 16
+      graphql: 17.0.2
 
   graphql-sock@1.0.1:
     resolution: {integrity: sha512-gSA0CXdNMvNlpEnH2GY1//SUY7laDsAn51sDm4yh6TTH5UkfbNINydyUAoMHHkAaCaOLNXELQmu3GVcSOw4twg==}
     hasBin: true
     peerDependencies:
-      graphql: 15.x || 16.x || 17.x
+      graphql: 17.0.2
 
   graphql-subscriptions@3.0.0:
     resolution: {integrity: sha512-kZCdevgmzDjGAOqH7GlDmQXYAkuHoKpMlJrqF40HMPhUhM5ZWSFSxCwD/nSi6AkaijmMfsFhoJRGJ27UseCvRA==}
     peerDependencies:
-      graphql: ^15.7.2 || ^16.0.0
+      graphql: 17.0.2
 
   graphql-tag@2.12.6:
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
     engines: {node: '>=10'}
     peerDependencies:
-      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
 
   graphql-ws@6.0.8:
     resolution: {integrity: sha512-m3EOaNsUBXwAnkBWbzPfe0Nq8pXUfxsWnolC54sru3FzHvhTZL0Ouf/BoQsaGAXqM+YPerXOJ47BUnmgmoupCw==}
@@ -6878,7 +6860,7 @@ packages:
     peerDependencies:
       '@fastify/websocket': ^10 || ^11
       crossws: ~0.3
-      graphql: ^15.10.1 || ^16
+      graphql: 17.0.2
       ws: ^8
     peerDependenciesMeta:
       '@fastify/websocket':
@@ -6892,11 +6874,11 @@ packages:
     resolution: {integrity: sha512-PS37UoDihx8209RRl1ogttzWevNYDnGvP7beHkwHzUpUdfZTHsVRTVe1ysGXre1EjwUAePbpez302YSrq70Ngw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      graphql: ^15.2.0 || ^16.0.0
+      graphql: 17.0.2
 
-  graphql@16.14.0:
-    resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+  graphql@17.0.2:
+    resolution: {integrity: sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==}
+    engines: {node: ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -8872,7 +8854,7 @@ packages:
     resolution: {integrity: sha512-jgTyBngLdKF/MrHC/mZOelAmWAhF7FIVQIb3PDEzw2mfiTvuUkVm99ogy633uWoKu4XRVvG56qWvxbX5dqEFLg==}
     peerDependencies:
       apollo-client: ^2.4.13
-      graphql: ^14.1.1 || ^15.0.0
+      graphql: 17.0.2
       graphql-tag: ^2.10.1
 
   stop-iteration-iterator@1.1.0:
@@ -9423,7 +9405,7 @@ packages:
   urql@3.0.4:
     resolution: {integrity: sha512-okmQKQ9pF4t8O8iCC5gH9acqfFji5lkhW3nLBjx8WKDd2zZG7PXoUpUK19VQEMK87L6VFBOO/XZ52MMKFEI0AA==}
     peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       react: '>= 16.8.0'
 
   use-sync-external-store@1.6.0:
@@ -9470,7 +9452,7 @@ packages:
   villus@3.5.2:
     resolution: {integrity: sha512-Tn6zAXVigaY91lTgWuT5WecAwfxRjTX5ezwRU1e2A/sD3yRi3v0tnVgRQJ7EjaMSNrbY+iXWHMVCGhof1llSvQ==}
     peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: 17.0.2
       vue: ^3.0.0 || ^2.7.0
 
   vite@8.0.13:
@@ -9811,20 +9793,20 @@ packages:
 
 snapshots:
 
-  '@0no-co/graphql.web@1.3.4(graphql@16.14.0)':
+  '@0no-co/graphql.web@1.3.4(graphql@17.0.2)':
     optionalDependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@apollo/client@3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@apollo/client@3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
       '@wry/caches': 1.0.1
       '@wry/equality': 0.5.7
       '@wry/trie': 0.5.0
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       hoist-non-react-statics: 3.3.2
       optimism: 0.18.1
       prop-types: 15.8.1
@@ -9834,26 +9816,26 @@ snapshots:
       tslib: 2.8.1
       zen-observable-ts: 1.2.5
     optionalDependencies:
-      graphql-ws: 6.0.8(graphql@16.14.0)(ws@8.20.1)
+      graphql-ws: 6.0.8(graphql@17.0.2)(ws@8.20.1)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - '@types/react'
 
-  '@ardatan/relay-compiler@12.0.0(graphql@16.14.0)(supports-color@10.2.2)':
+  '@ardatan/relay-compiler@12.0.0(graphql@17.0.2)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/generator': 7.29.8
       '@babel/parser': 7.29.8
       '@babel/runtime': 7.29.2
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      babel-preset-fbjs: 3.4.0(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      babel-preset-fbjs: 3.4.0(@babel/core@7.29.0)
       chalk: 4.1.2
       fb-watchman: 2.0.2
       fbjs: 3.0.5
       glob: 7.2.3
-      graphql: 16.14.0
+      graphql: 17.0.2
       immutable: 3.7.6
       invariant: 2.2.4
       nullthrows: 1.1.1
@@ -9864,10 +9846,10 @@ snapshots:
       - encoding
       - supports-color
 
-  '@ardatan/relay-compiler@13.0.1(graphql@16.14.0)':
+  '@ardatan/relay-compiler@13.0.1(graphql@17.0.2)':
     dependencies:
       '@babel/runtime': 7.29.2
-      graphql: 16.14.0
+      graphql: 17.0.2
       immutable: 5.1.5
       invariant: 2.2.4
 
@@ -9879,40 +9861,40 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.0(supports-color@10.2.2)':
+  '@babel/core@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/core@7.29.7(supports-color@10.2.2)':
+  '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@10.2.2)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -9939,32 +9921,32 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@10.2.2)
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@10.2.2)
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.12
     transitivePeerDependencies:
@@ -9972,35 +9954,35 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-member-expression-to-functions@7.28.5(supports-color@10.2.2)':
+  '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.29.7(supports-color@10.2.2)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@10.2.2)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@10.2.2)
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@10.2.2)
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -10010,27 +9992,27 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.28.6(supports-color@10.2.2)
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-wrap-function': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1(supports-color@10.2.2)':
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -10041,10 +10023,10 @@ snapshots:
 
   '@babel/helper-validator-option@7.29.7': {}
 
-  '@babel/helper-wrap-function@7.28.6(supports-color@10.2.2)':
+  '@babel/helper-wrap-function@7.28.6':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -10058,569 +10040,569 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@10.2.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@10.2.2)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
-    dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-globals': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.29.7
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@10.2.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
-    dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@10.2.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@10.2.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@10.2.2)
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/preset-env@7.29.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0(supports-color@10.2.2))
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.0)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
       core-js-compat: 3.49.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.0
       esutils: 2.0.3
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10632,7 +10614,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
 
-  '@babel/traverse@7.29.0(supports-color@10.2.2)':
+  '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
@@ -10640,11 +10622,11 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.29.8(supports-color@10.2.2)':
+  '@babel/traverse@7.29.8':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
@@ -10652,7 +10634,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/types': 7.29.8
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11145,19 +11127,19 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.0(jiti@2.7.0))':
     dependencies:
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5(supports-color@10.2.2)':
+  '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
@@ -11170,10 +11152,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5(supports-color@10.2.2)':
+  '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -11184,9 +11166,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@10.0.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))':
+  '@eslint/js@10.0.1(eslint@10.4.0(jiti@2.7.0))':
     optionalDependencies:
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -11197,560 +11179,560 @@ snapshots:
 
   '@fastify/busboy@3.2.0': {}
 
-  '@graphql-codegen/add@6.0.1(graphql@16.14.0)':
+  '@graphql-codegen/add@6.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/add@7.0.0(graphql@16.14.0)':
+  '@graphql-codegen/add@7.0.0(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 7.0.1(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/plugin-helpers': 7.0.1(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/c-sharp-common@2.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/c-sharp-common@2.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       tslib: 2.8.1
 
-  '@graphql-codegen/c-sharp-operations@4.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/c-sharp-operations@4.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/c-sharp-common': 2.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/c-sharp-common': 2.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       tslib: 2.8.1
 
-  '@graphql-codegen/c-sharp@6.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/c-sharp@6.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/c-sharp-common': 2.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/c-sharp-common': 2.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       change-case-all: 1.0.15
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
       unixify: 1.0.0
     transitivePeerDependencies:
       - graphql-tag
 
-  '@graphql-codegen/flow-operations@3.0.2(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-codegen/flow-operations@3.0.2(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/flow': 3.0.1(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.14.0)(supports-color@10.2.2)
+      '@graphql-codegen/flow': 3.0.1(graphql@17.0.2)
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@graphql-codegen/flow-resolvers@3.0.1(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-codegen/flow-resolvers@3.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/flow': 3.0.1(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-tools/utils': 10.11.0(graphql@16.14.0)
+      '@graphql-codegen/flow': 3.0.1(graphql@17.0.2)
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@17.0.2)
+      '@graphql-tools/utils': 10.11.0(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@graphql-codegen/flow-resolvers@3.0.2(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-codegen/flow-resolvers@3.0.2(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/flow': 3.0.1(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-codegen/flow': 3.0.1(graphql@17.0.2)
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@graphql-codegen/flow@3.0.1(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-codegen/flow@3.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.14.0)(supports-color@10.2.2)
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@graphql-codegen/flutter-freezed@5.0.1(graphql@16.14.0)':
+  '@graphql-codegen/flutter-freezed@5.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/schema-ast': 5.0.2(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/schema-ast': 5.0.2(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/hasura-allow-list@4.0.1(graphql@16.14.0)':
+  '@graphql-codegen/hasura-allow-list@4.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
       yaml: 1.10.3
 
-  '@graphql-codegen/import-types-preset@4.0.1(graphql@16.14.0)':
+  '@graphql-codegen/import-types-preset@4.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/add': 6.0.1(graphql@16.14.0)
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/add': 6.0.1(graphql@17.0.2)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/java-apollo-android@4.0.1(graphql@16.14.0)':
+  '@graphql-codegen/java-apollo-android@4.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/java-common': 4.0.1(graphql@16.14.0)
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/java-common': 4.0.1(graphql@17.0.2)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
+      graphql: 17.0.2
       pluralize: 8.0.0
       tslib: 2.8.1
 
-  '@graphql-codegen/java-common@4.0.1(graphql@16.14.0)':
+  '@graphql-codegen/java-common@4.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       min-indent: 1.0.1
       tslib: 2.8.1
       unixify: 1.0.0
 
-  '@graphql-codegen/java-resolvers@4.0.1(graphql@16.14.0)':
+  '@graphql-codegen/java-resolvers@4.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/java-common': 4.0.1(graphql@16.14.0)
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/java-common': 4.0.1(graphql@17.0.2)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/java@5.0.1(graphql@16.14.0)':
+  '@graphql-codegen/java@5.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/java-common': 4.0.1(graphql@16.14.0)
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/java-common': 4.0.1(graphql@17.0.2)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/kotlin@4.0.1(graphql@16.14.0)':
+  '@graphql-codegen/kotlin@4.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/java-common': 4.0.1(graphql@16.14.0)
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/java-common': 4.0.1(graphql@17.0.2)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/named-operations-object@4.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/named-operations-object@4.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
       change-case-all: 1.0.15
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       tslib: 2.8.1
 
-  '@graphql-codegen/near-operation-file-preset@5.2.1(graphql@16.14.0)':
+  '@graphql-codegen/near-operation-file-preset@5.2.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/add': 7.0.0(graphql@16.14.0)
-      '@graphql-codegen/plugin-helpers': 7.0.1(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 7.0.2(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/add': 7.0.0(graphql@17.0.2)
+      '@graphql-codegen/plugin-helpers': 7.0.1(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 7.0.2(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
+      graphql: 17.0.2
       parse-filepath: 1.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/plugin-helpers@2.7.2(graphql@16.14.0)':
+  '@graphql-codegen/plugin-helpers@2.7.2(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 8.13.1(graphql@16.14.0)
+      '@graphql-tools/utils': 8.13.1(graphql@17.0.2)
       change-case-all: 1.0.14
       common-tags: 1.8.2
-      graphql: 16.14.0
+      graphql: 17.0.2
       import-from: 4.0.0
       lodash: 4.17.23
       tslib: 2.4.1
 
-  '@graphql-codegen/plugin-helpers@3.1.2(graphql@16.14.0)':
+  '@graphql-codegen/plugin-helpers@3.1.2(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 9.2.1(graphql@16.14.0)
+      '@graphql-tools/utils': 9.2.1(graphql@17.0.2)
       change-case-all: 1.0.15
       common-tags: 1.8.2
-      graphql: 16.14.0
+      graphql: 17.0.2
       import-from: 4.0.0
       lodash: 4.17.23
       tslib: 2.4.1
 
-  '@graphql-codegen/plugin-helpers@6.3.0(graphql@16.14.0)':
+  '@graphql-codegen/plugin-helpers@6.3.0(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       change-case-all: 1.0.15
       common-tags: 1.8.2
-      graphql: 16.14.0
+      graphql: 17.0.2
       import-from: 4.0.0
       tslib: 2.8.1
 
-  '@graphql-codegen/plugin-helpers@7.0.1(graphql@16.14.0)':
+  '@graphql-codegen/plugin-helpers@7.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       change-case-all: 2.1.0
       common-tags: 1.8.2
-      graphql: 16.14.0
+      graphql: 17.0.2
       import-from: 4.0.0
       tslib: 2.8.1
 
-  '@graphql-codegen/schema-ast@2.6.1(graphql@16.14.0)':
+  '@graphql-codegen/schema-ast@2.6.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.14.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@17.0.2)
+      '@graphql-tools/utils': 9.2.1(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.4.1
 
-  '@graphql-codegen/schema-ast@5.0.2(graphql@16.14.0)':
+  '@graphql-codegen/schema-ast@5.0.2(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-apollo-angular@5.0.1(graphql@16.14.0)':
+  '@graphql-codegen/typescript-apollo-angular@5.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-apollo-client-helpers@4.0.1(graphql@16.14.0)':
+  '@graphql-codegen/typescript-apollo-client-helpers@4.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-generic-sdk@5.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/typescript-generic-sdk@5.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-graphql-files-modules@4.0.1(graphql@16.14.0)':
+  '@graphql-codegen/typescript-graphql-files-modules@4.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-graphql-request@7.0.1(graphql-request@6.1.0(graphql@16.14.0))(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/typescript-graphql-request@7.0.1(graphql-request@7.4.0(graphql@17.0.2))(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
-      graphql-request: 6.1.0(graphql@16.14.0)
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-request: 7.4.0(graphql@17.0.2)
+      graphql-tag: 2.12.6(graphql@17.0.2)
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-mongodb@4.0.2(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/typescript-mongodb@4.0.2(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/typescript': 5.0.10(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/typescript': 5.0.10(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       lodash: 4.18.1
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-msw@4.0.1(graphql@16.14.0)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))':
+  '@graphql-codegen/typescript-msw@4.0.1(graphql@17.0.2)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
+      graphql: 17.0.2
       msw: 2.14.6(@types/node@24.12.4)(typescript@5.9.3)
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-nhost@1.0.1(graphql@16.14.0)':
+  '@graphql-codegen/typescript-nhost@1.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/typescript': 5.0.10(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
-      '@urql/introspection': 1.2.1(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/typescript': 5.0.10(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
+      '@urql/introspection': 1.2.1(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-react-apollo@4.4.2(graphql@16.14.0)':
+  '@graphql-codegen/typescript-react-apollo@4.4.2(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-react-query@4.1.0(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-codegen/typescript-react-query@4.1.0(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.1(graphql@16.14.0)(supports-color@10.2.2)
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 2.13.1(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.4.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@graphql-codegen/typescript-rtk-query@4.0.1(@reduxjs/toolkit@2.12.0(react@19.2.6))(graphql-request@6.1.0(graphql@16.14.0))(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/typescript-rtk-query@4.0.1(@reduxjs/toolkit@2.12.0(react@19.2.6))(graphql-request@7.4.0(graphql@17.0.2))(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       '@reduxjs/toolkit': 2.12.0(react@19.2.6)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       tslib: 2.8.1
     optionalDependencies:
-      graphql-request: 6.1.0(graphql@16.14.0)
+      graphql-request: 7.4.0(graphql@17.0.2)
 
-  '@graphql-codegen/typescript-stencil-apollo@4.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)(stencil-apollo@0.1.6(apollo-client@2.6.10(graphql@16.14.0))(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0))':
+  '@graphql-codegen/typescript-stencil-apollo@4.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)(stencil-apollo@0.1.6(apollo-client@2.6.10(graphql@17.0.2))(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2))':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
-      stencil-apollo: 0.1.6(apollo-client@2.6.10(graphql@16.14.0))(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
+      stencil-apollo: 0.1.6(apollo-client@2.6.10(graphql@17.0.2))(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-type-graphql@3.0.1(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-codegen/typescript-type-graphql@3.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.14.0)
-      '@graphql-codegen/typescript': 2.8.8(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.14.0)(supports-color@10.2.2)
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@17.0.2)
+      '@graphql-codegen/typescript': 2.8.8(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@graphql-codegen/typescript-urql@5.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/typescript-urql@5.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-vue-apollo-smart-ops@4.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/typescript-vue-apollo-smart-ops@4.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-vue-apollo@5.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/typescript-vue-apollo@5.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-vue-urql@4.0.1(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-codegen/typescript-vue-urql@4.0.1(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript@2.8.8(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-codegen/typescript@2.8.8(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.14.0)
-      '@graphql-codegen/schema-ast': 2.6.1(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.14.0)(supports-color@10.2.2)
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@17.0.2)
+      '@graphql-codegen/schema-ast': 2.6.1(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.4.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@graphql-codegen/typescript@5.0.10(graphql@16.14.0)':
+  '@graphql-codegen/typescript@5.0.10(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-codegen/schema-ast': 5.0.2(graphql@16.14.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-codegen/schema-ast': 5.0.2(graphql@17.0.2)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@17.0.2)
       auto-bind: 4.0.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/urql-introspection@4.0.1(graphql@16.14.0)':
+  '@graphql-codegen/urql-introspection@4.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@urql/introspection': 0.3.3(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@urql/introspection': 0.3.3(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/visitor-plugin-common@2.13.1(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-codegen/visitor-plugin-common@2.13.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 2.7.2(graphql@16.14.0)
-      '@graphql-tools/optimize': 1.4.0(graphql@16.14.0)
-      '@graphql-tools/relay-operation-optimizer': 6.5.18(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-tools/utils': 8.13.1(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 2.7.2(graphql@17.0.2)
+      '@graphql-tools/optimize': 1.4.0(graphql@17.0.2)
+      '@graphql-tools/relay-operation-optimizer': 6.5.18(graphql@17.0.2)
+      '@graphql-tools/utils': 8.13.1(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.14
       dependency-graph: 0.11.0
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       parse-filepath: 1.0.2
       tslib: 2.4.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@graphql-codegen/visitor-plugin-common@2.13.8(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-codegen/visitor-plugin-common@2.13.8(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.14.0)
-      '@graphql-tools/optimize': 1.4.0(graphql@16.14.0)
-      '@graphql-tools/relay-operation-optimizer': 6.5.18(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-tools/utils': 9.2.1(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@17.0.2)
+      '@graphql-tools/optimize': 1.4.0(graphql@17.0.2)
+      '@graphql-tools/relay-operation-optimizer': 6.5.18(graphql@17.0.2)
+      '@graphql-tools/utils': 9.2.1(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
       dependency-graph: 0.11.0
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       parse-filepath: 1.0.2
       tslib: 2.4.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@graphql-codegen/visitor-plugin-common@6.3.0(graphql@16.14.0)':
+  '@graphql-codegen/visitor-plugin-common@6.3.0(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.0)
-      '@graphql-tools/optimize': 2.0.0(graphql@16.14.0)
-      '@graphql-tools/relay-operation-optimizer': 7.1.4(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@17.0.2)
+      '@graphql-tools/optimize': 2.0.0(graphql@17.0.2)
+      '@graphql-tools/relay-operation-optimizer': 7.1.4(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
       dependency-graph: 1.0.0
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       parse-filepath: 1.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/visitor-plugin-common@7.0.2(graphql@16.14.0)':
+  '@graphql-codegen/visitor-plugin-common@7.0.2(graphql@17.0.2)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 7.0.1(graphql@16.14.0)
-      '@graphql-tools/optimize': 2.0.0(graphql@16.14.0)
-      '@graphql-tools/relay-operation-optimizer': 7.1.4(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 7.0.1(graphql@17.0.2)
+      '@graphql-tools/optimize': 2.0.0(graphql@17.0.2)
+      '@graphql-tools/relay-operation-optimizer': 7.1.4(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       auto-bind: 5.0.1
       change-case-all: 2.1.0
       dependency-graph: 1.0.0
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
       parse-filepath: 1.0.2
       tslib: 2.8.1
 
   '@graphql-hive/signal@2.0.0': {}
 
-  '@graphql-tools/apollo-engine-loader@8.0.30(graphql@16.14.0)':
+  '@graphql-tools/apollo-engine-loader@8.0.30(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       '@whatwg-node/fetch': 0.10.13
-      graphql: 16.14.0
+      graphql: 17.0.2
       sync-fetch: 0.6.0
       tslib: 2.8.1
 
-  '@graphql-tools/batch-execute@10.0.8(graphql@16.14.0)':
+  '@graphql-tools/batch-execute@10.0.8(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/code-file-loader@8.1.39(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-tools/code-file-loader@8.1.39(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 8.3.37(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-tools/utils': 12.0.1(graphql@16.14.0)
+      '@graphql-tools/graphql-tag-pluck': 8.3.37(graphql@17.0.2)
+      '@graphql-tools/utils': 12.0.1(graphql@17.0.2)
       globby: 11.1.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
       unixify: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/delegate@12.0.16(graphql@16.14.0)':
+  '@graphql-tools/delegate@12.0.16(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/batch-execute': 10.0.8(graphql@16.14.0)
-      '@graphql-tools/executor': 1.5.3(graphql@16.14.0)
-      '@graphql-tools/schema': 10.0.33(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/batch-execute': 10.0.8(graphql@17.0.2)
+      '@graphql-tools/executor': 1.5.3(graphql@17.0.2)
+      '@graphql-tools/schema': 10.0.33(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/documents@1.0.1(graphql@16.14.0)':
+  '@graphql-tools/documents@1.0.1(graphql@17.0.2)':
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
       lodash.sortby: 4.7.0
       tslib: 2.8.1
 
-  '@graphql-tools/executor-common@1.0.6(graphql@16.14.0)':
+  '@graphql-tools/executor-common@1.0.6(graphql@17.0.2)':
     dependencies:
       '@envelop/core': 5.5.1
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
+      graphql: 17.0.2
 
-  '@graphql-tools/executor-graphql-ws@3.1.5(graphql@16.14.0)':
+  '@graphql-tools/executor-graphql-ws@3.1.5(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/executor-common': 1.0.6(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/executor-common': 1.0.6(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       '@whatwg-node/disposablestack': 0.0.6
-      graphql: 16.14.0
-      graphql-ws: 6.0.8(graphql@16.14.0)(ws@8.20.1)
+      graphql: 17.0.2
+      graphql-ws: 6.0.8(graphql@17.0.2)(ws@8.20.1)
       isows: 1.0.7(ws@8.20.1)
       tslib: 2.8.1
       ws: 8.20.1
@@ -11760,26 +11742,26 @@ snapshots:
       - crossws
       - utf-8-validate
 
-  '@graphql-tools/executor-http@3.3.0(@types/node@24.12.4)(graphql@16.14.0)':
+  '@graphql-tools/executor-http@3.3.0(@types/node@24.12.4)(graphql@17.0.2)':
     dependencies:
       '@graphql-hive/signal': 2.0.0
-      '@graphql-tools/executor-common': 1.0.6(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/executor-common': 1.0.6(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/disposablestack': 0.0.6
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
-      graphql: 16.14.0
+      graphql: 17.0.2
       meros: 1.3.2(@types/node@24.12.4)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/node'
 
-  '@graphql-tools/executor-legacy-ws@1.1.28(graphql@16.14.0)':
+  '@graphql-tools/executor-legacy-ws@1.1.28(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       '@types/ws': 8.18.1
-      graphql: 16.14.0
+      graphql: 17.0.2
       isomorphic-ws: 5.0.0(ws@8.20.1)
       tslib: 2.8.1
       ws: 8.20.1
@@ -11787,21 +11769,21 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@graphql-tools/executor@1.5.3(graphql@16.14.0)':
+  '@graphql-tools/executor@1.5.3(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.0)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/disposablestack': 0.0.6
       '@whatwg-node/promise-helpers': 1.3.2
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/git-loader@8.0.36(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-tools/git-loader@8.0.36(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 8.3.31(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-tools/graphql-tag-pluck': 8.3.31(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
+      graphql: 17.0.2
       is-glob: 4.0.3
       micromatch: 4.0.8
       tslib: 2.8.1
@@ -11809,128 +11791,128 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/github-loader@9.1.2(@types/node@24.12.4)(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-tools/github-loader@9.1.2(@types/node@24.12.4)(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/executor-http': 3.3.0(@types/node@24.12.4)(graphql@16.14.0)
-      '@graphql-tools/graphql-tag-pluck': 8.3.37(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/executor-http': 3.3.0(@types/node@24.12.4)(graphql@17.0.2)
+      '@graphql-tools/graphql-tag-pluck': 8.3.37(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
-      graphql: 16.14.0
+      graphql: 17.0.2
       sync-fetch: 0.6.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
 
-  '@graphql-tools/graphql-file-loader@8.1.12(graphql@16.14.0)':
+  '@graphql-tools/graphql-file-loader@8.1.12(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/import': 7.1.14(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/import': 7.1.14(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       globby: 11.1.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
       unixify: 1.0.0
 
-  '@graphql-tools/graphql-tag-pluck@8.3.31(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-tools/graphql-tag-pluck@8.3.31(graphql@17.0.2)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/parser': 7.29.8
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/graphql-tag-pluck@8.3.37(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-tools/graphql-tag-pluck@8.3.37(graphql@17.0.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.8
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@graphql-tools/utils': 12.0.1(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-tools/utils': 12.0.1(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/import@7.1.14(graphql@16.14.0)':
+  '@graphql-tools/import@7.1.14(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
+      graphql: 17.0.2
       resolve-from: 5.0.0
       tslib: 2.8.1
 
-  '@graphql-tools/json-file-loader@8.0.28(graphql@16.14.0)':
+  '@graphql-tools/json-file-loader@8.0.28(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       globby: 11.1.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
       unixify: 1.0.0
 
-  '@graphql-tools/load@8.1.10(graphql@16.14.0)':
+  '@graphql-tools/load@8.1.10(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/schema': 10.0.33(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-tools/schema': 10.0.33(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
+      graphql: 17.0.2
       p-limit: 3.1.0
       tslib: 2.8.1
 
-  '@graphql-tools/merge@9.2.4(graphql@16.14.0)':
+  '@graphql-tools/merge@9.2.4(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 12.0.1(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-tools/utils': 12.0.1(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/optimize@1.4.0(graphql@16.14.0)':
+  '@graphql-tools/optimize@1.4.0(graphql@17.0.2)':
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/optimize@2.0.0(graphql@16.14.0)':
+  '@graphql-tools/optimize@2.0.0(graphql@17.0.2)':
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/relay-operation-optimizer@6.5.18(graphql@16.14.0)(supports-color@10.2.2)':
+  '@graphql-tools/relay-operation-optimizer@6.5.18(graphql@17.0.2)':
     dependencies:
-      '@ardatan/relay-compiler': 12.0.0(graphql@16.14.0)(supports-color@10.2.2)
-      '@graphql-tools/utils': 9.2.1(graphql@16.14.0)
-      graphql: 16.14.0
+      '@ardatan/relay-compiler': 12.0.0(graphql@17.0.2)
+      '@graphql-tools/utils': 9.2.1(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@graphql-tools/relay-operation-optimizer@7.1.4(graphql@16.14.0)':
+  '@graphql-tools/relay-operation-optimizer@7.1.4(graphql@17.0.2)':
     dependencies:
-      '@ardatan/relay-compiler': 13.0.1(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@ardatan/relay-compiler': 13.0.1(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/schema@10.0.33(graphql@16.14.0)':
+  '@graphql-tools/schema@10.0.33(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/merge': 9.2.4(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-tools/merge': 9.2.4(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/url-loader@9.1.2(@types/node@24.12.4)(graphql@16.14.0)':
+  '@graphql-tools/url-loader@9.1.2(@types/node@24.12.4)(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/executor-graphql-ws': 3.1.5(graphql@16.14.0)
-      '@graphql-tools/executor-http': 3.3.0(@types/node@24.12.4)(graphql@16.14.0)
-      '@graphql-tools/executor-legacy-ws': 1.1.28(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
-      '@graphql-tools/wrap': 11.1.15(graphql@16.14.0)
+      '@graphql-tools/executor-graphql-ws': 3.1.5(graphql@17.0.2)
+      '@graphql-tools/executor-http': 3.3.0(@types/node@24.12.4)(graphql@17.0.2)
+      '@graphql-tools/executor-legacy-ws': 1.1.28(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
+      '@graphql-tools/wrap': 11.1.15(graphql@17.0.2)
       '@types/ws': 8.18.1
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
-      graphql: 16.14.0
+      graphql: 17.0.2
       isomorphic-ws: 5.0.0(ws@8.20.1)
       sync-fetch: 0.6.0
       tslib: 2.8.1
@@ -11942,69 +11924,69 @@ snapshots:
       - crossws
       - utf-8-validate
 
-  '@graphql-tools/utils@10.11.0(graphql@16.14.0)':
+  '@graphql-tools/utils@10.11.0(graphql@17.0.2)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
       '@whatwg-node/promise-helpers': 1.3.2
       cross-inspect: 1.0.1
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/utils@11.2.0(graphql@16.14.0)':
+  '@graphql-tools/utils@11.2.0(graphql@17.0.2)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
       '@whatwg-node/promise-helpers': 1.3.2
       cross-inspect: 1.0.1
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/utils@12.0.1(graphql@16.14.0)':
+  '@graphql-tools/utils@12.0.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
       '@whatwg-node/promise-helpers': 1.3.2
       cross-inspect: 1.0.1
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/utils@8.13.1(graphql@16.14.0)':
+  '@graphql-tools/utils@8.13.1(graphql@17.0.2)':
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/utils@9.2.1(graphql@16.14.0)':
+  '@graphql-tools/utils@9.2.1(graphql@17.0.2)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.0)
-      graphql: 16.14.0
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/wrap@11.1.15(graphql@16.14.0)':
+  '@graphql-tools/wrap@11.1.15(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/delegate': 12.0.16(graphql@16.14.0)
-      '@graphql-tools/schema': 10.0.33(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/delegate': 12.0.16(graphql@17.0.2)
+      '@graphql-tools/schema': 10.0.33(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       '@whatwg-node/promise-helpers': 1.3.2
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.0)':
+  '@graphql-typed-document-node/core@3.2.0(graphql@17.0.2)':
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
 
   '@graphql-yoga/logger@2.0.1':
     dependencies:
       tslib: 2.8.1
 
-  '@graphql-yoga/plugin-defer-stream@3.21.0(graphql-yoga@5.21.0(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-yoga/plugin-defer-stream@3.21.0(graphql-yoga@5.21.0(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 10.11.0(graphql@16.14.0)
-      graphql: 16.14.0
-      graphql-yoga: 5.21.0(graphql@16.14.0)
+      '@graphql-tools/utils': 10.11.0(graphql@17.0.2)
+      graphql: 17.0.2
+      graphql-yoga: 5.21.0(graphql@17.0.2)
 
-  '@graphql-yoga/plugin-persisted-operations@3.21.0(graphql-yoga@5.21.0(graphql@16.14.0))(graphql@16.14.0)':
+  '@graphql-yoga/plugin-persisted-operations@3.21.0(graphql-yoga@5.21.0(graphql@17.0.2))(graphql@17.0.2)':
     dependencies:
       '@whatwg-node/promise-helpers': 1.3.2
-      graphql: 16.14.0
-      graphql-yoga: 5.21.0(graphql@16.14.0)
+      graphql: 17.0.2
+      graphql-yoga: 5.21.0(graphql@17.0.2)
 
   '@graphql-yoga/subscription@5.0.5':
     dependencies:
@@ -12056,11 +12038,11 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@ianvs/prettier-plugin-sort-imports@4.4.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)(supports-color@10.2.2)':
+  '@ianvs/prettier-plugin-sort-imports@4.4.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)':
     dependencies:
       '@babel/generator': 7.29.8
       '@babel/parser': 7.29.8
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       prettier: 3.8.3
       semver: 7.8.0
@@ -12069,11 +12051,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ianvs/prettier-plugin-sort-imports@4.7.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)(supports-color@10.2.2)':
+  '@ianvs/prettier-plugin-sort-imports@4.7.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)':
     dependencies:
       '@babel/generator': 7.29.8
       '@babel/parser': 7.29.8
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       prettier: 3.8.3
       semver: 7.8.0
@@ -12576,10 +12558,10 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@npmcli/config@8.3.4(bluebird@3.7.2)':
+  '@npmcli/config@8.3.4':
     dependencies:
       '@npmcli/map-workspaces': 3.0.6
-      '@npmcli/package-json': 5.2.1(bluebird@3.7.2)
+      '@npmcli/package-json': 5.2.1
       ci-info: 4.4.0
       ini: 4.1.3
       nopt: 7.2.1
@@ -12589,14 +12571,14 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
 
-  '@npmcli/git@5.0.8(bluebird@3.7.2)':
+  '@npmcli/git@5.0.8':
     dependencies:
       '@npmcli/promise-spawn': 7.0.2
       ini: 4.1.3
       lru-cache: 10.4.3
       npm-pick-manifest: 9.1.0
       proc-log: 4.2.0
-      promise-inflight: 1.0.1(bluebird@3.7.2)
+      promise-inflight: 1.0.1
       promise-retry: 2.0.1
       semver: 7.8.0
       which: 4.0.0
@@ -12612,9 +12594,9 @@ snapshots:
 
   '@npmcli/name-from-folder@2.0.0': {}
 
-  '@npmcli/package-json@5.2.1(bluebird@3.7.2)':
+  '@npmcli/package-json@5.2.1':
     dependencies:
-      '@npmcli/git': 5.0.8(bluebird@3.7.2)
+      '@npmcli/git': 5.0.8
       glob: 10.5.0
       hosted-git-info: 7.0.2
       json-parse-even-better-errors: 3.0.2
@@ -12955,25 +12937,25 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.6(react@19.2.6)
 
-  '@theguild/eslint-config@0.13.4(bluebird@3.7.2)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(is-bun-module@2.0.0)(supports-color@10.2.2)(typescript@6.0.3)':
+  '@theguild/eslint-config@0.13.4(eslint@10.4.0(jiti@2.7.0))(is-bun-module@2.0.0)(typescript@6.0.3)':
     dependencies:
       '@rushstack/eslint-patch': 1.16.1
-      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-config-prettier: 10.1.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-import-resolver-typescript: 4.2.1(eslint-plugin-import@2.31.0)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(is-bun-module@2.0.0)(supports-color@10.2.2)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-      eslint-plugin-jsonc: 2.19.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-mdx: 3.2.0(bluebird@3.7.2)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-      eslint-plugin-n: 17.16.2(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-promise: 7.2.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-react: 7.37.4(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-react-hooks: 5.2.0(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-sonarjs: 3.0.2(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-unicorn: 57.0.0(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-yml: 1.17.0(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
+      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-config-prettier: 10.1.1(eslint@10.4.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 4.2.1(eslint-plugin-import@2.31.0)(eslint@10.4.0(jiti@2.7.0))(is-bun-module@2.0.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-jsonc: 2.19.1(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-mdx: 3.2.0(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-n: 17.16.2(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-promise: 7.2.1(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-react: 7.37.4(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-react-hooks: 5.2.0(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-sonarjs: 3.0.2(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-unicorn: 57.0.0(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-yml: 1.17.0(eslint@10.4.0(jiti@2.7.0))
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@eslint/json'
@@ -12984,9 +12966,9 @@ snapshots:
       - remark-lint-file-extension
       - supports-color
 
-  '@theguild/prettier-config@3.0.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)(supports-color@10.2.2)':
+  '@theguild/prettier-config@3.0.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)':
     dependencies:
-      '@ianvs/prettier-plugin-sort-imports': 4.4.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)(supports-color@10.2.2)
+      '@ianvs/prettier-plugin-sort-imports': 4.4.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)
       prettier: 3.8.3
       prettier-plugin-pkg: 0.18.1(prettier@3.8.3)
       prettier-plugin-sh: 0.15.0(prettier@3.8.3)
@@ -13103,9 +13085,6 @@ snapshots:
 
   '@types/parse-filepath@1.0.2': {}
 
-  '@types/parse-json@4.0.2':
-    optional: true
-
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -13147,15 +13126,15 @@ snapshots:
 
   '@types/zen-observable@0.8.7': {}
 
-  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/type-utils': 8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.3
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -13163,23 +13142,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.3
       '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.3
-      debug: 4.4.3(supports-color@10.2.2)
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.4.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.3(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.59.3(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.3
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -13193,13 +13172,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      debug: 4.4.3(supports-color@10.2.2)
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.4.0(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -13207,13 +13186,13 @@ snapshots:
 
   '@typescript-eslint/types@8.59.3': {}
 
-  '@typescript-eslint/typescript-estree@8.59.3(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.59.3(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.3(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.59.3(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/visitor-keys': 8.59.3
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.0
       tinyglobby: 0.2.16
@@ -13222,13 +13201,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.59.3
       '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(supports-color@10.2.2)(typescript@6.0.3)
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@6.0.3)
+      eslint: 10.4.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -13344,29 +13323,29 @@ snapshots:
   '@unrs/rspack-resolver-binding-win32-x64-msvc@1.3.0':
     optional: true
 
-  '@urql/core@3.2.2(graphql@16.14.0)':
+  '@urql/core@3.2.2(graphql@17.0.2)':
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
       wonka: 6.3.6
 
-  '@urql/core@6.0.3(graphql@16.14.0)':
+  '@urql/core@6.0.3(graphql@17.0.2)':
     dependencies:
-      '@0no-co/graphql.web': 1.3.4(graphql@16.14.0)
+      '@0no-co/graphql.web': 1.3.4(graphql@17.0.2)
       wonka: 6.3.6
     transitivePeerDependencies:
       - graphql
 
-  '@urql/introspection@0.3.3(graphql@16.14.0)':
+  '@urql/introspection@0.3.3(graphql@17.0.2)':
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
 
-  '@urql/introspection@1.2.1(graphql@16.14.0)':
+  '@urql/introspection@1.2.1(graphql@17.0.2)':
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
 
-  '@urql/vue@2.1.0(@urql/core@6.0.3(graphql@16.14.0))(vue@3.5.34(typescript@6.0.3))':
+  '@urql/vue@2.1.0(@urql/core@6.0.3(graphql@17.0.2))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
-      '@urql/core': 6.0.3(graphql@16.14.0)
+      '@urql/core': 6.0.3(graphql@17.0.2)
       vue: 3.5.34(typescript@6.0.3)
       wonka: 6.3.6
 
@@ -13437,18 +13416,16 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28(typescript@6.0.3)':
+  '@volar/typescript@2.4.28':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
-    optionalDependencies:
-      typescript: 6.0.3
 
-  '@vue/apollo-composable@4.2.2(@apollo/client@3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(graphql@16.14.0)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))':
+  '@vue/apollo-composable@4.2.2(@apollo/client@3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(graphql@17.0.2)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))':
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1))(graphql@16.14.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      graphql: 16.14.0
+      '@apollo/client': 3.14.1(@types/react@19.2.14)(graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1))(graphql@17.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      graphql: 17.0.2
       throttle-debounce: 5.0.2
       ts-essentials: 9.4.2(typescript@6.0.3)
       vue: 3.5.34(typescript@6.0.3)
@@ -13589,13 +13566,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@6.0.2(supports-color@10.2.2):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  agent-base@6.0.2(supports-color@8.1.1):
+  agent-base@6.0.2:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -13646,37 +13617,37 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  apollo-cache@1.3.5(graphql@16.14.0):
+  apollo-cache@1.3.5(graphql@17.0.2):
     dependencies:
-      apollo-utilities: 1.3.4(graphql@16.14.0)
-      graphql: 16.14.0
+      apollo-utilities: 1.3.4(graphql@17.0.2)
+      graphql: 17.0.2
       tslib: 1.14.1
 
-  apollo-client@2.6.10(graphql@16.14.0):
+  apollo-client@2.6.10(graphql@17.0.2):
     dependencies:
       '@types/zen-observable': 0.8.7
-      apollo-cache: 1.3.5(graphql@16.14.0)
-      apollo-link: 1.2.14(graphql@16.14.0)
-      apollo-utilities: 1.3.4(graphql@16.14.0)
-      graphql: 16.14.0
+      apollo-cache: 1.3.5(graphql@17.0.2)
+      apollo-link: 1.2.14(graphql@17.0.2)
+      apollo-utilities: 1.3.4(graphql@17.0.2)
+      graphql: 17.0.2
       symbol-observable: 1.2.0
       ts-invariant: 0.4.4
       tslib: 1.14.1
       zen-observable: 0.8.15
 
-  apollo-link@1.2.14(graphql@16.14.0):
+  apollo-link@1.2.14(graphql@17.0.2):
     dependencies:
-      apollo-utilities: 1.3.4(graphql@16.14.0)
-      graphql: 16.14.0
+      apollo-utilities: 1.3.4(graphql@17.0.2)
+      graphql: 17.0.2
       ts-invariant: 0.4.4
       tslib: 1.14.1
       zen-observable-ts: 0.8.21
 
-  apollo-utilities@1.3.4(graphql@16.14.0):
+  apollo-utilities@1.3.4(graphql@17.0.2):
     dependencies:
       '@wry/equality': 0.1.11
       fast-json-stable-stringify: 2.1.0
-      graphql: 16.14.0
+      graphql: 17.0.2
       ts-invariant: 0.4.4
       tslib: 1.14.1
 
@@ -13797,21 +13768,11 @@ snapshots:
 
   axe-core@4.11.4: {}
 
-  axios@1.16.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2):
+  axios@1.16.1(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
-      https-proxy-agent: 5.0.1(supports-color@10.2.2)
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  axios@1.16.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
-      form-data: 4.0.5
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -13819,68 +13780,61 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-plugin-macros@3.1.0:
-    dependencies:
-      '@babel/runtime': 7.29.2
-      cosmiconfig: 7.1.0
-      resolve: 1.22.12
-    optional: true
-
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2):
+  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
 
-  babel-preset-fbjs@3.4.0(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2):
+  babel-preset-fbjs@3.4.0(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.29.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
+      '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
       babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
     transitivePeerDependencies:
       - supports-color
@@ -14207,23 +14161,11 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression@1.8.1(supports-color@10.2.2):
+  compression@1.8.1:
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9(supports-color@10.2.2)
-      negotiator: 0.6.4
-      on-headers: 1.1.0
-      safe-buffer: 5.2.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  compression@1.8.1(supports-color@8.1.1):
-    dependencies:
-      bytes: 3.1.2
-      compressible: 2.0.18
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -14261,15 +14203,6 @@ snapshots:
       browserslist: 4.28.2
 
   core-util-is@1.0.2: {}
-
-  cosmiconfig@7.1.0:
-    dependencies:
-      '@types/parse-json': 4.0.2
-      import-fresh: 3.3.1
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      yaml: 1.10.3
-    optional: true
 
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
@@ -14388,35 +14321,15 @@ snapshots:
 
   debounce@3.0.0: {}
 
-  debug@2.6.9(supports-color@10.2.2):
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    optionalDependencies:
-      supports-color: 10.2.2
-
-  debug@2.6.9(supports-color@8.1.1):
-    dependencies:
-      ms: 2.0.0
-    optionalDependencies:
-      supports-color: 8.1.1
-
-  debug@3.2.7(supports-color@10.2.2):
-    dependencies:
-      ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.2.2
 
   debug@3.2.7(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
-
-  debug@4.4.3(supports-color@10.2.2):
-    dependencies:
-      ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.2.2
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
@@ -14742,28 +14655,28 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-compat-utils@0.5.1(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       semver: 7.8.0
 
-  eslint-compat-utils@0.6.5(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-compat-utils@0.6.5(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       semver: 7.8.0
 
-  eslint-config-next@13.5.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
+  eslint-config-next@13.5.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
       '@next/eslint-plugin-next': 13.5.1
       '@rushstack/eslint-patch': 1.16.1
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-import-resolver-node: 0.3.10(supports-color@10.2.2)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-react: 7.37.5(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-react: 7.37.5(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@10.4.0(jiti@2.7.0))
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -14771,113 +14684,113 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-prettier@10.1.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-config-prettier@10.1.1(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
 
-  eslint-import-resolver-node@0.3.10(supports-color@10.2.2):
+  eslint-import-resolver-node@0.3.10:
     dependencies:
-      debug: 3.2.7(supports-color@10.2.2)
+      debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.16.2
       resolve: 2.0.0-next.6
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@10.2.2)
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.4.0(jiti@2.7.0)
       get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.2.1(eslint-plugin-import@2.31.0)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(is-bun-module@2.0.0)(supports-color@10.2.2):
+  eslint-import-resolver-typescript@4.2.1(eslint-plugin-import@2.31.0)(eslint@10.4.0(jiti@2.7.0))(is-bun-module@2.0.0):
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.4.0(jiti@2.7.0)
       get-tsconfig: 4.14.0
       rspack-resolver: 1.3.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.16
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0))
       is-bun-module: 2.0.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-json-compat-utils@0.2.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@2.4.2):
+  eslint-json-compat-utils@0.2.3(eslint@10.4.0(jiti@2.7.0))(jsonc-eslint-parser@2.4.2):
     dependencies:
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       esquery: 1.7.0
       jsonc-eslint-parser: 2.4.2
 
-  eslint-mdx@3.7.0(bluebird@3.7.2)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-mdx@3.7.0(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       espree: 10.4.0
       estree-util-visit: 2.0.0
-      remark-mdx: 3.1.1(supports-color@10.2.2)
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       synckit: 0.11.12
       unified: 11.0.5
-      unified-engine: 11.2.2(bluebird@3.7.2)(supports-color@10.2.2)
+      unified-engine: 11.2.2
       unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      debug: 3.2.7(supports-color@10.2.2)
+      debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-import-resolver-node: 0.3.10(supports-color@10.2.2)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
+      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      debug: 3.2.7(supports-color@10.2.2)
+      debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-import-resolver-node: 0.3.10(supports-color@10.2.2)
-      eslint-import-resolver-typescript: 4.2.1(eslint-plugin-import@2.31.0)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(is-bun-module@2.0.0)(supports-color@10.2.2)
+      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 4.2.1(eslint-plugin-import@2.31.0)(eslint@10.4.0(jiti@2.7.0))(is-bun-module@2.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-es-x@7.8.0(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-es-x@7.8.0(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-compat-utils: 0.5.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-compat-utils: 0.5.1(eslint@10.4.0(jiti@2.7.0))
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
-      debug: 3.2.7(supports-color@10.2.2)
+      debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-import-resolver-node: 0.3.10(supports-color@10.2.2)
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -14889,24 +14802,24 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
-      debug: 3.2.7(supports-color@10.2.2)
+      debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-import-resolver-node: 0.3.10(supports-color@10.2.2)
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -14918,47 +14831,18 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-plugin-jsonc@2.19.1(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7(supports-color@10.2.2)
-      doctrine: 2.1.0
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-import-resolver-node: 0.3.10(supports-color@10.2.2)
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@10.2.2))(eslint-import-resolver-typescript@4.2.1)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-      hasown: 2.0.3
-      is-core-module: 2.16.2
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-jsonc@2.19.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-compat-utils: 0.6.5(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-json-compat-utils: 0.2.3(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@2.4.2)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0))
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-compat-utils: 0.6.5(eslint@10.4.0(jiti@2.7.0))
+      eslint-json-compat-utils: 0.2.3(eslint@10.4.0(jiti@2.7.0))(jsonc-eslint-parser@2.4.2)
       espree: 9.6.1
       graphemer: 1.4.0
       jsonc-eslint-parser: 2.4.2
@@ -14967,7 +14851,7 @@ snapshots:
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -14977,7 +14861,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -14986,13 +14870,13 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-mdx@3.2.0(bluebird@3.7.2)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-plugin-mdx@3.2.0(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-mdx: 3.7.0(bluebird@3.7.2)(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
-      remark-mdx: 3.1.1(supports-color@10.2.2)
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-mdx: 3.7.0(eslint@10.4.0(jiti@2.7.0))
+      mdast-util-from-markdown: 2.0.3
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       synckit: 0.9.3
       tslib: 2.8.1
@@ -15003,32 +14887,32 @@ snapshots:
       - remark-lint-file-extension
       - supports-color
 
-  eslint-plugin-n@17.16.2(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-n@17.16.2(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0))
       enhanced-resolve: 5.21.3
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-plugin-es-x: 7.8.0(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-plugin-es-x: 7.8.0(eslint@10.4.0(jiti@2.7.0))
       get-tsconfig: 4.14.0
       globals: 15.15.0
       ignore: 5.3.2
       minimatch: 9.0.9
       semver: 7.8.0
 
-  eslint-plugin-promise@7.2.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-promise@7.2.1(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0))
+      eslint: 10.4.0(jiti@2.7.0)
 
-  eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
 
-  eslint-plugin-react-hooks@5.2.0(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-react-hooks@5.2.0(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
 
-  eslint-plugin-react@7.37.4(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-react@7.37.4(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -15036,7 +14920,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       estraverse: 5.3.0
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
@@ -15050,7 +14934,7 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-react@7.37.5(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-react@7.37.5(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -15058,7 +14942,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       estraverse: 5.3.0
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
@@ -15072,12 +14956,12 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-sonarjs@3.0.2(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-sonarjs@3.0.2(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       '@eslint-community/regexpp': 4.12.1
       builtin-modules: 3.3.0
       bytes: 3.1.2
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       functional-red-black-tree: 1.0.1
       jsx-ast-utils: 3.3.5
       minimatch: 9.0.5
@@ -15085,14 +14969,14 @@ snapshots:
       semver: 7.7.1
       typescript: 5.9.3
 
-  eslint-plugin-unicorn@57.0.0(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-unicorn@57.0.0(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0))
       ci-info: 4.4.0
       clean-regexp: 1.0.0
       core-js-compat: 3.49.0
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       esquery: 1.7.0
       globals: 15.15.0
       indent-string: 5.0.0
@@ -15105,15 +14989,15 @@ snapshots:
       semver: 7.8.0
       strip-indent: 4.1.1
 
-  eslint-plugin-unicorn@64.0.0(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-unicorn@64.0.0(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0))
       change-case: 5.4.4
       ci-info: 4.4.0
       clean-regexp: 1.0.0
       core-js-compat: 3.49.0
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.4.0(jiti@2.7.0)
       find-up-simple: 1.0.1
       globals: 17.6.0
       indent-string: 5.0.0
@@ -15125,12 +15009,12 @@ snapshots:
       semver: 7.8.0
       strip-indent: 4.1.1
 
-  eslint-plugin-yml@1.17.0(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-plugin-yml@1.17.0(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
-      eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-compat-utils: 0.6.5(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-compat-utils: 0.6.5(eslint@10.4.0(jiti@2.7.0))
       natural-compare: 1.4.0
       yaml-eslint-parser: 1.3.2
     transitivePeerDependencies:
@@ -15149,11 +15033,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2):
+  eslint@10.4.0(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5(supports-color@10.2.2)
+      '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.6.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.1
@@ -15163,7 +15047,7 @@ snapshots:
       '@types/estree': 1.0.9
       ajv: 6.15.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -15397,11 +15281,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@10.2.2)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
@@ -15602,16 +15482,16 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-config@5.1.6(@types/node@24.12.4)(graphql@16.14.0)(typescript@6.0.3):
+  graphql-config@5.1.6(@types/node@24.12.4)(graphql@17.0.2)(typescript@6.0.3):
     dependencies:
-      '@graphql-tools/graphql-file-loader': 8.1.12(graphql@16.14.0)
-      '@graphql-tools/json-file-loader': 8.0.28(graphql@16.14.0)
-      '@graphql-tools/load': 8.1.10(graphql@16.14.0)
-      '@graphql-tools/merge': 9.2.4(graphql@16.14.0)
-      '@graphql-tools/url-loader': 9.1.2(@types/node@24.12.4)(graphql@16.14.0)
-      '@graphql-tools/utils': 11.2.0(graphql@16.14.0)
+      '@graphql-tools/graphql-file-loader': 8.1.12(graphql@17.0.2)
+      '@graphql-tools/json-file-loader': 8.0.28(graphql@17.0.2)
+      '@graphql-tools/load': 8.1.10(graphql@17.0.2)
+      '@graphql-tools/merge': 9.2.4(graphql@17.0.2)
+      '@graphql-tools/url-loader': 9.1.2(@types/node@24.12.4)(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.0(graphql@17.0.2)
       cosmiconfig: 8.3.6(typescript@6.0.3)
-      graphql: 16.14.0
+      graphql: 17.0.2
       jiti: 2.7.0
       minimatch: 10.2.5
       string-env-interpolation: 1.0.1
@@ -15624,59 +15504,51 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  graphql-helix@1.13.0(graphql@16.14.0):
+  graphql-helix@1.13.0(graphql@17.0.2):
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
 
-  graphql-request@6.1.0(graphql@16.14.0):
+  graphql-request@7.4.0(graphql@17.0.2):
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.0)
-      cross-fetch: 3.2.0
-      graphql: 16.14.0
-    transitivePeerDependencies:
-      - encoding
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
+      graphql: 17.0.2
 
-  graphql-request@7.4.0(graphql@16.14.0):
+  graphql-sock@1.0.1(graphql@17.0.2):
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.0)
-      graphql: 16.14.0
+      graphql: 17.0.2
 
-  graphql-sock@1.0.1(graphql@16.14.0):
+  graphql-subscriptions@3.0.0(graphql@17.0.2):
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
 
-  graphql-subscriptions@3.0.0(graphql@16.14.0):
+  graphql-tag@2.12.6(graphql@17.0.2):
     dependencies:
-      graphql: 16.14.0
-
-  graphql-tag@2.12.6(graphql@16.14.0):
-    dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
       tslib: 2.8.1
 
-  graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.1):
+  graphql-ws@6.0.8(graphql@17.0.2)(ws@8.20.1):
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
     optionalDependencies:
       ws: 8.20.1
 
-  graphql-yoga@5.21.0(graphql@16.14.0):
+  graphql-yoga@5.21.0(graphql@17.0.2):
     dependencies:
       '@envelop/core': 5.5.1
       '@envelop/instrumentation': 1.0.0
-      '@graphql-tools/executor': 1.5.3(graphql@16.14.0)
-      '@graphql-tools/schema': 10.0.33(graphql@16.14.0)
-      '@graphql-tools/utils': 10.11.0(graphql@16.14.0)
+      '@graphql-tools/executor': 1.5.3(graphql@17.0.2)
+      '@graphql-tools/schema': 10.0.33(graphql@17.0.2)
+      '@graphql-tools/utils': 10.11.0(graphql@17.0.2)
       '@graphql-yoga/logger': 2.0.1
       '@graphql-yoga/subscription': 5.0.5
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       '@whatwg-node/server': 0.10.18
-      graphql: 16.14.0
+      graphql: 17.0.2
       lru-cache: 10.4.3
       tslib: 2.8.1
 
-  graphql@16.14.0: {}
+  graphql@17.0.2: {}
 
   has-bigints@1.1.0: {}
 
@@ -15729,16 +15601,9 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  https-proxy-agent@5.0.1(supports-color@10.2.2):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@10.2.2)
-      debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@5.0.1(supports-color@8.1.1):
-    dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -16249,9 +16114,9 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
-  load-plugin@6.0.3(bluebird@3.7.2):
+  load-plugin@6.0.3:
     dependencies:
-      '@npmcli/config': 8.3.4(bluebird@3.7.2)
+      '@npmcli/config': 8.3.4
       import-meta-resolve: 4.2.0
     transitivePeerDependencies:
       - bluebird
@@ -16336,14 +16201,14 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdast-util-from-markdown@2.0.3(supports-color@10.2.2):
+  mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@10.2.2)
+      micromark: 4.0.2
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -16353,18 +16218,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1(supports-color@10.2.2):
+  mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0(supports-color@10.2.2):
+  mdast-util-mdx-jsx@3.2.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
@@ -16372,7 +16237,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -16381,23 +16246,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0(supports-color@10.2.2):
+  mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
-      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1(supports-color@10.2.2):
+  mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -16632,10 +16497,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@10.2.2):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -16735,7 +16600,7 @@ snapshots:
       '@open-draft/deferred-promise': 3.0.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
-      graphql: 16.14.0
+      graphql: 17.0.2
       headers-polyfill: 5.0.1
       is-node-process: 1.2.0
       outvariant: 1.4.3
@@ -16760,7 +16625,7 @@ snapshots:
       '@open-draft/deferred-promise': 3.0.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
-      graphql: 16.14.0
+      graphql: 17.0.2
       headers-polyfill: 5.0.1
       is-node-process: 1.2.0
       outvariant: 1.4.3
@@ -16799,7 +16664,7 @@ snapshots:
 
   negotiator@0.6.4: {}
 
-  next@15.5.18(@babel/core@7.29.0(supports-color@10.2.2))(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@15.5.18(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
@@ -16807,7 +16672,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@7.29.0(supports-color@10.2.2))(babel-plugin-macros@3.1.0)(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.18
       '@next/swc-darwin-x64': 15.5.18
@@ -17224,11 +17089,11 @@ snapshots:
       prettier: 3.8.3
       svelte: 5.55.7(@typescript-eslint/types@8.59.3)
 
-  prettier-plugin-tailwindcss@0.8.0(@ianvs/prettier-plugin-sort-imports@4.7.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)(supports-color@10.2.2))(prettier-plugin-svelte@3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.8.0(@ianvs/prettier-plugin-sort-imports@4.7.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3))(prettier-plugin-svelte@3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(prettier@3.8.3):
     dependencies:
       prettier: 3.8.3
     optionalDependencies:
-      '@ianvs/prettier-plugin-sort-imports': 4.7.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)(supports-color@10.2.2)
+      '@ianvs/prettier-plugin-sort-imports': 4.7.1(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)
       prettier-plugin-svelte: 3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3))
 
   prettier@2.8.8: {}
@@ -17248,9 +17113,7 @@ snapshots:
 
   process@0.11.10: {}
 
-  promise-inflight@1.0.1(bluebird@3.7.2):
-    optionalDependencies:
-      bluebird: 3.7.2
+  promise-inflight@1.0.1: {}
 
   promise-retry@2.0.1:
     dependencies:
@@ -17436,17 +17299,17 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  remark-mdx@3.1.1(supports-color@10.2.2):
+  remark-mdx@3.1.1:
     dependencies:
-      mdast-util-mdx: 3.0.0(supports-color@10.2.2)
+      mdast-util-mdx: 3.0.0
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0(supports-color@10.2.2):
+  remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -17651,7 +17514,7 @@ snapshots:
       path-to-regexp: 3.3.0
       range-parser: 1.2.0
 
-  serve@14.2.6(supports-color@10.2.2):
+  serve@14.2.6:
     dependencies:
       '@zeit/schemas': 2.36.0
       ajv: 8.18.0
@@ -17660,23 +17523,7 @@ snapshots:
       chalk: 5.0.1
       chalk-template: 0.4.0
       clipboardy: 3.0.0
-      compression: 1.8.1(supports-color@10.2.2)
-      is-port-reachable: 4.0.0
-      serve-handler: 6.1.7
-      update-check: 1.5.4
-    transitivePeerDependencies:
-      - supports-color
-
-  serve@14.2.6(supports-color@8.1.1):
-    dependencies:
-      '@zeit/schemas': 2.36.0
-      ajv: 8.18.0
-      arg: 5.0.2
-      boxen: 7.0.0
-      chalk: 5.0.1
-      chalk-template: 0.4.0
-      clipboardy: 3.0.0
-      compression: 1.8.1(supports-color@8.1.1)
+      compression: 1.8.1
       is-port-reachable: 4.0.0
       serve-handler: 6.1.7
       update-check: 1.5.4
@@ -17863,20 +17710,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  start-server-and-test@3.0.5(supports-color@10.2.2):
-    dependencies:
-      arg: 5.0.2
-      bluebird: 3.7.2
-      check-more-types: 2.24.0
-      debug: 4.4.3(supports-color@10.2.2)
-      execa: 5.1.1
-      lazy-ass: 1.6.0
-      tree-kill: 1.2.2
-      wait-on: 9.0.10(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  start-server-and-test@3.0.5(supports-color@8.1.1):
+  start-server-and-test@3.0.5:
     dependencies:
       arg: 5.0.2
       bluebird: 3.7.2
@@ -17885,7 +17719,7 @@ snapshots:
       execa: 5.1.1
       lazy-ass: 1.6.0
       tree-kill: 1.2.2
-      wait-on: 9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      wait-on: 9.0.10(debug@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -17897,12 +17731,12 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  stencil-apollo@0.1.6(apollo-client@2.6.10(graphql@16.14.0))(graphql-tag@2.12.6(graphql@16.14.0))(graphql@16.14.0):
+  stencil-apollo@0.1.6(apollo-client@2.6.10(graphql@17.0.2))(graphql-tag@2.12.6(graphql@17.0.2))(graphql@17.0.2):
     dependencies:
       '@stencil/state-tunnel': 1.0.1
-      apollo-client: 2.6.10(graphql@16.14.0)
-      graphql: 16.14.0
-      graphql-tag: 2.12.6(graphql@16.14.0)
+      apollo-client: 2.6.10(graphql@17.0.2)
+      graphql: 17.0.2
+      graphql-tag: 2.12.6(graphql@17.0.2)
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -18023,13 +17857,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.0(supports-color@10.2.2))(babel-plugin-macros@3.1.0)(react@19.2.6):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.6):
     dependencies:
       client-only: 0.0.1
       react: 19.2.6
     optionalDependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      babel-plugin-macros: 3.1.0
+      '@babel/core': 7.29.0
 
   sucrase@3.35.1:
     dependencies:
@@ -18271,13 +18104,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@swc/core@1.15.33)(jiti@2.7.0)(postcss@8.5.14)(supports-color@10.2.2)(tsx@4.22.0)(typescript@6.0.3)(yaml@2.9.0):
+  tsup@8.5.1(@swc/core@1.15.33)(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.0)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -18420,7 +18253,7 @@ snapshots:
 
   unicorn-magic@0.1.0: {}
 
-  unified-engine@11.2.2(bluebird@3.7.2)(supports-color@10.2.2):
+  unified-engine@11.2.2:
     dependencies:
       '@types/concat-stream': 2.0.3
       '@types/debug': 4.1.13
@@ -18428,13 +18261,13 @@ snapshots:
       '@types/node': 22.19.19
       '@types/unist': 3.0.3
       concat-stream: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       extend: 3.0.2
       glob: 10.5.0
       ignore: 6.0.2
       is-empty: 1.2.0
       is-plain-obj: 4.1.0
-      load-plugin: 6.0.3(bluebird@3.7.2)
+      load-plugin: 6.0.3
       parse-json: 7.1.1
       trough: 2.2.0
       unist-util-inspect: 8.1.0
@@ -18545,10 +18378,10 @@ snapshots:
 
   urlpattern-polyfill@10.1.0: {}
 
-  urql@3.0.4(graphql@16.14.0)(react@19.2.6):
+  urql@3.0.4(graphql@17.0.2)(react@19.2.6):
     dependencies:
-      '@urql/core': 3.2.2(graphql@16.14.0)
-      graphql: 16.14.0
+      '@urql/core': 3.2.2(graphql@17.0.2)
+      graphql: 17.0.2
       react: 19.2.6
       wonka: 6.3.6
 
@@ -18606,9 +18439,9 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  villus@3.5.2(graphql@16.14.0)(vue@3.5.34(typescript@6.0.3)):
+  villus@3.5.2(graphql@17.0.2)(vue@3.5.34(typescript@6.0.3)):
     dependencies:
-      graphql: 16.14.0
+      graphql: 17.0.2
       vue: 3.5.34(typescript@6.0.3)
 
   vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0):
@@ -18666,7 +18499,7 @@ snapshots:
 
   vue-tsc@3.2.9(typescript@6.0.3):
     dependencies:
-      '@volar/typescript': 2.4.28(typescript@6.0.3)
+      '@volar/typescript': 2.4.28
       '@vue/language-core': 3.2.9
       typescript: 6.0.3
 
@@ -18680,20 +18513,9 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  wait-on@9.0.10(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2):
+  wait-on@9.0.10(debug@4.4.3):
     dependencies:
-      axios: 1.16.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
-      joi: 18.2.1
-      lodash: 4.18.1
-      minimist: 1.2.8
-      rxjs: 7.8.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  wait-on@9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      axios: 1.16.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      axios: 1.16.1(debug@4.4.3)
       joi: 18.2.1
       lodash: 4.18.1
       minimist: 1.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ allowBuilds:
   vue-demi: false
   workerd: false
 overrides:
+  graphql: 17.0.2 # keep in sync with the root devDependency so every workspace package resolves a single graphql install
   '@rushstack/eslint-patch': 1.16.1
   '@typescript-eslint/eslint-plugin': 8.59.3
   '@typescript-eslint/parser': 8.59.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,15 @@ allowBuilds:
   vue-demi: false
   workerd: false
 overrides:
-  graphql: 17.0.2 # keep in sync with the root devDependency so every workspace package resolves a single graphql install
+  # Without this, transitive deps (e.g. graphql-helix, used by @graphql-codegen/testing)
+  # resolve their own graphql@16.x copy alongside the root's graphql@17.x, creating two
+  # physically distinct `graphql` installs. TypeScript then treats types like
+  # `GraphQLSchema` from each copy as incompatible with each other (a "dual package
+  # hazard"), which breaks `pnpm build` with a TS2345 error. Forcing a single resolved
+  # version keeps the whole workspace on one graphql install. Keep this in sync with the
+  # root devDependency's graphql version, and with scripts/match-graphql.js, which applies
+  # the same kind of override for CI's graphql 15/16/17 test matrix.
+  graphql: 17.0.2
   '@rushstack/eslint-patch': 1.16.1
   '@typescript-eslint/eslint-plugin': 8.59.3
   '@typescript-eslint/parser': 8.59.3


### PR DESCRIPTION
## Description

Bumps the repo's own dev-time `graphql` dependency to v17 and closes the last CI gap in testing against graphql 15/16/17.

- Bump the root devDependency and every `examples/*` package's `graphql` dependency from `16.14.0` to `17.0.2` (npm's `latest` dist-tag).
- Add a `pnpm-workspace.yaml` override pinning `graphql` to `17.0.2` so the whole workspace resolves a single `graphql` install for local/dev builds — see the comment added in that file for why this is needed (a real dual-package-install TS2345 build error otherwise), and `scripts/match-graphql.js`, which does the same kind of override for CI.
- Add `graphql_version: 17` to the `test-watcher` CI job's matrix, matching the main `test` job which already runs `[15, 16, 17]`.

All packages' `peerDependencies` already declared support for `^17.0.0`, and the main `test` job's graphql-17 matrix leg was already green on `master`, so this only closes the remaining dev/CI gaps — no public API or peerDependency ranges change.

Related # (no linked issue — internal dev/CI maintenance task)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(This is a dev-tooling/CI maintenance change — none of the above apply.)

## How Has This Been Tested?

- `pnpm build` — passes with a single resolved `graphql@17.0.2` across the workspace.
- `pnpm bob check` (ESM/CJS export integrity) — passes.
- `pnpm test --exclude="**/tests/watcher.run.spec.ts"` — 892 passing, same 7 pre-existing failures as on the unmodified `graphql@16.14.0` baseline (unicode terminal rendering in `init.spec.ts`, and a network-egress-blocked live API call in the `graphql-request` example — both sandbox artifacts, verified to reproduce identically before this change).

**Test Environment**:

- OS: Linux (CI sandbox)
- `@graphql-codegen/...`: workspace (unreleased)
- NodeJS: 22

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Further comments

The one non-obvious part: bumping the root `graphql` devDependency alone isn't sufficient. Without the `pnpm-workspace.yaml` override, transitive dev dependencies (e.g. `graphql-helix`, used by `@graphql-codegen/testing`) kept resolving their own `graphql@16.x` copy independently, producing two physically distinct `graphql` installs. TypeScript then treated `GraphQLSchema` from each copy as incompatible, breaking `pnpm build` with a TS2345 error. The override forces one resolved version workspace-wide, mirroring what `scripts/match-graphql.js` already does for CI's version-matrix runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LxCkKw7qMqLagNbBSFuKM

---
_Generated by [Claude Code](https://claude.ai/code/session_011LxCkKw7qMqLagNbBSFuKM)_